### PR TITLE
minor parsing fixes

### DIFF
--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -533,6 +533,7 @@ impl cda_interfaces::EcuManager for EcuManager {
                         param.short_name
                     ))
                 })?;
+                uds_payload.set_last_read_byte_pos(param.byte_pos as usize);
                 self.map_param_from_uds(
                     mapped_service,
                     param,

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -2146,13 +2146,6 @@ impl EcuManager {
     ) -> Result<(), DiagServiceError> {
         // Byte pos is the relative position of the data in the uds_payload
         let byte_pos = mux_dop.byte_position as usize;
-        if uds_payload.len() < byte_pos + 1 {
-            return Err(DiagServiceError::BadPayload(format!(
-                "Not enough data for mux: {} < {}",
-                uds_payload.len(),
-                byte_pos + 1,
-            )));
-        }
 
         let switch_key = &mux_dop
             .switch_key
@@ -3085,11 +3078,12 @@ mod tests {
             true,
         );
 
-        assert!(
-            response
-                .unwrap_err()
-                .to_string()
-                .contains("Not enough data for mux")
+        assert_eq!(
+            response.unwrap_err(),
+            DiagServiceError::NotEnoughData {
+                expected: 4, // the case expects 4 bytes for the float param
+                actual: 0
+            }
         );
     }
 

--- a/cda-database/src/datatypes/data_operation.rs
+++ b/cda-database/src/datatypes/data_operation.rs
@@ -266,6 +266,10 @@ impl TryInto<f32> for &Limit {
 impl TryInto<f64> for &Limit {
     type Error = DiagServiceError;
     fn try_into(self) -> Result<f64, Self::Error> {
+        if self.value.is_empty() {
+            // treat empty string as 0
+            return Ok(f64::default());
+        }
         self.value.parse().map_err(|e| {
             DiagServiceError::ParameterConversionError(format!(
                 "Cannot convert Limit with value {} into f64, {e:?}",

--- a/cda-database/src/datatypes/data_operation.rs
+++ b/cda-database/src/datatypes/data_operation.rs
@@ -826,7 +826,7 @@ mod tests {
         };
 
         let result: Result<f32, _> = (&limit).try_into();
-        assert_eq!(result.unwrap(), 0.0f32);
+        assert_eq!(result.unwrap(), 0.0_f32);
     }
 
     #[test]
@@ -837,18 +837,18 @@ mod tests {
         };
 
         let result: Result<f64, _> = (&limit).try_into();
-        assert_eq!(result.unwrap(), 0.0f64);
+        assert_eq!(result.unwrap(), 0.0_f64);
     }
 
     #[test]
-    fn test_limit_try_into_u64_empty_string() {
+    fn test_limit_try_into_u32_empty_string() {
         let limit = Limit {
             value: "".to_string(),
             interval_type: IntervalType::Closed,
         };
 
         let result: Result<u32, _> = (&limit).try_into();
-        assert_eq!(result.unwrap(), 0u32);
+        assert_eq!(result.unwrap(), 0_u32);
     }
 
     #[test]

--- a/cda-database/src/datatypes/data_operation.rs
+++ b/cda-database/src/datatypes/data_operation.rs
@@ -254,6 +254,10 @@ impl TryInto<i32> for &Limit {
 impl TryInto<f32> for &Limit {
     type Error = DiagServiceError;
     fn try_into(self) -> Result<f32, Self::Error> {
+        if self.value.is_empty() {
+            // treat empty string as 0
+            return Ok(f32::default());
+        }
         self.value.parse().map_err(|e| {
             DiagServiceError::ParameterConversionError(format!(
                 "Cannot convert Limit with value {} into f32, {e:?}",
@@ -813,6 +817,39 @@ impl TryFrom<i32> for Radix {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_limit_try_into_f32_empty_string() {
+        let limit = Limit {
+            value: "".to_string(),
+            interval_type: IntervalType::Closed,
+        };
+
+        let result: Result<f32, _> = (&limit).try_into();
+        assert_eq!(result.unwrap(), 0.0f32);
+    }
+
+    #[test]
+    fn test_limit_try_into_f64_empty_string() {
+        let limit = Limit {
+            value: "".to_string(),
+            interval_type: IntervalType::Closed,
+        };
+
+        let result: Result<f64, _> = (&limit).try_into();
+        assert_eq!(result.unwrap(), 0.0f64);
+    }
+
+    #[test]
+    fn test_limit_try_into_u64_empty_string() {
+        let limit = Limit {
+            value: "".to_string(),
+            interval_type: IntervalType::Closed,
+        };
+
+        let result: Result<u32, _> = (&limit).try_into();
+        assert_eq!(result.unwrap(), 0u32);
+    }
 
     #[test]
     fn test_limit_try_into_vec_u8_hex_values() {


### PR DESCRIPTION
This PR fixes some issues I encountered in UDS response parsing when testing for changes related to #37:
 - the ECU database can have a limit value of `""` this caused a parse error in the original implementation and is now changed to be treated as a limit of `0` for numeric types.
 - due to skipping of non `DATA` and `SERVICEIDRQ` the offset in the `uds_payload` struct was not always set as expected, causing the resulting data to not be interpreted correctly for some payloads.
 - ensure that when parsing a MUX the subslice starts at mux_dop.byte_pos as specified in the standard.

Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)