### PR TITLE
Support Building for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,26 @@ jobs:
       - name: Check banned practises
         run: cargo deny check bans
 
+  build_windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.88.0
+          components: clippy, rustfmt
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo build --locked --verbose
+      - name: Test
+        run: cargo test --locked -- --show-output
+
   check_copyright_headers:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,7 +1623,7 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 [[package]]
 name = "mimalloc"
 version = "3.0.1"
-source = "git+https://github.com/theswiftfox/mimalloc.git?rev=7a6f28b#7a6f28b407f3c83b10641b62a50386c76b5939e8"
+source = "git+https://github.com/theswiftfox/mimalloc.git?rev=afbaaa5#afbaaa50e6df2e28be0c721c55463cc52e86b89a"
 dependencies = [
  "cc",
  "libc",

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -480,6 +480,7 @@ fn create_socket(
     socket
         .set_reuse_address(true)
         .map_err(|e| format!("DoipGateway: Failed to set reuse address: {e:?}"))?;
+    #[cfg(target_family = "unix")]
     socket
         .set_reuse_port(true)
         .map_err(|e| format!("DoipGateway: Failed to set reuse port: {e:?}"))?;

--- a/cda-main/Cargo.toml
+++ b/cda-main/Cargo.toml
@@ -37,7 +37,7 @@ figment = { version = "0.10.19", default-features = false, features = [
 futures = { version = "0.3" }
 hashbrown = { version = "0.15", features = ["serde"] }
 # allocator
-mimalloc = { git = "https://github.com/theswiftfox/mimalloc.git", rev = "7a6f28b" }
+mimalloc = { git = "https://github.com/theswiftfox/mimalloc.git", rev = "afbaaa5" }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.43.0", features = [
   "rt-multi-thread",


### PR DESCRIPTION
 Out of curiosity I decided to try to build with native Windows. With two small changes the build works and we can run it on windows as well :
 - Bump mimalloc to version that builds for windows
 - set reuse_port only for unix families of OSes
 
 Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)