### PR TITLE
Missing parameters for UDS should result in an error

### DIFF
--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -691,6 +691,10 @@ impl cda_interfaces::EcuManager for EcuManager {
 
                         if let Some(value) = json_values.get(&short_name) {
                             self.map_param_to_uds(param, value, &mut uds)?;
+                        } else {
+                            return Err(DiagServiceError::BadPayload(format!(
+                                "Missing parameter: {short_name}"
+                            )));
                         }
                     }
                 }


### PR DESCRIPTION
 add an else to the check if the payload contains the expected uds param key. In the else case an error is returned.

Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)