### PR TITLE
Add include-schema to the rest of the endpoints

### DIFF
--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -892,6 +892,17 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
         self.send(ecu_name, request, Some(data), true).await
     }
 
+    async fn ecu_lookup_service_through_func_class(
+        &self,
+        ecu_name: &str,
+        func_class_name: &str,
+        service_id: u8,
+    ) -> Result<DiagComm, DiagServiceError> {
+        let ecu_diag_service = self.ecus.get(ecu_name).ok_or(DiagServiceError::NotFound)?;
+        let ecu = ecu_diag_service.read().await;
+        ecu.lookup_service_through_func_class(func_class_name, service_id)
+    }
+
     async fn ecu_flash_transfer_start(
         &self,
         ecu_name: &str,

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -1183,10 +1183,13 @@ impl cda_interfaces::EcuManager for EcuManager {
                                     _ => return None,
                                 };
 
-                                service_types
-                                    .iter()
-                                    .find(|s| ((*s).clone() as u8).to_string() == *sub_function_id)
-                                    .map(|dsp| (service, dsp))
+                                service_types.iter().find_map(|s| {
+                                    if ((*s).clone() as u8).to_string() == *sub_function_id {
+                                        Some((service, s))
+                                    } else {
+                                        None
+                                    }
+                                })
                             })
                         })
                     })

--- a/cda-interfaces/src/ecuuds.rs
+++ b/cda-interfaces/src/ecuuds.rs
@@ -175,6 +175,15 @@ pub trait UdsEcu: Send + Sync + 'static {
         service_id: u8,
         data: UdsPayloadData,
     ) -> impl Future<Output = Result<Self::Response, DiagServiceError>> + Send;
+    /// Lookup a service on the ECU by a given function class name and service id.
+    /// # Errors
+    /// * DiagServiceError::NotFound if the ECU or service lookup failed.
+    fn ecu_lookup_service_through_func_class(
+        &self,
+        ecu_name: &str,
+        func_class_name: &str,
+        service_id: u8,
+    ) -> impl Future<Output = Result<DiagComm, DiagServiceError>> + Send;
     /// Start a flash transfer for the given ECU.
     /// Setting the ECU into the appropriate session and security access must be done
     /// before calling this function, otherwise the ECU will not accept the transfer.

--- a/cda-sovd-interfaces/Cargo.toml
+++ b/cda-sovd-interfaces/Cargo.toml
@@ -20,9 +20,8 @@ hashbrown = { workspace = true, features = ["serde"] }
 chrono = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-schemars = { workspace = true, optional = true, features = ["hashbrown"] }
+schemars = { workspace = true, features = ["hashbrown"] }
 
 [features]
 default = []
-openapi = ["dep:schemars"]
 auth = []

--- a/cda-sovd-interfaces/src/apps.rs
+++ b/cda-sovd-interfaces/src/apps.rs
@@ -80,6 +80,9 @@ pub mod sovd2uds {
                 pub struct Response {
                     pub id: String,
                     pub data: Vec<crate::apps::sovd2uds::data::network_structure::NetworkStructure>,
+                    #[cfg_attr(feature = "openapi", schemars(skip))]
+                    #[serde(skip_serializing_if = "Option::is_none")]
+                    pub schema: Option<schemars::Schema>,
                 }
             }
         }

--- a/cda-sovd-interfaces/src/apps.rs
+++ b/cda-sovd-interfaces/src/apps.rs
@@ -26,7 +26,7 @@ pub mod sovd2uds {
 
             #[derive(Serialize)]
             #[serde(rename_all = "PascalCase")]
-            #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+            #[derive(schemars::JsonSchema)]
             pub struct Ecu {
                 /// ECU name
                 pub qualifier: String,
@@ -43,7 +43,7 @@ pub mod sovd2uds {
 
             #[derive(Serialize)]
             #[serde(rename_all = "PascalCase")]
-            #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+            #[derive(schemars::JsonSchema)]
             pub struct Gateway {
                 /// Gateway ECU name
                 pub name: String,
@@ -57,7 +57,7 @@ pub mod sovd2uds {
 
             #[derive(Serialize)]
             #[serde(rename_all = "PascalCase")]
-            #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+            #[derive(schemars::JsonSchema)]
             pub struct FunctionalGroup {
                 pub qualifier: String,
                 pub ecus: Vec<Ecu>,
@@ -65,7 +65,7 @@ pub mod sovd2uds {
 
             #[derive(Serialize)]
             #[serde(rename_all = "PascalCase")]
-            #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+            #[derive(schemars::JsonSchema)]
             pub struct NetworkStructure {
                 pub functional_groups: Vec<FunctionalGroup>,
                 pub gateways: Vec<Gateway>,
@@ -74,13 +74,12 @@ pub mod sovd2uds {
             pub mod get {
                 use serde::Serialize;
 
-                #[derive(Serialize)]
-                #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
-                #[cfg_attr(feature = "openapi", schemars(rename = "NetworkStructureResponse"))]
+                #[derive(Serialize, schemars::JsonSchema)]
+                #[schemars(rename = "NetworkStructureResponse")]
                 pub struct Response {
                     pub id: String,
                     pub data: Vec<crate::apps::sovd2uds::data::network_structure::NetworkStructure>,
-                    #[cfg_attr(feature = "openapi", schemars(skip))]
+                    #[schemars(skip)]
                     #[serde(skip_serializing_if = "Option::is_none")]
                     pub schema: Option<schemars::Schema>,
                 }

--- a/cda-sovd-interfaces/src/components/ecu/mod.rs
+++ b/cda-sovd-interfaces/src/components/ecu/mod.rs
@@ -34,6 +34,9 @@ pub struct Ecu {
     #[serde(rename = "x-single-ecu-jobs")]
     pub single_ecu_jobs: String,
     pub faults: String,
+    #[cfg_attr(feature = "openapi", schemars(skip))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<schemars::Schema>,
 }
 
 pub type ComponentData = Items<ComponentDataInfo>;
@@ -107,6 +110,9 @@ pub mod configurations {
     #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
     pub struct Components {
         pub items: Vec<ComponentItem>,
+        #[cfg_attr(feature = "openapi", schemars(skip))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub schema: Option<schemars::Schema>,
     }
 
     #[derive(Deserialize, Serialize, Debug)]
@@ -119,6 +125,8 @@ pub mod configurations {
         #[serde(rename = "x-sovd2uds-ServiceAbstract")]
         pub service_abstract: Vec<String>,
     }
+
+    pub type ConfigurationsQuery = crate::IncludeSchemaQuery;
 
     pub mod get {
         use super::*;
@@ -146,23 +154,15 @@ pub mod data {
     }
 
     pub mod service {
-        use super::*;
-        pub mod get {
-            use super::*;
-            #[derive(Deserialize)]
-            #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
-            pub struct DiagServiceQuery {
-                #[serde(rename = "x-include-sdgs")]
-                pub include_sdgs: Option<bool>,
-                #[serde(rename = "include-schema")]
-                pub include_schema: Option<bool>,
-            }
+        pub mod put {
+            pub type Query = crate::IncludeSchemaQuery;
         }
     }
 
     pub mod get {
         use super::*;
         pub type Response = ComponentData;
+        pub type Query = crate::IncludeSchemaQuery;
     }
 }
 
@@ -174,6 +174,7 @@ pub mod x {
                     use crate::{Items, sovd2uds::File};
 
                     pub type Response = Items<File>;
+                    pub type Query = crate::IncludeSchemaQuery;
                 }
             }
         }
@@ -198,10 +199,15 @@ pub mod x {
                     #[cfg_attr(feature = "openapi", schemars(rename = "FlashTransferResponse"))]
                     pub struct Response {
                         pub id: String,
+                        #[cfg_attr(feature = "openapi", schemars(skip))]
+                        #[serde(skip_serializing_if = "Option::is_none")]
+                        pub schema: Option<schemars::Schema>,
                     }
                 }
                 pub mod get {
                     use serde::Serialize;
+
+                    use crate::Items;
 
                     #[derive(Serialize, Clone)]
                     #[serde(rename_all = "PascalCase")]
@@ -215,6 +221,9 @@ pub mod x {
                         pub status: DataTransferStatus,
                         #[serde(skip_serializing_if = "Option::is_none")]
                         pub error: Option<Vec<DataTransferError>>,
+                        #[cfg_attr(feature = "openapi", schemars(skip))]
+                        #[serde(skip_serializing_if = "Option::is_none")]
+                        pub schema: Option<schemars::Schema>,
                     }
 
                     #[derive(Serialize, Clone)]
@@ -237,7 +246,7 @@ pub mod x {
                         Queued,
                     }
 
-                    pub type Response = Vec<DataTransferMetaData>;
+                    pub type Response = Items<DataTransferMetaData>;
 
                     pub mod id {
                         use super::*;
@@ -268,6 +277,9 @@ pub mod x {
                         pub parameters: serde_json::Map<String, serde_json::Value>,
                         #[serde(skip_serializing_if = "Vec::is_empty")]
                         pub errors: Vec<DataError<T>>,
+                        #[cfg_attr(feature = "openapi", schemars(skip))]
+                        #[serde(skip_serializing_if = "Option::is_none")]
+                        pub schema: Option<schemars::Schema>,
                     }
                 }
             }
@@ -340,6 +352,10 @@ pub mod x {
 
             #[serde(rename = "x-prog-code")]
             pub prog_codes: Vec<ProgCode>,
+
+            #[cfg_attr(feature = "openapi", schemars(skip))]
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub schema: Option<schemars::Schema>,
         }
 
         // Clippy would prefer if we would pass Option<&LongName> instead.

--- a/cda-sovd-interfaces/src/components/ecu/mod.rs
+++ b/cda-sovd-interfaces/src/components/ecu/mod.rs
@@ -85,6 +85,9 @@ pub enum SdSdg {
 #[derive(Serialize, schemars::JsonSchema)]
 pub struct ServicesSdgs {
     pub items: HashMap<String, ServiceSdgs>,
+    #[schemars(skip)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<schemars::Schema>,
 }
 #[derive(Serialize, schemars::JsonSchema)]
 pub struct ServiceSdgs {

--- a/cda-sovd-interfaces/src/components/ecu/mod.rs
+++ b/cda-sovd-interfaces/src/components/ecu/mod.rs
@@ -201,7 +201,7 @@ pub mod x {
                     use crate::Items;
 
                     #[derive(Serialize, Clone)]
-                    #[serde(rename_all = "PascalCase")]
+                    #[serde(rename_all = "camelCase")]
                     #[derive(schemars::JsonSchema)]
                     pub struct DataTransferMetaData {
                         pub acknowledged_bytes: u64,

--- a/cda-sovd-interfaces/src/components/ecu/mod.rs
+++ b/cda-sovd-interfaces/src/components/ecu/mod.rs
@@ -415,8 +415,8 @@ pub mod faults {
             pub severity: Option<u32>,
             /// The scope to retrieve faults for. If not provided, all scopes are considered.
             pub scope: Option<String>,
-            #[serde(rename = "include-schema")]
-            pub include_schema: Option<bool>,
+            #[serde(rename = "include-schema", default)]
+            pub include_schema: bool,
         }
 
         #[derive(Serialize, Debug, schemars::JsonSchema)]

--- a/cda-sovd-interfaces/src/components/ecu/mod.rs
+++ b/cda-sovd-interfaces/src/components/ecu/mod.rs
@@ -19,8 +19,7 @@ use crate::Items;
 pub mod modes;
 pub mod operations;
 
-#[derive(Serialize)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[derive(Serialize, schemars::JsonSchema)]
 pub struct Ecu {
     pub id: String,
     pub name: String,
@@ -34,15 +33,14 @@ pub struct Ecu {
     #[serde(rename = "x-single-ecu-jobs")]
     pub single_ecu_jobs: String,
     pub faults: String,
-    #[cfg_attr(feature = "openapi", schemars(skip))]
+    #[schemars(skip)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<schemars::Schema>,
 }
 
 pub type ComponentData = Items<ComponentDataInfo>;
 
-#[derive(Deserialize, Serialize, Debug)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[derive(Deserialize, Serialize, Debug, schemars::JsonSchema)]
 pub struct ComponentDataInfo {
     pub category: String,
     pub id: String,
@@ -51,7 +49,7 @@ pub struct ComponentDataInfo {
 
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[derive(schemars::JsonSchema)]
 pub enum SdSdg {
     /// A single special data group
     Sd {
@@ -79,21 +77,16 @@ pub enum SdSdg {
         /// The list of SD or SDGs in the SDG
         #[serde(skip_serializing_if = "Vec::is_empty")]
         #[serde(default)]
-        #[cfg_attr(
-            feature = "openapi",
-            schemars(with = "Vec<serde_json::Map<String, serde_json::Value>>")
-        )]
+        #[schemars(with = "Vec<serde_json::Map<String, serde_json::Value>>")]
         sdgs: Vec<SdSdg>,
     },
 }
 
-#[derive(Serialize)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[derive(Serialize, schemars::JsonSchema)]
 pub struct ServicesSdgs {
     pub items: HashMap<String, ServiceSdgs>,
 }
-#[derive(Serialize)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[derive(Serialize, schemars::JsonSchema)]
 pub struct ServiceSdgs {
     pub sdgs: Vec<SdSdg>,
 }
@@ -106,17 +99,15 @@ pub mod get {
 pub mod configurations {
     use super::*;
 
-    #[derive(Deserialize, Serialize, Debug)]
-    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+    #[derive(Deserialize, Serialize, Debug, schemars::JsonSchema)]
     pub struct Components {
         pub items: Vec<ComponentItem>,
-        #[cfg_attr(feature = "openapi", schemars(skip))]
+        #[schemars(skip)]
         #[serde(skip_serializing_if = "Option::is_none")]
         pub schema: Option<schemars::Schema>,
     }
 
-    #[derive(Deserialize, Serialize, Debug)]
-    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+    #[derive(Deserialize, Serialize, Debug, schemars::JsonSchema)]
     pub struct ComponentItem {
         pub id: String,
         pub name: String,
@@ -141,8 +132,7 @@ pub mod data {
     use super::*;
     use crate::Payload;
 
-    #[derive(Deserialize)]
-    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+    #[derive(Deserialize, schemars::JsonSchema)]
     pub struct DataRequestPayload {
         data: HashMap<String, serde_json::Value>,
     }
@@ -182,9 +172,8 @@ pub mod x {
             pub mod flash_transfer {
                 pub mod post {
                     use serde::{Deserialize, Serialize};
-                    #[derive(Debug, Deserialize)]
-                    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
-                    #[cfg_attr(feature = "openapi", schemars(rename = "FlashTransferRequest"))]
+                    #[derive(Debug, Deserialize, schemars::JsonSchema)]
+                    #[schemars(rename = "FlashTransferRequest")]
                     pub struct Request {
                         #[serde(rename = "blocksequencecounter")]
                         pub block_sequence_counter: u8,
@@ -194,12 +183,11 @@ pub mod x {
                         pub id: String,
                     }
 
-                    #[derive(Debug, Serialize)]
-                    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
-                    #[cfg_attr(feature = "openapi", schemars(rename = "FlashTransferResponse"))]
+                    #[derive(Debug, Serialize, schemars::JsonSchema)]
+                    #[schemars(rename = "FlashTransferResponse")]
                     pub struct Response {
                         pub id: String,
-                        #[cfg_attr(feature = "openapi", schemars(skip))]
+                        #[schemars(skip)]
                         #[serde(skip_serializing_if = "Option::is_none")]
                         pub schema: Option<schemars::Schema>,
                     }
@@ -211,7 +199,7 @@ pub mod x {
 
                     #[derive(Serialize, Clone)]
                     #[serde(rename_all = "PascalCase")]
-                    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+                    #[derive(schemars::JsonSchema)]
                     pub struct DataTransferMetaData {
                         pub acknowledged_bytes: u64,
                         pub blocksize: usize,
@@ -221,20 +209,19 @@ pub mod x {
                         pub status: DataTransferStatus,
                         #[serde(skip_serializing_if = "Option::is_none")]
                         pub error: Option<Vec<DataTransferError>>,
-                        #[cfg_attr(feature = "openapi", schemars(skip))]
+                        #[schemars(skip)]
                         #[serde(skip_serializing_if = "Option::is_none")]
                         pub schema: Option<schemars::Schema>,
                     }
 
-                    #[derive(Serialize, Clone)]
-                    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+                    #[derive(Serialize, Clone, schemars::JsonSchema)]
                     pub struct DataTransferError {
                         pub text: String,
                     }
 
                     #[derive(Serialize, Debug, Clone, PartialEq)]
                     #[serde(rename_all = "lowercase")]
-                    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+                    #[derive(schemars::JsonSchema)]
                     // allow unused because not all variants are used in the sovd
                     // context yet but are needed to match the CDA internal types
                     // and are useful for an sovd server as well
@@ -262,22 +249,20 @@ pub mod x {
 
                     use crate::error::DataError;
 
-                    #[derive(Deserialize)]
-                    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
-                    #[cfg_attr(feature = "openapi", schemars(rename = "RequestDownloadRequest"))]
+                    #[derive(Deserialize, schemars::JsonSchema)]
+                    #[schemars(rename = "RequestDownloadRequest")]
                     pub struct Request {
                         #[serde(rename = "requestdownload")]
                         pub parameters: HashMap<String, serde_json::Value>,
                     }
-                    #[derive(Serialize)]
-                    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
-                    #[cfg_attr(feature = "openapi", schemars(rename = "RequestDownloadResponse"))]
+                    #[derive(Serialize, schemars::JsonSchema)]
+                    #[schemars(rename = "RequestDownloadResponse")]
                     pub struct Response<T> {
                         #[serde(rename = "requestdownload")]
                         pub parameters: serde_json::Map<String, serde_json::Value>,
                         #[serde(skip_serializing_if = "Vec::is_empty")]
                         pub errors: Vec<DataError<T>>,
-                        #[cfg_attr(feature = "openapi", schemars(skip))]
+                        #[schemars(skip)]
                         #[serde(skip_serializing_if = "Option::is_none")]
                         pub schema: Option<schemars::Schema>,
                     }
@@ -289,8 +274,7 @@ pub mod x {
     pub mod single_ecu_job {
         use serde::{Deserialize, Serialize};
 
-        #[derive(Serialize, Deserialize)]
-        #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+        #[derive(Serialize, Deserialize, schemars::JsonSchema)]
         pub struct LongName {
             #[serde(skip_serializing_if = "Option::is_none")]
             #[serde(default)]
@@ -301,8 +285,7 @@ pub mod x {
             pub ti: Option<String>,
         }
 
-        #[derive(Serialize, Deserialize)]
-        #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+        #[derive(Serialize, Deserialize, schemars::JsonSchema)]
         pub struct Param {
             pub short_name: String,
 
@@ -321,8 +304,7 @@ pub mod x {
             pub long_name: Option<LongName>,
         }
 
-        #[derive(Serialize, Deserialize)]
-        #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+        #[derive(Serialize, Deserialize, schemars::JsonSchema)]
         pub struct ProgCode {
             pub code_file: String,
             #[serde(skip_serializing_if = "Option::is_none")]
@@ -338,8 +320,7 @@ pub mod x {
             pub entrypoint: String,
         }
 
-        #[derive(Serialize, Deserialize)]
-        #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+        #[derive(Serialize, Deserialize, schemars::JsonSchema)]
         pub struct Job {
             #[serde(rename = "x-input-params")]
             pub input_params: Vec<Param>,
@@ -353,7 +334,7 @@ pub mod x {
             #[serde(rename = "x-prog-code")]
             pub prog_codes: Vec<ProgCode>,
 
-            #[cfg_attr(feature = "openapi", schemars(skip))]
+            #[schemars(skip)]
             #[serde(skip_serializing_if = "Option::is_none")]
             pub schema: Option<schemars::Schema>,
         }
@@ -383,8 +364,7 @@ pub mod faults {
         /// * Translation IDs
         ///
         /// This is still compliant with the OpenSOVD specification, as these fields are optional.
-        #[derive(Serialize)]
-        #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+        #[derive(Serialize, schemars::JsonSchema)]
         pub struct Fault {
             ///Fault code in the native representation of the entity.
             pub code: String,
@@ -405,8 +385,7 @@ pub mod faults {
             pub status: Option<FaultStatus>,
         }
 
-        #[derive(Debug, Serialize, Deserialize)]
-        #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+        #[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
         /// Query parameters for filtering DTC by the given fields.
         pub struct FaultQuery {
             /// Filters the elements based on a status, if the value ia a full match.
@@ -437,8 +416,7 @@ pub mod faults {
             pub include_schema: Option<bool>,
         }
 
-        #[derive(Serialize, Debug)]
-        #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+        #[derive(Serialize, Debug, schemars::JsonSchema)]
         #[serde(rename_all = "camelCase")]
         pub struct FaultStatus {
             #[serde(skip_serializing_if = "Option::is_none")]
@@ -461,11 +439,10 @@ pub mod faults {
             pub mask: Option<String>,
         }
 
-        #[derive(Serialize)]
-        #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+        #[derive(Serialize, schemars::JsonSchema)]
         pub struct Response {
             pub items: Vec<Fault>,
-            #[cfg_attr(feature = "openapi", schemars(skip))]
+            #[schemars(skip)]
             #[serde(skip_serializing_if = "Option::is_none")]
             pub schema: Option<schemars::Schema>,
         }

--- a/cda-sovd-interfaces/src/components/ecu/modes.rs
+++ b/cda-sovd-interfaces/src/components/ecu/modes.rs
@@ -13,8 +13,7 @@
 
 use serde::Serialize;
 
-#[derive(Debug, Serialize)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[derive(Debug, Serialize, schemars::JsonSchema)]
 pub struct Mode<T> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
@@ -24,7 +23,7 @@ pub struct Mode<T> {
     pub translation_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<T>,
-    #[cfg_attr(feature = "openapi", schemars(skip))]
+    #[schemars(skip)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<schemars::Schema>,
 }
@@ -42,16 +41,14 @@ pub mod put {
 
     pub type Query = crate::IncludeSchemaQuery;
 
-    #[derive(Debug, Deserialize)]
-    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+    #[derive(Debug, Deserialize, schemars::JsonSchema)]
     pub struct ModeKey {
         #[serde(rename = "Send_Key")]
         pub send_key: String,
     }
 
-    #[derive(Debug, Deserialize)]
-    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
-    #[cfg_attr(feature = "openapi", schemars(rename = "UpdateModesRequest"))]
+    #[derive(Debug, Deserialize, schemars::JsonSchema)]
+    #[schemars(rename = "UpdateModesRequest")]
     pub struct Request {
         pub value: String,
         /// Defines after how many seconds the
@@ -67,13 +64,12 @@ pub mod put {
         pub key: Option<ModeKey>,
     }
 
-    #[derive(Debug, Serialize)]
-    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
-    #[cfg_attr(feature = "openapi", schemars(rename = "UpdateModesResponse"))]
+    #[derive(Debug, Serialize, schemars::JsonSchema)]
+    #[schemars(rename = "UpdateModesResponse")]
     pub struct Response<T> {
         pub id: String,
         pub value: T,
-        #[cfg_attr(feature = "openapi", schemars(skip))]
+        #[schemars(skip)]
         #[serde(skip_serializing_if = "Option::is_none")]
         pub schema: Option<schemars::Schema>,
     }

--- a/cda-sovd-interfaces/src/components/ecu/modes.rs
+++ b/cda-sovd-interfaces/src/components/ecu/modes.rs
@@ -24,7 +24,9 @@ pub struct Mode<T> {
     pub translation_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<T>,
-    // todo after POC: add open api schema for ?include_schema=true
+    #[cfg_attr(feature = "openapi", schemars(skip))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<schemars::Schema>,
 }
 
 pub mod get {
@@ -32,10 +34,13 @@ pub mod get {
     use crate::Items;
 
     pub type Response = Items<Mode<()>>;
+    pub type Query = crate::IncludeSchemaQuery;
 }
 
 pub mod put {
     use serde::{Deserialize, Serialize};
+
+    pub type Query = crate::IncludeSchemaQuery;
 
     #[derive(Debug, Deserialize)]
     #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
@@ -68,5 +73,8 @@ pub mod put {
     pub struct Response<T> {
         pub id: String,
         pub value: T,
+        #[cfg_attr(feature = "openapi", schemars(skip))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub schema: Option<schemars::Schema>,
     }
 }

--- a/cda-sovd-interfaces/src/components/ecu/operations.rs
+++ b/cda-sovd-interfaces/src/components/ecu/operations.rs
@@ -134,7 +134,12 @@ pub mod comparams {
             pub struct Response {
                 pub id: String,
                 pub status: Status,
+                #[cfg_attr(feature = "openapi", schemars(skip))]
+                #[serde(skip_serializing_if = "Option::is_none")]
+                pub schema: Option<schemars::Schema>,
             }
+
+            pub type Query = crate::IncludeSchemaQuery;
         }
 
         pub mod get {
@@ -142,6 +147,7 @@ pub mod comparams {
             use crate::Items;
 
             pub type Response = Items<Item>;
+            pub type Query = crate::IncludeSchemaQuery;
         }
 
         pub mod id {
@@ -157,7 +163,12 @@ pub mod comparams {
                     // use trait items here to allow for other execution types than comparam
                     pub parameters: HashMap<String, ComParamValue>,
                     pub status: Status,
+                    #[cfg_attr(feature = "openapi", schemars(skip))]
+                    #[serde(skip_serializing_if = "Option::is_none")]
+                    pub schema: Option<schemars::Schema>,
                 }
+
+                pub type Query = crate::IncludeSchemaQuery;
             }
         }
     }
@@ -175,6 +186,9 @@ pub mod service {
             pub parameters: serde_json::Map<String, serde_json::Value>,
             #[serde(skip_serializing_if = "Vec::is_empty")]
             pub errors: Vec<DataError<T>>,
+            #[cfg_attr(feature = "openapi", schemars(skip))]
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub schema: Option<schemars::Schema>,
         }
 
         #[derive(Deserialize, Serialize, Debug)]
@@ -193,5 +207,7 @@ pub mod service {
                     .map_or(HashMap::new(), std::clone::Clone::clone)
             }
         }
+
+        pub type Query = crate::IncludeSchemaQuery;
     }
 }

--- a/cda-sovd-interfaces/src/components/ecu/operations.rs
+++ b/cda-sovd-interfaces/src/components/ecu/operations.rs
@@ -19,15 +19,13 @@ pub mod comparams {
 
     use super::*;
 
-    #[derive(Deserialize, Serialize, Clone, Debug)]
-    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+    #[derive(Deserialize, Serialize, Clone, Debug, schemars::JsonSchema)]
     pub struct Unit {
         pub factor_to_si_unit: Option<f64>,
         pub offset_to_si_unit: Option<f64>,
     }
 
-    #[derive(Serialize, Clone)]
-    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+    #[derive(Serialize, Clone, schemars::JsonSchema)]
     pub struct ComParamSimpleValue {
         pub value: String,
         pub unit: Option<Unit>,
@@ -66,13 +64,10 @@ pub mod comparams {
 
     #[derive(Deserialize, Serialize, Clone)]
     #[serde(untagged)]
-    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+    #[derive(schemars::JsonSchema)]
     pub enum ComParamValue {
         Simple(ComParamSimpleValue),
-        #[cfg_attr(
-            feature = "openapi",
-            schemars(with = "serde_json::Map<String, serde_json::Value>")
-        )]
+        #[schemars(with = "serde_json::Map<String, serde_json::Value>")]
         Complex(ComplexComParamValue),
     }
 
@@ -90,7 +85,7 @@ pub mod comparams {
 
         #[derive(Deserialize, Serialize, Clone)]
         #[serde(rename_all = "lowercase")]
-        #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+        #[derive(schemars::JsonSchema)]
         pub enum Status {
             Running,
             Completed,
@@ -99,7 +94,7 @@ pub mod comparams {
 
         #[derive(Deserialize, Serialize, Clone)]
         #[serde(rename_all = "lowercase")]
-        #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+        #[derive(schemars::JsonSchema)]
         pub enum Capability {
             Execute,
             Stop,
@@ -108,8 +103,7 @@ pub mod comparams {
             Status,
         }
 
-        #[derive(Serialize)]
-        #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+        #[derive(Serialize, schemars::JsonSchema)]
         pub struct Item {
             pub id: String,
         }
@@ -119,8 +113,8 @@ pub mod comparams {
             // todo: which ones are optional or not
             #[derive(Deserialize)]
             #[allow(dead_code)]
-            #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
-            #[cfg_attr(feature = "openapi", schemars(rename = "UpdateExecutionRequest"))]
+            #[derive(schemars::JsonSchema)]
+            #[schemars(rename = "UpdateExecutionRequest")]
             pub struct Request {
                 pub capability: Option<Capability>,
                 pub timeout: Option<u32>,
@@ -128,13 +122,12 @@ pub mod comparams {
                 pub proximity_response: Option<String>,
             }
 
-            #[derive(Serialize)]
-            #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
-            #[cfg_attr(feature = "openapi", schemars(rename = "UpdateExecutionResponse"))]
+            #[derive(Serialize, schemars::JsonSchema)]
+            #[schemars(rename = "UpdateExecutionResponse")]
             pub struct Response {
                 pub id: String,
                 pub status: Status,
-                #[cfg_attr(feature = "openapi", schemars(skip))]
+                #[schemars(skip)]
                 #[serde(skip_serializing_if = "Option::is_none")]
                 pub schema: Option<schemars::Schema>,
             }
@@ -154,16 +147,15 @@ pub mod comparams {
             use super::*;
             pub mod get {
                 use super::*;
-                #[derive(Serialize)]
-                #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
-                #[cfg_attr(feature = "openapi", schemars(rename = "GetExecutionResponse"))]
+                #[derive(Serialize, schemars::JsonSchema)]
+                #[schemars(rename = "GetExecutionResponse")]
                 pub struct Response {
                     pub capability: Capability,
                     // todo: probably out of scope for now:
                     // use trait items here to allow for other execution types than comparam
                     pub parameters: HashMap<String, ComParamValue>,
                     pub status: Status,
-                    #[cfg_attr(feature = "openapi", schemars(skip))]
+                    #[schemars(skip)]
                     #[serde(skip_serializing_if = "Option::is_none")]
                     pub schema: Option<schemars::Schema>,
                 }
@@ -180,20 +172,18 @@ pub mod service {
         use super::*;
         use crate::{Payload, error::DataError};
 
-        #[derive(Serialize)]
-        #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+        #[derive(Serialize, schemars::JsonSchema)]
         pub struct Response<T> {
             pub parameters: serde_json::Map<String, serde_json::Value>,
             #[serde(skip_serializing_if = "Vec::is_empty")]
             pub errors: Vec<DataError<T>>,
-            #[cfg_attr(feature = "openapi", schemars(skip))]
+            #[schemars(skip)]
             #[serde(skip_serializing_if = "Option::is_none")]
             pub schema: Option<schemars::Schema>,
         }
 
-        #[derive(Deserialize, Serialize, Debug)]
-        #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
-        #[cfg_attr(feature = "openapi", schemars(rename = "FlashTransferRequest"))]
+        #[derive(Deserialize, Serialize, Debug, schemars::JsonSchema)]
+        #[schemars(rename = "FlashTransferRequest")]
         pub struct Request {
             #[serde(skip_serializing_if = "Option::is_none")]
             pub timeout: Option<u32>,

--- a/cda-sovd-interfaces/src/components/mod.rs
+++ b/cda-sovd-interfaces/src/components/mod.rs
@@ -11,8 +11,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use serde::Deserialize;
+
 pub mod ecu;
 
 pub mod get {
     pub type Response = crate::ResourceResponse;
+}
+
+#[derive(Deserialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+pub struct ComponentQuery {
+    #[serde(rename = "x-include-sdgs")]
+    pub include_sdgs: Option<bool>,
+    #[serde(rename = "include-schema")]
+    pub include_schema: Option<bool>,
 }

--- a/cda-sovd-interfaces/src/components/mod.rs
+++ b/cda-sovd-interfaces/src/components/mod.rs
@@ -19,8 +19,7 @@ pub mod get {
     pub type Response = crate::ResourceResponse;
 }
 
-#[derive(Deserialize)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[derive(Deserialize, schemars::JsonSchema)]
 pub struct ComponentQuery {
     #[serde(rename = "x-include-sdgs")]
     pub include_sdgs: Option<bool>,

--- a/cda-sovd-interfaces/src/components/mod.rs
+++ b/cda-sovd-interfaces/src/components/mod.rs
@@ -21,8 +21,8 @@ pub mod get {
 
 #[derive(Deserialize, schemars::JsonSchema)]
 pub struct ComponentQuery {
-    #[serde(rename = "x-include-sdgs")]
-    pub include_sdgs: Option<bool>,
-    #[serde(rename = "include-schema")]
-    pub include_schema: Option<bool>,
+    #[serde(rename = "x-include-sdgs", default)]
+    pub include_sdgs: bool,
+    #[serde(rename = "include-schema", default)]
+    pub include_schema: bool,
 }

--- a/cda-sovd-interfaces/src/error.rs
+++ b/cda-sovd-interfaces/src/error.rs
@@ -96,6 +96,8 @@ pub struct ApiErrorResponse<T> {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "x-errorsource")]
     pub error_source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<schemars::Schema>,
 }
 
 #[derive(Serialize, Debug, schemars::JsonSchema)]

--- a/cda-sovd-interfaces/src/error.rs
+++ b/cda-sovd-interfaces/src/error.rs
@@ -19,7 +19,7 @@ use serde::Serialize;
 // allowed, so we can pre-fill this with all sovd error codes
 // even though not all are used yet.
 #[allow(dead_code)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[derive(schemars::JsonSchema)]
 pub enum ErrorCode {
     /// Details are specified in the `vendor_code`
     VendorSpecific,
@@ -85,8 +85,7 @@ pub enum ErrorCode {
     UpdateExecutionInProgress,
 }
 
-#[derive(Serialize, Debug)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[derive(Serialize, Debug, schemars::JsonSchema)]
 pub struct ApiErrorResponse<T> {
     pub message: String,
     pub error_code: ErrorCode,
@@ -99,8 +98,7 @@ pub struct ApiErrorResponse<T> {
     pub error_source: Option<String>,
 }
 
-#[derive(Serialize, Debug)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[derive(Serialize, Debug, schemars::JsonSchema)]
 pub struct DataError<T> {
     pub path: String,
     pub error: ApiErrorResponse<T>,

--- a/cda-sovd-interfaces/src/lib.rs
+++ b/cda-sovd-interfaces/src/lib.rs
@@ -25,8 +25,7 @@ pub trait Payload {
     fn get_data_map(&self) -> HashMap<String, serde_json::Value>;
 }
 
-#[derive(Serialize)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[derive(Serialize, schemars::JsonSchema)]
 pub struct Resource {
     pub href: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -34,45 +33,40 @@ pub struct Resource {
     pub name: String,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[derive(Deserialize, Serialize, Debug, schemars::JsonSchema)]
 pub struct Items<T> {
     pub items: Vec<T>,
-    #[cfg_attr(feature = "openapi", schemars(skip))]
+    #[schemars(skip)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<schemars::Schema>,
 }
 
-#[derive(Serialize)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[derive(Serialize, schemars::JsonSchema)]
 pub struct ResourceResponse {
     pub items: Vec<Resource>,
-    #[cfg_attr(feature = "openapi", schemars(skip))]
+    #[schemars(skip)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<schemars::Schema>,
 }
 
-#[derive(Serialize, Debug)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[derive(Serialize, Debug, schemars::JsonSchema)]
 pub struct ObjectDataItem<T> {
     pub id: String,
     pub data: serde_json::Map<String, serde_json::Value>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub errors: Vec<DataError<T>>,
-    #[cfg_attr(feature = "openapi", schemars(skip))]
+    #[schemars(skip)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<schemars::Schema>,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[derive(Deserialize, Serialize, Debug, schemars::JsonSchema)]
 pub struct ArrayDataItem {
     pub id: String,
     pub data: Vec<serde_json::Value>,
 }
 
-#[derive(Deserialize)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[derive(Deserialize, schemars::JsonSchema)]
 pub struct IncludeSchemaQuery {
     #[serde(rename = "include-schema")]
     pub include_schema: Option<bool>,
@@ -83,20 +77,18 @@ pub mod sovd2uds {
 
     use serde::Serialize;
 
-    #[derive(Serialize)]
-    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+    #[derive(Serialize, schemars::JsonSchema)]
     pub struct FileList {
         #[serde(rename = "items")]
         pub files: Vec<File>,
         #[serde(skip_serializing)]
         pub path: Option<PathBuf>,
-        #[cfg_attr(feature = "openapi", schemars(skip))]
+        #[schemars(skip)]
         #[serde(skip_serializing_if = "Option::is_none")]
         pub schema: Option<schemars::Schema>,
     }
 
-    #[derive(Serialize, Debug, Clone)]
-    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+    #[derive(Serialize, Debug, Clone, schemars::JsonSchema)]
     pub struct File {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub hash: Option<String>,
@@ -108,8 +100,7 @@ pub mod sovd2uds {
         #[serde(rename = "x-sovd2uds-OrigPath")]
         pub origin_path: String,
     }
-    #[derive(Serialize, Debug, Clone)]
-    #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+    #[derive(Serialize, Debug, Clone, schemars::JsonSchema)]
     pub enum HashAlgorithm {
         None,
         // todo: support hashing algorithms

--- a/cda-sovd-interfaces/src/lib.rs
+++ b/cda-sovd-interfaces/src/lib.rs
@@ -68,8 +68,8 @@ pub struct ArrayDataItem {
 
 #[derive(Deserialize, schemars::JsonSchema)]
 pub struct IncludeSchemaQuery {
-    #[serde(rename = "include-schema")]
-    pub include_schema: Option<bool>,
+    #[serde(rename = "include-schema", default)]
+    pub include_schema: bool,
 }
 
 pub mod sovd2uds {

--- a/cda-sovd-interfaces/src/lib.rs
+++ b/cda-sovd-interfaces/src/lib.rs
@@ -66,7 +66,7 @@ pub struct ArrayDataItem {
     pub data: Vec<serde_json::Value>,
 }
 
-#[derive(Deserialize, schemars::JsonSchema)]
+#[derive(Deserialize, Debug, schemars::JsonSchema)]
 pub struct IncludeSchemaQuery {
     #[serde(rename = "include-schema", default)]
     pub include_schema: bool,

--- a/cda-sovd-interfaces/src/lib.rs
+++ b/cda-sovd-interfaces/src/lib.rs
@@ -38,12 +38,18 @@ pub struct Resource {
 #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
 pub struct Items<T> {
     pub items: Vec<T>,
+    #[cfg_attr(feature = "openapi", schemars(skip))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<schemars::Schema>,
 }
 
 #[derive(Serialize)]
 #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
 pub struct ResourceResponse {
     pub items: Vec<Resource>,
+    #[cfg_attr(feature = "openapi", schemars(skip))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<schemars::Schema>,
 }
 
 #[derive(Serialize, Debug)]
@@ -65,6 +71,13 @@ pub struct ArrayDataItem {
     pub data: Vec<serde_json::Value>,
 }
 
+#[derive(Deserialize)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+pub struct IncludeSchemaQuery {
+    #[serde(rename = "include-schema")]
+    pub include_schema: Option<bool>,
+}
+
 pub mod sovd2uds {
     use std::path::PathBuf;
 
@@ -77,6 +90,9 @@ pub mod sovd2uds {
         pub files: Vec<File>,
         #[serde(skip_serializing)]
         pub path: Option<PathBuf>,
+        #[cfg_attr(feature = "openapi", schemars(skip))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub schema: Option<schemars::Schema>,
     }
 
     #[derive(Serialize, Debug, Clone)]

--- a/cda-sovd-interfaces/src/locking.rs
+++ b/cda-sovd-interfaces/src/locking.rs
@@ -15,8 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Items;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct Lock {
     pub id: String,
 
@@ -26,9 +25,8 @@ pub struct Lock {
     pub owned: Option<bool>,
 }
 
-#[derive(Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
-#[cfg_attr(feature = "openapi", schemars(rename = "CreateLockRequest"))]
+#[derive(Serialize, Deserialize, schemars::JsonSchema)]
+#[schemars(rename = "CreateLockRequest")]
 pub struct Request {
     pub lock_expiration: u64,
 }
@@ -49,9 +47,8 @@ pub mod id {
     use super::*;
     pub mod get {
         use super::*;
-        #[derive(Serialize, Deserialize)]
-        #[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
-        #[cfg_attr(feature = "openapi", schemars(rename = "LockResponse"))]
+        #[derive(Serialize, Deserialize, schemars::JsonSchema)]
+        #[schemars(rename = "LockResponse")]
         pub struct Response {
             pub lock_expiration: String,
         }

--- a/cda-sovd/Cargo.toml
+++ b/cda-sovd/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 [dependencies]
 # internal dependencies
 cda-interfaces = { workspace = true }
-sovd-interfaces = { workspace = true, features = ["openapi"] }
+sovd-interfaces = { workspace = true }
 
 tokio = { workspace = true, features = ["net"] }
 futures = { workspace = true }                         # external

--- a/cda-sovd/src/openapi.rs
+++ b/cda-sovd/src/openapi.rs
@@ -193,6 +193,7 @@ pub(crate) fn error_forbidden(op: TransformOperation) -> TransformOperation {
             vendor_code: None,
             parameters: None,
             error_source: None,
+            schema: None,
         })
     })
 }
@@ -206,6 +207,7 @@ pub(crate) fn error_not_found(op: TransformOperation) -> TransformOperation {
                 vendor_code: Some(sovd::error::VendorErrorCode::NotFound),
                 parameters: None,
                 error_source: None,
+                schema: None,
             })
     })
 }
@@ -219,6 +221,7 @@ pub(crate) fn error_bad_gateway(op: TransformOperation) -> TransformOperation {
                 vendor_code: None,
                 parameters: None,
                 error_source: Some("ECU".to_string()),
+                schema: None,
             })
     })
 }
@@ -232,6 +235,7 @@ pub(crate) fn error_internal_server(op: TransformOperation) -> TransformOperatio
                 vendor_code: None,
                 parameters: None,
                 error_source: None,
+                schema: None,
             })
     })
 }
@@ -245,6 +249,7 @@ pub(crate) fn error_conflict(op: TransformOperation) -> TransformOperation {
                 vendor_code: None,
                 parameters: None,
                 error_source: None,
+                schema: None,
             })
     })
 }
@@ -258,6 +263,7 @@ pub(crate) fn error_bad_request(op: TransformOperation) -> TransformOperation {
                 vendor_code: Some(sovd::error::VendorErrorCode::BadRequest),
                 parameters: None,
                 error_source: None,
+                schema: None,
             })
     })
 }
@@ -271,6 +277,7 @@ pub(crate) fn comparam_execution_errors(op: TransformOperation) -> TransformOper
                 vendor_code: Some(sovd::error::VendorErrorCode::BadRequest),
                 parameters: None,
                 error_source: None,
+                schema: None,
             })
     })
     .response_with::<404, Json<ApiErrorResponse<sovd::error::VendorErrorCode>>, _>(|res| {
@@ -281,6 +288,7 @@ pub(crate) fn comparam_execution_errors(op: TransformOperation) -> TransformOper
                 vendor_code: Some(sovd::error::VendorErrorCode::NotFound),
                 parameters: None,
                 error_source: None,
+                schema: None,
             })
     })
 }

--- a/cda-sovd/src/sovd/apps.rs
+++ b/cda-sovd/src/sovd/apps.rs
@@ -28,12 +28,7 @@ pub(crate) async fn get(
     >,
     OriginalUri(uri): OriginalUri,
 ) -> Response {
-    resource_response(
-        &host,
-        &uri,
-        vec![("sovd2uds", None)],
-        query.include_schema.unwrap_or(false),
-    )
+    resource_response(&host, &uri, vec![("sovd2uds", None)], query.include_schema)
 }
 
 pub(crate) mod sovd2uds {
@@ -47,12 +42,7 @@ pub(crate) mod sovd2uds {
         >,
         OriginalUri(uri): OriginalUri,
     ) -> Response {
-        resource_response(
-            &host,
-            &uri,
-            vec![("bulk-data", None)],
-            query.include_schema.unwrap_or(false),
-        )
+        resource_response(&host, &uri, vec![("bulk-data", None)], query.include_schema)
     }
 
     pub(crate) mod bulk_data {
@@ -70,7 +60,7 @@ pub(crate) mod sovd2uds {
                 &host,
                 &uri,
                 vec![("flashfiles", None)],
-                query.include_schema.unwrap_or(false),
+                query.include_schema,
             )
         }
 
@@ -166,7 +156,7 @@ pub(crate) mod sovd2uds {
                 >,
                 State(state): State<WebserverState>,
             ) -> Response {
-                let include_schema = query.include_schema.unwrap_or(false);
+                let include_schema = query.include_schema;
                 let flash_files = &mut state.flash_data.as_ref().write().await;
                 let files = if let Some(flash_files_path) = &flash_files.path {
                     process_directory(flash_files_path.clone()).await
@@ -251,7 +241,7 @@ pub(crate) mod sovd2uds {
             ) -> Response {
                 let networkstructure_data = gateway.get_network_structure().await.into_sovd();
 
-                let schema = if query.include_schema.unwrap_or(false) {
+                let schema = if query.include_schema {
                     Some(create_schema!(
                         sovd_interfaces::apps::sovd2uds::data::network_structure::get::Response
                     ))

--- a/cda-sovd/src/sovd/auth.rs
+++ b/cda-sovd/src/sovd/auth.rs
@@ -60,7 +60,11 @@ pub(crate) async fn authorize(
 ) -> impl IntoApiResponse {
     // Check if the user sent the credentials
     if let Err(e) = check_auth_payload(&payload) {
-        return ErrorWrapper(ApiError::Forbidden(Some(format!("{e:?}")))).into_response();
+        return ErrorWrapper {
+            error: ApiError::Forbidden(Some(format!("{e:?}"))),
+            include_schema: false,
+        }
+        .into_response();
     }
 
     let claims = Claims {
@@ -71,7 +75,11 @@ pub(crate) async fn authorize(
     let token = match encode(&Header::default(), &claims, &KEYS.encoding) {
         Ok(token) => token,
         Err(_) => {
-            return ErrorWrapper(ApiError::InternalServerError(None)).into_response();
+            return ErrorWrapper {
+                error: ApiError::InternalServerError(None),
+                include_schema: false,
+            }
+            .into_response();
         }
     };
 

--- a/cda-sovd/src/sovd/components/ecu/configurations.rs
+++ b/cda-sovd/src/sovd/components/ecu/configurations.rs
@@ -37,8 +37,7 @@ pub(crate) async fn get<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManage
         ApiError,
     >,
 ) -> Response {
-    let include_schema = query.include_schema.unwrap_or(false);
-    let schema = if include_schema {
+    let schema = if query.include_schema {
         Some(create_schema!(sovd_configurations::get::Response))
     } else {
         None
@@ -56,7 +55,7 @@ pub(crate) async fn get<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManage
         }
         Err(e) => ErrorWrapper {
             error: ApiError::from(e),
-            include_schema,
+            include_schema: query.include_schema,
         }
         .into_response(),
     }
@@ -139,7 +138,7 @@ pub(crate) mod diag_service {
         State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<R, T, U>>,
         body: Bytes,
     ) -> Response {
-        let include_schema = query.include_schema.unwrap_or(false);
+        let include_schema = query.include_schema;
         if service.contains('/') {
             return ErrorWrapper {
                 error: ApiError::BadRequest("Invalid path".to_owned()),

--- a/cda-sovd/src/sovd/components/ecu/data.rs
+++ b/cda-sovd/src/sovd/components/ecu/data.rs
@@ -23,8 +23,7 @@ pub(crate) async fn get<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManage
     >,
     State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<R, T, U>>,
 ) -> Response {
-    let include_schema = query.include_schema.unwrap_or(false);
-    let schema = if include_schema {
+    let schema = if query.include_schema {
         Some(create_schema!(
             sovd_interfaces::components::ecu::data::get::Response
         ))
@@ -41,7 +40,7 @@ pub(crate) async fn get<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManage
         }
         Err(e) => ErrorWrapper {
             error: ApiError::BadRequest(e),
-            include_schema,
+            include_schema: query.include_schema,
         }
         .into_response(),
     }
@@ -177,8 +176,8 @@ pub(crate) mod diag_service {
         >,
         State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<R, T, U>>,
     ) -> Response {
-        let include_schema = query.include_schema.unwrap_or(false);
-        if Some(true) == query.include_sdgs {
+        let include_schema = query.include_schema;
+        if query.include_sdgs {
             get_sdgs_handler::<T>(diag_service, &ecu_name, &uds, include_schema).await
         } else {
             if diag_service.contains('/') {
@@ -235,7 +234,7 @@ pub(crate) mod diag_service {
         State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<R, T, U>>,
         body: Bytes,
     ) -> Response {
-        let include_schema = query.include_schema.unwrap_or(false);
+        let include_schema = query.include_schema;
         if service.contains('/') {
             return ErrorWrapper {
                 error: ApiError::BadRequest("Invalid path".to_owned()),

--- a/cda-sovd/src/sovd/components/ecu/faults.rs
+++ b/cda-sovd/src/sovd/components/ecu/faults.rs
@@ -23,7 +23,6 @@ use cda_interfaces::{
     UdsEcu, datatypes::DtcRecordAndStatus, diagservices::DiagServiceResponse,
     file_manager::FileManager,
 };
-use schemars::JsonSchema;
 use serde_qs::axum::QsQuery;
 use sovd_interfaces::components::ecu::{
     faults,
@@ -32,7 +31,7 @@ use sovd_interfaces::components::ecu::{
 
 use crate::{
     openapi,
-    sovd::{IntoSovd, WebserverEcuState, error::ApiError},
+    sovd::{IntoSovd, WebserverEcuState, create_schema, error::ApiError},
 };
 
 impl IntoSovd for DtcRecordAndStatus {
@@ -67,10 +66,7 @@ impl IntoSovd for DtcRecordAndStatus {
 }
 
 fn create_faults_schema() -> Result<schemars::Schema, ApiError> {
-    let mut generator = schemars::SchemaGenerator::new(
-        schemars::generate::SchemaSettings::draft07().with(|s| s.inline_subschemas = true),
-    );
-    let schema = Fault::json_schema(&mut generator);
+    let schema = create_schema!(Fault);
     let mut val = schema.to_value();
 
     crate::sovd::remove_descriptions_recursive(&mut val);

--- a/cda-sovd/src/sovd/components/ecu/faults.rs
+++ b/cda-sovd/src/sovd/components/ecu/faults.rs
@@ -101,7 +101,7 @@ pub(crate) async fn get<
         }
     };
 
-    let schema = if query.include_schema.is_some_and(|v| v) {
+    let schema = if query.include_schema {
         match create_faults_schema() {
             Ok(schema) => Some(schema),
             Err(e) => return e.into_response(),

--- a/cda-sovd/src/sovd/components/ecu/mod.rs
+++ b/cda-sovd/src/sovd/components/ecu/mod.rs
@@ -54,7 +54,7 @@ pub(crate) async fn get<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManage
         ApiError,
     >,
 ) -> impl IntoApiResponse {
-    let include_schema = query.include_schema.unwrap_or(false);
+    let include_schema = query.include_schema;
     let base_path = format!("http://localhost:20002/vehicle/v15/components/{ecu_name}");
     let variant = match uds.get_variant(&ecu_name).await {
         Ok(v) => v,
@@ -67,7 +67,7 @@ pub(crate) async fn get<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManage
         }
     };
 
-    let sdgs = if query.include_sdgs.unwrap_or(false) {
+    let sdgs = if query.include_sdgs {
         match uds
             .get_sdgs(&ecu_name, None)
             .await

--- a/cda-sovd/src/sovd/components/ecu/modes.rs
+++ b/cda-sovd/src/sovd/components/ecu/modes.rs
@@ -59,6 +59,8 @@ pub(crate) async fn get(
                     name: Some(SESSION_NAME.to_string()),
                     translation_id: None,
                     value: None,
+                    // we do not include the subschemas as the complete schema
+                    // included in the root of the response already contains them
                     schema: None,
                 },
                 sovd_modes::Mode {

--- a/cda-sovd/src/sovd/components/ecu/modes.rs
+++ b/cda-sovd/src/sovd/components/ecu/modes.rs
@@ -45,7 +45,7 @@ const SECURITY_NAME: &str = "Security access";
 pub(crate) async fn get(
     WithRejection(Query(query), _): WithRejection<Query<sovd_modes::get::Query>, ApiError>,
 ) -> Response {
-    let schema = if query.include_schema.unwrap_or(false) {
+    let schema = if query.include_schema {
         Some(create_schema!(sovd_modes::get::Response))
     } else {
         None
@@ -129,7 +129,7 @@ pub(crate) mod session {
             ApiError,
         >,
     ) -> Response {
-        let include_schema = query.include_schema.unwrap_or(false);
+        let include_schema = query.include_schema;
         if let Some(response) = validate_lock(&claims, &ecu_name, locks, include_schema).await {
             return response;
         }
@@ -192,7 +192,7 @@ pub(crate) mod session {
         WithRejection(Query(query), _): WithRejection<Query<sovd_modes::get::Query>, ApiError>,
         State(WebserverEcuState { uds, ecu_name, .. }): State<WebserverEcuState<R, T, U>>,
     ) -> Response {
-        let include_schema = query.include_schema.unwrap_or(false);
+        let include_schema = query.include_schema;
         let schema = if include_schema {
             Some(create_schema!(sovd_modes::Mode::<String>))
         } else {
@@ -265,7 +265,7 @@ pub(crate) mod security {
             ..
         }): State<WebserverEcuState<R, T, U>>,
     ) -> Response {
-        let include_schema = query.include_schema.unwrap_or(false);
+        let include_schema = query.include_schema;
         if let Some(value) = validate_lock(&claims, &ecu_name, locks, include_schema).await {
             return value;
         }
@@ -336,7 +336,7 @@ pub(crate) mod security {
             }
         }
 
-        let include_schema = query.include_schema.unwrap_or(false);
+        let include_schema = query.include_schema;
 
         if let Some(value) = validate_lock(&claims, &ecu_name, locks, include_schema).await {
             return value;
@@ -394,7 +394,7 @@ pub(crate) mod security {
             Ok((security_access, response)) => match response.response_type() {
                 DiagServiceResponseType::Positive => match security_access {
                     SecurityAccess::RequestSeed(_) => {
-                        let schema = if query.include_schema.unwrap_or(false) {
+                        let schema = if query.include_schema {
                             Some(create_schema!(SovdRequestSeedResponse))
                         } else {
                             None
@@ -418,7 +418,7 @@ pub(crate) mod security {
                     }
 
                     SecurityAccess::SendKey(_) => {
-                        let schema = if query.include_schema.unwrap_or(false) {
+                        let schema = if query.include_schema {
                             Some(create_schema!(sovd_modes::put::Response::<String>))
                         } else {
                             None

--- a/cda-sovd/src/sovd/components/ecu/operations.rs
+++ b/cda-sovd/src/sovd/components/ecu/operations.rs
@@ -48,7 +48,7 @@ pub(crate) mod comparams {
                 ..
             }): State<WebserverEcuState<R, T, U>>,
         ) -> Response {
-            handler_read(comparam_executions, query.include_schema.unwrap_or(false)).await
+            handler_read(comparam_executions, query.include_schema).await
         }
 
         pub(crate) fn docs_get(op: TransformOperation) -> TransformOperation {
@@ -83,13 +83,7 @@ pub(crate) mod comparams {
             } else {
                 None
             };
-            handler_write(
-                comparam_executions,
-                path,
-                body,
-                query.include_schema.unwrap_or(false),
-            )
-            .await
+            handler_write(comparam_executions, path, body, query.include_schema).await
         }
 
         pub(crate) fn docs_post(op: TransformOperation) -> TransformOperation {
@@ -195,7 +189,7 @@ pub(crate) mod comparams {
                     ..
                 }): State<WebserverEcuState<R, T, U>>,
             ) -> Response {
-                let include_schema = query.include_schema.unwrap_or(false);
+                let include_schema = query.include_schema;
                 let id = match Uuid::parse_str(&id) {
                     Ok(v) => v,
                     Err(e) => {
@@ -343,7 +337,7 @@ pub(crate) mod comparams {
                     ApiError,
                 >,
             ) -> Response {
-                let include_schema = query.include_schema.unwrap_or(false);
+                let include_schema = query.include_schema;
                 let id = match Uuid::parse_str(&id) {
                     Ok(v) => v,
                     Err(e) => {
@@ -467,7 +461,7 @@ pub(crate) mod service {
                 &uds,
                 headers,
                 None,
-                query.include_schema.unwrap_or(false),
+                query.include_schema,
             )
             .await
         }
@@ -502,7 +496,7 @@ pub(crate) mod service {
                 &uds,
                 headers,
                 Some(body),
-                query.include_schema.unwrap_or(false),
+                query.include_schema,
             )
             .await
         }

--- a/cda-sovd/src/sovd/components/ecu/operations.rs
+++ b/cda-sovd/src/sovd/components/ecu/operations.rs
@@ -645,8 +645,10 @@ pub(crate) mod service {
                         {
                             Ok(v) => v,
                             Err(e) => {
-                                log::error!(
-                                    "Failed to get schema for diag service {diag_service:?}: {e:?}"
+                                tracing::error!(
+                                    error = ?e,
+                                    diag_service = ?diag_service,
+                                    "Failed to get schema for diag service"
                                 );
                                 None
                             }
@@ -803,8 +805,10 @@ pub(crate) mod service {
                 {
                     Ok(v) => v,
                     Err(e) => {
-                        log::error!(
-                            "Failed to get schema for diag service {diag_service:?}: {e:?}"
+                        tracing::error!(
+                            error = ?e,
+                            diag_service = ?diag_service,
+                            "Failed to get schema for diag service"
                         );
                         None
                     }

--- a/cda-sovd/src/sovd/components/ecu/x_single_ecu_jobs.rs
+++ b/cda-sovd/src/sovd/components/ecu/x_single_ecu_jobs.rs
@@ -39,7 +39,7 @@ pub(crate) mod single_ecu {
         >,
         State(WebserverEcuState { uds, ecu_name, .. }): State<WebserverEcuState<R, T, U>>,
     ) -> Response {
-        let include_schema = query.include_schema.unwrap_or(false);
+        let include_schema = query.include_schema;
         let schema = if include_schema {
             Some(create_schema!(
                 sovd_interfaces::components::ecu::ComponentData
@@ -88,7 +88,7 @@ pub(crate) mod single_ecu {
             >,
             State(WebserverEcuState { uds, ecu_name, .. }): State<WebserverEcuState<R, T, U>>,
         ) -> Response {
-            let include_schema = query.include_schema.unwrap_or(false);
+            let include_schema = query.include_schema;
             let mut job = match uds
                 .get_single_ecu_job(&ecu_name, &job_name)
                 .await

--- a/cda-sovd/src/sovd/components/ecu/x_sovd2uds_bulk_data.rs
+++ b/cda-sovd/src/sovd/components/ecu/x_sovd2uds_bulk_data.rs
@@ -111,7 +111,10 @@ pub(crate) mod mdd_embedded_files {
 
     pub(crate) mod id {
         use super::*;
-        use crate::{openapi, sovd::components::IdPathParam};
+        use crate::{
+            openapi,
+            sovd::{components::IdPathParam, error::ErrorWrapper},
+        };
         pub(crate) async fn get<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManager>(
             Path(id): Path<IdPathParam>,
             State(WebserverEcuState {
@@ -125,10 +128,11 @@ pub(crate) mod mdd_embedded_files {
                     payload,
                 )
                     .into_response(),
-                Err(e) => {
-                    let api_error: ApiError = e.into();
-                    api_error.into_response()
+                Err(e) => ErrorWrapper {
+                    error: ApiError::from(e),
+                    include_schema: false,
                 }
+                .into_response(),
             }
         }
         pub(crate) fn docs_get(op: TransformOperation) -> TransformOperation {

--- a/cda-sovd/src/sovd/components/ecu/x_sovd2uds_bulk_data.rs
+++ b/cda-sovd/src/sovd/components/ecu/x_sovd2uds_bulk_data.rs
@@ -32,7 +32,7 @@ pub(crate) async fn get(
         &host,
         &uri,
         vec![("mdd-embedded-files", None)],
-        query.include_schema.unwrap_or(false),
+        query.include_schema,
     )
 }
 
@@ -63,7 +63,7 @@ pub(crate) mod mdd_embedded_files {
             mdd_embedded_files, ..
         }): State<WebserverEcuState<R, T, U>>,
     ) -> Response {
-        let schema = if query.include_schema.unwrap_or(false) {
+        let schema = if query.include_schema {
             Some(create_schema!(
                 sovd2uds::bulk_data::embedded_files::get::Response
             ))

--- a/cda-sovd/src/sovd/components/ecu/x_sovd2uds_download.rs
+++ b/cda-sovd/src/sovd/components/ecu/x_sovd2uds_download.rs
@@ -84,7 +84,7 @@ pub(crate) async fn get(
         &host,
         &uri,
         vec![("RequestDownload", Some("requestdownload"))],
-        query.include_schema.unwrap_or(false),
+        query.include_schema,
     )
 }
 
@@ -130,7 +130,7 @@ pub(crate) mod request_download {
         State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<R, T, U>>,
         body: Json<sovd2uds::download::request_download::put::Request>,
     ) -> Response {
-        let include_schema = query.include_schema.unwrap_or(false);
+        let include_schema = query.include_schema;
         let schema = if include_schema {
             'schema: {
                 let Ok(service) = uds
@@ -275,7 +275,7 @@ pub(crate) mod flash_transfer {
         }): State<WebserverEcuState<R, T, U>>,
         body: Json<sovd2uds::download::flash_transfer::post::Request>,
     ) -> Response {
-        let include_schema = query.include_schema.unwrap_or(false);
+        let include_schema = query.include_schema;
         match flash_data
             .read()
             .await
@@ -364,7 +364,7 @@ pub(crate) mod flash_transfer {
         >,
         State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<R, T, U>>,
     ) -> Response {
-        let include_schema = query.include_schema.unwrap_or(false);
+        let include_schema = query.include_schema;
         let schema = if include_schema {
             Some(create_schema!(
                 sovd2uds::download::flash_transfer::get::Response
@@ -422,7 +422,7 @@ pub(crate) mod flash_transfer {
             >,
             State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<R, T, U>>,
         ) -> Response {
-            let include_schema = query.include_schema.unwrap_or(false);
+            let include_schema = query.include_schema;
             match uds.ecu_flash_transfer_status_id(&ecu_name, &id).await {
                 Ok(data) => {
                     let mut data = data.into_sovd();

--- a/cda-sovd/src/sovd/components/mod.rs
+++ b/cda-sovd/src/sovd/components/mod.rs
@@ -44,6 +44,7 @@ impl From<FieldParseErrorWrapper> for DataError<VendorErrorCode> {
                     ),
                 ])),
                 error_source: None,
+                schema: None,
             },
         }
     }

--- a/cda-sovd/src/sovd/locks.rs
+++ b/cda-sovd/src/sovd/locks.rs
@@ -300,6 +300,7 @@ pub(crate) mod ecu {
                         id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
                         owned: Some(true),
                     }],
+                    schema: None,
                 })
                 .description("List of ECU locks.")
             })
@@ -439,6 +440,7 @@ pub(crate) mod vehicle {
                         id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
                         owned: Some(true),
                     }],
+                    schema: None,
                 })
                 .description("List of vehicle locks.")
             })
@@ -580,6 +582,7 @@ pub(crate) mod functional_group {
                         id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
                         owned: Some(true),
                     }],
+                    schema: None,
                 })
                 .description("List of functional group locks.")
             })
@@ -660,6 +663,7 @@ pub(crate) fn get_locks(
                 .filter(|(map_key, _)| entity_name == Some(*map_key))
                 .filter_map(|(_, lock_opt)| lock_opt.as_ref().map(|l| l.to_sovd_lock(claims)))
                 .collect(),
+            schema: None,
         },
         ReadLock::OptionLock(l) => sovd_interfaces::locking::get::Response {
             items: l
@@ -667,6 +671,7 @@ pub(crate) fn get_locks(
                 .map(|lock| lock.to_sovd_lock(claims))
                 .into_iter()
                 .collect(),
+            schema: None,
         },
     }
 }

--- a/cda-sovd/src/sovd/mod.rs
+++ b/cda-sovd/src/sovd/mod.rs
@@ -148,7 +148,7 @@ pub async fn route<R: DiagServiceResponse, T: UdsEcu + SchemaProvider + Clone, U
                 Query<sovd_interfaces::IncludeSchemaQuery>,
                 ApiError,
             >| async move {
-                let schema = if query.include_schema.unwrap_or(false) {
+                let schema = if query.include_schema {
                     Some(crate::sovd::create_schema!(
                         sovd_interfaces::ResourceResponse
                     ))


### PR DESCRIPTION
As a follow up to #37 this PR adds the query parameter to the rest of the services that can return JSON responses (except locking, as the spec states there explicitly that no query-params are supported).
Additionally error cases now respect the include-schema parameter as well.

As a sidenote: the `openapi` feature is removed from `sovd-interfaces`, due to it making not much sense in the way it was used currently and schemas / openapi being an integral part of the sovd spec.

Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)