### PR TITLE
fault-by-id make schema param optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,6 +2839,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_qs",
  "strum",
 ]
 

--- a/cda-sovd-interfaces/Cargo.toml
+++ b/cda-sovd-interfaces/Cargo.toml
@@ -26,6 +26,9 @@ serde_json = { workspace = true }
 schemars = { workspace = true, features = ["hashbrown"] }
 strum = { workspace = true, features = ["derive"] }
 
+[dev-dependencies]
+serde_qs = { workspace = true }
+
 [features]
 default = []
 auth = []

--- a/cda-sovd-interfaces/src/components/ecu/mod.rs
+++ b/cda-sovd-interfaces/src/components/ecu/mod.rs
@@ -466,6 +466,7 @@ pub mod faults {
                 /// If true, snapshot data from 0x19 04 is included in the response
                 #[serde(default = "default_true")]
                 pub include_snapshot_data: bool,
+                #[serde(default)]
                 pub include_schema: bool,
             }
 
@@ -511,5 +512,26 @@ pub mod faults {
                 pub schema: Option<schemars::Schema>,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_deserialize_dtc_id_query() {
+        let query_str = "include-extended-data=false&include-snapshot-data=true";
+        let query: super::faults::id::get::DtcIdQuery = serde_qs::from_str(query_str).unwrap();
+
+        assert!(!query.include_extended_data);
+        assert!(query.include_snapshot_data);
+        assert!(!query.include_schema);
+
+        let query_str_with_schema =
+            "include-extended-data=true&include-snapshot-data=false&include-schema=true";
+        let query_with_schema: super::faults::id::get::DtcIdQuery =
+            serde_qs::from_str(query_str_with_schema).unwrap();
+        assert!(query_with_schema.include_extended_data);
+        assert!(!query_with_schema.include_snapshot_data);
+        assert!(query_with_schema.include_schema);
     }
 }


### PR DESCRIPTION
without adding a default or wrapping the field
'include-schema' in an option, serde cannot parse the value when the field is not given.
Fixed by adding a default_false impl.

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->


Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
