### PR TITLE
tracing: add an optional feature to write logs into log 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,8 @@ jobs:
   all-features:
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: "--cfg tokio_unstable"
+      RUSTFLAGS: "--cfg tokio_unstable -L /usr/local/lib"
+      PKG_CONFIG_PATH: "/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -67,6 +68,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
+      - name: Setup DLT
+        uses: eclipse-opensovd/dlt-tracing-lib/.github/actions/setup-dlt@main
       - name: Clippy
         run: cargo clippy --locked --all-targets --all-features -- -D warnings
       - name: Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.46"
+version = "1.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97463e1064cb1b1c1384ad0a0b9c8abd0988e2a91f52606c80ef14aadb63e36"
+checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -462,6 +462,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-core",
+ "tracing-dlt",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]
@@ -771,6 +772,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dlt-rs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652f3e705c41ce2b929b82ee99e9a3c262cf9c88df53597b67a6b59b1c2a3b4"
+dependencies = [
+ "dlt-sys",
+ "thiserror 2.0.17",
+ "tokio",
+]
+
+[[package]]
+name = "dlt-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df6ecdd4d79c8bb5dc542acc814e44b001333a38d9adbd5bc77b886b4d57db1"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1171,9 +1192,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hdrhistogram"
@@ -1544,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -3498,6 +3519,20 @@ checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-dlt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac5a08f9173385ae43a9bc33a1d1e19aa9030cd4cdabf2d53717815a8c6d5798"
+dependencies = [
+ "dlt-rs",
+ "indexmap",
+ "tokio",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ xz2 = "0.1.7"
 hex = "0.4.3"
 strum = "0.27.2"
 strum_macros = "0.27.2"
-indexmap = "2.12.0"
+indexmap = "2.12.1"
 http = "1.3.1"
 mime = "0.3.17"
 jsonwebtoken = { version = "10.2.0", features = ["rust_crypto"] }
@@ -85,6 +85,7 @@ tracing-core = "0.1.34"
 tracing-appender = "0.2.3"
 tracing-opentelemetry = "0.32.0"
 tracing-subscriber = { version = "0.3.20", default-features = false }
+tracing-dlt = { version = "0.1.0" }
 strip-ansi-escapes = "0.2.1"
 nu-ansi-term = "0.50"
 console-subscriber = "0.5.0"

--- a/cda-comm-doip/Cargo.toml
+++ b/cda-comm-doip/Cargo.toml
@@ -46,3 +46,4 @@ tracing = { workspace = true }
 [features]
 default = []
 openssl-vendored = ["openssl/vendored"]
+dlt-tracing = ["cda-interfaces/dlt-tracing"]

--- a/cda-comm-doip/src/ecu_connection.rs
+++ b/cda-comm-doip/src/ecu_connection.rs
@@ -13,7 +13,7 @@
 
 use std::time::Duration;
 
-use cda_interfaces::DiagServiceError;
+use cda_interfaces::{DiagServiceError, dlt_ctx};
 use doip_definitions::{
     message::DoipMessage,
     payload::{ActivationCode, DoipPayload, RoutingActivationRequest, RoutingActivationResponse},
@@ -21,7 +21,6 @@ use doip_definitions::{
 use tokio::sync::Mutex;
 
 use crate::ConnectionError;
-
 const ENABLED_SSL_CIPHERS: [&str; 4] = [
     "ECDHE-RSA-AES128-GCM-SHA256",
     "ECDHE-ECDSA-AES128-SHA256",
@@ -193,7 +192,8 @@ impl ECUConnectionRead for EcuConnectionReadVariant {
         gateway_ip,
         gateway_name,
         connect_timeout_ms = connect_timeout.as_millis(),
-        routing_timeout_ms = routing_activation_timeout.as_millis()
+        routing_timeout_ms = routing_activation_timeout.as_millis(),
+        dlt_context = dlt_ctx!("DOIP"),
     )
 )]
 pub(crate) async fn establish_ecu_connection(
@@ -285,7 +285,8 @@ pub(crate) async fn establish_ecu_connection(
         gateway_ip,
         gateway_name,
         connect_timeout_ms = connnect_timeout.as_millis(),
-        routing_timeout_ms = routing_activation_timeout.as_millis()
+        routing_timeout_ms = routing_activation_timeout.as_millis(),
+        dlt_context = dlt_ctx!("DOIP"),
     )
 )]
 pub(crate) async fn establish_tls_ecu_connection(
@@ -368,6 +369,7 @@ pub(crate) async fn establish_tls_ecu_connection(
         gateway_name = %_gateway_name,
         gateway_ip   = %_gateway_ip,
         timeout_ms   = timeout.as_millis(),
+        dlt_context  = dlt_ctx!("DOIP"),
     )
 )]
 async fn try_read_routing_activation_response(

--- a/cda-comm-uds/Cargo.toml
+++ b/cda-comm-uds/Cargo.toml
@@ -44,3 +44,4 @@ strum = { workspace = true }
 [features]
 default = []
 openssl-vendored = ["openssl/vendored"]
+dlt-tracing = ["cda-interfaces/dlt-tracing"]

--- a/cda-core/Cargo.toml
+++ b/cda-core/Cargo.toml
@@ -49,3 +49,4 @@ cda-database = { workspace = true, features = ["database-builder"] }
 
 [features]
 default = []
+dlt-tracing = ["cda-interfaces/dlt-tracing"]

--- a/cda-core/src/diag_kernel/schema.rs
+++ b/cda-core/src/diag_kernel/schema.rs
@@ -11,7 +11,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use cda_database::datatypes::{self, DiagService, DiagnosticDatabase};
-use cda_interfaces::{DiagServiceError, EcuAddressProvider, EcuSchemaProvider, SchemaDescription};
+use cda_interfaces::{
+    DiagServiceError, EcuAddressProvider, EcuSchemaProvider, SchemaDescription, dlt_ctx,
+};
 use cda_plugin_security::SecurityPlugin;
 
 use crate::EcuManager;
@@ -159,6 +161,11 @@ impl ResponseJsonSchema for datatypes::Response<'_> {
     }
 }
 
+#[tracing::instrument(skip_all,
+    fields(
+        dlt_context = dlt_ctx!("CORE"),
+    )
+)]
 fn params_to_schema(
     params: &[datatypes::Parameter],
     ctx: &str,
@@ -397,6 +404,11 @@ fn map_struct_to_schema(
     params_to_schema(&params, ctx, ecu_db, request)
 }
 
+#[tracing::instrument(skip_all,
+    fields(
+        dlt_context = dlt_ctx!("CORE"),
+    )
+)]
 fn map_dop_field_to_schema(
     dop_field: Option<&datatypes::DopField>,
     ctx: &str,
@@ -426,6 +438,11 @@ fn map_dop_field_to_schema(
     }
 }
 
+#[tracing::instrument(skip_all,
+    fields(
+        dlt_context = dlt_ctx!("CORE"),
+    )
+)]
 fn map_mux_to_schema(
     mux: &datatypes::MuxDop,
     ctx: &str,

--- a/cda-core/src/diag_kernel/variant_detection.rs
+++ b/cda-core/src/diag_kernel/variant_detection.rs
@@ -12,8 +12,9 @@
  */
 
 use cda_database::datatypes;
-use cda_interfaces::{DiagServiceError, HashMap, HashSet, diagservices::DiagServiceResponse};
-
+use cda_interfaces::{
+    DiagServiceError, HashMap, HashSet, diagservices::DiagServiceResponse, dlt_ctx,
+};
 pub(super) type DiagServiceId = String;
 
 pub(super) struct VariantDetection {
@@ -55,7 +56,10 @@ pub(super) fn prepare_variant_detection(
 
 #[tracing::instrument(
     skip(service_responses, diagnostic_database),
-    fields(response_count = service_responses.len())
+    fields(
+        response_count = service_responses.len(),
+        dlt_context = dlt_ctx!("CORE"),
+    )
 )]
 pub(super) fn evaluate_variant<T: DiagServiceResponse + Sized>(
     service_responses: HashMap<String, T>,

--- a/cda-database/Cargo.toml
+++ b/cda-database/Cargo.toml
@@ -53,6 +53,7 @@ toml = { workspace = true }
 default = []
 gen-protos = []
 gen-flatbuffers = []
+dlt-tracing = ["cda-interfaces/dlt-tracing"]
 
 # Guard the database builder, as it should not be used
 # in production code because creating the database manually

--- a/cda-database/src/datatypes/data_operation.rs
+++ b/cda-database/src/datatypes/data_operation.rs
@@ -12,7 +12,7 @@
  */
 
 //
-use cda_interfaces::{DiagServiceError, util::decode_hex};
+use cda_interfaces::{DiagServiceError, dlt_ctx, util::decode_hex};
 
 use crate::{datatypes, flatbuf::diagnostic_description::dataformat};
 
@@ -70,6 +70,12 @@ pub struct CompuRationalCoefficients {
 }
 
 impl From<dataformat::CompuCategory> for CompuCategory {
+    #[tracing::instrument(
+        skip_all,
+        fields(
+            dlt_context = dlt_ctx!("DB"),
+        )
+    )]
     fn from(value: dataformat::CompuCategory) -> Self {
         match value {
             dataformat::CompuCategory::IDENTICAL => CompuCategory::Identical,

--- a/cda-database/src/datatypes/mod.rs
+++ b/cda-database/src/datatypes/mod.rs
@@ -16,6 +16,7 @@ use std::fmt::Debug;
 use cda_interfaces::{
     DiagServiceError,
     datatypes::{ComParamConfig, ComParamValue, DeserializableCompParam, FlatbBufConfig},
+    dlt_ctx,
 };
 pub use comparam::*;
 pub use data_operation::*;
@@ -563,7 +564,8 @@ impl DiagnosticDatabase {
         skip(self),
         fields(
             protocol = ?protocol,
-            param_name = %com_param.name
+            param_name = %com_param.name,
+            dlt_context = dlt_ctx!("DB"),
         )
     )]
     pub fn find_com_param<T: DeserializableCompParam + Serialize + Debug + Clone>(

--- a/cda-database/src/mdd_data/files.rs
+++ b/cda-database/src/mdd_data/files.rs
@@ -17,7 +17,7 @@ use std::{
 };
 
 use cda_interfaces::{
-    HashMap,
+    HashMap, dlt_ctx,
     file_manager::{Chunk, ChunkMetaData, MddError},
 };
 use tokio::sync::RwLock;
@@ -36,6 +36,11 @@ struct CacheEntry {
 }
 
 impl FileManager {
+    #[tracing::instrument(skip_all,
+        fields(
+            dlt_context = dlt_ctx!("DB"),
+        )
+    )]
     #[must_use]
     pub fn new(mdd_path: String, files: Vec<Chunk>) -> Self {
         let mdd_name = mdd_path.split('/').next_back().unwrap_or("mdd").to_string();

--- a/cda-database/src/mdd_data/mod.rs
+++ b/cda-database/src/mdd_data/mod.rs
@@ -16,6 +16,7 @@ use std::{io::Read, time::Instant};
 use cda_interfaces::{
     HashMap,
     datatypes::FlatbBufConfig,
+    dlt_ctx,
     file_manager::{Chunk, ChunkMetaData, ChunkType, MddError},
 };
 use flatbuffers::VerifierOptions;
@@ -82,7 +83,11 @@ impl From<&ChunkType> for ChunkDataType {
 /// or parsed correctly.
 #[tracing::instrument(
     skip(chunk),
-    fields(mdd_file, chunk_name = %chunk.meta_data.name)
+    fields(
+        mdd_file,
+        chunk_name = %chunk.meta_data.name,
+        dlt_context = dlt_ctx!("DB"),
+    )
 )]
 pub fn load_chunk<'a>(chunk: &'a mut Chunk, mdd_file: &str) -> Result<&'a Vec<u8>, MddError> {
     if chunk.payload.is_none() {

--- a/cda-interfaces/Cargo.toml
+++ b/cda-interfaces/Cargo.toml
@@ -47,3 +47,4 @@ tracing = { workspace = true }
 [features]
 default = []
 tokio-tracing = ["tokio/tracing"]
+dlt-tracing = []

--- a/cda-interfaces/src/util.rs
+++ b/cda-interfaces/src/util.rs
@@ -48,6 +48,28 @@ pub mod tokio_ext {
     }
 }
 
+pub mod dlt_ext {
+    #[macro_export]
+    #[cfg(feature = "dlt-tracing")]
+    macro_rules! dlt_ctx {
+        ($ctx_id:expr) => {
+            $ctx_id
+        };
+    }
+
+    #[macro_export]
+    #[cfg(not(feature = "dlt-tracing"))]
+    macro_rules! dlt_ctx {
+        ($ctx_id:expr) => {
+            // tracing, will not include this
+            // so dlt_context = dlt_ctx!("FOO")
+            // with disabled dlt-tracing feature will omit the
+            // dlt_context span completely
+            None::<&str>
+        };
+    }
+}
+
 /// Pad a byte slice to 4 bytes for u32 conversion.
 /// # Errors
 /// Returns `DiagServiceError::ParameterConversionError` if the input slice is longer than 4 bytes.

--- a/cda-main/Cargo.toml
+++ b/cda-main/Cargo.toml
@@ -84,3 +84,4 @@ openssl-vendored = [
   "cda-comm-doip/openssl-vendored",
   "cda-comm-uds/openssl-vendored",
 ]
+dlt-tracing = ["cda-tracing/dlt-tracing"]

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -21,6 +21,7 @@ use cda_interfaces::{
     DoipGatewaySetupError, EcuAddressProvider, EcuManager as EcuManagerTrait, HashMap,
     HashMapEntry, HashMapExtensions, HashSet, Protocol,
     datatypes::{ComParams, DatabaseNamingConvention, FlatbBufConfig},
+    dlt_ctx,
     file_manager::{Chunk, ChunkType},
 };
 use cda_plugin_security::{SecurityPlugin, SecurityPluginLoader};
@@ -207,7 +208,13 @@ async fn mark_duplicate_ecus_by_address<S: SecurityPlugin>(
 }
 
 #[allow(clippy::too_many_arguments)]
-#[tracing::instrument(skip_all, fields(paths_count = paths.len()))]
+#[tracing::instrument(
+    skip_all,
+    fields(
+        paths_count = paths.len(),
+        dlt_context = dlt_ctx!("MAIN"),
+    )
+)]
 async fn load_database<S: SecurityPlugin>(
     protocol: Protocol,
     database: Arc<RwLock<LoadedEcuMap<S>>>,
@@ -393,7 +400,12 @@ type UdsManagerType<S> =
 /// Creates a new UDS manager for the webserver.
 // type alias does not allow specifying hasher, we set the hasher globally.
 #[allow(clippy::implicit_hasher)]
-#[tracing::instrument(skip_all, fields(database_count = databases.len()))]
+#[tracing::instrument(skip_all,
+    fields(
+        database_count = databases.len(),
+        dlt_context = dlt_ctx!("MAIN"),
+    )
+)]
 pub fn create_uds_manager<S: SecurityPlugin>(
     gateway: DoipDiagGateway<EcuManager<S>>,
     databases: Arc<HashMap<String, RwLock<EcuManager<S>>>>,
@@ -407,7 +419,10 @@ pub fn create_uds_manager<S: SecurityPlugin>(
 /// Returns a string error if the gateway cannot be initialized.
 #[tracing::instrument(
     skip(databases, variant_detection, shutdown_signal),
-    fields(database_count = databases.len())
+    fields(
+        database_count = databases.len(),
+        dlt_context = dlt_ctx!("MAIN"),
+    )
 )]
 pub async fn create_diagnostic_gateway<S: SecurityPlugin>(
     databases: Arc<DatabaseMap<S>>,
@@ -422,7 +437,10 @@ pub async fn create_diagnostic_gateway<S: SecurityPlugin>(
 #[allow(clippy::implicit_hasher)]
 #[tracing::instrument(
     skip(file_managers, webserver_config, ecu_uds, shutdown_signal, custom_route_provider),
-    fields(file_manager_count = file_managers.len())
+    fields(
+        file_manager_count = file_managers.len(),
+        dlt_context = dlt_ctx!("MAIN"),
+    )
 )]
 pub fn start_webserver<
     S: SecurityPlugin,

--- a/cda-sovd/Cargo.toml
+++ b/cda-sovd/Cargo.toml
@@ -90,3 +90,4 @@ percent-encoding = { workspace = true }
 [features]
 default = []
 auth = []
+dlt-tracing = ["cda-interfaces/dlt-tracing"]

--- a/cda-sovd/src/lib.rs
+++ b/cda-sovd/src/lib.rs
@@ -21,7 +21,7 @@ use axum::{
 };
 use cda_interfaces::{
     DoipGatewaySetupError, HashMap, SchemaProvider, UdsEcu, diagservices::DiagServiceResponse,
-    file_manager::FileManager,
+    dlt_ctx, file_manager::FileManager,
 };
 use cda_plugin_security::SecurityPluginLoader;
 use futures::future::FutureExt;
@@ -274,6 +274,7 @@ where
                         status_code = tracing::field::Empty,
                         latency = tracing::field::Empty,
                         error = tracing::field::Empty,
+                        dlt_context = dlt_ctx!("SOVD"),
                 )
             })
             .on_request(|request: &axum::http::Request<_>, _span: &tracing::Span| {

--- a/cda-tracing/Cargo.toml
+++ b/cda-tracing/Cargo.toml
@@ -42,6 +42,7 @@ tracing-subscriber = { workspace = true, features = [
   "parking_lot",
   "std",
 ] }
+tracing-dlt = { workspace = true, optional = true }
 strip-ansi-escapes = { workspace = true } # Strip ANSI escape codes from strings, used for file logging
 nu-ansi-term = { workspace = true } # ANSI terminal support for terminal log output
 # otel
@@ -58,3 +59,5 @@ console-subscriber = { workspace = true, optional = true }
 [features]
 default = []
 tokio-tracing = ["dep:console-subscriber", "tokio/tracing"]
+dlt-tracing = ["dep:tracing-dlt"]
+dlt-tracing-load-control = ["dlt-tracing", "tracing-dlt?/trace_load_ctrl"]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

DLT is widely used and often times a hard requirement in the automotive industry.
This PR adds functionality to optionally enable DLT output into the CDA. 

Example dlt log output
```
2025/11/25 12:44:20.612500 1735045407 000 ECU1 CDA- SOVD log debug V 8 [request{method=GET, path="/vehicle/v15/components/ecu"}: cda_sovd: Request received method = GET path = /vehicle/v15/components/ecu]
```

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->


---

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
