### PR TITLE
pin odxtools to v11.0.0

### DIFF
--- a/testcontainer/odx/docker/Dockerfile
+++ b/testcontainer/odx/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim-trixie
 
-RUN pip install odxtools
+RUN pip install odxtools==11.0.0
 
 WORKDIR /data
 


### PR DESCRIPTION
## Summary
When building the container docker/Dockerfile the current available module odxtools will be installed and used. To improve reproducablility and avoid issue with untested version pin odxtools to v11.0.0

## Checklist
- [X] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

## Notes for Reviewers
