### PR TITLE
Ensure session & level name are case insensitive

### DIFF
--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -855,6 +855,7 @@ impl cda_interfaces::EcuManager for EcuManager {
         session: &str,
     ) -> Result<(cda_interfaces::Id, DiagComm), DiagServiceError> {
         let session_state_chart = self.state_chart(semantics::SESSION)?;
+        let lookup_session = session.to_lowercase();
 
         let target_session = session_state_chart
             .states
@@ -862,7 +863,7 @@ impl cda_interfaces::EcuManager for EcuManager {
             .find(|(_, state)| {
                 STRINGS
                     .get(state.short_name)
-                    .is_some_and(|name| name == session)
+                    .is_some_and(|name| name == lookup_session)
             })
             .map(|(_, state)| state)
             .ok_or_else(|| {
@@ -929,6 +930,7 @@ impl cda_interfaces::EcuManager for EcuManager {
     ) -> Result<SecurityAccess, DiagServiceError> {
         let security_state_chart = self.state_chart(semantics::SECURITY)?;
         let session_control = self.access_control.lock();
+        let lookup_level = level.to_lowercase();
 
         let target_access_level = security_state_chart
             .states
@@ -936,7 +938,7 @@ impl cda_interfaces::EcuManager for EcuManager {
             .find(|(_, state)| {
                 STRINGS
                     .get(state.short_name)
-                    .is_some_and(|name| name.to_lowercase() == level.to_lowercase())
+                    .is_some_and(|name| name.to_lowercase() == lookup_level)
             })
             .map(|(_, state)| state)
             .ok_or_else(|| {


### PR DESCRIPTION
## Summary
This PR changes .../modes/session to no longer require matching casing of session names. The comparison to the state charts is handled case insenstive.
Additionally the response for PUT .../modes/session now fetches the set value for the session instead of returning the input value in case of a positive response - this ensures consistency with the returned response from a GET afterwards.

Example:
```
curl -s -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer $ACCESS_TOKEN" http://localhost:20002/vehicle/v15/components/FLXC1000/modes/session --data '{"value": "eXtENdEd" }' | jq .
{
  "id": "SECURITY",
  "value": "extended"
}
```

## Related
Fixes #58 

Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
