### PR TITLE
capability-enum: make case insensitive

### DIFF
--- a/cda-sovd-interfaces/src/components/ecu/operations.rs
+++ b/cda-sovd-interfaces/src/components/ecu/operations.rs
@@ -102,6 +102,7 @@ pub mod comparams {
         }
 
         #[derive(Deserialize, Serialize, Clone)]
+        #[serde(rename_all = "lowercase")]
         #[cfg_attr(feature = "swagger-ui", derive(ToSchema))]
         pub enum Capability {
             Execute,


### PR DESCRIPTION
The capability enums should be deserialized ignoring case

Mark Schmitt [mark.schmitt@mercedes-benz.com](mailto:mark.schmitt@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH [Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)