### PR TITLE
Simplify logic for genericservice check

### DIFF
--- a/cda-sovd/src/sovd/mod.rs
+++ b/cda-sovd/src/sovd/mod.rs
@@ -510,7 +510,18 @@ fn get_octet_stream_payload(
         return Ok(None);
     }
 
-    Ok(Some(UdsPayloadData::Raw(body.to_vec())))
+    let mut data = body.to_vec();
+
+    if data.len() < content_length {
+        return Err(ApiError::BadRequest(format!(
+            "Invalid Content-Length: {content_length} is bigger than the size of the data {}",
+            data.len()
+        )));
+    }
+
+    data.truncate(content_length);
+
+    Ok(Some(UdsPayloadData::Raw(data)))
 }
 
 /// Helper Fn to convert a serde_json::Value into a schemars::Schema, without cloning


### PR DESCRIPTION
 - improve logic to match only SIDRQ to get a matching service
 - do not require 3 bytes, but instead at least 1 byte, as that is the minimum to provide a valid SIDRQ

 Fixes #32
 
 With this change, the CDA supports sending any genericservice that can be mapped to any SIDRQ for the given ECU. 
 In the issue '0x37' is noted as an example service with a single byte payload for the SID. This is now also supported.
 
```
 echo -en '\x37' | curl -X PUT -H "Authorization: Bearer $BEARER" -H "Accept: application/octet-stream" -H "Content-Type: application/octet-stream" --data-binary @- http://localhost:20002/vehicle/v15/components/`<ecu>/genericservice | hexdump -C
00000000  7f 37 33                                          |.73|
00000003
```
In this example the service is found in the DB and therefore sent to the ECU. As the ECU is running in application it returns an NRC, due to the service requiring boot mode for the example ECU.

Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)