### PR TITLE
comm: always receive broadcasts from 0.0.0.0

### DIFF
--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -218,6 +218,8 @@ impl<T: EcuAddressProvider + DoipComParamProvider> DoipDiagGateway<T> {
         };
 
         vir_vam::listen_for_vams(
+            tester_ip.to_owned(),
+            gateway_port,
             mask,
             gateway.clone(),
             variant_detection,


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
gateways may sent VAMs to 255.255.255.255:13400
Broadcasts from the wildcard broadcast are only received when we're listening on the wildcard address 0.0.0.0.0. VAMs sent on an interface broadcast address i.e. 192.168.0.255 are still received when listening on 0.0.0.0.
This also fixes the issue that the sim must run first during integration tests.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

--- 


Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)