### PR TITLE
fix pedantic clippy warnings

### DIFF
--- a/cda-comm-doip/Cargo.toml
+++ b/cda-comm-doip/Cargo.toml
@@ -11,6 +11,9 @@ description = "DoIP communication layer used in CDA"
 homepage.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/lib.rs"
 

--- a/cda-comm-doip/src/ecu_connection.rs
+++ b/cda-comm-doip/src/ecu_connection.rs
@@ -222,6 +222,9 @@ pub(crate) async fn establish_tls_ecu_connection(
     }
 }
 
+// Allow the underscore bindings because the variables
+// are not used, but we want them in the tracing fields.
+#[allow(clippy::used_underscore_binding)]
 #[tracing::instrument(
     skip(reader),
     fields(

--- a/cda-comm-uds/Cargo.toml
+++ b/cda-comm-uds/Cargo.toml
@@ -11,6 +11,9 @@ description = "UDS communication layer used in CDA"
 homepage.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/lib.rs"
 

--- a/cda-core/Cargo.toml
+++ b/cda-core/Cargo.toml
@@ -11,6 +11,9 @@ description = "Diagnostic Core of CDA"
 homepage.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/lib.rs"
 

--- a/cda-core/src/diag_kernel/diagservices.rs
+++ b/cda-core/src/diag_kernel/diagservices.rs
@@ -161,7 +161,7 @@ impl DiagServiceResponse for DiagServiceResponseStruct {
                         .collect::<Vec<_>>();
                     Some(results.into_iter().flatten().flatten().collect())
                 }
-                _ => None,
+                DiagDataTypeContainer::RawContainer(_) => None,
             }
         }
 
@@ -279,7 +279,7 @@ impl DiagServiceResponseStruct {
                             errors,
                             format!("{path}/{k}").as_str(),
                         ) {
-                            Ok(_) => DiagDataValue::Struct(nested_mapped),
+                            Ok(()) => DiagDataValue::Struct(nested_mapped),
                             Err(e) => {
                                 if let DiagServiceError::DataError(ref error) = e {
                                     errors.push(FieldParseError {
@@ -303,7 +303,7 @@ impl DiagServiceResponseStruct {
                                 errors,
                                 format!("{path}/{k}").as_str(),
                             ) {
-                                Ok(_) => nested_vec.push(inner_mapped),
+                                Ok(()) => nested_vec.push(inner_mapped),
                                 Err(e) => {
                                     if let DiagServiceError::DataError(ref error) = e {
                                         errors.push(FieldParseError {

--- a/cda-core/src/diag_kernel/variant_detection.rs
+++ b/cda-core/src/diag_kernel/variant_detection.rs
@@ -39,7 +39,7 @@ pub(super) fn prepare_variant_detection(
                                     mp.diag_service()
                                         .and_then(|ds| ds.diag_comm())
                                         .and_then(|dc| dc.short_name())
-                                        .map(|name| name.to_owned())
+                                        .map(ToOwned::to_owned)
                                 })
                             })
                         })
@@ -54,97 +54,85 @@ pub(super) fn prepare_variant_detection(
     })
 }
 
-impl VariantDetection {
-    // Note: It's extremely important to skip the diagnostic_database
-    // otherwise the tracing macro will try to get the debug representation of it
-    // which _will_ take several seconds (up to 60s for large DBs)
-    #[tracing::instrument(
-        skip(self, service_responses, diagnostic_database),
-        fields(response_count = service_responses.len())
-    )]
-    pub(super) fn evaluate_variant<'a, T: DiagServiceResponse + Sized>(
-        &self,
-        service_responses: HashMap<String, T>,
-        diagnostic_database: &'a datatypes::DiagnosticDatabase,
-    ) -> Result<datatypes::Variant<'a>, DiagServiceError> {
-        let service_responses = service_responses
-            .into_iter()
-            .map(|(service, res)| {
-                let json = res.into_json()?;
-                let params = json
-                    .data
-                    .as_object()
-                    .ok_or_else(|| {
-                        DiagServiceError::ParameterConversionError(
-                            "Expected JSON object".to_owned(),
-                        )
-                    })?
-                    .into_iter()
-                    .map(|(name, value)| (name.clone(), value.to_string().replace('"', "")))
-                    .collect::<HashMap<String, String>>();
-                Ok((service, params))
-            })
-            .collect::<Result<HashMap<String, HashMap<String, String>>, DiagServiceError>>()?;
+#[tracing::instrument(
+    skip(service_responses, diagnostic_database),
+    fields(response_count = service_responses.len())
+)]
+pub(super) fn evaluate_variant<T: DiagServiceResponse + Sized>(
+    service_responses: HashMap<String, T>,
+    diagnostic_database: &datatypes::DiagnosticDatabase,
+) -> Result<datatypes::Variant<'_>, DiagServiceError> {
+    let service_responses = service_responses
+        .into_iter()
+        .map(|(service, res)| {
+            let json = res.into_json()?;
+            let params = json
+                .data
+                .as_object()
+                .ok_or_else(|| {
+                    DiagServiceError::ParameterConversionError("Expected JSON object".to_owned())
+                })?
+                .into_iter()
+                .map(|(name, value)| (name.clone(), value.to_string().replace('"', "")))
+                .collect::<HashMap<String, String>>();
+            Ok((service, params))
+        })
+        .collect::<Result<HashMap<String, HashMap<String, String>>, DiagServiceError>>()?;
 
-        let variants = diagnostic_database.ecu_data()?.variants().ok_or_else(|| {
-            DiagServiceError::InvalidDatabase(format!(
-                "ECU {:?} has no variants!",
-                diagnostic_database
-                    .ecu_data()
-                    .ok()
-                    .and_then(|ecu| ecu.ecu_name())
-            ))
-        })?;
+    let variants = diagnostic_database.ecu_data()?.variants().ok_or_else(|| {
+        DiagServiceError::InvalidDatabase(format!(
+            "ECU {:?} has no variants!",
+            diagnostic_database.ecu_name()
+        ))
+    })?;
 
-        variants
-            .iter()
-            .find(|variant| {
-                variant
-                    .variant_pattern()
-                    .map(|patterns| {
-                        patterns.iter().any(|pattern| {
-                            pattern
-                                .matching_parameter()
-                                .map(|params| {
-                                    params.iter().all(|matching_param| {
-                                        let expected_value =
-                                            matching_param.expected_value().unwrap_or_default();
-                                        let expected_param = matching_param
-                                            .out_param()
-                                            .and_then(|out_param| out_param.short_name())
-                                            .unwrap_or_default();
-                                        let service = matching_param
-                                            .diag_service()
-                                            .and_then(|ds| ds.diag_comm())
-                                            .and_then(|dc| dc.short_name())
-                                            .unwrap_or_default();
+    variants
+        .iter()
+        .find(|variant| {
+            variant.variant_pattern().is_some_and(|patterns| {
+                patterns.iter().any(|pattern| {
+                    pattern.matching_parameter().is_some_and(|params| {
+                        params.iter().all(|matching_param| {
+                            let expected_value =
+                                matching_param.expected_value().unwrap_or_default();
+                            let expected_param = matching_param
+                                .out_param()
+                                .and_then(|out_param| out_param.short_name())
+                                .unwrap_or_default();
+                            let service = matching_param
+                                .diag_service()
+                                .and_then(|ds| ds.diag_comm())
+                                .and_then(|dc| dc.short_name())
+                                .unwrap_or_default();
 
-                                        service_responses
-                                            .get(service)
-                                            .and_then(|params| {
-                                                params
-                                                    .iter()
-                                                    .find(|(name, _)| **name == expected_param)
-                                                    .map(|(_name, value)| {
-                                                        value.replace('"', "") == expected_value
-                                                    })
-                                            })
-                                            .unwrap_or(false)
-                                    })
+                            service_responses
+                                .get(service)
+                                .and_then(|params| {
+                                    params
+                                        .iter()
+                                        .find(|(name, _)| **name == expected_param)
+                                        .map(|(_name, value)| {
+                                            value.replace('"', "") == expected_value
+                                        })
                                 })
                                 .unwrap_or(false)
                         })
                     })
-                    .unwrap_or(false)
+                })
             })
-            .or(variants.iter().find(|variant| variant.is_base_variant()))
-            .map(datatypes::Variant)
-            .ok_or_else(move || {
-                tracing::debug!(
-                    received_responses = ?service_responses,
-                    "No variant found for expected services"
-                );
-                DiagServiceError::VariantDetectionError("No variant found".to_owned())
-            })
-    }
+        })
+        .or(variants.iter().find(|variant| {
+            // Closure is not redundant, as we cannot access the inner type
+            // of variant directly.
+            #[allow(clippy::redundant_closure)]
+            variant.is_base_variant()
+        }))
+        .map(datatypes::Variant)
+        .ok_or_else(move || {
+            tracing::debug!(
+                received_responses = ?service_responses,
+                "No variant found for expected services"
+            );
+            DiagServiceError::VariantDetectionError("No variant found".to_owned())
+        })
 }

--- a/cda-database/Cargo.toml
+++ b/cda-database/Cargo.toml
@@ -11,6 +11,9 @@ description = "ECU Database for CDA"
 homepage.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/lib.rs"
 

--- a/cda-database/build.rs
+++ b/cda-database/build.rs
@@ -102,7 +102,7 @@ fn get_flatbuffers_info() -> std::io::Result<(String, String)> {
 #[cfg(feature = "gen-flatbuffers")]
 fn generate_flatbuffers() -> std::io::Result<()> {
     let (flatc_repo, flatc_rev) = get_flatbuffers_info()?;
-    let flatc_dir = PathBuf::from(out_dir()?).join("flatc");
+    let flatc_dir = std::path::PathBuf::from(out_dir()?).join("flatc");
 
     if !flatc_dir.exists() {
         std::process::Command::new("git")
@@ -169,6 +169,7 @@ fn out_dir() -> Result<String, std::io::Error> {
     Ok(out_dir)
 }
 
+#[cfg(any(feature = "gen-protos", feature = "gen-flatbuffers"))]
 fn main() -> std::io::Result<()> {
     #[cfg(feature = "gen-protos")]
     generate_protos()?;
@@ -178,3 +179,6 @@ fn main() -> std::io::Result<()> {
 
     Ok(())
 }
+
+#[cfg(not(any(feature = "gen-protos", feature = "gen-flatbuffers")))]
+fn main() {}

--- a/cda-database/src/datatypes/comparam.rs
+++ b/cda-database/src/datatypes/comparam.rs
@@ -39,13 +39,11 @@ pub(super) fn lookup(
                 cp_ref
                     .protocol()
                     .and_then(|p| p.diag_layer().and_then(|dl| dl.short_name()))
-                    .map(|sn| sn == protocol_name)
-                    .unwrap_or(false)
+                    .is_some_and(|sn| sn == protocol_name)
                     && cp_ref
                         .com_param()
                         .and_then(|cp| cp.short_name())
-                        .map(|n| n == param_name)
-                        .unwrap_or(false)
+                        .is_some_and(|n| n == param_name)
             })
         })
         .ok_or(DiagServiceError::DatabaseEntryNotFound(format!(
@@ -120,6 +118,9 @@ fn resolve_with_value(
     }
 }
 
+/// Resolve a `ComParamRef` into its name and value.
+/// # Errors
+/// If the `ComParamRef` is invalid or has no value.
 pub fn resolve_comparam(
     cpref: &dataformat::ComParamRef,
 ) -> Result<(String, ComParamValue), DiagServiceError> {

--- a/cda-database/src/datatypes/database_builder.rs
+++ b/cda-database/src/datatypes/database_builder.rs
@@ -158,13 +158,14 @@ pub struct EcuDataBuilder<'a> {
     max_param_id: u32,
 }
 
-impl<'a> Default for EcuDataBuilder<'a> {
+impl Default for EcuDataBuilder<'_> {
     fn default() -> Self {
         Self::new()
     }
 }
 
 impl<'a> EcuDataBuilder<'a> {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             fbb: flatbuffers::FlatBufferBuilder::new(),
@@ -463,7 +464,7 @@ impl<'a> EcuDataBuilder<'a> {
 
     pub fn create_param(
         &mut self,
-        params: ParameterParams<'a>,
+        params: &ParameterParams<'a>,
     ) -> WIPOffset<dataformat::Param<'a>> {
         let short_name_offset = params.short_name.map(|s| self.fbb.create_string(s));
         let semantic_offset = params.semantic.map(|s| self.fbb.create_string(s));
@@ -511,7 +512,7 @@ impl<'a> EcuDataBuilder<'a> {
             .value_offset(),
         );
 
-        self.create_param(ParameterParams {
+        self.create_param(&ParameterParams {
             param_type: dataformat::ParamType::CODED_CONST,
             short_name: Some(name),
             semantic: None,
@@ -542,7 +543,7 @@ impl<'a> EcuDataBuilder<'a> {
             .value_offset(),
         );
 
-        self.create_param(ParameterParams {
+        self.create_param(&ParameterParams {
             param_type: dataformat::ParamType::VALUE,
             short_name: Some(name),
             semantic: None,

--- a/cda-database/src/datatypes/dtc.rs
+++ b/cda-database/src/datatypes/dtc.rs
@@ -16,11 +16,11 @@ impl From<dataformat::DTC<'_>> for cda_interfaces::datatypes::DtcRecord {
     fn from(val: dataformat::DTC<'_>) -> Self {
         cda_interfaces::datatypes::DtcRecord {
             code: val.trouble_code(),
-            display_code: val.display_trouble_code().map(|s| s.to_owned()),
-            fault_name: val
-                .short_name()
-                .map(|s| s.to_owned())
-                .unwrap_or_else(|| format!("DTC_{}", val.trouble_code())),
+            display_code: val.display_trouble_code().map(ToOwned::to_owned),
+            fault_name: val.short_name().map_or_else(
+                || format!("DTC_{}", val.trouble_code()),
+                std::borrow::ToOwned::to_owned,
+            ),
             severity: val.level().unwrap_or_default().to_owned(),
         }
     }

--- a/cda-database/src/datatypes/jobs.rs
+++ b/cda-database/src/datatypes/jobs.rs
@@ -28,7 +28,7 @@ impl From<dataformat::JobParam<'_>> for cda_interfaces::datatypes::single_ecu::P
             short_name: val.short_name().map(ToOwned::to_owned).unwrap_or_default(),
             physical_default_value: val.physical_default_value().map(ToOwned::to_owned),
             semantic: val.semantic().map(ToOwned::to_owned),
-            long_name: val.long_name().map(|ln| ln.into()),
+            long_name: val.long_name().map(Into::into),
         }
     }
 }
@@ -50,15 +50,15 @@ impl From<dataformat::SingleEcuJob<'_>> for cda_interfaces::datatypes::single_ec
         cda_interfaces::datatypes::single_ecu::Job {
             input_params: val
                 .input_params()
-                .map(|p| p.iter().map(|jp| jp.into()).collect())
+                .map(|p| p.iter().map(Into::into).collect())
                 .unwrap_or_default(),
             output_params: val
                 .output_params()
-                .map(|p| p.iter().map(|jp| jp.into()).collect())
+                .map(|p| p.iter().map(Into::into).collect())
                 .unwrap_or_default(),
             neg_output_params: val
                 .neg_output_params()
-                .map(|p| p.iter().map(|jp| jp.into()).collect())
+                .map(|p| p.iter().map(Into::into).collect())
                 .unwrap_or_default(),
             prog_codes: val
                 .prog_codes()

--- a/cda-database/src/flatbuf/mod.rs
+++ b/cda-database/src/flatbuf/mod.rs
@@ -15,5 +15,5 @@
 
 
 #[rustfmt::skip]
-#[allow(clippy::all, dead_code, unused_imports)]
+#[allow(clippy::all, dead_code, unused_imports, warnings)]
 pub mod diagnostic_description;

--- a/cda-database/src/mdd_data/files.rs
+++ b/cda-database/src/mdd_data/files.rs
@@ -65,7 +65,9 @@ impl FileManager {
                         .filter_map(|entry| {
                             entry.last_accessed.map(|last_accessed| {
                                 let elapsed = now.duration_since(last_accessed);
-                                if elapsed >= cache_lifetime {
+                                if let Some(lifetime) = cache_lifetime.checked_sub(elapsed) {
+                                    Some(lifetime)
+                                } else {
                                     tracing::debug!(
                                         file_name = %entry.chunk.meta_data.name,
                                         elapsed = ?elapsed,
@@ -74,8 +76,6 @@ impl FileManager {
                                     );
                                     entry.chunk.payload = None;
                                     None
-                                } else {
-                                    Some(cache_lifetime - elapsed)
                                 }
                             })
                         })

--- a/cda-database/src/mdd_data/mod.rs
+++ b/cda-database/src/mdd_data/mod.rs
@@ -241,13 +241,13 @@ pub fn load_proto_data(
         chunks_loaded = proto_data.len(),
         "Loaded ECU data"
     );
-    Ok((proto_file.ecu_name.to_string(), proto_data))
+    Ok((proto_file.ecu_name.clone(), proto_data))
 }
 
-pub(crate) fn read_ecudata(
-    bytes: &[u8],
-    flatbuf_config: FlatbBufConfig,
-) -> Result<dataformat::EcuData<'_>, String> {
+pub(crate) fn read_ecudata<'a>(
+    bytes: &'a [u8],
+    flatbuf_config: &FlatbBufConfig,
+) -> Result<dataformat::EcuData<'a>, String> {
     let start = Instant::now();
     let ecu_data = if flatbuf_config.verify {
         dataformat::root_as_ecu_data_with_opts(
@@ -272,7 +272,7 @@ pub(crate) fn read_ecudata(
     tracing::trace!(
         duration = ?end.saturating_duration_since(start),
         ecu_name = %ecu_data.as_ref()
-            .ok().and_then(|ecu_data| ecu_data.ecu_name()).unwrap_or("unknown"),
+            .ok().and_then(dataformat::EcuData::ecu_name).unwrap_or("unknown"),
         "Parsed flatbuff data"
     );
     ecu_data

--- a/cda-database/src/proto/mod.rs
+++ b/cda-database/src/proto/mod.rs
@@ -14,5 +14,5 @@
 // @generated
 
 #[rustfmt::skip]
-#[allow(clippy::all, dead_code)]
+#[allow(clippy::all, dead_code, warnings)]
 pub mod fileformat;

--- a/cda-interfaces/Cargo.toml
+++ b/cda-interfaces/Cargo.toml
@@ -11,6 +11,9 @@ description = "Interfaces and Types used in CDA"
 homepage.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/lib.rs"
 

--- a/cda-interfaces/src/datatypes/database_naming_convention.rs
+++ b/cda-interfaces/src/datatypes/database_naming_convention.rs
@@ -51,6 +51,7 @@ impl DatabaseNamingConvention {
     /// The first matching affix is removed and the result is returned.
     /// Affixes must be lowercase for correct matching.
     /// Returns the trimmed name or the original if no affix matches.
+    #[must_use]
     pub fn trim_long_name_affixes(&self, long_name: &str) -> String {
         let long_name_lowercase = long_name.to_lowercase();
         for affix in &self.long_name_affixes {
@@ -72,6 +73,7 @@ impl DatabaseNamingConvention {
     /// The first matching affix is removed and the result is returned.
     /// Affixes must be lowercase for correct matching.
     /// Returns the trimmed name or the original if no affix matches.
+    #[must_use]
     pub fn trim_short_name_affixes(&self, short_name: &str) -> String {
         let short_name_lowercase = short_name.to_lowercase();
         for affix in &self.short_name_affixes {
@@ -93,7 +95,8 @@ impl DatabaseNamingConvention {
 impl Default for DatabaseNamingConvention {
     /// Creates a default configuration that assumes data is suffixed, with '_dump' as
     /// the last suffix for short names, followed by '_write' or '_read'.
-    /// 'configuration_service_parameter_semantic_id' is used to identify the parameter of a service
+    /// '`configuration_service_parameter_semantic_id`'
+    /// is used to identify the parameter of a service
     /// that distinguishes services from each other.
     /// The long name is the description; the same trimming rules apply.
     fn default() -> Self {

--- a/cda-interfaces/src/datatypes/faults.rs
+++ b/cda-interfaces/src/datatypes/faults.rs
@@ -38,6 +38,7 @@ impl DtcReadInformationFunction {
     /// Describes the default scope for each DTC function.
     /// This will be used if there is no associated functional class in the service definition.
     /// Otherwise, the functional class name will be used instead.
+    #[must_use]
     pub fn default_scope(&self) -> &str {
         match self {
             Self::FaultMemoryByStatusMask
@@ -49,6 +50,7 @@ impl DtcReadInformationFunction {
         }
     }
 
+    #[must_use]
     pub fn all() -> Vec<Self> {
         Self::iter().collect()
     }
@@ -68,6 +70,7 @@ pub enum DtcMask {
 }
 
 impl DtcMask {
+    #[must_use]
     pub fn all_bits() -> u8 {
         let mut mask = 0u8;
         Self::iter().for_each(|m| mask |= m as u8);
@@ -99,6 +102,8 @@ pub struct DtcField {
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]
+// The warning is allowed because the bools represent the status bits of a DTC.
+#[allow(clippy::struct_excessive_bools)]
 pub struct DtcStatus {
     pub test_failed: bool,
     pub test_failed_this_operation_cycle: bool,

--- a/cda-interfaces/src/diagservices.rs
+++ b/cda-interfaces/src/diagservices.rs
@@ -53,10 +53,19 @@ pub trait DiagServiceResponse: Sized + Send + Sync + 'static {
     fn service_name(&self) -> String;
     fn response_type(&self) -> DiagServiceResponseType;
     fn get_raw(&self) -> &[u8];
+    /// Convert the response into a JSON representation.
+    /// # Errors
+    /// Returns `DiagServiceError` if the conversion fails, depending on what went wrong exactly.
     fn into_json(self) -> Result<DiagServiceJsonResponse, DiagServiceError>;
+    /// Map the response as a Negative Response Code (NRC).
+    /// # Errors
+    /// Returns `String` if on failure to map the response as NRC.
     fn as_nrc(&self) -> Result<MappedNRC, String>;
 
     /// Extract data trouble codes from the response, if any.
+    /// # Errors
+    /// Returns `DiagServiceError` if unable to extract DTCs, for example if
+    /// this is used on a response that is not mapped.
     fn get_dtcs(&self) -> Result<Vec<(DtcField, DtcRecord)>, DiagServiceError>;
 }
 
@@ -84,6 +93,7 @@ impl std::fmt::Display for UdsPayloadData {
 }
 
 impl DiagServiceJsonResponse {
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.data.is_null() && self.errors.is_empty()
     }

--- a/cda-interfaces/src/ecugateway.rs
+++ b/cda-interfaces/src/ecugateway.rs
@@ -63,16 +63,16 @@ pub trait EcuGateway: Clone + Send + Sync + 'static {
     /// Multiple responses can be sent, e.g. for a request that requires multiple responses,
     /// i.e. response pending NRCs 0x78.
     /// # Errors
-    /// * DiagServiceError::EcuOffline if the ECU cannot be reached, is not found, or is offline.
-    /// * DiagServiceError::Nack when the ECU responds with a NACK, that cannot be
+    /// * `DiagServiceError::EcuOffline` if the ECU cannot be reached, is not found, or is offline.
+    /// * `DiagServiceError::Nack` when the ECU responds with a NACK, that cannot be
     ///   handled by the gateway.
     ///   In this case the error is informational,
     ///   and it will not be handled anymore by the UDS layer, but
     ///   will only be forwarded to i.e. SOVD to be returned to the client.
-    /// * DiagServiceError::UnexpectedResponse if the responses are out of order or unexpected,
+    /// * `DiagServiceError::UnexpectedResponse` if the responses are out of order or unexpected,
     ///   for example if a NACK/ACK was expected but a different response was received.
-    /// * DiagServiceError::NoResponse if an error occurs while waiting for a response
-    /// * DiagServiceError::Timeout if the nack/ack/response is
+    /// * `DiagServiceError::NoResponse` if an error occurs while waiting for a response
+    /// * `DiagServiceError::Timeout` if the nack/ack/response is
     ///   not received within the specified timeout.
     fn send(
         &self,
@@ -86,7 +86,7 @@ pub trait EcuGateway: Clone + Send + Sync + 'static {
     /// Returns an error if the ECU is not online or if the ECU cannot be reached.
     /// Otherwise, returns `Ok(())`.
     /// # Errors
-    ///  DiagServiceError::EcuOffline if the ECU cannot be reached, is not found, or is offline.
+    ///  `DiagServiceError::EcuOffline` if the ECU cannot be reached, is not found, or is offline.
     fn ecu_online<T: EcuAddressProvider>(
         &self,
         ecu_name: &str,

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -100,6 +100,9 @@ pub trait EcuManager:
     ) -> impl Future<Output = Result<(), DiagServiceError>> + Send;
     fn get_variant_detection_requests(&self) -> &HashSet<String>;
     /// Communication parameters for the ECU.
+    /// # Errors
+    /// Will return `DiagServiceError` if the communication
+    /// parameters cannot be found in the database.
     fn comparams(&self) -> Result<ComplexComParamValue, DiagServiceError>;
     fn sdgs(
         &self,
@@ -189,10 +192,16 @@ pub trait EcuManager:
     ) -> Result<SecurityAccess, DiagServiceError>;
     /// Retrieves the name of the current ecu session, i.e. 'extended', 'programming' or 'default'.
     /// The examples above differ depending on the parameterization of the ECU.
+    /// # Errors
+    /// Will return `DiagServiceError` if the session cannot be found in the database
+    /// or no session is currently set or no variant is loaded.
     fn session(&self) -> Result<String, DiagServiceError>;
     /// Retrieves the name of the current ecu security level,
-    /// i.e. 'level_42'
+    /// i.e. `level_42`
     /// The exact values depends on the ECU parameterization.
+    /// # Errors
+    /// Will return `DiagServiceError` if the security access cannot be found in the database
+    /// or no security access is currently set or no variant is loaded.
     fn security_access(&self) -> Result<String, DiagServiceError>;
     /// Lookup a service by a given function class name and service id.
     /// # Errors
@@ -210,12 +219,16 @@ pub trait EcuManager:
     /// Retrieve all `read` services for the current ECU variant.
     fn get_components_data_info(&self) -> Vec<ComponentDataInfo>;
     /// Retrieve all configuration type services for the current ECU variant.
+    /// # Errors
+    /// Returns `DiagServiceError` if the lookup failed.
     fn get_components_configurations_info(
         &self,
     ) -> Result<Vec<ComponentConfigurationsInfo>, DiagServiceError>;
     /// Retrieve all 'single ecu' jobs for the current ECU variant.
     fn get_components_single_ecu_jobs_info(&self) -> Vec<ComponentDataInfo>;
     /// Lookup DTC services for the given service types in the current ECU variant.
+    /// # Errors
+    /// Returns `DiagServiceError` if the lookup failed.
     fn lookup_dtc_services(
         &self,
         service_types: Vec<DtcReadInformationFunction>,

--- a/cda-interfaces/src/ecuuds.rs
+++ b/cda-interfaces/src/ecuuds.rs
@@ -84,7 +84,7 @@ pub trait UdsEcu: Send + Sync + 'static {
         ecu: &str,
         job_name: &str,
     ) -> impl Future<Output = Result<single_ecu::Job, DiagServiceError>> + Send;
-    /// Send a message via the given DiagComm and Payload to the ECU.
+    /// Send a message via the given `DiagComm` and Payload to the ECU.
     /// The timeout is set to the given duration, instead of the default timeout.
     /// Can be used to override the default timeout for a specific request, especially
     /// for requests which expect to take longer.
@@ -97,7 +97,7 @@ pub trait UdsEcu: Send + Sync + 'static {
         map_to_json: bool,
         timeout: Duration,
     ) -> impl Future<Output = Result<Self::Response, DiagServiceError>> + Send;
-    /// Send a message via the given DiagComm and Payload to the ECU.
+    /// Send a message via the given `DiagComm` and Payload to the ECU.
     /// The default timeouts of the ECU, read from the communication parameters, will be used.
     /// # Error
     /// Will return `Err` if the ECU does not exist or if the request fails.
@@ -129,7 +129,7 @@ pub trait UdsEcu: Send + Sync + 'static {
     /// Expiration is used to reset the ECU to the default session after the given duration.
     /// Upon positive response, the internally tracked session is updated.
     /// # Errors
-    /// * DiagServiceError::NotFound if the ECU or service lookup failed.
+    /// * `DiagServiceError::NotFound` if the ECU or service lookup failed.
     ///
     /// Forwards errors from the `send` function.
     fn set_ecu_session(
@@ -147,7 +147,7 @@ pub trait UdsEcu: Send + Sync + 'static {
     ///
     /// Expiration is used to reset the ECU to the default security access after the given duration
     /// # Errors
-    /// * DiagServiceError::NotFound if the ECU or service lookup failed.
+    /// * `DiagServiceError::NotFound` if the ECU or service lookup failed.
     ///
     /// Forwards errors from the `send` function.
     fn set_ecu_security_access(
@@ -177,7 +177,7 @@ pub trait UdsEcu: Send + Sync + 'static {
     /// Lookup the service id on the ECU and restrict the result to the function class.
     /// After the successful lookup, the found service will be executed with the given payload.
     /// # Errors
-    /// * DiagServiceError::NotFound if the ECU or service lookup failed.
+    /// * `DiagServiceError::NotFound` if the ECU or service lookup failed.
     ///
     /// Furthermore, errors from the `send` function are forwarded.
     fn ecu_exec_service_from_function_class(
@@ -190,7 +190,7 @@ pub trait UdsEcu: Send + Sync + 'static {
     ) -> impl Future<Output = Result<Self::Response, DiagServiceError>> + Send;
     /// Lookup a service on the ECU by a given function class name and service id.
     /// # Errors
-    /// * DiagServiceError::NotFound if the ECU or service lookup failed.
+    /// * `DiagServiceError::NotFound` if the ECU or service lookup failed.
     fn ecu_lookup_service_through_func_class(
         &self,
         ecu_name: &str,
@@ -202,26 +202,26 @@ pub trait UdsEcu: Send + Sync + 'static {
     /// Setting the ECU into the appropriate session and security access must be done
     /// before calling this function, otherwise the ECU will not accept the transfer.
     /// # Errors
-    /// * DiagServiceError::InvalidRequest
+    /// * `DiagServiceError::InvalidRequest`
     ///   * A transfer is already in progress for the given ECU.
     ///   * The given file path does not exist or is not readable.
     ///   * The offset and length do not match the file size.
-    /// * DiagServiceError::NotFound
+    /// * `DiagServiceError::NotFound`
     ///   * The ECU with the given name does not exist.
-    fn ecu_flash_transfer_start<'a>(
+    fn ecu_flash_transfer_start(
         &self,
         ecu_name: &str,
         func_class_name: &str,
         security_plugin: &DynamicPlugin,
-        parameters: FlashTransferStartParams<'a>,
+        parameters: FlashTransferStartParams<'_>,
     ) -> impl Future<Output = Result<(), DiagServiceError>> + Send;
     /// Once the transfer has finished transfer exit must be called to finalize the transfer.
     /// No new transfer can be started before this is called.
     /// # Errors
-    /// * DiagServiceError::NotFound
+    /// * `DiagServiceError::NotFound`
     ///  * The ECU with the given name does not exist.
     ///  * The transfer with the given ID does not exist.
-    /// * DiagServiceError::InvalidRequest
+    /// * `DiagServiceError::InvalidRequest`
     ///   * The transfer is not in a state where it can be exited, e.g. it is still in progress.
     ///   * Failures on retrieving the transfer exit status.
     fn ecu_flash_transfer_exit(
@@ -231,7 +231,7 @@ pub trait UdsEcu: Send + Sync + 'static {
     ) -> impl Future<Output = Result<(), DiagServiceError>> + Send;
     /// Fetch all flash transfers for the given ECU.
     /// # Errors
-    /// * DiagServiceError::NotFound
+    /// * `DiagServiceError::NotFound`
     ///   * The ECU with the given name does not exist.
     fn ecu_flash_transfer_status(
         &self,
@@ -239,7 +239,7 @@ pub trait UdsEcu: Send + Sync + 'static {
     ) -> impl Future<Output = Result<Vec<DataTransferMetaData>, DiagServiceError>> + Send;
     /// Fetch the status of a specific flash transfer by its ID.
     /// # Errors
-    /// * DiagServiceError::NotFound
+    /// * `DiagServiceError::NotFound`
     ///   * The ECU with the given name does not exist.
     ///   * The transfer with the given ID does not exist.
     fn ecu_flash_transfer_status_id(

--- a/cda-interfaces/src/lib.rs
+++ b/cda-interfaces/src/lib.rs
@@ -61,6 +61,7 @@ pub struct DiagComm {
 }
 
 impl DiagComm {
+    #[must_use]
     pub fn action(&self) -> DiagCommAction {
         self.type_.clone().into()
     }
@@ -71,10 +72,10 @@ impl From<DiagCommType> for DiagCommAction {
         match value {
             DiagCommType::Configurations => DiagCommAction::Write,
             DiagCommType::Data => DiagCommAction::Read,
-            // actually Clear or Read, but doesn't matter here
-            DiagCommType::Faults => DiagCommAction::Start,
-            DiagCommType::Modes => DiagCommAction::Start,
-            DiagCommType::Operations => DiagCommAction::Start,
+            // Faults is actually Clear or Read, but doesn't matter here
+            DiagCommType::Faults | DiagCommType::Modes | DiagCommType::Operations => {
+                DiagCommAction::Start
+            }
         }
     }
 }
@@ -252,7 +253,7 @@ pub enum DiagServiceError {
     Timeout,
     AccessDenied(String),
     DataError(DataParseError),
-    /// Returned in case the provided value for security plugin cannot be used as SecurityApi
+    /// Returned in case the provided value for security plugin cannot be used as `SecurityApi`
     InvalidSecurityPlugin,
 }
 

--- a/cda-interfaces/src/schema.rs
+++ b/cda-interfaces/src/schema.rs
@@ -29,6 +29,7 @@ pub struct SchemaDescription {
 }
 
 impl SchemaDescription {
+    #[must_use]
     pub fn new(name: String, title: String, schema: Option<schemars::Schema>) -> Self {
         Self {
             name,
@@ -36,19 +37,24 @@ impl SchemaDescription {
             schema,
         }
     }
+    #[must_use]
     pub fn title(&self) -> &str {
         &self.title
     }
+    #[must_use]
     pub fn name(&self) -> &str {
         &self.name
     }
+    #[must_use]
     pub fn schema(&self) -> Option<&schemars::Schema> {
         self.schema.as_ref()
     }
+    #[must_use]
     pub fn into_schema(self) -> Option<schemars::Schema> {
         self.schema
     }
 
+    #[must_use]
     pub fn get_param_properties(&self) -> Option<&serde_json::Map<String, serde_json::Value>> {
         let properties = self.schema()?;
 

--- a/cda-interfaces/src/strings.rs
+++ b/cda-interfaces/src/strings.rs
@@ -70,6 +70,7 @@ impl From<usize> for StringId {
 }
 
 impl Strings {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             strings: RwLock::new(Vec::new()),

--- a/cda-main/Cargo.toml
+++ b/cda-main/Cargo.toml
@@ -11,6 +11,9 @@ description = "Eclipse OpenSOVD CDA - A modern open source Classic Diagnostic Ad
 homepage.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "opensovd-cda"
 path = "src/main.rs"

--- a/cda-main/src/config/configfile.rs
+++ b/cda-main/src/config/configfile.rs
@@ -43,6 +43,8 @@ pub struct DoipConfig {
 
 pub trait ConfigSanity {
     /// Checks the configuration for common mistakes and returns an error message if found.
+    /// # Errors
+    /// Returns `Err(String)` if a sanity check fails, with a descriptive error message.
     fn validate_sanity(&self) -> Result<(), String>;
 }
 
@@ -80,6 +82,8 @@ impl ConfigSanity for Configuration {
 impl ConfigSanity for DatabaseNamingConvention {
     fn validate_sanity(&self) -> Result<(), String> {
         const SHORT_NAME_AFFIX_KEY: &str = "database_naming_convention.short_name_affixes";
+        const LONG_NAME_AFFIX_KEY: &str = "database_naming_convention.long_name_affixes";
+
         // Check short name affixes
         for affix in &self.short_name_affixes {
             match self.short_name_affix_position {
@@ -99,7 +103,7 @@ impl ConfigSanity for DatabaseNamingConvention {
                 }
             }
         }
-        const LONG_NAME_AFFIX_KEY: &str = "database_naming_convention.long_name_affixes";
+
         // Check long name affixes
         for affix in &self.long_name_affixes {
             match self.long_name_affix_position {

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -141,14 +141,14 @@ pub async fn load_databases<S: SecurityPlugin>(
         .write()
         .await
         .drain()
-        .map(|(k, v)| (k.to_lowercase().to_string(), RwLock::new(v)))
+        .map(|(k, v)| (k.to_lowercase().clone(), RwLock::new(v)))
         .collect::<HashMap<String, RwLock<EcuManager<S>>>>();
 
     let file_managers = file_managers
         .write()
         .await
         .drain()
-        .map(|(k, v)| (k.to_lowercase().to_string(), v))
+        .map(|(k, v)| (k.to_lowercase().clone(), v))
         .collect::<HashMap<String, FileManager>>();
 
     tracing::info!(database_count = %databases_count.load(Ordering::Relaxed), duration = ?{end - start}, "Loaded databases");
@@ -278,20 +278,20 @@ async fn load_database<S: SecurityPlugin>(
 type UdsManagerType<S> =
     UdsManager<DoipDiagGateway<EcuManager<S>>, DiagServiceResponseStruct, EcuManager<S>>;
 
+/// Creates a new UDS manager for the webserver.
 #[tracing::instrument(skip_all, fields(database_count = databases.len()))]
-pub async fn create_uds_manager<S: SecurityPlugin>(
+pub fn create_uds_manager<S: SecurityPlugin>(
     gateway: DoipDiagGateway<EcuManager<S>>,
     databases: Arc<HashMap<String, RwLock<EcuManager<S>>>>,
     variant_detection_receiver: mpsc::Receiver<Vec<String>>,
     tester_present_sender: mpsc::Receiver<TesterPresentControlMessage>,
-) -> Result<UdsManagerType<S>, String> {
+) -> UdsManagerType<S> {
     UdsManager::new(
         gateway,
         databases,
         variant_detection_receiver,
         tester_present_sender,
     )
-    .await
 }
 
 /// Creates a new diagnostic gateway for the webserver.

--- a/cda-main/src/main.rs
+++ b/cda-main/src/main.rs
@@ -153,20 +153,12 @@ async fn main() -> Result<(), String> {
         }
     };
 
-    let uds = match opensovd_cda_lib::create_uds_manager(
+    let uds = opensovd_cda_lib::create_uds_manager(
         diagnostic_gateway,
         databases,
         variant_detection_rx,
         tester_present_rx,
-    )
-    .await
-    {
-        Ok(uds) => uds,
-        Err(e) => {
-            tracing::error!(error = %e, "Failed to create uds manager");
-            return Err(e);
-        }
-    };
+    );
 
     match opensovd_cda_lib::start_webserver(
         flash_files_path,

--- a/cda-plugin-security/Cargo.toml
+++ b/cda-plugin-security/Cargo.toml
@@ -11,6 +11,9 @@ description = "Security Plugin APIs used in CDA"
 homepage.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/lib.rs"
 

--- a/cda-plugin-security/src/default_security_plugin.rs
+++ b/cda-plugin-security/src/default_security_plugin.rs
@@ -140,22 +140,19 @@ impl AuthorizationRequestHandler for DefaultSecurityPlugin {
             exp: 2_000_000_000, // May 2033
         };
         // Create the authorization token
-        let token = match encode(&Header::default(), &claims, &KEYS.encoding) {
-            Ok(token) => token,
-            Err(_) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ApiErrorResponse::<()> {
-                        message: "Internal server error".to_string(),
-                        error_code: ErrorCode::SovdServerFailure,
-                        vendor_code: None,
-                        parameters: None,
-                        error_source: None,
-                        schema: None,
-                    }),
-                )
-                    .into_response();
-            }
+        let Ok(token) = encode(&Header::default(), &claims, &KEYS.encoding) else {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiErrorResponse::<()> {
+                    message: "Internal server error".to_string(),
+                    error_code: ErrorCode::SovdServerFailure,
+                    vendor_code: None,
+                    parameters: None,
+                    error_source: None,
+                    schema: None,
+                }),
+            )
+                .into_response();
         };
 
         // Send the authorized token

--- a/cda-plugin-security/src/lib.rs
+++ b/cda-plugin-security/src/lib.rs
@@ -41,6 +41,9 @@ pub trait AuthApi: Send + Sync + 'static {
 }
 
 pub trait SecurityApi: Send + Sync + 'static {
+    /// Validate if the given service can be accessed by the current user.
+    /// # Errors
+    /// Returns `DiagServiceError` if the service is not accessible.
     fn validate_service(
         &self,
         service: &cda_database::datatypes::DiagService,

--- a/cda-sovd-interfaces/Cargo.toml
+++ b/cda-sovd-interfaces/Cargo.toml
@@ -14,6 +14,9 @@ license.workspace = true
 [lib]
 path = "src/lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 # external dependencies
 hashbrown = { workspace = true, features = ["serde"] }

--- a/cda-sovd-interfaces/src/apps.rs
+++ b/cda-sovd-interfaces/src/apps.rs
@@ -32,7 +32,7 @@ pub mod sovd2uds {
                 pub qualifier: String,
                 /// ECU variant
                 pub variant: String,
-                /// ECU state \[Online, Offline, NotTested]
+                /// ECU state \[Online, Offline, `NotTested`]
                 #[serde(rename = "EcuState")]
                 pub state: String,
                 /// ECU logical address

--- a/cda-sovd-interfaces/src/components/ecu/mod.rs
+++ b/cda-sovd-interfaces/src/components/ecu/mod.rs
@@ -95,12 +95,12 @@ pub struct ServiceSdgs {
 }
 
 pub mod get {
-    use super::*;
+    use super::Ecu;
     pub type Response = Ecu;
 }
 
 pub mod configurations {
-    use super::*;
+    use super::{Deserialize, Serialize};
 
     #[derive(Deserialize, Serialize, Debug, schemars::JsonSchema)]
     pub struct Components {
@@ -123,7 +123,7 @@ pub mod configurations {
     pub type ConfigurationsQuery = crate::IncludeSchemaQuery;
 
     pub mod get {
-        use super::*;
+        use super::Components;
         pub type Response = Components;
     }
 }
@@ -132,7 +132,7 @@ pub mod data {
     use hashbrown::HashMap;
     use serde::Deserialize;
 
-    use super::*;
+    use super::ComponentData;
     use crate::Payload;
 
     #[derive(Deserialize, schemars::JsonSchema)]
@@ -153,7 +153,7 @@ pub mod data {
     }
 
     pub mod get {
-        use super::*;
+        use super::ComponentData;
         pub type Response = ComponentData;
         pub type Query = crate::IncludeSchemaQuery;
     }
@@ -238,7 +238,7 @@ pub mod x {
                     pub type Response = Items<DataTransferMetaData>;
 
                     pub mod id {
-                        use super::*;
+                        use super::DataTransferMetaData;
                         pub type Response = DataTransferMetaData;
                     }
                 }
@@ -354,16 +354,16 @@ pub mod x {
 }
 
 pub mod faults {
-    use super::*;
+    use super::{Deserialize, HashMap, Serialize};
 
     /// Representation of a fault / DTC (Diagnostic Trouble Code)
-    /// as described in the OpenSOVD specification.
+    /// as described in the `OpenSOVD` specification.
     /// The following fields are omitted because the CDA does not provide
     /// this information:
     /// * Symptom
     /// * Translation IDs
     ///
-    /// This is still compliant with the OpenSOVD specification, as these fields are optional.
+    /// This is still compliant with the `OpenSOVD` specification, as these fields are optional.
     #[derive(Serialize, schemars::JsonSchema)]
     pub struct Fault {
         ///Fault code in the native representation of the entity.
@@ -408,7 +408,7 @@ pub mod faults {
     }
 
     pub mod get {
-        use super::*;
+        use super::{Deserialize, Fault, HashMap, Serialize};
 
         #[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
         /// Query parameters for filtering DTC by the given fields.
@@ -452,9 +452,9 @@ pub mod faults {
     }
 
     pub mod id {
-        use super::*;
+        use super::{Deserialize, Fault, HashMap, Serialize};
         pub mod get {
-            use super::*;
+            use super::{Deserialize, Fault, HashMap, Serialize};
             use crate::{default_true, error::DataError};
 
             #[derive(Serialize, Deserialize, schemars::JsonSchema)]

--- a/cda-sovd-interfaces/src/components/ecu/modes.rs
+++ b/cda-sovd-interfaces/src/components/ecu/modes.rs
@@ -39,7 +39,7 @@ pub enum ModeType {
 pub type Query = crate::IncludeSchemaQuery;
 
 pub mod get {
-    use super::*;
+    use super::Mode;
     use crate::Items;
 
     pub type Response = Items<Mode<()>>;

--- a/cda-sovd-interfaces/src/components/ecu/operations.rs
+++ b/cda-sovd-interfaces/src/components/ecu/operations.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 pub mod comparams {
     use serde::Deserializer;
 
-    use super::*;
+    use super::{Deserialize, HashMap, Serialize};
 
     #[derive(Deserialize, Serialize, Clone, Debug, schemars::JsonSchema)]
     pub struct Unit {
@@ -81,7 +81,7 @@ pub mod comparams {
     }
 
     pub mod executions {
-        use super::*;
+        use super::{ComParamValue, Deserialize, HashMap, Serialize};
 
         #[derive(Deserialize, Serialize, Clone)]
         #[serde(rename_all = "lowercase")]
@@ -109,7 +109,7 @@ pub mod comparams {
         }
 
         pub mod update {
-            use super::*;
+            use super::{Capability, ComParamValue, Deserialize, HashMap, Serialize, Status};
             // todo: which ones are optional or not
             #[derive(Deserialize)]
             #[allow(dead_code)]
@@ -136,7 +136,7 @@ pub mod comparams {
         }
 
         pub mod get {
-            use super::*;
+            use super::Item;
             use crate::Items;
 
             pub type Response = Items<Item>;
@@ -144,9 +144,9 @@ pub mod comparams {
         }
 
         pub mod id {
-            use super::*;
+            use super::{Capability, ComParamValue, HashMap, Serialize, Status};
             pub mod get {
-                use super::*;
+                use super::{Capability, ComParamValue, HashMap, Serialize, Status};
                 #[derive(Serialize, schemars::JsonSchema)]
                 #[schemars(rename = "GetExecutionResponse")]
                 pub struct Response {
@@ -167,9 +167,9 @@ pub mod comparams {
 }
 
 pub mod service {
-    use super::*;
+    use super::{Deserialize, HashMap, Serialize};
     pub mod executions {
-        use super::*;
+        use super::{Deserialize, HashMap, Serialize};
         use crate::{Payload, error::DataError};
 
         #[derive(Serialize, schemars::JsonSchema)]

--- a/cda-sovd-interfaces/src/locking.rs
+++ b/cda-sovd-interfaces/src/locking.rs
@@ -38,15 +38,15 @@ impl From<Request> for chrono::DateTime<chrono::Utc> {
 }
 
 pub mod get {
-    use super::*;
+    use super::{Items, Lock};
 
     pub type Response = Items<Lock>;
 }
 
 pub mod id {
-    use super::*;
+    use super::{Deserialize, Serialize};
     pub mod get {
-        use super::*;
+        use super::{Deserialize, Serialize};
         #[derive(Serialize, Deserialize, schemars::JsonSchema)]
         #[schemars(rename = "LockResponse")]
         pub struct Response {
@@ -56,6 +56,6 @@ pub mod id {
 }
 
 pub mod post_put {
-    use super::*;
+    use super::Lock;
     pub type Response = Lock;
 }

--- a/cda-sovd/Cargo.toml
+++ b/cda-sovd/Cargo.toml
@@ -14,6 +14,9 @@ license.workspace = true
 [lib]
 path = "src/lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 # internal dependencies
 cda-interfaces = { workspace = true }

--- a/cda-sovd/src/lib.rs
+++ b/cda-sovd/src/lib.rs
@@ -147,7 +147,7 @@ fn rewrite_request_uri<B>(mut req: Request<B>) -> Request<B> {
     // needing to decode them later on.
     let decoded = percent_encoding::percent_decode_str(
         uri.path_and_query()
-            .map(|pq| pq.as_str())
+            .map(http::uri::PathAndQuery::as_str)
             .unwrap_or_default(),
     )
     .decode_utf8()

--- a/cda-sovd/src/sovd/apps.rs
+++ b/cda-sovd/src/sovd/apps.rs
@@ -32,7 +32,9 @@ pub(crate) async fn get(
 }
 
 pub(crate) mod sovd2uds {
-    use super::*;
+    use super::{
+        ApiError, Host, OriginalUri, Query, Response, UseApi, WithRejection, resource_response,
+    };
 
     pub(crate) async fn get(
         UseApi(Host(host), _): UseApi<Host, String>,
@@ -46,7 +48,9 @@ pub(crate) mod sovd2uds {
     }
 
     pub(crate) mod bulk_data {
-        use super::*;
+        use super::{
+            ApiError, Host, OriginalUri, Query, Response, UseApi, WithRejection, resource_response,
+        };
 
         pub(crate) async fn get(
             UseApi(Host(host), _): UseApi<Host, String>,
@@ -296,12 +300,12 @@ impl IntoSovd for cda_interfaces::datatypes::NetworkStructure {
             functional_groups: self
                 .functional_groups
                 .into_iter()
-                .map(|fg| fg.into_sovd())
+                .map(super::IntoSovd::into_sovd)
                 .collect(),
             gateways: self
                 .gateways
                 .into_iter()
-                .map(|gateway| gateway.into_sovd())
+                .map(super::IntoSovd::into_sovd)
                 .collect(),
         }
     }
@@ -315,7 +319,11 @@ impl IntoSovd for cda_interfaces::datatypes::Gateway {
             name: self.name,
             network_address: self.network_address,
             logical_address: self.logical_address,
-            ecus: self.ecus.into_iter().map(|ecu| ecu.into_sovd()).collect(),
+            ecus: self
+                .ecus
+                .into_iter()
+                .map(super::IntoSovd::into_sovd)
+                .collect(),
         }
     }
 }
@@ -326,7 +334,11 @@ impl IntoSovd for cda_interfaces::datatypes::FunctionalGroup {
     fn into_sovd(self) -> Self::SovdType {
         Self::SovdType {
             qualifier: self.qualifier,
-            ecus: self.ecus.into_iter().map(|ecu| ecu.into_sovd()).collect(),
+            ecus: self
+                .ecus
+                .into_iter()
+                .map(super::IntoSovd::into_sovd)
+                .collect(),
         }
     }
 }

--- a/cda-sovd/src/sovd/components/ecu/configurations.rs
+++ b/cda-sovd/src/sovd/components/ecu/configurations.rs
@@ -47,7 +47,7 @@ pub(crate) async fn get<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManage
             let sovd_component_configuration = sovd_configurations::get::Response {
                 items: items
                     .drain(0..)
-                    .map(|c| c.into_sovd())
+                    .map(crate::sovd::IntoSovd::into_sovd)
                     .collect::<Vec<sovd_configurations::ComponentItem>>(),
                 schema,
             };
@@ -90,8 +90,11 @@ impl IntoSovd for ComponentConfigurationsInfo {
                 .map(|service_abstract| {
                     service_abstract
                         .iter()
-                        .map(|byte| format!("{byte:02X}"))
-                        .collect()
+                        .fold(String::new(), |mut acc, byte| {
+                            use std::fmt::Write;
+                            write!(&mut acc, "{byte:02X}").unwrap();
+                            acc
+                        })
                 })
                 .collect(),
         }

--- a/cda-sovd/src/sovd/components/ecu/data.rs
+++ b/cda-sovd/src/sovd/components/ecu/data.rs
@@ -13,7 +13,10 @@
 
 use sovd_interfaces::error::ApiErrorResponse;
 
-use super::*;
+use super::{
+    ApiError, DiagServiceResponse, ErrorWrapper, FileManager, IntoResponse, Json, Query, Response,
+    State, StatusCode, TransformOperation, UdsEcu, WebserverEcuState, WithRejection,
+};
 use crate::sovd::{self, create_schema};
 
 pub(crate) async fn get<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManager>(
@@ -33,7 +36,10 @@ pub(crate) async fn get<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManage
     match uds.get_components_data_info(&ecu_name).await {
         Ok(mut items) => {
             let sovd_component_data = sovd_interfaces::components::ecu::data::get::Response {
-                items: items.drain(0..).map(|info| info.into_sovd()).collect(),
+                items: items
+                    .drain(0..)
+                    .map(crate::sovd::IntoSovd::into_sovd)
+                    .collect(),
                 schema,
             };
             (StatusCode::OK, Json(sovd_component_data)).into_response()

--- a/cda-sovd/src/sovd/components/ecu/faults.rs
+++ b/cda-sovd/src/sovd/components/ecu/faults.rs
@@ -106,7 +106,10 @@ pub(crate) async fn get<
     };
 
     let faults = faults::get::Response {
-        items: dtcs.into_values().map(|dtc| dtc.into_sovd()).collect(),
+        items: dtcs
+            .into_values()
+            .map(crate::sovd::IntoSovd::into_sovd)
+            .collect(),
         schema,
     };
 
@@ -166,9 +169,11 @@ pub(crate) mod id {
         fn into_sovd(self) -> Self::SovdType {
             Self::SovdType {
                 data: self.data,
-                errors: self
-                    .errors
-                    .map(|v| v.into_iter().map(|e| e.into_sovd()).collect()),
+                errors: self.errors.map(|v| {
+                    v.into_iter()
+                        .map(crate::sovd::IntoSovd::into_sovd)
+                        .collect()
+                }),
             }
         }
     }
@@ -181,9 +186,11 @@ pub(crate) mod id {
                 data: self
                     .data
                     .map(|d| d.into_iter().map(|(k, v)| (k, v.into_sovd())).collect()),
-                errors: self
-                    .errors
-                    .map(|v| v.into_iter().map(|e| e.into_sovd()).collect()),
+                errors: self.errors.map(|v| {
+                    v.into_iter()
+                        .map(crate::sovd::IntoSovd::into_sovd)
+                        .collect()
+                }),
             }
         }
     }
@@ -201,8 +208,10 @@ pub(crate) mod id {
                     || self.extended_data_records.is_some()
                 {
                     Some(EnvironmentData {
-                        snapshots: self.snapshots.map(|s| s.into_sovd()),
-                        extended_data_records: self.extended_data_records.map(|e| e.into_sovd()),
+                        snapshots: self.snapshots.map(crate::sovd::IntoSovd::into_sovd),
+                        extended_data_records: self
+                            .extended_data_records
+                            .map(crate::sovd::IntoSovd::into_sovd),
                     })
                 } else {
                     None

--- a/cda-sovd/src/sovd/components/ecu/genericservice.rs
+++ b/cda-sovd/src/sovd/components/ecu/genericservice.rs
@@ -21,7 +21,7 @@ use cda_interfaces::{
 use cda_plugin_security::Secured;
 use http::{HeaderMap, header};
 
-use super::*;
+use super::{ApiError, DynamicPlugin, ErrorWrapper, IntoResponse, StatusCode, TransformOperation};
 use crate::{
     openapi,
     sovd::{WebserverEcuState, get_octet_stream_payload},
@@ -86,7 +86,7 @@ pub(crate) async fn put<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManage
             None,
         )
         .await
-        .map_err(std::convert::Into::into)
+        .map_err(Into::into)
     {
         Err(e) => {
             return ErrorWrapper {

--- a/cda-sovd/src/sovd/components/ecu/modes.rs
+++ b/cda-sovd/src/sovd/components/ecu/modes.rs
@@ -258,7 +258,7 @@ pub(crate) mod session {
                         .into_response()
                 }
                 DiagServiceResponseType::Negative => {
-                    api_error_from_diag_response(response, include_schema)
+                    api_error_from_diag_response(&response, include_schema)
                 }
             },
             Err(e) => ErrorWrapper {
@@ -374,7 +374,6 @@ pub(crate) mod security {
         }: WebserverEcuState<R, T, U>,
         request_body: sovd_modes::put::Request,
     ) -> Response {
-        let claims = security_plugin.as_auth_plugin().claims();
         fn split_at_last_underscore(input: &str) -> (String, Option<String>) {
             let parts: Vec<&str> = input.split('_').collect();
 
@@ -387,6 +386,7 @@ pub(crate) mod security {
             }
         }
 
+        let claims = security_plugin.as_auth_plugin().claims();
         let include_schema = query.include_schema;
 
         if let Some(value) = validate_lock(&claims, &ecu_name, &locks, include_schema).await {
@@ -487,7 +487,7 @@ pub(crate) mod security {
                     }
                 },
                 DiagServiceResponseType::Negative => {
-                    api_error_from_diag_response(response, include_schema)
+                    api_error_from_diag_response(&response, include_schema)
                 }
             },
             Err(e) => ErrorWrapper {

--- a/cda-sovd/src/sovd/components/ecu/x_single_ecu_jobs.rs
+++ b/cda-sovd/src/sovd/components/ecu/x_single_ecu_jobs.rs
@@ -50,7 +50,10 @@ pub(crate) mod single_ecu {
         match uds.get_components_single_ecu_jobs_info(&ecu_name).await {
             Ok(mut items) => {
                 let sovd_component_data = sovd_interfaces::components::ecu::ComponentData {
-                    items: items.drain(0..).map(|c| c.into_sovd()).collect(),
+                    items: items
+                        .drain(0..)
+                        .map(crate::sovd::IntoSovd::into_sovd)
+                        .collect(),
                     schema,
                 };
                 (StatusCode::OK, Json(sovd_component_data)).into_response()
@@ -92,7 +95,7 @@ pub(crate) mod single_ecu {
             let mut job = match uds
                 .get_single_ecu_job(&ecu_name, &job_name)
                 .await
-                .map(|job| job.into_sovd())
+                .map(crate::sovd::IntoSovd::into_sovd)
             {
                 Ok(job) => job,
                 Err(e) => {
@@ -156,7 +159,10 @@ pub(crate) mod single_ecu {
                 Self::Sdg { caption, si, sdgs } => Self::SovdType::Sdg {
                     caption: caption.clone(),
                     si: si.clone(),
-                    sdgs: sdgs.into_iter().map(|sdg| sdg.into_sovd()).collect(),
+                    sdgs: sdgs
+                        .into_iter()
+                        .map(crate::sovd::IntoSovd::into_sovd)
+                        .collect(),
                 },
             }
         }
@@ -166,7 +172,9 @@ pub(crate) mod single_ecu {
         type SovdType = Vec<sovd_interfaces::components::ecu::SdSdg>;
 
         fn into_sovd(self) -> Self::SovdType {
-            self.into_iter().map(|sdg| sdg.into_sovd()).collect()
+            self.into_iter()
+                .map(crate::sovd::IntoSovd::into_sovd)
+                .collect()
         }
     }
 
@@ -203,7 +211,7 @@ pub(crate) mod single_ecu {
                 short_name: self.short_name,
                 physical_default_value: self.physical_default_value,
                 semantic: self.semantic,
-                long_name: self.long_name.map(|ln| ln.into_sovd()),
+                long_name: self.long_name.map(crate::sovd::IntoSovd::into_sovd),
             }
         }
     }
@@ -212,7 +220,9 @@ pub(crate) mod single_ecu {
         type SovdType = Vec<sovd_interfaces::components::ecu::x::single_ecu_job::Param>;
 
         fn into_sovd(self) -> Self::SovdType {
-            self.into_iter().map(|p| p.into_sovd()).collect()
+            self.into_iter()
+                .map(crate::sovd::IntoSovd::into_sovd)
+                .collect()
         }
     }
 
@@ -227,7 +237,7 @@ pub(crate) mod single_ecu {
                 prog_codes: self
                     .prog_codes
                     .into_iter()
-                    .map(|pc| pc.into_sovd())
+                    .map(crate::sovd::IntoSovd::into_sovd)
                     .collect(),
                 schema: None,
             }

--- a/cda-sovd/src/sovd/components/ecu/x_sovd2uds_bulk_data.rs
+++ b/cda-sovd/src/sovd/components/ecu/x_sovd2uds_bulk_data.rs
@@ -110,7 +110,11 @@ pub(crate) mod mdd_embedded_files {
     }
 
     pub(crate) mod id {
-        use super::*;
+        use super::{
+            ApiError, DiagServiceResponse, FileManager, IntoResponse, Path, Response, State,
+            StatusCode, TransformOperation, UdsEcu, WebserverEcuState, content_type_from_meta,
+            header,
+        };
         use crate::{
             openapi,
             sovd::{components::IdPathParam, error::ErrorWrapper},

--- a/cda-sovd/src/sovd/components/mod.rs
+++ b/cda-sovd/src/sovd/components/mod.rs
@@ -24,8 +24,8 @@ pub(crate) mod ecu;
 
 crate::openapi::aide_helper::gen_path_param!(IdPathParam id String);
 
-/// Wrapper Struct around [FieldParseError] to allow implementing
-/// [From] for [DataError<VendorErrorCode>]
+/// Wrapper Struct around [`FieldParseError`] to allow implementing
+/// [From] for [`DataError`<VendorErrorCode>]
 struct FieldParseErrorWrapper(FieldParseError);
 impl From<FieldParseErrorWrapper> for DataError<VendorErrorCode> {
     fn from(value: FieldParseErrorWrapper) -> Self {

--- a/cda-sovd/src/sovd/error.rs
+++ b/cda-sovd/src/sovd/error.rs
@@ -51,11 +51,8 @@ impl From<DiagServiceError> for ApiError {
             | DiagServiceError::DatabaseEntryNotFound(_)
             | DiagServiceError::VariantDetectionError(_)
             | DiagServiceError::EcuOffline(_)
-            | DiagServiceError::ConnectionClosed => {
-                ApiError::InternalServerError(Some(value.to_string()))
-            }
-
-            DiagServiceError::InvalidRequest(_)
+            | DiagServiceError::ConnectionClosed
+            | DiagServiceError::InvalidRequest(_)
             | DiagServiceError::SendFailed(_)
             | DiagServiceError::ParameterConversionError(_)
             | DiagServiceError::BadPayload(_)
@@ -250,7 +247,7 @@ impl IntoResponse for ErrorWrapper {
 }
 
 pub(crate) fn api_error_from_diag_response(
-    response: impl DiagServiceResponse,
+    response: &impl DiagServiceResponse,
     include_schema: bool,
 ) -> Response {
     let nrc = match response.as_nrc() {

--- a/cda-sovd/src/sovd/locks.rs
+++ b/cda-sovd/src/sovd/locks.rs
@@ -169,11 +169,19 @@ pub(crate) mod ecu {
     use aide::{UseApi, axum::IntoApiResponse, transform::TransformOperation};
     use cda_plugin_security::Secured;
 
-    use super::*;
+    use super::{
+        ApiError, DiagServiceResponse, ErrorWrapper, FileManager, IntoResponse, Json,
+        LockPathParam, Path, Response, State, UdsEcu, WebserverEcuState, WithRejection,
+        delete_handler, get_handler, get_id_handler, post_handler, put_handler, vehicle_read_lock,
+    };
     use crate::sovd;
 
     pub(crate) mod lock {
-        use super::*;
+        use super::{
+            ApiError, DiagServiceResponse, FileManager, Json, LockPathParam, Path, Response,
+            Secured, State, TransformOperation, UdsEcu, UseApi, WebserverEcuState, WithRejection,
+            delete_handler, get_id_handler, put_handler,
+        };
         use crate::openapi;
         pub(crate) async fn delete<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManager>(
             Path(lock): Path<LockPathParam>,
@@ -322,11 +330,19 @@ pub(crate) mod vehicle {
     use aide::{UseApi, transform::TransformOperation};
     use cda_plugin_security::Secured;
 
-    use super::*;
+    use super::{
+        ApiError, ErrorWrapper, IntoResponse, Json, LockPathParam, Path, Response, State,
+        WebserverState, WithRejection, all_locks_owned, delete_handler, get_handler,
+        get_id_handler, post_handler, put_handler, validate_claim,
+    };
     use crate::openapi;
 
     pub(crate) mod lock {
-        use super::*;
+        use super::{
+            ApiError, Json, LockPathParam, Path, Response, Secured, State, TransformOperation,
+            UseApi, WebserverState, WithRejection, delete_handler, get_id_handler, openapi,
+            put_handler,
+        };
 
         pub(crate) async fn delete(
             Path(lock): Path<LockPathParam>,
@@ -483,13 +499,20 @@ pub(crate) mod functional_group {
     use aide::{UseApi, transform::TransformOperation};
     use cda_plugin_security::Secured;
 
-    use super::*;
+    use super::{
+        ApiError, ErrorWrapper, IntoResponse, Json, Path, Response, State, WebserverState,
+        WithRejection, delete_handler, get_handler, get_id_handler, post_handler, put_handler,
+        vehicle_read_lock,
+    };
     use crate::openapi;
 
     openapi::aide_helper::gen_path_param!(FunctionalGroupLockPathParam group String);
 
     pub(crate) mod lock {
-        use super::*;
+        use super::{
+            ApiError, Json, Path, Response, Secured, State, TransformOperation, UseApi,
+            WebserverState, WithRejection, delete_handler, get_id_handler, openapi, put_handler,
+        };
 
         openapi::aide_helper::gen_path_param!(
             FunctionalGroupLockWithIdPathParam group String lock String

--- a/cda-tracing/Cargo.toml
+++ b/cda-tracing/Cargo.toml
@@ -11,6 +11,9 @@ description = "SOVD webserver used in CDA"
 homepage.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/lib.rs"
 

--- a/cda-tracing/src/lib.rs
+++ b/cda-tracing/src/lib.rs
@@ -56,6 +56,7 @@ pub struct TokioTracingConfig {
 
 type BoxedLayer<T> = Box<dyn Layer<T> + Send + Sync + 'static>;
 
+#[must_use]
 pub fn new() -> Layered<EnvFilter, Registry> {
     if std::env::var("RUST_LOG").is_err() {
         #[cfg(feature = "tokio-tracing")]
@@ -99,6 +100,9 @@ pub fn new_term_subscriber<S: tracing_core::Subscriber + for<'a> LookupSpan<'a>>
     term_subscriber.boxed()
 }
 
+/// Creates a new file subscriber layer.
+/// # Errors
+/// Returns a string error if the file subscriber cannot be created.
 pub fn new_file_subscriber<S: tracing_core::Subscriber + for<'a> LookupSpan<'a>>(
     config: &LogFileConfig,
 ) -> Result<(WorkerGuard, BoxedLayer<S>), String> {
@@ -138,6 +142,9 @@ pub fn new_file_subscriber<S: tracing_core::Subscriber + for<'a> LookupSpan<'a>>
     Ok((guard, file_subscriber.boxed()))
 }
 
+/// Creates a new OpenTelemetry subscriber layer.
+/// # Errors
+/// Returns a string error if the OpenTelemetry subscriber cannot be created.
 pub fn new_otel_subscriber<
     S: tracing_core::Subscriber + for<'a> LookupSpan<'a> + Send + Sync + 'static,
 >(


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
since the project has moved to using a workspace configuration in cargo, the strict and pedantic linter settings where not applied to all crates anymore.
To enable linting in the workspace a

```
[lints]
workspace = true
```

block is needed in the Cargo.toml.
This change introduces the necessary configuration and fixes the resulting linter warnings.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
