### PR TITLE
genericservice: add genericservice endpoint

### DIFF
--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -105,6 +105,14 @@ pub trait EcuManager:
         raw_payload: &[u8],
         map_to_json: bool,
     ) -> Result<Self::Response, DiagServiceError>;
+    /// Creates a `ServicePayload` and processes transitions based on raw UDS data,
+    /// as received from a generic data endpoint.
+    ///
+    /// Returns the `ServicePayload` with resolved transitions.
+    ///
+    /// # Errors
+    /// Returns `Err` if the payload cannot be matched to any diagnostic service.
+    fn check_genericservice(&self, rawdata: Vec<u8>) -> Result<ServicePayload, DiagServiceError>;
     /// Converts given `UdsPayloadData` into a UDS request payload for the given `DiagService`.
     ///
     /// # Errors

--- a/cda-interfaces/src/ecuuds.rs
+++ b/cda-interfaces/src/ecuuds.rs
@@ -98,6 +98,18 @@ pub trait UdsEcu: Send + Sync + 'static {
         payload: Option<UdsPayloadData>,
         map_to_json: bool,
     ) -> impl Future<Output = Result<Self::Response, DiagServiceError>> + Send;
+    /// Send a raw uds packet to the ECU
+    /// The initial bytes of the packet are analyzed to resolve the diag-service,
+    /// but the rest of the data is not validated / checked for consistency
+    /// # Error
+    /// Will return `Err` if the ECU does not exist, the diag-service cannot be
+    /// resolved or if the request fails.
+    fn send_genericservice(
+        &self,
+        ecu_name: &str,
+        payload: Vec<u8>,
+        timeout: Option<Duration>,
+    ) -> impl Future<Output = Result<Vec<u8>, DiagServiceError>> + Send;
     /// Set the session for the given ECU.
     /// No authentication is done by the implementation itself, it is assumed that the
     /// caller has already set the appropriate security access if required.

--- a/cda-sovd/src/sovd/components/ecu/genericservice.rs
+++ b/cda-sovd/src/sovd/components/ecu/genericservice.rs
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use axum::{body::Bytes, extract::State, response::Response};
+use cda_interfaces::{
+    UdsEcu,
+    diagservices::{DiagServiceResponse, UdsPayloadData},
+    file_manager::FileManager,
+};
+use http::{HeaderMap, header};
+use sovd_interfaces::components::ecu::data::DataRequestPayload;
+
+use super::*;
+use crate::sovd::{WebserverEcuState, get_payload_data};
+
+pub(crate) async fn put<
+    R: DiagServiceResponse + Send + Sync,
+    T: UdsEcu + Send + Sync + Clone,
+    U: FileManager + Send + Sync + Clone,
+>(
+    headers: HeaderMap,
+    State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<R, T, U>>,
+    body: Bytes,
+) -> Response {
+    match headers.get(header::ACCEPT) {
+        Some(v) if v == mime::APPLICATION_OCTET_STREAM.essence_str() => (Some(v), false),
+        _ => {
+            return ErrorWrapper(ApiError::BadRequest(format!(
+                "Unsupported Accept, only {} is supported",
+                mime::APPLICATION_OCTET_STREAM
+            )))
+            .into_response();
+        }
+    };
+
+    let data = match get_payload_data::<DataRequestPayload>(&headers, &body) {
+        Ok(value) => value,
+        Err(e) => return ErrorWrapper(e).into_response(),
+    };
+    let uds_raw_payload = match data {
+        Some(UdsPayloadData::Raw(raw_data)) => raw_data,
+        _ => {
+            return ErrorWrapper(ApiError::BadRequest(format!(
+                "Unsupported payload, only Content-Type {} containing the raw uds packet is \
+                 supported ",
+                mime::APPLICATION_OCTET_STREAM
+            )))
+            .into_response();
+        }
+    };
+
+    let ecu_response = match uds
+        .send_genericservice(&ecu_name, uds_raw_payload, None)
+        .await
+        .map_err(std::convert::Into::into)
+    {
+        Err(e) => return ErrorWrapper(e).into_response(),
+        Ok(v) => v,
+    };
+    // Return the raw response
+    (StatusCode::OK, Bytes::from_owner(ecu_response)).into_response()
+}

--- a/cda-sovd/src/sovd/components/ecu/mod.rs
+++ b/cda-sovd/src/sovd/components/ecu/mod.rs
@@ -27,6 +27,7 @@ use crate::sovd::{
 
 pub(crate) mod configurations;
 pub(crate) mod data;
+pub(crate) mod genericservice;
 pub(crate) mod modes;
 pub(crate) mod operations;
 pub(crate) mod x_single_ecu_jobs;

--- a/cda-sovd/src/sovd/mod.rs
+++ b/cda-sovd/src/sovd/mod.rs
@@ -37,8 +37,8 @@ use uuid::Uuid;
 
 use crate::sovd::{
     components::ecu::{
-        configurations, data, modes, operations, x_single_ecu_jobs, x_sovd2uds_bulk_data,
-        x_sovd2uds_download,
+        configurations, data, genericservice, modes, operations, x_single_ecu_jobs,
+        x_sovd2uds_bulk_data, x_sovd2uds_download,
     },
     locks::{LockType, Locks},
 };
@@ -196,6 +196,7 @@ pub async fn route<
                     .post(data::diag_service::post)
                     .put(data::diag_service::put),
             )
+            .route("/genericservice", routing::put(genericservice::put))
             .route(
                 "/operations/comparam/executions",
                 routing::get(operations::comparams::executions::get)


### PR DESCRIPTION
 - pass UDS packets unmodified to ECU and return response
 - allows for direct unmodified communication with an ECU
 - parses packets to ensure transitions are tracked properly

Mark Schmitt [mark.schmitt@mercedes-benz.com](mailto:mark.schmitt@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH [Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)