### PR TITLE
improve: de-duplicate databases with duplicated ECU names

### DIFF
--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -143,6 +143,11 @@ impl<S: SecurityPlugin> cda_interfaces::EcuAddressProvider for EcuManager<S> {
     fn ecu_name(&self) -> String {
         self.ecu_name.clone()
     }
+
+    fn logical_address_eq<T: cda_interfaces::EcuAddressProvider>(&self, other: &T) -> bool {
+        self.logical_address == other.logical_address()
+            && self.logical_gateway_address() == other.logical_gateway_address()
+    }
 }
 
 impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
@@ -1237,6 +1242,18 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
     fn mark_as_duplicate(&mut self) {
         self.variant.state = EcuState::Duplicate;
         self.diag_database.unload();
+    }
+
+    fn revision(&self) -> String {
+        // We cannot remove the closure because there is no direct
+        // access to the underlying flatbuf type, as it's not exported from the database
+        // crate.
+        #[allow(clippy::redundant_closure_for_method_calls)]
+        self.diag_database
+            .ecu_data()
+            .ok()
+            .and_then(|s| s.revision())
+            .map_or_else(|| "0.0.0".to_owned(), ToOwned::to_owned)
     }
 }
 

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -73,6 +73,8 @@ pub trait EcuAddressProvider: Send + Sync + 'static {
     fn logical_functional_address(&self) -> u16;
     #[must_use]
     fn ecu_name(&self) -> String;
+    #[must_use]
+    fn logical_address_eq<T: EcuAddressProvider>(&self, other: &T) -> bool;
 }
 
 pub trait EcuManager:
@@ -270,6 +272,9 @@ pub trait EcuManager:
         service: &DiagComm,
         security_plugin: &DynamicPlugin,
     ) -> impl Future<Output = Result<(), DiagServiceError>> + Send;
+    /// Retrieve the revision of the ECU variant if available,
+    /// otherwise return 0.0.0
+    fn revision(&self) -> String;
 }
 
 impl Protocol {

--- a/cda-interfaces/src/lib.rs
+++ b/cda-interfaces/src/lib.rs
@@ -38,7 +38,11 @@ pub use schema::*;
 // Together with the foldhash hasher, this is virtually the same as using hashbrown.
 pub type Hasher = foldhash::fast::RandomState;
 pub type HashMap<K, V> = std::collections::HashMap<K, V, Hasher>;
+pub type HashMapEntry<'a, K, V> = std::collections::hash_map::Entry<'a, K, V>;
+
 pub type HashSet<V> = std::collections::HashSet<V, Hasher>;
+// Note: hash_set_entry is unstable, hence not defining it.
+
 pub use foldhash::{HashMapExt as HashMapExtensions, HashSetExt as HashSetExtensions};
 
 /// # strings module


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

If an ECU name is found multiple times,
this commit adds the following behaviour:
* If the logical gateway and ecu address different all ECUs with this name are ignored
* If the addresses are equal, the ECU with the latest revision will be used.

In both cases a warning is logged.

Solves #105 

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->


Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)