### PR TITLE
Use custom error types instead of Strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,7 @@ dependencies = [
  "hashbrown 0.16.0",
  "openssl",
  "socket2",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -387,6 +388,7 @@ dependencies = [
 name = "cda-interfaces"
 version = "0.1.0"
 dependencies = [
+ "cda-tracing",
  "deepsize",
  "hashbrown 0.16.0",
  "hex",
@@ -396,6 +398,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -429,6 +432,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-extra",
+ "cda-comm-doip",
  "cda-interfaces",
  "cda-plugin-security",
  "chrono",
@@ -466,6 +470,7 @@ dependencies = [
  "opentelemetry_sdk",
  "serde",
  "strip-ansi-escapes",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -1980,6 +1985,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strip-ansi-escapes",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "tracing-appender",

--- a/cda-comm-doip/Cargo.toml
+++ b/cda-comm-doip/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/lib.rs"
 cda-interfaces = { workspace = true }
 # external
 hashbrown = { workspace = true, features = ["serde"] }
+thiserror = { workspace = true }
 # DoIP
 doip-definitions = { workspace = true }
 doip-sockets = { workspace = true, features = ["ssl"] }

--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -18,11 +18,13 @@ use doip_definitions::payload::{
     ActivationType, AliveCheckRequest, DiagnosticMessage, DoipPayload, RoutingActivationRequest,
 };
 use hashbrown::HashMap;
+use thiserror::Error;
 use tokio::sync::{Mutex, RwLock, broadcast, mpsc, watch};
 
 use crate::{
     ConnectionError, DiagnosticResponse, DoipConnection, DoipEcu, DoipTarget,
     NRC_BUSY_REPEAT_REQUEST, NRC_RESPONSE_PENDING, NRC_TEMPORARILY_NOT_AVAILABLE, SLEEP_INTERVAL,
+    connections::EcuError::EcuConnectionError,
     ecu_connection::{self, ECUConnection, EcuConnectionTarget},
 };
 
@@ -34,6 +36,20 @@ struct ConnectionSettings {
     retry_delay: Duration,
     connect_timeout: Duration,
     max_retry_attempts: u32,
+}
+
+#[derive(Error, Debug, Clone)]
+pub enum EcuError {
+    #[error("Resource not found: `{0}`")]
+    ResourceNotFound(String),
+    #[error("Connection error: `{0}`")]
+    EcuConnectionError(ConnectionError),
+}
+
+impl From<ConnectionError> for EcuError {
+    fn from(value: ConnectionError) -> Self {
+        EcuConnectionError(value)
+    }
 }
 
 #[tracing::instrument(
@@ -49,14 +65,14 @@ pub(crate) async fn handle_gateway_connection<T>(
     doip_connections: &Arc<RwLock<Vec<Arc<DoipConnection>>>>,
     ecus: &Arc<HashMap<String, RwLock<T>>>,
     gateway_ecu_map: &HashMap<u16, Vec<u16>>,
-) -> Result<u16, String>
+) -> Result<u16, EcuError>
 where
     T: EcuAddressProvider + DoipComParamProvider,
 {
     let tester_address = ecus
         .get(&gateway.ecu)
         .map(|ecu| async { ecu.read().await.tester_address() })
-        .ok_or_else(|| "ECU not found".to_owned())?
+        .ok_or_else(|| EcuError::ResourceNotFound("ECU not found".to_owned()))?
         .await;
 
     let routing_activation_request = RoutingActivationRequest {
@@ -68,15 +84,19 @@ where
     let ecu_ids: Vec<u16> = if let Some(ecu_ids) = gateway_ecu_map.get(&gateway.logical_address) {
         ecu_ids.clone()
     } else {
-        return Err(format!(
+        return Err(EcuError::ResourceNotFound(format!(
             "No ECUs found for gateway address {}. Skipping, as the gateway cannot be used.",
             gateway.logical_address
-        ));
+        )));
     };
 
     let gateway_ecu = match ecus.get(&gateway.ecu) {
         Some(ecu) => ecu.read().await,
-        None => return Err("Failed to find gateway ECU".to_owned()),
+        None => {
+            return Err(EcuError::ResourceNotFound(
+                "Failed to find gateway ECU".to_owned(),
+            ));
+        }
     };
     let routing_activation_timeout = gateway_ecu.routing_activation_timeout();
     let connection_retry_delay = gateway_ecu.connection_retry_delay();
@@ -99,7 +119,12 @@ where
     {
         Ok((sender, receiver)) => (sender, receiver),
         Err(e) => {
-            return Err(format!("Failed to connect to {}: {}", gateway.ecu, e));
+            return Err(EcuError::EcuConnectionError(
+                ConnectionError::ConnectionFailed(format!(
+                    "Failed to connect to {}: {}",
+                    gateway.ecu, e
+                )),
+            ));
         }
     };
 
@@ -121,7 +146,7 @@ where
 fn create_ecu_receiver_map(
     ecus: Vec<u16>,
     sender: &mpsc::Sender<DiagnosticMessage>, // sender is shared between all ecus of a gateway
-    receiver: &HashMap<u16, broadcast::Receiver<Result<DiagnosticResponse, String>>>,
+    receiver: &HashMap<u16, broadcast::Receiver<Result<DiagnosticResponse, EcuError>>>,
 ) -> HashMap<u16, Arc<Mutex<DoipEcu>>> {
     let mut doip_ecus: HashMap<u16, Arc<Mutex<DoipEcu>>> = HashMap::new();
     for logical_address in ecus {
@@ -136,7 +161,8 @@ fn create_ecu_receiver_map(
                 );
             }
             None => {
-                tracing::warn!(logical_address = %format!("{:#06x}", logical_address), "ECU not found in receiver map");
+                tracing::warn!(logical_address = %format!("{:#06x}", logical_address),
+                    "ECU not found in receiver map");
             }
         }
     }
@@ -162,24 +188,24 @@ async fn connection_handler(
 ) -> Result<
     (
         mpsc::Sender<DiagnosticMessage>,
-        HashMap<u16, broadcast::Receiver<Result<DiagnosticResponse, String>>>,
+        HashMap<u16, broadcast::Receiver<Result<DiagnosticResponse, EcuError>>>,
     ),
-    String,
+    EcuError,
 > {
     // channel to send messages to the gateway / ecus
     let (intx, inrx) = mpsc::channel::<DiagnosticMessage>(50);
 
     // channel to receive messages from the gateway / ecus
-    let mut outrx: HashMap<u16, broadcast::Receiver<Result<DiagnosticResponse, String>>> =
+    let mut outrx: HashMap<u16, broadcast::Receiver<Result<DiagnosticResponse, EcuError>>> =
         HashMap::new();
     // channel used by the receiver task to distribute messages to the correct ecu,
     // counterpart to outrx
-    let mut outtx: HashMap<u16, broadcast::Sender<Result<DiagnosticResponse, String>>> =
+    let mut outtx: HashMap<u16, broadcast::Sender<Result<DiagnosticResponse, EcuError>>> =
         HashMap::new();
 
     // create ecu response channels
     for ecu in ecus {
-        let (tx, rx) = broadcast::channel::<Result<DiagnosticResponse, String>>(10);
+        let (tx, rx) = broadcast::channel::<Result<DiagnosticResponse, EcuError>>(10);
 
         outtx.insert(ecu, tx);
         outrx.insert(ecu, rx);
@@ -244,7 +270,7 @@ async fn setup_connection(
     gateway_name: &str,
     connect_timeout: Duration,
     routing_activation_timeout: Duration,
-) -> Result<EcuConnectionTarget, String> {
+) -> Result<EcuConnectionTarget, ConnectionError> {
     ecu_connection::establish_ecu_connection(
         gateway_ip,
         gateway_name,
@@ -440,7 +466,7 @@ fn spawn_gateway_sender_task(
 fn spawn_gateway_receiver_task(
     gateway_ip: String,
     gateway_name: String,
-    outtx: HashMap<u16, broadcast::Sender<Result<DiagnosticResponse, String>>>,
+    outtx: HashMap<u16, broadcast::Sender<Result<DiagnosticResponse, EcuError>>>,
     gateway_conn: Arc<Mutex<EcuConnectionTarget>>,
     mut send_pending_rx: watch::Receiver<bool>,
     reset_tx: mpsc::Sender<ConnectionResetReason>,
@@ -497,7 +523,7 @@ fn spawn_gateway_receiver_task(
     async fn handle_response(
         gateway_name: &str,
         gateway_ip: &str,
-        outtx: &HashMap<u16, broadcast::Sender<Result<DiagnosticResponse, String>>>,
+        outtx: &HashMap<u16, broadcast::Sender<Result<DiagnosticResponse, EcuError>>>,
         reset_tx: &mpsc::Sender<ConnectionResetReason>,
         response: Option<Result<DiagnosticResponse, ConnectionError>>,
     ) {

--- a/cda-comm-doip/src/ecu_connection.rs
+++ b/cda-comm-doip/src/ecu_connection.rs
@@ -13,10 +13,13 @@
 
 use std::time::Duration;
 
+use cda_interfaces::DiagServiceError;
 use doip_definitions::{
     message::DoipMessage,
     payload::{ActivationCode, DoipPayload, RoutingActivationRequest, RoutingActivationResponse},
 };
+
+use crate::ConnectionError;
 
 const ENABLED_SSL_CIPHERS: [&str; 4] = [
     "ECDHE-RSA-AES128-GCM-SHA256",
@@ -37,7 +40,7 @@ const ELIPTIC_CURVE_GROUPS: [&str; 8] = [
 ];
 
 pub(crate) trait ECUConnection {
-    async fn send(&mut self, msg: DoipPayload) -> Result<(), String>
+    async fn send(&mut self, msg: DoipPayload) -> Result<(), ConnectionError>
     where
         Self: std::borrow::Borrow<Self>;
     async fn read(&mut self) -> Option<Result<DoipMessage, doip_sockets::Error>>
@@ -57,12 +60,12 @@ pub(crate) struct EcuConnectionTarget {
 }
 
 impl ECUConnection for EcuConnectionVariant {
-    async fn send(&mut self, msg: DoipPayload) -> Result<(), String> {
+    async fn send(&mut self, msg: DoipPayload) -> Result<(), ConnectionError> {
         match self {
             EcuConnectionVariant::Tls(conn) => conn.send(msg).await,
             EcuConnectionVariant::Plain(conn) => conn.send(msg).await,
         }
-        .map_err(|e| format!("Failed to send message: {e:?}"))
+        .map_err(|e| ConnectionError::SendFailed(format!("Failed to send message: {e:?}")))
     }
 
     async fn read(&mut self) -> Option<Result<DoipMessage, doip_sockets::Error>> {
@@ -88,7 +91,7 @@ pub(crate) async fn establish_ecu_connection(
     routing_activation_request: RoutingActivationRequest,
     connect_timeout: Duration,
     routing_activation_timeout: Duration,
-) -> Result<EcuConnectionTarget, String> {
+) -> Result<EcuConnectionTarget, ConnectionError> {
     let mut gateway_conn: EcuConnectionVariant = match tokio::time::timeout(
         connect_timeout,
         doip_sockets::tcp::TcpStream::connect(format!("{}:{}", gateway_ip, 13400)), // unencrypted
@@ -96,8 +99,12 @@ pub(crate) async fn establish_ecu_connection(
     .await
     {
         Ok(Ok(stream)) => EcuConnectionVariant::Plain(stream),
-        Ok(Err(e)) => return Err(format!("Connect failed: {e:?}")),
-        Err(_) => return Err("Connect timed out after 10 seconds".to_owned()),
+        Ok(Err(e)) => return Err(ConnectionError::ConnectionFailed(e.to_string())),
+        Err(_) => {
+            return Err(ConnectionError::Timeout(
+                "Connect timed out after 10 seconds".to_owned(),
+            ));
+        }
     };
 
     if let Err(e) = gateway_conn
@@ -106,7 +113,9 @@ pub(crate) async fn establish_ecu_connection(
         ))
         .await
     {
-        return Err(format!("Failed to send routing activation: {e:?}"));
+        return Err(ConnectionError::RoutingError(format!(
+            "Failed to send routing activation: {e:?}"
+        )));
     }
 
     match try_read_routing_activation_response(
@@ -150,13 +159,15 @@ pub(crate) async fn establish_ecu_connection(
                         gateway_ip: gateway_ip.to_owned(),
                     })
                 }
-                _ => Err(format!(
+                _ => Err(ConnectionError::RoutingError(format!(
                     "Failed to activate routing: {:?}",
                     msg.activation_code
-                )),
+                ))),
             }
         }
-        Err(e) => Err(format!("Failed to activate routing: {e:?}")),
+        Err(e) => Err(ConnectionError::RoutingError(format!(
+            "Failed to activate routing: {e:?}"
+        ))),
     }
 }
 
@@ -175,7 +186,7 @@ pub(crate) async fn establish_tls_ecu_connection(
     routing_activation_request: RoutingActivationRequest,
     connnect_timeout: Duration,
     routing_activation_timeout: Duration,
-) -> Result<EcuConnectionVariant, String> {
+) -> Result<EcuConnectionVariant, ConnectionError> {
     let mut gateway_conn: EcuConnectionVariant = match tokio::time::timeout(
         connnect_timeout,
         doip_sockets::tcp::DoIpSslStream::connect_with_ciphers(
@@ -187,8 +198,16 @@ pub(crate) async fn establish_tls_ecu_connection(
     .await
     {
         Ok(Ok(stream)) => EcuConnectionVariant::Tls(stream),
-        Ok(Err(e)) => return Err(format!("Connect failed: {e:?}")),
-        Err(_) => return Err("Connect timed out after 10 seconds".to_owned()),
+        Ok(Err(e)) => {
+            return Err(ConnectionError::ConnectionFailed(format!(
+                "Connect failed: {e:?}"
+            )));
+        }
+        Err(_) => {
+            return Err(ConnectionError::Timeout(
+                "Connect timed out after 10 seconds".to_owned(),
+            ));
+        }
     };
 
     if let Err(e) = gateway_conn
@@ -197,7 +216,9 @@ pub(crate) async fn establish_tls_ecu_connection(
         ))
         .await
     {
-        return Err(format!("Failed to send routing activation: {e:?}"));
+        return Err(ConnectionError::RoutingError(format!(
+            "Failed to send routing activation: {e:?}"
+        )));
     }
 
     match try_read_routing_activation_response(
@@ -210,15 +231,17 @@ pub(crate) async fn establish_tls_ecu_connection(
     {
         Ok(msg) => {
             if msg.activation_code != ActivationCode::SuccessfullyActivated {
-                return Err(format!(
+                return Err(ConnectionError::RoutingError(format!(
                     "Failed to activate routing: {:?}",
                     msg.activation_code
-                ));
+                )));
             }
             tracing::info!("Routing activated");
             Ok(gateway_conn) // Routing activated
         }
-        Err(e) => Err(format!("Failed to activate routing: {e:?}")),
+        Err(e) => Err(ConnectionError::RoutingError(format!(
+            "Failed to activate routing: {e:?}"
+        ))),
     }
 }
 
@@ -238,7 +261,7 @@ async fn try_read_routing_activation_response(
     reader: &mut impl ECUConnection,
     _gateway_name: &str,
     _gateway_ip: &str,
-) -> Result<RoutingActivationResponse, String> {
+) -> Result<RoutingActivationResponse, DiagServiceError> {
     match tokio::time::timeout(timeout, reader.read()).await {
         Ok(Some(Ok(msg))) => match msg.payload {
             DoipPayload::RoutingActivationResponse(routing_activation_response) => {
@@ -249,10 +272,14 @@ async fn try_read_routing_activation_response(
                 );
                 Ok(routing_activation_response)
             }
-            _ => Err(format!("Received non-routing activation response: {msg:?}")),
+            _ => Err(DiagServiceError::UnexpectedResponse(Some(format!(
+                "Received non-routing activation response: {msg:?}"
+            )))),
         },
-        Ok(Some(Err(e))) => Err(format!("Error reading from gateway: {e:?}")),
-        Ok(None) => Err("Gateway closed connection".to_owned()),
-        Err(_) => Err("Timeout waiting for Routing Activation Response".to_owned()),
+        Ok(Some(Err(e))) => Err(DiagServiceError::UnexpectedResponse(Some(format!(
+            "Error reading from gateway: {e:?}"
+        )))),
+        Ok(None) => Err(DiagServiceError::ConnectionClosed),
+        Err(_) => Err(DiagServiceError::Timeout),
     }
 }

--- a/cda-core/src/diag_kernel/diagservices.rs
+++ b/cda-core/src/diag_kernel/diagservices.rs
@@ -85,13 +85,15 @@ impl DiagServiceResponse for DiagServiceResponseStruct {
         self.serialize_to_json()
     }
 
-    fn as_nrc(&self) -> Result<MappedNRC, String> {
+    fn as_nrc(&self) -> Result<MappedNRC, DiagServiceError> {
         let Some(MappedResponseData {
             data: mapped_data,
             errors: _,
         }) = &self.mapped_data
         else {
-            return Err("Unexpected negative response from ECU".to_owned());
+            return Err(DiagServiceError::UnexpectedResponse(Some(
+                "Unexpected negative response from ECU".to_owned(),
+            )));
         };
         let nrc_code = mapped_data
             .get("NRC")

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -380,7 +380,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
                     None
                 }
             })
-            .ok_or(DiagServiceError::NotFound)?;
+            .ok_or(DiagServiceError::NotFound(None))?;
         let mapped_dc = mapped_service.diag_comm().map(datatypes::DiagComm).ok_or(
             DiagServiceError::InvalidDatabase("Service is missing DiagComm".to_owned()),
         )?;
@@ -716,7 +716,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
                     })
             })
             .map(Into::into)
-            .ok_or(DiagServiceError::NotFound)
+            .ok_or(DiagServiceError::NotFound(None))
     }
 
     /// Lookup a service by a given function class name and service id.
@@ -742,7 +742,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
                 .is_some()
         })
         .and_then(|service| service.try_into().ok())
-        .ok_or(DiagServiceError::NotFound)
+        .ok_or(DiagServiceError::NotFound(None))
     }
 
     /// Lookup a service by its service id for the current ECU variant.
@@ -900,7 +900,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
                             .is_some_and(|r| r.params().is_some_and(|p| p.len() == 2))
                         && name_matches
                 })
-                .ok_or(DiagServiceError::NotFound)?;
+                .ok_or(DiagServiceError::NotFound(None))?;
 
             let request_seed_service = request_seed_service.try_into()?;
 
@@ -984,7 +984,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
                     )
                 })
             })
-            .ok_or(DiagServiceError::NotFound)?;
+            .ok_or(DiagServiceError::NotFound(None))?;
 
         let configuration_sids = [
             service_ids::READ_DATA_BY_IDENTIFIER,
@@ -1551,7 +1551,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         if let Some(Some(location)) = self.db_cache.diag_services.read().await.get(&lookup_id) {
             return match self.get_service_by_location(location) {
                 Some(service) => Ok(service),
-                None => Err(DiagServiceError::NotFound), // cached negative result
+                None => Err(DiagServiceError::NotFound(None)), // cached negative result
             };
         }
 
@@ -1580,7 +1580,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
             .write()
             .await
             .insert(lookup_id, None);
-        Err(DiagServiceError::NotFound)
+        Err(DiagServiceError::NotFound(None))
     }
 
     fn search_with_location<F>(
@@ -2945,7 +2945,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     semantic = %semantic,
                     "State chart with given semantic not found in base variant"
                 );
-                DiagServiceError::NotFound
+                DiagServiceError::NotFound(None)
             })?;
 
         let service = self
@@ -2972,7 +2972,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     semantic,
                     "Failed to find service for state transition"
                 );
-                DiagServiceError::NotFound
+                DiagServiceError::NotFound(None)
             })?;
 
         service.try_into()
@@ -2991,7 +2991,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     .find(|sc| sc.semantic().is_some_and(|sem| sem == semantic))
             })
             .map(datatypes::StateChart)
-            .ok_or(DiagServiceError::NotFound)
+            .ok_or(DiagServiceError::NotFound(None))
     }
 
     fn default_state(&self, semantic: &str) -> Result<String, DiagServiceError> {
@@ -3048,7 +3048,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
             .collect::<Vec<_>>();
 
         if services.is_empty() {
-            Err(DiagServiceError::NotFound)
+            Err(DiagServiceError::NotFound(None))
         } else {
             Ok(services)
         }

--- a/cda-interfaces/Cargo.toml
+++ b/cda-interfaces/Cargo.toml
@@ -18,11 +18,15 @@ workspace = true
 path = "src/lib.rs"
 
 [dependencies]
+# internal dependencies
+cda-tracing = { workspace = true }
+
 hashbrown = { workspace = true, features = ["serde"] }
 parking_lot = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 #tokio
 tokio = { workspace = true, features = ["sync"] }
 # runtime size info

--- a/cda-interfaces/src/diagservices.rs
+++ b/cda-interfaces/src/diagservices.rs
@@ -60,7 +60,7 @@ pub trait DiagServiceResponse: Sized + Send + Sync + 'static {
     /// Map the response as a Negative Response Code (NRC).
     /// # Errors
     /// Returns `String` if on failure to map the response as NRC.
-    fn as_nrc(&self) -> Result<MappedNRC, String>;
+    fn as_nrc(&self) -> Result<MappedNRC, DiagServiceError>;
 
     /// Extract data trouble codes from the response, if any.
     /// # Errors

--- a/cda-interfaces/src/ecuuds.rs
+++ b/cda-interfaces/src/ecuuds.rs
@@ -49,7 +49,7 @@ pub trait UdsEcu: Send + Sync + 'static {
         &self,
         ecu: &str,
         service: Option<&DiagComm>,
-    ) -> impl Future<Output = Result<Vec<SdSdg>, String>> + Send;
+    ) -> impl Future<Output = Result<Vec<SdSdg>, DiagServiceError>> + Send;
     /// Retrieves the communication parameters for a specific ECU.
     /// # Errors
     /// Will return `Err` if the ECU does not exist.
@@ -63,7 +63,7 @@ pub trait UdsEcu: Send + Sync + 'static {
     fn get_components_data_info(
         &self,
         ecu: &str,
-    ) -> impl Future<Output = Result<Vec<ComponentDataInfo>, String>> + Send;
+    ) -> impl Future<Output = Result<Vec<ComponentDataInfo>, DiagServiceError>> + Send;
     /// Retrieve all configuration type services for the given ECU on the detected variant.
     /// # Errors
     /// Will return `Err` if the ECU does not exist
@@ -77,7 +77,7 @@ pub trait UdsEcu: Send + Sync + 'static {
     fn get_components_single_ecu_jobs_info(
         &self,
         ecu: &str,
-    ) -> impl Future<Output = Result<Vec<ComponentDataInfo>, String>> + Send;
+    ) -> impl Future<Output = Result<Vec<ComponentDataInfo>, DiagServiceError>> + Send;
     /// Retrieve a specific single ecu job for the given ECU.
     fn get_single_ecu_job(
         &self,
@@ -260,13 +260,19 @@ pub trait UdsEcu: Send + Sync + 'static {
     /// # Errors
     /// Will return `Err` if the variant detection cannot be triggered, e.g. if the given ECU
     /// does not exist or no service for variant detection is available.
-    fn detect_variant(&self, ecu_name: &str) -> impl Future<Output = Result<(), String>> + Send;
+    fn detect_variant(
+        &self,
+        ecu_name: &str,
+    ) -> impl Future<Output = Result<(), DiagServiceError>> + Send;
 
     /// Get the name of the variant for the given ECU.
     /// # Errors
     /// Will return Err if the ECU does not exist.
     /// If the variant is cannot be resolved, "Unknown" will be returned.
-    fn get_variant(&self, ecu_name: &str) -> impl Future<Output = Result<String, String>> + Send;
+    fn get_variant(
+        &self,
+        ecu_name: &str,
+    ) -> impl Future<Output = Result<String, DiagServiceError>> + Send;
 
     /// trigger the variant detection process for all ECUs.
     /// Main work will be done in the background, there is no result returned,

--- a/cda-main/Cargo.toml
+++ b/cda-main/Cargo.toml
@@ -48,6 +48,7 @@ tokio = { workspace = true, features = [
   "signal",
 ] }
 # logging & tracing
+thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-core = { workspace = true }
 tracing-appender = { workspace = true }

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -24,7 +24,7 @@ use cda_comm_uds::UdsManager;
 use cda_core::{DiagServiceResponseStruct, EcuManager};
 use cda_database::{FileManager, ProtoLoadConfig};
 use cda_interfaces::{
-    Protocol,
+    DoipGatewaySetupError, Protocol,
     datatypes::{ComParams, DatabaseNamingConvention, FlatbBufConfig},
     file_manager::{Chunk, ChunkType},
 };
@@ -307,7 +307,7 @@ pub async fn create_diagnostic_gateway<S: SecurityPlugin>(
     doip_gateway_port: u16,
     variant_detection: mpsc::Sender<Vec<String>>,
     shutdown_signal: impl std::future::Future<Output = ()> + Send + Clone + 'static,
-) -> Result<DoipDiagGateway<EcuManager<S>>, String> {
+) -> Result<DoipDiagGateway<EcuManager<S>>, DoipGatewaySetupError> {
     DoipDiagGateway::new(
         doip_tester_address,
         doip_tester_subnet,
@@ -329,7 +329,7 @@ pub fn start_webserver<S: SecurityPlugin, L: SecurityPluginLoader>(
     webserver_config: WebServerConfig,
     ecu_uds: UdsManager<DoipDiagGateway<EcuManager<S>>, DiagServiceResponseStruct, EcuManager<S>>,
     shutdown_signal: impl std::future::Future<Output = ()> + Send + 'static,
-) -> tokio::task::JoinHandle<Result<(), String>> {
+) -> tokio::task::JoinHandle<Result<(), DoipGatewaySetupError>> {
     cda_interfaces::spawn_named!("webserver", async move {
         cda_sovd::launch_webserver::<_, DiagServiceResponseStruct, _, _, L>(
             webserver_config,

--- a/cda-sovd/Cargo.toml
+++ b/cda-sovd/Cargo.toml
@@ -22,6 +22,7 @@ workspace = true
 cda-interfaces = { workspace = true }
 cda-plugin-security = { workspace = true }
 sovd-interfaces = { workspace = true }
+cda-comm-doip = { workspace = true }
 
 tokio = { workspace = true, features = ["net"] }
 futures = { workspace = true }                         # external

--- a/cda-sovd/src/lib.rs
+++ b/cda-sovd/src/lib.rs
@@ -20,7 +20,8 @@ use axum::{
     middleware, routing,
 };
 use cda_interfaces::{
-    SchemaProvider, UdsEcu, diagservices::DiagServiceResponse, file_manager::FileManager,
+    DoipGatewaySetupError, SchemaProvider, UdsEcu, diagservices::DiagServiceResponse,
+    file_manager::FileManager,
 };
 use cda_plugin_security::SecurityPluginLoader;
 use futures::future::FutureExt;
@@ -62,7 +63,7 @@ pub async fn launch_webserver<F, R, T, M, S>(
     flash_files_path: String,
     file_manager: HashMap<String, M>,
     shutdown_signal: F,
-) -> Result<(), String>
+) -> Result<(), DoipGatewaySetupError>
 where
     F: Future<Output = ()> + Send + 'static,
     R: DiagServiceResponse,
@@ -127,7 +128,9 @@ where
             axum::serve(listener, app_with_middleware.into_make_service())
                 .with_graceful_shutdown(clonable_shutdown_signal)
                 .await
-                .map_err(|e| format!("Axum serve error: {e}"))?;
+                .map_err(|e| {
+                    DoipGatewaySetupError::ServerError(format!("Axum serve error: {e}"))
+                })?;
         }
         Err(e) => {
             tracing::error!(

--- a/cda-sovd/src/sovd/components/ecu/data.rs
+++ b/cda-sovd/src/sovd/components/ecu/data.rs
@@ -45,7 +45,7 @@ pub(crate) async fn get<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManage
             (StatusCode::OK, Json(sovd_component_data)).into_response()
         }
         Err(e) => ErrorWrapper {
-            error: ApiError::BadRequest(e),
+            error: e.into(),
             include_schema: query.include_schema,
         }
         .into_response(),
@@ -160,7 +160,7 @@ pub(crate) mod diag_service {
                 }
                 Err(e) => {
                     return ErrorWrapper {
-                        error: ApiError::BadRequest(e),
+                        error: e.into(),
                         include_schema,
                     }
                     .into_response();

--- a/cda-sovd/src/sovd/components/ecu/mod.rs
+++ b/cda-sovd/src/sovd/components/ecu/mod.rs
@@ -62,7 +62,7 @@ pub(crate) async fn get<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManage
         Ok(v) => HashMap::from([("name".to_owned(), v)]),
         Err(e) => {
             return ErrorWrapper {
-                error: ApiError::BadRequest(e),
+                error: e.into(),
                 include_schema,
             }
             .into_response();
@@ -70,11 +70,7 @@ pub(crate) async fn get<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManage
     };
 
     let sdgs = if query.include_sdgs {
-        match uds
-            .get_sdgs(&ecu_name, None)
-            .await
-            .map_err(ApiError::BadRequest)
-        {
+        match uds.get_sdgs(&ecu_name, None).await {
             Ok(v) => Some(
                 v.into_iter()
                     .map(super::super::IntoSovd::into_sovd)
@@ -82,7 +78,7 @@ pub(crate) async fn get<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManage
             ),
             Err(e) => {
                 return ErrorWrapper {
-                    error: e,
+                    error: e.into(),
                     include_schema,
                 }
                 .into_response();
@@ -165,7 +161,7 @@ async fn update<T: UdsEcu + Clone>(ecu_name: &str, uds: T) -> Response {
     match uds.detect_variant(ecu_name).await {
         Ok(()) => (StatusCode::CREATED, ()).into_response(),
         Err(e) => ErrorWrapper {
-            error: ApiError::BadRequest(e),
+            error: e.into(),
             include_schema: false,
         }
         .into_response(),

--- a/cda-sovd/src/sovd/components/ecu/x_single_ecu_jobs.rs
+++ b/cda-sovd/src/sovd/components/ecu/x_single_ecu_jobs.rs
@@ -59,7 +59,7 @@ pub(crate) mod single_ecu {
                 (StatusCode::OK, Json(sovd_component_data)).into_response()
             }
             Err(e) => ErrorWrapper {
-                error: ApiError::BadRequest(e),
+                error: e.into(),
                 include_schema,
             }
             .into_response(),

--- a/cda-sovd/src/sovd/error.rs
+++ b/cda-sovd/src/sovd/error.rs
@@ -44,16 +44,21 @@ pub enum ApiError {
 impl From<DiagServiceError> for ApiError {
     fn from(value: DiagServiceError) -> Self {
         match &value {
-            DiagServiceError::UdsLookupError(_) => ApiError::NotFound(Some(value.to_string())),
-            DiagServiceError::NotFound => ApiError::NotFound(None),
+            DiagServiceError::UdsLookupError(_) | DiagServiceError::NotFound(Some(_) | None) => {
+                ApiError::NotFound(Some(value.to_string()))
+            }
 
             DiagServiceError::InvalidDatabase(_)
             | DiagServiceError::DatabaseEntryNotFound(_)
             | DiagServiceError::VariantDetectionError(_)
             | DiagServiceError::EcuOffline(_)
+            | DiagServiceError::ConfigurationError(_)
+            | DiagServiceError::SetupError(_)
+            | DiagServiceError::ResourceError(_)
             | DiagServiceError::ConnectionClosed
             | DiagServiceError::InvalidRequest(_)
             | DiagServiceError::SendFailed(_)
+            | DiagServiceError::InvalidAddress(_)
             | DiagServiceError::ParameterConversionError(_)
             | DiagServiceError::BadPayload(_)
             | DiagServiceError::NotEnoughData { .. }
@@ -61,11 +66,12 @@ impl From<DiagServiceError> for ApiError {
             | DiagServiceError::Nack(_)
             | DiagServiceError::InvalidSession(_)
             | DiagServiceError::UnknownOperation
-            | DiagServiceError::UnexpectedResponse
+            | DiagServiceError::UnexpectedResponse(_)
             | DiagServiceError::RequestNotSupported(_)
             | DiagServiceError::Timeout
             | DiagServiceError::DataError(_)
             | DiagServiceError::AccessDenied(_) => ApiError::BadRequest(value.to_string()),
+
             DiagServiceError::InvalidSecurityPlugin => {
                 ApiError::InternalServerError(Some(value.to_string()))
             }

--- a/cda-tracing/Cargo.toml
+++ b/cda-tracing/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/lib.rs"
 hashbrown = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true }
+thiserror = { workspace = true }
 # logging & tracing
 tracing = { workspace = true }
 tracing-core = { workspace = true }


### PR DESCRIPTION
This PR replaces all errors that are returned as Strings by custom error types to make error recovery and diagnostics easier as suggested in #4.
The custom error types are implemented as enums which hold a string and implement the Display trait. 

Closes #4 
