### PR TITLE
Only update session/securityaccess on pos response

### DIFF
--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -146,7 +146,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
                 .expect("ECU name has been already checked")
                 .read()
                 .await
-                .convert_from_uds(&service, &msg.expect("response expected").data, map_to_json),
+                .convert_from_uds(&service, &msg.expect("response expected"), map_to_json),
             Err(e) => Err(e),
         };
 
@@ -235,21 +235,6 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
                     Ok(Some(result)) => {
                         match result {
                             Ok(Some(UdsResponse::Message(msg))) => {
-                                if let Some(new_session) = payload.new_session_id.as_ref() {
-                                    ecu.write()
-                                        .await
-                                        .set_session(*new_session, Duration::from_secs(u64::MAX))?;
-                                }
-
-                                if let Some(new_security_access) =
-                                    payload.new_security_access_id.as_ref()
-                                {
-                                    ecu.write().await.set_security_access(
-                                        *new_security_access,
-                                        Duration::from_secs(u64::MAX),
-                                    )?;
-                                }
-
                                 break 'read_uds_messages Ok(msg);
                             }
                             Ok(Some(UdsResponse::BusyRepeatRequest(_))) => {

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -446,11 +446,11 @@ impl cda_interfaces::EcuManager for EcuManager {
     /// elements of the response cannot be correctly mapped from the raw data.
     #[tracing::instrument(
         target = "convert_from_uds",
-        skip(self, diag_service, raw_payload),
+        skip(self, diag_service, payload),
         fields(
             ecu_name = self.ecu_data.ecu_name,
             service = diag_service.name,
-            input = util::tracing::print_hex(raw_payload, 10),
+            input = util::tracing::print_hex(&payload.data, 10),
             output = tracing::field::Empty,
         ),
         err
@@ -458,11 +458,11 @@ impl cda_interfaces::EcuManager for EcuManager {
     fn convert_from_uds(
         &self,
         diag_service: &DiagComm,
-        raw_payload: &[u8],
+        payload: &ServicePayload,
         map_to_json: bool,
     ) -> Result<DiagServiceResponseStruct, DiagServiceError> {
         let mapped_service = self.lookup_diag_comm(diag_service)?;
-        let mut uds_payload = Payload::new(raw_payload);
+        let mut uds_payload = Payload::new(&payload.data);
         let sid = uds_payload
             .first()
             .ok_or_else(|| DiagServiceError::BadPayload("Missing SID".to_owned()))?
@@ -502,6 +502,16 @@ impl cda_interfaces::EcuManager for EcuManager {
                     }
             })
         }) {
+            // in case of a positive response update potential session or security access changes
+            if *t == datatypes::ResponseType::Positive {
+                if let Some(new_session) = payload.new_session_id.as_ref() {
+                    self.set_session(*new_session, Duration::from_secs(u64::MAX))?;
+                }
+
+                if let Some(new_security_access) = payload.new_security_access_id.as_ref() {
+                    self.set_security_access(*new_security_access, Duration::from_secs(u64::MAX))?;
+                }
+            }
             let raw_uds_payload = {
                 let base_offset = params
                     .iter()
@@ -3556,12 +3566,22 @@ mod tests {
         (ecu_manager, service, sid, dtc_code)
     }
 
+    fn create_payload(data: Vec<u8>) -> ServicePayload {
+        ServicePayload {
+            data,
+            source_address: 0u16,
+            target_address: 0u16,
+            new_security_access_id: None,
+            new_session_id: None,
+        }
+    }
+
     #[test]
     fn test_mux_from_uds_invalid_case_no_default() {
         let (ecu_manager, service, sid) = create_ecu_manager_with_mux_service(None, None, None);
         let response = ecu_manager.convert_from_uds(
             &service,
-            &[
+            &create_payload(vec![
                 // Service ID
                 sid,
                 // This does not belong to our mux, it's here to test, if the start byte is used
@@ -3569,7 +3589,7 @@ mod tests {
                 // Mux param starts here
                 // there is no switch value for 0xffff
                 0xff, 0xff,
-            ],
+            ]),
             true,
         );
         assert!(response.is_err());
@@ -3581,7 +3601,7 @@ mod tests {
         let response = ecu_manager
             .convert_from_uds(
                 &service,
-                &[
+                &create_payload(vec![
                     // Service ID
                     sid,
                     // This does not belong to our mux, it's here to test, if the start byte is used
@@ -3591,7 +3611,7 @@ mod tests {
                     0xff, 0xff, //
                     // value for param 1 of default structure
                     0x42,
-                ],
+                ]),
                 true,
             )
             .unwrap();
@@ -3615,14 +3635,14 @@ mod tests {
         let (ecu_manager, service, sid) = create_ecu_manager_with_mux_service(None, None, None);
         let response = ecu_manager.convert_from_uds(
             &service,
-            &[
+            &create_payload(vec![
                 // Service ID
                 sid,
                 // This does not belong to our mux, it's here to test, if the start byte is used
                 0xff, // Mux param starts here
                 // + switch key byte 0
                 0x0, 0x0a, // valid switch key but no data, expect error from decode.
-            ],
+            ]),
             true,
         );
         assert!(response.is_err());
@@ -3633,14 +3653,14 @@ mod tests {
         let (ecu_manager, service, sid) = create_ecu_manager_with_mux_service(None, None, None);
         let response = ecu_manager.convert_from_uds(
             &service,
-            &[
+            &create_payload(vec![
                 // Service ID
                 sid,
                 // This does not belong to our mux, it's here to test, if the start byte is used
                 0xff, // Mux param starts here
                 // + switch key byte 0
                 0x00, 0x0a, // valid switch key but no data, expect error from decode.
-            ],
+            ]),
             true,
         );
 
@@ -3764,7 +3784,9 @@ mod tests {
         data: &Vec<u8>,
         mux_1_json: serde_json::Value,
     ) {
-        let response = ecu_manager.convert_from_uds(service, data, true).unwrap();
+        let response = ecu_manager
+            .convert_from_uds(service, &create_payload(data.to_vec()), true)
+            .unwrap();
 
         // JSON for the response assertion
         let expected_response_json = {
@@ -3987,7 +4009,9 @@ mod tests {
             0x56, 0x78, // item_param2 = 0x5678
         ];
 
-        let response = ecu_manager.convert_from_uds(&service, &data, true).unwrap();
+        let response = ecu_manager
+            .convert_from_uds(&service, &create_payload(data), true)
+            .unwrap();
 
         let expected_json = json!({
             "end_pdu_param": [
@@ -4022,7 +4046,9 @@ mod tests {
             0x56, 0x78, // item_param2 = 0x5678
         ];
 
-        let response = ecu_manager.convert_from_uds(&service, &data, true).unwrap();
+        let response = ecu_manager
+            .convert_from_uds(&service, &create_payload(data), true)
+            .unwrap();
 
         let expected_json = json!({
             "end_pdu_param": [
@@ -4054,7 +4080,9 @@ mod tests {
             0xAA, 0xFF, // Third item, incomplete and exceeding limit, will be ignored
         ];
 
-        let response = ecu_manager.convert_from_uds(&service, &data, true).unwrap();
+        let response = ecu_manager
+            .convert_from_uds(&service, &create_payload(data), true)
+            .unwrap();
         let expected_json = json!({
             "end_pdu_param": [
                 {
@@ -4083,7 +4111,9 @@ mod tests {
             sid, // Service ID
         ];
 
-        let response = ecu_manager.convert_from_uds(&service, &data, true).unwrap();
+        let response = ecu_manager
+            .convert_from_uds(&service, &create_payload(data), true)
+            .unwrap();
         let expected_json = json!({
             "end_pdu_param": [
             ],
@@ -4106,7 +4136,9 @@ mod tests {
             0xD0, 0x0F, // extra data at the end, will be ignored
         ];
 
-        let response = ecu_manager.convert_from_uds(&service, &data, true).unwrap();
+        let response = ecu_manager
+            .convert_from_uds(&service, &create_payload(data), true)
+            .unwrap();
         let expected_json = json!({
             "end_pdu_param": [
                 {
@@ -4136,7 +4168,7 @@ mod tests {
         payload.extend_from_slice(&dtc_code.to_be_bytes());
 
         let response = ecu_manager
-            .convert_from_uds(&service, &payload, true)
+            .convert_from_uds(&service, &create_payload(payload), true)
             .unwrap();
 
         let expected_json = json!({
@@ -4162,7 +4194,7 @@ mod tests {
         ];
 
         let response = ecu_manager
-            .convert_from_uds(&service, &payload, true)
+            .convert_from_uds(&service, &create_payload(payload), true)
             .unwrap();
 
         let expected_json = json!({
@@ -4186,7 +4218,7 @@ mod tests {
             0x11, 0x22, 0x33, 0x44,
         ];
 
-        let response = ecu_manager.convert_from_uds(&service, &payload, true);
+        let response = ecu_manager.convert_from_uds(&service, &create_payload(payload), true);
 
         assert_eq!(
             response.err(),

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -110,7 +110,7 @@ pub trait EcuManager:
     fn convert_from_uds(
         &self,
         diag_service: &DiagComm,
-        raw_payload: &[u8],
+        payload: &ServicePayload,
         map_to_json: bool,
     ) -> Result<Self::Response, DiagServiceError>;
     /// Creates a `ServicePayload` and processes transitions based on raw UDS data,


### PR DESCRIPTION
 - move update logic for session and security access from UDS response handling to ecumanager, where we have the information if the response is positive or negative
 - this will not update the session or security access, if the received response cannot be found in the ecu database.
 
 Fixes #61 

Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)