### PR TITLE
remove converter hint from remove-readme-note

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@ It handles the communication to the ECUs, by using the communication parameters 
 
 To run the CDA you will need at least one `MDD` file. Check out [eclipse-opensovd/odx-converter](https://github.com/eclipse-opensovd/odx-converter) on how to get started with creating `MDD`(s) from ODX.  
 
-> [!IMPORTANT]
-> At the moment it is necessary to use the [floroks/flatbuffers-ng](https://github.com/eclipse-opensovd/odx-converter/tree/floroks/flatbuffers-ng) branch to create `MDD` files containing the ECU description in the flatbuf format.
-
-
 Once you have the `MDD`(s) you can update the config in `opensovd-cda.toml` to point `databases_path` to the directory containing the files. Alternatively you can pass the config via arg `--databases-path MY_PATH`.
 
 ### running


### PR DESCRIPTION
solves #82

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
ODX converter is merged, note is not needed anymore

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
Fixes https://github.com/eclipse-opensovd/classic-diagnostic-adapter/issues/82

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

---

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)