### PR TITLE
allow extending locks by second put call

### DIFF
--- a/cda-interfaces/src/ecuuds.rs
+++ b/cda-interfaces/src/ecuuds.rs
@@ -278,6 +278,12 @@ pub trait UdsEcu: Send + Sync + 'static {
         type_: TesterPresentType,
     ) -> impl Future<Output = Result<(), DiagServiceError>> + Send;
 
+    /// Check if a tester present is active for the given type.
+    fn check_tester_present_active(
+        &self,
+        type_: &TesterPresentType,
+    ) -> impl Future<Output = bool> + Send;
+
     // Retrieve all faults for the given ECU, with optional filtering by status, severity and scope.
     // W/o fmt::skip 'impl Future...' is put on the same line by rustfmt,
     // then it complains about the line being too long...


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

to simplify locking, it is important that a second call to put is extending the lock
This behaviour was broken because the UDS ECU tried to spawn a new tester present task, when one was already running. This change adds a check to make sure that tester present is only started when neccessary.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->


Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
