### PR TITLE
[#3] tracing: replace log with tracing throughout codebase

### DIFF
--- a/CODESTYLE.md
+++ b/CODESTYLE.md
@@ -52,7 +52,7 @@ Additionally the import granularity is set to `crate` to group all imports from 
 - Prefer explicit over implicit: always annotate types when not obvious.
 - Use `const` and `static` for constants.
 - Use `Arc`, `Mutex`, and `RwLock` for shared state, as seen in the codebase.
-- Use logging macros, like `log::info!`, as appropriate to record relevant information.
+- Use tracing macros, like `tracing::info!`, as appropriate to record relevant information.
 - Annotate functions with `tracing::instrument` when they are important for creating new tracing spans.
 - Error messages should start with a capital letter.
 - Literal suffixes (i.e. `u8` vs `_u8`) are preferably written without seperator.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,6 @@ dependencies = [
  "doip-definitions",
  "doip-sockets",
  "hashbrown 0.15.4",
- "log",
  "openssl",
  "socket2",
  "tokio",
@@ -410,7 +409,6 @@ version = "0.1.0"
 dependencies = [
  "cda-interfaces",
  "hashbrown 0.15.4",
- "log",
  "openssl",
  "serde_json",
  "socket2",
@@ -426,7 +424,6 @@ dependencies = [
  "cda-database",
  "cda-interfaces",
  "hashbrown 0.15.4",
- "log",
  "num-traits",
  "parking_lot",
  "schemars",
@@ -443,12 +440,12 @@ dependencies = [
  "cda-interfaces",
  "deepsize",
  "hashbrown 0.15.4",
- "log",
  "prost 0.14.1",
  "prost-build",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "uuid",
  "xz2",
 ]
@@ -467,6 +464,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -483,7 +481,6 @@ dependencies = [
  "http",
  "indexmap 2.10.0",
  "jsonwebtoken",
- "log",
  "mime",
  "percent-encoding",
  "regex",
@@ -505,7 +502,6 @@ version = "0.1.0"
 dependencies = [
  "console-subscriber",
  "hashbrown 0.15.4",
- "log",
  "nu-ansi-term",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -517,7 +513,6 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-core",
- "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]
@@ -1810,7 +1805,6 @@ dependencies = [
  "futures",
  "hashbrown 0.15.4",
  "http",
- "log",
  "mimalloc",
  "mime",
  "nu-ansi-term",
@@ -1822,7 +1816,6 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-core",
- "tracing-log",
  "tracing-subscriber",
 ]
 
@@ -3268,7 +3261,6 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
  "tracing-serde",
 ]
 

--- a/cda-comm-doip/Cargo.toml
+++ b/cda-comm-doip/Cargo.toml
@@ -34,8 +34,7 @@ tokio = { version = "1.43.0", default-features = false, features = [
   "fs",
   "sync",
 ] }
-# logging
-log = "0.4"
+# logging & tracing
 tracing = "0.1.41"
 
 [features]

--- a/cda-comm-uds/Cargo.toml
+++ b/cda-comm-uds/Cargo.toml
@@ -30,12 +30,12 @@ tokio = { version = "1.43.0", default-features = false, features = [
   "fs",
   "time",
   "rt",
+  "io-util",
 ] }
 
 serde_json = "1.0"
 
-# logging
-log = "0.4"
+# logging & tracing
 tracing = "0.1.41"
 strum = "0.27.2"
 

--- a/cda-core/Cargo.toml
+++ b/cda-core/Cargo.toml
@@ -28,8 +28,7 @@ tokio = { version = "1.43.0", default-features = false }
 
 schemars = { workspace = true }
 
-# logging
-log = "0.4"
+# logging & tracing
 tracing = "0.1.41"
 
 [dev-dependencies]

--- a/cda-database/Cargo.toml
+++ b/cda-database/Cargo.toml
@@ -32,8 +32,7 @@ uuid = { version = "1.16.0", features = ["v4"] }
 xz2 = { version = "0.1.6", features = ["static"] }
 
 # logging
-log = "0.4"
-# tracing = "0.1.41"
+tracing = "0.1.41"
 
 # runtime size info
 deepsize = { version = "0.2.0", features = ["hashbrown"], optional = true }

--- a/cda-database/src/datatypes/comparam.rs
+++ b/cda-database/src/datatypes/comparam.rs
@@ -98,16 +98,17 @@ pub(super) fn get_comparams(ecu_data: &dataformat::EcuData) -> ComParamMap {
         .collect::<ComParamMap>()
 }
 
+#[tracing::instrument(skip(r), fields(ctx = %_ctx))]
 pub(super) fn map_comparam_ref(
     r: &dataformat::ComParamRef,
-    ctx: &str,
+    _ctx: &str,
 ) -> Option<Result<ComParamRef, DiagServiceError>> {
     let Some(com_param_id) = r
         .com_param
         .as_ref()
         .and_then(|cpr| cpr.r#ref.as_ref().map(|obid| obid.value))
     else {
-        log::debug!(target: ctx, "Skipping ComParamRef with no comParam.ref_pb");
+        tracing::debug!("Skipping ComParamRef with no comParam.ref_pb");
         return None;
     };
     let complex_value = match r.complex_value.as_ref().map(map_complex_value).transpose() {

--- a/cda-database/src/datatypes/dtc.rs
+++ b/cda-database/src/datatypes/dtc.rs
@@ -53,7 +53,7 @@ pub(super) fn get_dtcs(ecu_data: &EcuData, ecu_db_path: &str) -> DtcMap {
         .filter_map(|res: Result<(u32, Dtc), DiagServiceError>| match res {
             Ok((id, param)) => Some((id, param)),
             Err(e) => {
-                log::debug!(target: &ecu_db_path, "Error processing dtc: {e:?}");
+                tracing::error!(error = %e, ecu_db_path = %ecu_db_path, "Error processing dtc");
                 None
             }
         })

--- a/cda-database/src/datatypes/parameter.rs
+++ b/cda-database/src/datatypes/parameter.rs
@@ -74,7 +74,14 @@ pub struct ReservedParam {
     pub bit_length: u32,
 }
 
-pub(super) fn get_parameters(ecu_data: &EcuData, ecu_db_path: &str) -> ParameterMap {
+#[tracing::instrument(
+    skip(ecu_data),
+    fields(
+        ecu_db_path = %_ecu_db_path,
+        param_count = ecu_data.params.len()
+    )
+)]
+pub(super) fn get_parameters(ecu_data: &EcuData, _ecu_db_path: &str) -> ParameterMap {
     ecu_data
         .params
         .iter()
@@ -166,7 +173,7 @@ pub(super) fn get_parameters(ecu_data: &EcuData, ecu_db_path: &str) -> Parameter
         .filter_map(|res| match res {
             Ok((id, param)) => Some((id, param)),
             Err(e) => {
-                log::debug!(target: &ecu_db_path, "Error processing parameter: {e:?}");
+                tracing::debug!(error = ?e, "Error processing parameter");
                 None
             }
         })

--- a/cda-database/src/datatypes/sd_sdg.rs
+++ b/cda-database/src/datatypes/sd_sdg.rs
@@ -42,7 +42,15 @@ pub enum SdOrSdgRef {
     Sdg(Id),
 }
 
-pub(super) fn get_sdgs(ecu_data: &EcuData, ecu_db_path: &str, ids: &[Id]) -> SdgMap {
+#[tracing::instrument(
+    skip(ecu_data, ids),
+    fields(
+        ecu_db_path = %_ecu_db_path,
+        sdg_count = ecu_data.sdgs.len(),
+        id_count = ids.len()
+    )
+)]
+pub(super) fn get_sdgs(ecu_data: &EcuData, _ecu_db_path: &str, ids: &[Id]) -> SdgMap {
     ecu_data
         .sdgs
         .iter()
@@ -70,7 +78,7 @@ pub(super) fn get_sdgs(ecu_data: &EcuData, ecu_db_path: &str, ids: &[Id]) -> Sdg
                                     Some(SdOrSdgRef::Sdg(id.value))
                                 }
                                 _ => {
-                                    log::warn!(target: &ecu_db_path, "SDOrSDG has no value");
+                                    tracing::warn!("SDOrSDG has no value");
                                     None
                                 }
                             })
@@ -82,6 +90,7 @@ pub(super) fn get_sdgs(ecu_data: &EcuData, ecu_db_path: &str, ids: &[Id]) -> Sdg
         .collect()
 }
 
+#[tracing::instrument(skip(ecu_data), fields(sd_count = ecu_data.sds.len()))]
 pub(super) fn get_sds(ecu_data: &EcuData) -> SdMap {
     ecu_data
         .sds

--- a/cda-database/src/mdd_data/files.rs
+++ b/cda-database/src/mdd_data/files.rs
@@ -66,9 +66,11 @@ impl FileManager {
                             entry.last_accessed.map(|last_accessed| {
                                 let elapsed = now.duration_since(last_accessed);
                                 if elapsed >= cache_lifetime {
-                                    log::debug!(
-                                        "Removing expired cache entry for file {}",
-                                        entry.chunk.meta_data.name
+                                    tracing::debug!(
+                                        file_name = %entry.chunk.meta_data.name,
+                                        elapsed = ?elapsed,
+                                        cache_lifetime = ?cache_lifetime,
+                                        "Removing expired cache entry for file"
                                     );
                                     entry.chunk.payload = None;
                                     None

--- a/cda-interfaces/Cargo.toml
+++ b/cda-interfaces/Cargo.toml
@@ -27,6 +27,8 @@ deepsize = { version = "0.2.0", features = ["hashbrown"], optional = true }
 hex = "0.4.3"
 strum = "0.27.2"
 strum_macros = "0.27.2"
+# logging
+tracing = "0.1.41"
 
 [features]
 default = []

--- a/cda-interfaces/src/strings.rs
+++ b/cda-interfaces/src/strings.rs
@@ -95,6 +95,7 @@ impl Strings {
     }
 
     /// Get a `StringId` for a given `String` value, inserting it if it does not exist.
+    #[tracing::instrument(skip(self), fields(string_length = value.len()))]
     pub fn get_or_insert(&self, value: &str) -> StringId {
         if let Some(id) = self.lookup.read().get(value) {
             return *id;
@@ -185,7 +186,7 @@ macro_rules! get_string_with_default {
         match $id {
             Ok(s) => s,
             Err(e) => {
-                log::error!("{e}");
+                tracing::error!(error = %e, "String lookup failed, using empty string");
                 String::new() // Return an empty string if the ID is not found
             }
         }
@@ -227,7 +228,7 @@ macro_rules! get_string_from_option {
         $opt.and_then(|id| match cda_interfaces::get_string!(id) {
             Ok(s) => Some(s),
             Err(e) => {
-                log::error!("{e}");
+                tracing::error!(error = %e, "String lookup failed, returning None");
                 None // Return None if the ID is not found
             }
         })

--- a/cda-main/Cargo.toml
+++ b/cda-main/Cargo.toml
@@ -47,11 +47,9 @@ tokio = { version = "1.43.0", features = [
   "signal",
 ] }
 # logging & tracing
-log = "0.4"
 tracing = "0.1.41"
 tracing-core = "0.1.34"
 tracing-appender = "0.2.3"
-tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.20", default-features = false, features = [
   "ansi",
   "chrono",
@@ -60,7 +58,6 @@ tracing-subscriber = { version = "0.3.20", default-features = false, features = 
   "json",
   "parking_lot",
   "std",
-  "tracing-log",
 ] }
 strip-ansi-escapes = "0.2.1" # Strip ANSI escape codes from strings, used for file logging
 nu-ansi-term = "0.50" # ANSI terminal support for terminal log output

--- a/cda-sovd/Cargo.toml
+++ b/cda-sovd/Cargo.toml
@@ -69,7 +69,6 @@ tower-http = { version = "0.6", default-features = false, features = [
 ] }
 
 # logging
-log = "0.4"
 tracing = "0.1.41"
 percent-encoding = "2.3.1"
 

--- a/cda-sovd/src/sovd/auth.rs
+++ b/cda-sovd/src/sovd/auth.rs
@@ -35,8 +35,9 @@ use crate::sovd::error::{ApiError, ErrorWrapper};
 // allowed because the variant for enabled auth needs the Result
 #[allow(clippy::unnecessary_wraps)]
 #[cfg(not(feature = "auth"))]
+#[tracing::instrument(skip(_payload))]
 fn check_auth_payload(_payload: &AuthPayload) -> Result<(), AuthError> {
-    log::debug!("Skipping auth payload check, ignoring credentials");
+    tracing::debug!("Skipping auth payload check, ignoring credentials");
     Ok(())
 }
 
@@ -115,13 +116,13 @@ where
             .extract::<TypedHeader<Authorization<Bearer>>>()
             .await
             .map_err(|e| {
-                log::warn!("Failed to extract token: {e}");
+                tracing::warn!(error = %e, "Failed to extract token");
                 AuthError::InvalidToken
             })?;
         // Decode the user data
         let token_data =
             decode::<Claims>(bearer.token(), &KEYS.decoding, &validation()).map_err(|e| {
-                log::warn!("Failed to decode token: {e}");
+                tracing::warn!(error = %e, "Failed to decode token");
                 AuthError::InvalidToken
             })?;
         Ok(token_data.claims)

--- a/cda-sovd/src/sovd/components/ecu/modes.rs
+++ b/cda-sovd/src/sovd/components/ecu/modes.rs
@@ -93,6 +93,14 @@ pub(crate) mod session {
     use super::*;
     use crate::openapi;
 
+    #[tracing::instrument(
+        skip(claims, locks, uds),
+        fields(
+            ecu_name = %ecu_name,
+            session_value = %request_body.value,
+            mode_expiration = ?request_body.mode_expiration
+        )
+    )]
     pub(crate) async fn put<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManager>(
         UseApi(claims, _): UseApi<Claims, ()>,
         State(WebserverEcuState {
@@ -109,7 +117,7 @@ pub(crate) mod session {
         if let Some(response) = validate_lock(&claims, &ecu_name, locks).await {
             return response;
         }
-        log::info!("sovd set session to {}", request_body.value);
+        tracing::info!("Setting ECU session mode");
         match uds
             .set_ecu_session(
                 &ecu_name,

--- a/cda-tracing/Cargo.toml
+++ b/cda-tracing/Cargo.toml
@@ -19,11 +19,9 @@ hashbrown = { version = "0.15" }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.43.0" }
 # logging & tracing
-log = "0.4"
 tracing = "0.1.41"
 tracing-core = "0.1.34"
 tracing-appender = "0.2.3"
-tracing-log = "0.2.0"
 tracing-opentelemetry = { version = "0.31.0" }
 tracing-subscriber = { version = "0.3.20", default-features = false, features = [
   "ansi",
@@ -33,7 +31,6 @@ tracing-subscriber = { version = "0.3.20", default-features = false, features = 
   "json",
   "parking_lot",
   "std",
-  "tracing-log",
 ] }
 strip-ansi-escapes = "0.2.1" # Strip ANSI escape codes from strings, used for file logging
 nu-ansi-term = "0.50" # ANSI terminal support for terminal log output

--- a/cda-tracing/src/subscriber.rs
+++ b/cda-tracing/src/subscriber.rs
@@ -16,7 +16,6 @@ use std::path::Path;
 use hashbrown::{HashMap, HashSet};
 use nu_ansi_term::{Color, Style};
 use tracing::{Event, Level, Subscriber, field::Visit};
-use tracing_log::NormalizeEvent;
 use tracing_subscriber::{
     field::VisitOutput as _,
     fmt::{
@@ -70,8 +69,7 @@ where
     ) -> std::fmt::Result {
         let colored = self.colored && writer.has_ansi_escapes();
 
-        let normalized_meta = event.normalized_metadata();
-        let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
+        let meta = event.metadata();
 
         let dimmed_style = Style::new().dimmed();
         let lvl_style = CdaFormatter::style_for(*meta.level());
@@ -92,7 +90,9 @@ where
         write_colored!(writer, colored, lvl_style, "{}", meta.level());
 
         write_colored!(writer, colored, dimmed_style, " in ");
-        if meta.name() != "log event" && !meta.name().starts_with("event src/") {
+        if meta.name() != "log event"
+            && !(meta.name().starts_with("event cda-") && meta.name().contains("/src/"))
+        {
             write_colored!(writer, colored, bold_style, "{}", meta.name());
         } else {
             write_colored!(writer, colored, bold_style, "{}", meta.target());


### PR DESCRIPTION
As per issue https://github.com/eclipse-opensovd/classic-diagnostic-adapter/issues/3 migrate to using the tracing crate instead of loggin.

I tried to take advantage of using spans where it makes sense, also moved data into fields to gain advantage of tracing's structured logging.

~~Put in draft, let's merge #44 first~~ 

closes #3 

Mark Schmitt [mark.schmitt@mercedes-benz.com](mailto:mark.schmitt@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH [Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)