### PR TITLE
Add tester-subnet config param

### DIFF
--- a/cda-main/src/config/configfile.rs
+++ b/cda-main/src/config/configfile.rs
@@ -37,6 +37,7 @@ pub struct ServerConfig {
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct DoipConfig {
     pub tester_address: String,
+    pub tester_subnet: String,
     pub gateway_port: u16,
 }
 
@@ -57,6 +58,7 @@ impl Default for Configuration {
             },
             doip: DoipConfig {
                 tester_address: "10.2.1.240".to_owned(),
+                tester_subnet: "255.255.0.0".to_owned(),
                 gateway_port: 13400,
             },
             logging: cda_tracing::LoggingConfig::default(),

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -294,6 +294,7 @@ pub async fn create_uds_manager(
 pub async fn create_diagnostic_gateway(
     databases: Arc<HashMap<String, RwLock<EcuManager>>>,
     doip_tester_address: &str,
+    doip_tester_subnet: &str,
     doip_gateway_port: u16,
     variant_detection: mpsc::Sender<Vec<String>>,
     tester_present: mpsc::Sender<TesterPresentControlMessage>,
@@ -301,6 +302,7 @@ pub async fn create_diagnostic_gateway(
 ) -> Result<DoipDiagGateway<EcuManager>, String> {
     DoipDiagGateway::new(
         doip_tester_address,
+        doip_tester_subnet,
         doip_gateway_port,
         databases,
         variant_detection,

--- a/cda-main/src/main.rs
+++ b/cda-main/src/main.rs
@@ -29,6 +29,9 @@ struct AppArgs {
     tester_address: Option<String>,
 
     #[arg(long)]
+    tester_subnet: Option<String>,
+
+    #[arg(long)]
     gateway_port: Option<u16>,
 
     // cannot use Action::SetTrue as it will treat
@@ -133,6 +136,7 @@ async fn main() -> Result<(), String> {
     let diagnostic_gateway = match opensovd_cda_lib::create_diagnostic_gateway(
         Arc::clone(&databases),
         &config.doip.tester_address,
+        &config.doip.tester_subnet,
         config.doip.gateway_port,
         variant_detection_tx,
         tester_present_tx,
@@ -202,6 +206,9 @@ impl AppArgs {
         }
         if let Some(tester_address) = self.tester_address {
             config.doip.tester_address = tester_address;
+        }
+        if let Some(tester_subnet) = self.tester_subnet {
+            config.doip.tester_subnet = tester_subnet;
         }
         if let Some(gateway_port) = self.gateway_port {
             config.doip.gateway_port = gateway_port;

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -6,6 +6,7 @@ databases_path = "."
 
 [doip]
 tester_address = "127.0.0.1"
+tester_subnet = "255.255.0.0"
 
 [logging.otel]
 enabled = false


### PR DESCRIPTION
 - in combination with tester_address this configures the subnet to use when reacting to VAMs

Fixes #53

Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)