### PR TITLE
Pass SecurityPluginInitializer as generic param

### DIFF
--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -28,7 +28,7 @@ use cda_interfaces::{
     datatypes::{ComParams, DatabaseNamingConvention, FlatbBufConfig},
     file_manager::{Chunk, ChunkType},
 };
-use cda_plugin_security::{DefaultSecurityPlugin, SecurityPlugin};
+use cda_plugin_security::{SecurityPlugin, SecurityPluginLoader};
 use cda_sovd::WebServerConfig;
 use hashbrown::HashMap;
 use tokio::{
@@ -318,7 +318,7 @@ pub async fn create_diagnostic_gateway<S: SecurityPlugin>(
     skip(file_managers, webserver_config, ecu_uds, shutdown_signal),
     fields(file_manager_count = file_managers.len())
 )]
-pub fn start_webserver<S: SecurityPlugin>(
+pub fn start_webserver<S: SecurityPlugin, L: SecurityPluginLoader>(
     flash_files_path: String,
     file_managers: HashMap<String, FileManager>,
     webserver_config: WebServerConfig,
@@ -326,7 +326,7 @@ pub fn start_webserver<S: SecurityPlugin>(
     shutdown_signal: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> tokio::task::JoinHandle<Result<(), String>> {
     cda_interfaces::spawn_named!("webserver", async move {
-        cda_sovd::launch_webserver::<_, DiagServiceResponseStruct, _, _, DefaultSecurityPlugin>(
+        cda_sovd::launch_webserver::<_, DiagServiceResponseStruct, _, _, L>(
             webserver_config,
             ecu_uds,
             flash_files_path,

--- a/cda-main/src/main.rs
+++ b/cda-main/src/main.rs
@@ -13,7 +13,7 @@
 
 use std::sync::Arc;
 
-use cda_plugin_security::DefaultSecurityPluginData;
+use cda_plugin_security::{DefaultSecurityPlugin, DefaultSecurityPluginData};
 use clap::Parser;
 use futures::future::FutureExt;
 use opensovd_cda_lib::{config::configfile::ConfigSanity, shutdown_signal};
@@ -154,7 +154,7 @@ async fn main() -> Result<(), String> {
     let uds =
         opensovd_cda_lib::create_uds_manager(diagnostic_gateway, databases, variant_detection_rx);
 
-    match opensovd_cda_lib::start_webserver(
+    match opensovd_cda_lib::start_webserver::<_, DefaultSecurityPlugin>(
         flash_files_path,
         file_managers,
         webserver_config,


### PR DESCRIPTION
 this change fixes the issue that the initializer is always the DefaultSecurityPlugin, by adding a second generic parameter to start_webserver, which is required to allow specifying a different security plugin via main.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally

Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
