### PR TITLE
Change ../modes/{id} to behave according to spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2686,6 +2686,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "strum",
 ]
 
 [[package]]
@@ -2714,6 +2715,9 @@ name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"

--- a/cda-sovd-interfaces/Cargo.toml
+++ b/cda-sovd-interfaces/Cargo.toml
@@ -21,6 +21,7 @@ chrono = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 schemars = { workspace = true, features = ["hashbrown"] }
+strum = { workspace = true, features = ["derive"] }
 
 [features]
 default = []

--- a/cda-sovd-interfaces/src/components/ecu/modes.rs
+++ b/cda-sovd-interfaces/src/components/ecu/modes.rs
@@ -12,6 +12,7 @@
  */
 
 use serde::Serialize;
+use strum::{Display, EnumString};
 
 #[derive(Debug, Serialize, schemars::JsonSchema)]
 pub struct Mode<T> {
@@ -28,18 +29,24 @@ pub struct Mode<T> {
     pub schema: Option<schemars::Schema>,
 }
 
+#[derive(Display, EnumString)]
+#[strum(serialize_all = "lowercase")]
+pub enum ModeType {
+    Session,
+    Security,
+}
+
+pub type Query = crate::IncludeSchemaQuery;
+
 pub mod get {
     use super::*;
     use crate::Items;
 
     pub type Response = Items<Mode<()>>;
-    pub type Query = crate::IncludeSchemaQuery;
 }
 
 pub mod put {
     use serde::{Deserialize, Serialize};
-
-    pub type Query = crate::IncludeSchemaQuery;
 
     #[derive(Debug, Deserialize, schemars::JsonSchema)]
     pub struct ModeKey {

--- a/cda-sovd/src/sovd/mod.rs
+++ b/cda-sovd/src/sovd/mod.rs
@@ -371,14 +371,9 @@ fn ecu_route<
         )
         .api_route("/modes", routing::get_with(modes::get, modes::docs_get))
         .api_route(
-            "/modes/session",
-            routing::get_with(modes::session::get, modes::session::docs_get)
-                .put_with(modes::session::put, modes::session::docs_put),
-        )
-        .api_route(
-            "/modes/security",
-            routing::get_with(modes::security::get, modes::security::docs_get)
-                .put_with(modes::security::put, modes::security::docs_put),
+            "/modes/{mode-id}",
+            routing::get_with(modes::id::get, modes::id::docs_get)
+                .put_with(modes::id::put, modes::id::docs_put),
         )
         .api_route(
             "/x-single-ecu-jobs",


### PR DESCRIPTION
With this PR the `../modes/{mode-id}` endpoints are implemented according to the spec.  
With this the noted inconsistencies in #70 are fixed. 

Fixes #71 


Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
