### PR TITLE
Ensure auth errors return sovd style response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -489,6 +489,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sovd-interfaces",
+ "thiserror 2.0.16",
  "tokio",
  "tower 0.5.2",
  "tower-http",
@@ -824,7 +825,7 @@ dependencies = [
  "doip-definitions",
  "futures",
  "openssl",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-openssl",
  "tokio-util",
@@ -1883,7 +1884,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tracing",
 ]
 
@@ -1913,7 +1914,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost 0.13.5",
  "reqwest",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tonic 0.13.1",
  "tracing",
@@ -1950,7 +1951,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.1",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -2583,7 +2584,7 @@ dependencies = [
  "percent-encoding",
  "ryu",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -2650,7 +2651,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "time",
 ]
 
@@ -2819,11 +2820,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -2839,9 +2840,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ cda-tracing = { path = "cda-tracing" }
 sovd-interfaces = { path = "cda-sovd-interfaces" }
 
 # ---- common crates ----
+thiserror = "2.0.16"
 hashbrown = "0.15"
 num-traits = "0.2"
 parking_lot = "0.12.4"

--- a/cda-sovd/Cargo.toml
+++ b/cda-sovd/Cargo.toml
@@ -59,6 +59,7 @@ serde_qs = { workspace = true, features = ["axum"] }
 regex = { workspace = true }
 # v4 - Version 4 UUIDs with random data.
 uuid = { workspace = true, features = ["v4"] }
+thiserror = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true, features = [
   "cors",


### PR DESCRIPTION
With this PR auth errors like missing auth header or errors during decoding are handled according to the SOVD spec.

Request with invalid token:
```
 curl -v -X PUT -H "Content-Type: application/json" "http://localhost:20002/vehicle/v15/components/flxc1000/modes/session" -H "Authorization: Bearer abc" --data '' | jq .
...
< HTTP/1.1 403 Forbidden
< content-type: application/json
< content-length: 97
< date: Mon, 22 Sep 2025 07:07:33 GMT
<
{ [97 bytes data]
100    97  100    97    0     0  75077      0 --:--:-- --:--:-- --:--:-- 97000
* Connection #0 to host localhost left intact
{
  "message": "Invalid token: Token could not be decoded",
  "error_code": "insufficient-access-rights"
}
```

Request without token at all:
```
curl -v -X PUT -H "Content-Type: application/json" "http://localhost:20002/vehicle/v15/components/flxc1000/modes/session" --data ''
...
< HTTP/1.1 401 Unauthorized
< content-length: 0
< date: Mon, 22 Sep 2025 07:07:50 GMT
<
```

Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)