### PR TITLE
extracted diag_service and split into data / configurations

### DIFF
--- a/cda-interfaces/src/lib.rs
+++ b/cda-interfaces/src/lib.rs
@@ -61,11 +61,19 @@ pub struct DiagComm {
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
+/// Enum representing diagnostic communication types according to ASAM SOVD.
+///
+/// Can be mapped to UDS service prefixes with [`DiagCommType::service_prefix`]
 pub enum DiagCommType {
+    /// Service Prefix `0x2E`
     Configurations,
+    /// Service Prefix `0x22`
     Data,
+    /// Service Prefixes `0x14`, `0x19`
     Faults,
+    /// Service Prefixes `0x10`, `0x11`, `0x28`, `0x85`, `0x27`, `0x29`
     Modes,
+    /// Service Prefixes `0x2F`, `0x31`, `0x34`, `0x36`, `0x37`
     Operations,
 }
 

--- a/cda-sovd-interfaces/src/components/ecu/mod.rs
+++ b/cda-sovd-interfaces/src/components/ecu/mod.rs
@@ -30,6 +30,7 @@ pub struct Ecu {
     pub locks: String,
     pub operations: String,
     pub data: String,
+    pub configurations: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sdgs: Option<Vec<SdSdg>>,
     #[serde(rename = "x-single-ecu-jobs")]

--- a/cda-sovd/src/sovd/components/ecu/operations.rs
+++ b/cda-sovd/src/sovd/components/ecu/operations.rs
@@ -304,7 +304,6 @@ pub(crate) mod service {
 
         use crate::sovd::{
             self, WebserverEcuState, api_error_from_diag_response,
-            data::Op,
             error::{ApiError, ErrorWrapper},
         };
 
@@ -446,7 +445,6 @@ pub(crate) mod service {
                         (StatusCode::OK, Bytes::from_owner(data)).into_response()
                     }
                 }
-                Op::Update => unreachable!("No put handler registered"),
             }
         }
 
@@ -537,6 +535,11 @@ pub(crate) mod service {
                     }
                 }
             }
+        }
+
+        enum Op {
+            Read,
+            Write,
         }
     }
 }

--- a/cda-sovd/src/sovd/mod.rs
+++ b/cda-sovd/src/sovd/mod.rs
@@ -189,12 +189,14 @@ pub async fn route<
                     .get(locks::ecu::lock::get),
             )
             .route("/configurations", routing::get(configurations::get))
+            .route(
+                "/configurations/{diag_service}",
+                routing::put(configurations::diag_service::put),
+            )
             .route("/data", routing::get(data::get))
             .route(
                 "/data/{diag_service}",
-                routing::get(data::diag_service::get)
-                    .post(data::diag_service::post)
-                    .put(data::diag_service::put),
+                routing::get(data::diag_service::get).put(data::diag_service::put),
             )
             .route(
                 "/operations/comparam/executions",


### PR DESCRIPTION
 - extracted diag_service so it can offer common functionality for both data/{diag_service} and configurations/{diag_service} endpoints.
 - moved post and put handlers from data (which is only read) to configurations (which is only write)

Mark Schmitt [mark.schmitt@mercedes-benz.com](mailto:mark.schmitt@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH [Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)