### PR TITLE
Improvements for flashing

### DIFF
--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -551,7 +551,7 @@ fn spawn_gateway_receiver_task(
         match response {
             Some(Ok(response)) => {
                 match response {
-                    DiagnosticResponse::Ack(source_address) => {
+                    DiagnosticResponse::Ack((source_address, _)) => {
                         tracing::debug!(
                             gateway_name = %gateway_name,
                             gateway_ip = %gateway_ip,
@@ -772,8 +772,9 @@ async fn try_read(
                 DoipPayload::GenericNack(nack) => Ok(DiagnosticResponse::GenericNack(nack)),
                 DoipPayload::DiagnosticMessageAck(ack) => {
                     tracing::debug!("Received diagnostic message ack");
-                    Ok(DiagnosticResponse::Ack(u16::from_be_bytes(
-                        ack.source_address,
+                    Ok(DiagnosticResponse::Ack((
+                        u16::from_be_bytes(ack.source_address),
+                        ack.previous_message,
                     )))
                 }
                 DoipPayload::AliveCheckResponse(_) => Ok(DiagnosticResponse::AliveCheckResponse),


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
This PR introduces a check to ensure a received ACK is only taken into account if it is relating to the previously sent message.
Additionally, when parsing a diagnostic message the SID is now correctly parsed for NRCs.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
The changes in this PR are again in the spirit of "warn about irregularities, but continue if possible". Therefore it is only logged if a non matching ACK is received and waiting continues.

Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)