### PR TITLE
extract send key parameter name from DB

### DIFF
--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -1121,6 +1121,27 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
         }
     }
 
+    async fn get_send_key_param_name(
+        &self,
+        ecu_name: &str,
+        level: &str,
+    ) -> Result<String, DiagServiceError> {
+        let ecu_diag_service = self.ecus.get(ecu_name).ok_or(DiagServiceError::NotFound)?;
+        let security_access = ecu_diag_service
+            .read()
+            .await
+            .lookup_security_access_change(level, None, true)?;
+        match &security_access {
+            SecurityAccess::RequestSeed(_) => {
+                unreachable!("Not reached, because has key is set to true above")
+            }
+            SecurityAccess::SendKey(dc) => {
+                let ecu = ecu_diag_service.read().await;
+                ecu.get_send_key_param_name(dc).await
+            }
+        }
+    }
+
     async fn get_ecu_reset_services(
         &self,
         ecu_name: &str,

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -193,6 +193,13 @@ pub trait EcuManager:
         seed_service: Option<&String>,
         has_key: bool,
     ) -> Result<SecurityAccess, DiagServiceError>;
+    /// Retrieves the name of the parameter used to send the key for security access.
+    /// # Errors
+    /// Will return `DiagServiceError` if the parameter cannot be found in the database
+    fn get_send_key_param_name(
+        &self,
+        diag_service: &DiagComm,
+    ) -> impl Future<Output = Result<String, DiagServiceError>> + Send;
     /// Retrieves the name of the current ecu session, i.e. 'extended', 'programming' or 'default'.
     /// The examples above differ depending on the parameterization of the ECU.
     /// # Errors

--- a/cda-interfaces/src/ecuuds.rs
+++ b/cda-interfaces/src/ecuuds.rs
@@ -159,6 +159,14 @@ pub trait UdsEcu: Send + Sync + 'static {
         security_plugin: &DynamicPlugin,
         expiration: Duration,
     ) -> impl Future<Output = Result<(SecurityAccess, Self::Response), DiagServiceError>> + Send;
+    /// Get the name of the parameter used to send the key for the given ECU and security level.
+    /// # Errors
+    /// Returns an error if the ECU or security level is not found.
+    fn get_send_key_param_name(
+        &self,
+        ecu_name: &str,
+        level: &str,
+    ) -> impl Future<Output = Result<String, DiagServiceError>> + Send;
     /// Retrieve service to reset the ECU.
     fn get_ecu_reset_services(
         &self,

--- a/cda-sovd-interfaces/src/components/ecu/mod.rs
+++ b/cda-sovd-interfaces/src/components/ecu/mod.rs
@@ -19,7 +19,7 @@ use crate::Items;
 pub mod modes;
 pub mod operations;
 
-#[derive(Serialize, schemars::JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct Ecu {
     pub id: String,
     pub name: String,
@@ -47,7 +47,7 @@ pub struct ComponentDataInfo {
     pub name: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 #[derive(schemars::JsonSchema)]
 pub enum SdSdg {
@@ -82,14 +82,14 @@ pub enum SdSdg {
     },
 }
 
-#[derive(Serialize, schemars::JsonSchema)]
+#[derive(Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ServicesSdgs {
     pub items: HashMap<String, ServiceSdgs>,
     #[schemars(skip)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<schemars::Schema>,
 }
-#[derive(Serialize, schemars::JsonSchema)]
+#[derive(Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ServiceSdgs {
     pub sdgs: Vec<SdSdg>,
 }

--- a/cda-sovd-interfaces/src/components/ecu/modes.rs
+++ b/cda-sovd-interfaces/src/components/ecu/modes.rs
@@ -11,10 +11,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
 
-#[derive(Debug, Serialize, schemars::JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct Mode<T> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
@@ -48,13 +48,27 @@ pub mod get {
 pub mod put {
     use serde::{Deserialize, Serialize};
 
-    #[derive(Debug, Deserialize, schemars::JsonSchema)]
+    #[derive(Serialize, Deserialize, schemars::JsonSchema)]
+    pub struct SovdSeed {
+        #[serde(rename = "Request_Seed")]
+        pub request_seed: String,
+    }
+
+    #[derive(Serialize, Deserialize, schemars::JsonSchema)]
+    pub struct RequestSeedResponse {
+        pub id: String,
+        pub seed: SovdSeed,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub schema: Option<schemars::Schema>,
+    }
+
+    #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
     pub struct ModeKey {
-        #[serde(rename = "Send_Key")]
+        #[serde(rename = "Send_Key", alias = "Security")]
         pub send_key: String,
     }
 
-    #[derive(Debug, Deserialize, schemars::JsonSchema)]
+    #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
     #[schemars(rename = "UpdateModesRequest")]
     pub struct Request {
         pub value: String,
@@ -67,11 +81,11 @@ pub mod put {
         // todo (strict-mode): if strict mode is enabled, this should be required
         pub mode_expiration: Option<u64>,
 
-        #[serde(rename = "Key")]
+        #[serde(rename = "Key", alias = "SendKey")]
         pub key: Option<ModeKey>,
     }
 
-    #[derive(Debug, Serialize, schemars::JsonSchema)]
+    #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
     #[schemars(rename = "UpdateModesResponse")]
     pub struct Response<T> {
         pub id: String,


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
Prior to this commit the name of the parameter containing the key the send key routine was hard coded to Send_Key. This commits reads the required parameter name from the database and uses this when when constructing the parameter data. An alias named 'Key' for modes::Put::Request::key is added, and the old name is kept for backwards compatibility, to simplify usage with straight forward names.
An alias 'Security' is added for modes::put::ModeKey::send_key for the same reason.

Additionally this commit refactors the RequestSeed response into the sovd interfaces crate, for re-use.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->



Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
