### PR TITLE
core: validate bit length for conversion from json

### DIFF
--- a/cda-core/src/diag_kernel/operations.rs
+++ b/cda-core/src/diag_kernel/operations.rs
@@ -10,8 +10,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-use cda_database::datatypes::{self, DataType};
+use cda_database::datatypes::{self, BitLength, DataType};
 use cda_interfaces::{
     DataParseError, DiagServiceError,
     util::{decode_hex, tracing::print_hex},
@@ -326,22 +325,23 @@ pub(in crate::diag_kernel) fn extract_diag_data_container(
 }
 
 pub(in crate::diag_kernel) fn json_value_to_uds_data(
-    diag_type: datatypes::DataType,
+    diag_type: &datatypes::DiagCodedType,
     compu_method: Option<datatypes::CompuMethod>,
     json_value: &serde_json::Value,
 ) -> Result<Vec<u8>, DiagServiceError> {
+    let base_type = diag_type.base_datatype();
     'compu: {
         if let Some(compu_method) = compu_method {
             match compu_method.category {
                 datatypes::CompuCategory::Identical => break 'compu,
                 category => {
-                    return compu_convert(diag_type, &compu_method, category, json_value);
+                    return compu_convert(base_type, &compu_method, category, json_value);
                 }
             }
         }
     }
 
-    match diag_type {
+    match base_type {
         DataType::Int32
         | DataType::UInt32
         | DataType::Float32
@@ -359,15 +359,22 @@ pub(in crate::diag_kernel) fn json_value_to_uds_data(
 // truncating values and sign loss is expected when converting float values into a vec<u8>
 #[allow(clippy::cast_possible_truncation)]
 #[allow(clippy::cast_sign_loss)]
-pub(in crate::diag_kernel) fn string_to_vec_u8(
-    data_type: DataType,
+fn numeric_type_str_to_byte_vec(
+    data_type: &datatypes::DiagCodedType,
     value: &str,
 ) -> Result<Vec<u8>, DiagServiceError> {
+    let base_type = data_type.base_datatype();
+    let bit_len = data_type.bit_len();
+    // static assertation for hard type lengths are already made when DataType
+    // `data_type` is constructed. This entails float and ascii length assertions,
+    // therefore there is no need to check them again here.
+    // Bit length validations are only done for types with actual variable bit lengths
+    // (basically all integer types)
     value
         .split_whitespace()
         .map(|value| {
             if value.chars().all(char::is_numeric) {
-                match data_type {
+                match base_type {
                     DataType::ByteField => value
                         .parse::<u64>()
                         .map_err(|_| {
@@ -377,6 +384,10 @@ pub(in crate::diag_kernel) fn string_to_vec_u8(
                             )
                         })
                         .and_then(|v| {
+                            if let Some(bit_len) = bit_len {
+                                validate_bit_len_unsigned(v, bit_len)?;
+                            }
+
                             let bytes = v.to_be_bytes();
                             // Find the first non-zero byte, or keep at least one byte
                             let start = bytes
@@ -392,19 +403,29 @@ pub(in crate::diag_kernel) fn string_to_vec_u8(
                         }),
                     DataType::Int32 => value
                         .parse::<i32>()
-                        .map(|v| v.to_be_bytes().to_vec())
                         .map_err(|_| {
                             DiagServiceError::ParameterConversionError(
                                 "Invalid value type for i32".to_owned(),
                             )
+                        })
+                        .and_then(|v| {
+                            if let Some(bit_len) = bit_len {
+                                validate_bit_len_signed(v, bit_len)?;
+                            }
+                            Ok(v.to_be_bytes().to_vec())
                         }),
                     DataType::UInt32 => value
                         .parse::<u32>()
-                        .map(|v| v.to_be_bytes().to_vec())
                         .map_err(|_| {
                             DiagServiceError::ParameterConversionError(
                                 "Invalid value type for u32".to_owned(),
                             )
+                        })
+                        .and_then(|v| {
+                            if let Some(bit_len) = bit_len {
+                                validate_bit_len_unsigned(v, bit_len)?;
+                            }
+                            Ok(v.to_be_bytes().to_vec())
                         }),
                     DataType::Float32 => value
                         .parse::<f32>()
@@ -433,7 +454,7 @@ pub(in crate::diag_kernel) fn string_to_vec_u8(
                     ))
                 })?;
 
-                match data_type {
+                match base_type {
                     DataType::ByteField => Ok((float_value as u8).to_be_bytes().to_vec()),
                     DataType::Int32 => Ok((float_value as i32).to_be_bytes().to_vec()),
                     DataType::UInt32 => Ok((float_value as u32).to_be_bytes().to_vec()),
@@ -455,38 +476,9 @@ pub(in crate::diag_kernel) fn string_to_vec_u8(
 
 fn json_value_to_byte_vector(
     json_value: &serde_json::Value,
-    data_type: DataType,
+    data_type: &datatypes::DiagCodedType,
 ) -> Result<Vec<u8>, DiagServiceError> {
-    fn convert_integer_to_bytes<T>(
-        json_value: &serde_json::Value,
-        min: T,
-        max: T,
-        data_type: DataType,
-    ) -> Result<Vec<u8>, DiagServiceError>
-    where
-        T: Into<i64> + Copy,
-        i64: From<T>,
-    {
-        let value = json_value
-            .as_i64()
-            .ok_or(DiagServiceError::ParameterConversionError(format!(
-                "Invalid value for {data_type:?}"
-            )))?;
-
-        if value < i64::from(min) || value > i64::from(max) {
-            return Err(DiagServiceError::ParameterConversionError(format!(
-                "Value out of range for {data_type:?}"
-            )));
-        }
-
-        Ok(i32::try_from(value)
-            .map_err(|e| {
-                DiagServiceError::ParameterConversionError(format!("Failed to convert to i32 {e}"))
-            })?
-            .to_be_bytes()
-            .to_vec())
-    }
-
+    let base_type = data_type.base_datatype();
     let data: Result<Vec<u8>, DiagServiceError> = if json_value.is_string() {
         let s = json_value
             .as_str()
@@ -494,16 +486,39 @@ fn json_value_to_byte_vector(
                 "Invalid numeric value".to_owned(),
             ))?;
 
-        string_to_vec_u8(data_type, s)
+        numeric_type_str_to_byte_vec(data_type, s)
     } else if json_value.is_number() {
-        match data_type {
-            DataType::Int32 => convert_integer_to_bytes(json_value, i32::MIN, i32::MAX, data_type),
-            DataType::UInt32 => convert_integer_to_bytes(
-                json_value,
-                i64::from(u32::MIN),
-                i64::from(u32::MAX),
-                data_type,
-            ),
+        match base_type {
+            DataType::Int32 => {
+                let value =
+                    json_value
+                        .as_i64()
+                        .ok_or(DiagServiceError::ParameterConversionError(format!(
+                            "Invalid value for {data_type:?}"
+                        )))?;
+                validate_bit_len_signed(value, data_type.bit_len().unwrap_or(32))?;
+                let int_val: i32 = value.try_into().map_err(|_| {
+                    DiagServiceError::ParameterConversionError(format!(
+                        "Failed to convert {value} to Int32"
+                    ))
+                })?;
+                Ok(int_val.to_be_bytes().to_vec())
+            }
+            DataType::UInt32 => {
+                let value =
+                    json_value
+                        .as_u64()
+                        .ok_or(DiagServiceError::ParameterConversionError(format!(
+                            "Invalid value for {data_type:?}"
+                        )))?;
+                validate_bit_len_unsigned(value, data_type.bit_len().unwrap_or(32))?;
+                let int_val: u32 = value.try_into().map_err(|_| {
+                    DiagServiceError::ParameterConversionError(format!(
+                        "Failed to convert {value} to UInt32"
+                    ))
+                })?;
+                Ok(int_val.to_be_bytes().to_vec())
+            }
             DataType::Float32 => {
                 #[allow(clippy::cast_possible_truncation)] // truncating f64 to f32 is intended here
                 json_value
@@ -530,11 +545,11 @@ fn json_value_to_byte_vector(
     };
 
     if let Ok(data) = data.as_ref() {
-        match data_type {
+        match base_type {
             DataType::Int32 | DataType::UInt32 | DataType::Float32 => {
                 if data.len() > 4 {
                     return Err(DiagServiceError::ParameterConversionError(format!(
-                        "Invalid data length for {data_type:?}: {}, value {json_value}",
+                        "Invalid data length {} for {base_type:?} value {json_value}",
                         data.len()
                     )));
                 }
@@ -542,7 +557,7 @@ fn json_value_to_byte_vector(
             DataType::Float64 => {
                 if data.len() > 8 {
                     return Err(DiagServiceError::ParameterConversionError(format!(
-                        "Invalid data length for {data_type:?}: {}, value {json_value}",
+                        "Invalid data length for {base_type:?}: {}, value {json_value}",
                         data.len()
                     )));
                 }
@@ -553,50 +568,163 @@ fn json_value_to_byte_vector(
     data
 }
 
+fn validate_bit_len_signed<T>(value: T, bit_len: BitLength) -> Result<(), DiagServiceError>
+where
+    T: Copy
+        + From<i8>
+        + PartialOrd
+        + std::fmt::Display
+        + num_traits::CheckedShl
+        + num_traits::CheckedNeg
+        + num_traits::CheckedSub
+        + num_traits::Saturating
+        + num_traits::bounds::UpperBounded
+        + num_traits::bounds::LowerBounded
+        + num_traits::Signed,
+{
+    if bit_len == 0 {
+        return Err(DiagServiceError::ParameterConversionError(
+            "Bit length 0 is not allowed for validation".to_owned(),
+        ));
+    }
+
+    let max_value = T::from(1)
+        .checked_shl(bit_len.saturating_sub(1))
+        .and_then(|v| v.checked_sub(&T::from(1)))
+        .unwrap_or_else(T::max_value); // min/max is needed, when bit length == size of T
+
+    let min_value = T::from(1)
+        .checked_shl(bit_len.saturating_sub(1))
+        .and_then(|v| v.checked_neg())
+        .unwrap_or_else(T::min_value);
+
+    if value < min_value {
+        return Err(DiagServiceError::ParameterConversionError(format!(
+            "Value {value} is below minimum {min_value} for bit length {bit_len}",
+        )));
+    }
+
+    if value > max_value {
+        return Err(DiagServiceError::ParameterConversionError(format!(
+            "Value {value} exceeds maximum {max_value} for bit length {bit_len}",
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_bit_len_unsigned<T>(value: T, bit_len: BitLength) -> Result<(), DiagServiceError>
+where
+    T: Copy
+        + From<u8>
+        + PartialOrd
+        + std::fmt::Display
+        + num_traits::CheckedShl
+        + num_traits::Saturating
+        + num_traits::bounds::UpperBounded
+        + num_traits::Unsigned,
+{
+    if bit_len == 0 {
+        return Err(DiagServiceError::ParameterConversionError(
+            "Bit length 0 is not allowed for validation".to_owned(),
+        ));
+    }
+
+    // range is 0 to 2^bits - 1
+    // (T::from(1) << bit_len) - T::from(1);
+    let max_value = T::from(1)
+        .checked_shl(bit_len)
+        // max is needed, when bit length == size of T
+        .map_or_else(T::max_value, |v| v.saturating_sub(T::from(1)));
+
+    if value > max_value {
+        return Err(DiagServiceError::ParameterConversionError(format!(
+            "Value {value} exceeds maximum {max_value} for bit length {bit_len}",
+        )));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use cda_database::datatypes::{
-        CompuCategory, CompuFunction, CompuMethod, CompuRationalCoefficients, CompuScale,
-        CompuValues, DataType, IntervalType, Limit,
+        BitLength, CompuCategory, CompuFunction, CompuMethod, CompuRationalCoefficients,
+        CompuScale, CompuValues, DataType, DiagCodedType, DiagCodedTypeVariant, IntervalType,
+        Limit, StandardLengthType,
     };
+
+    /// Helper function to create a `DiagCodedType` for testing
+    fn create_diag_coded_type(
+        data_type: DataType,
+        bit_length_override: Option<BitLength>,
+    ) -> DiagCodedType {
+        let bit_length = bit_length_override.unwrap_or(match data_type {
+            DataType::Int32 | DataType::UInt32 | DataType::Float32 => 32,
+            DataType::Float64 => 64,
+            DataType::ByteField
+            | DataType::AsciiString
+            | DataType::Utf8String
+            | DataType::Unicode2String => 8, // Default to 8 bits for variable length types
+        });
+        DiagCodedType::new(
+            data_type,
+            DiagCodedTypeVariant::StandardLength(StandardLengthType {
+                bit_length,
+                bit_mask: None,
+                condensed: false,
+            }),
+            true, // high-low byte order
+        )
+        .unwrap()
+    }
 
     #[test]
     fn test_hex_values() {
         let json_value = serde_json::json!("0x11223344");
-        let result = super::json_value_to_uds_data(DataType::ByteField, None, &json_value);
+        let diag_type = create_diag_coded_type(DataType::ByteField, None);
+        let result = super::json_value_to_uds_data(&diag_type, None, &json_value);
         assert_eq!(result, Ok(vec![0x11, 0x22, 0x33, 0x44]));
     }
 
     #[test]
     fn test_integer_out_of_range() {
         let json_value = serde_json::json!(i64::MAX);
-        assert!(super::json_value_to_uds_data(DataType::Int32, None, &json_value).is_err());
-        assert!(super::json_value_to_uds_data(DataType::UInt32, None, &json_value).is_err());
+        let int32_type = create_diag_coded_type(DataType::Int32, None);
+        let uint32_type = create_diag_coded_type(DataType::UInt32, None);
+        assert!(super::json_value_to_uds_data(&int32_type, None, &json_value).is_err());
+        assert!(super::json_value_to_uds_data(&uint32_type, None, &json_value).is_err());
     }
 
     #[test]
     fn test_hex_values_odd() {
         let json_value = serde_json::json!("0x1 0x2");
 
+        let bytefield_type = create_diag_coded_type(DataType::ByteField, None);
+        let float64_type = create_diag_coded_type(DataType::Float64, None);
+        let float32_type = create_diag_coded_type(DataType::Float32, None);
+        let int32_type = create_diag_coded_type(DataType::Int32, None);
+        let uint32_type = create_diag_coded_type(DataType::UInt32, None);
+
         let expected = Ok(vec![0x1, 0x2]);
         assert_eq!(
-            super::json_value_to_uds_data(DataType::ByteField, None, &json_value),
+            super::json_value_to_uds_data(&bytefield_type, None, &json_value),
             expected
         );
         assert_eq!(
-            super::json_value_to_uds_data(DataType::Float64, None, &json_value),
+            super::json_value_to_uds_data(&float64_type, None, &json_value),
             expected
         );
         assert_eq!(
-            super::json_value_to_uds_data(DataType::Float32, None, &json_value),
+            super::json_value_to_uds_data(&float32_type, None, &json_value),
             expected
         );
         assert_eq!(
-            super::json_value_to_uds_data(DataType::Int32, None, &json_value),
+            super::json_value_to_uds_data(&int32_type, None, &json_value),
             expected
         );
         assert_eq!(
-            super::json_value_to_uds_data(DataType::UInt32, None, &json_value),
+            super::json_value_to_uds_data(&uint32_type, None, &json_value),
             expected
         );
     }
@@ -604,25 +732,32 @@ mod tests {
     #[test]
     fn test_space_separated_hex_values() {
         let json_value = serde_json::json!("0x00 0x01 0x80 0x00");
+
+        let bytefield_type = create_diag_coded_type(DataType::ByteField, None);
+        let float64_type = create_diag_coded_type(DataType::Float64, None);
+        let float32_type = create_diag_coded_type(DataType::Float32, None);
+        let int32_type = create_diag_coded_type(DataType::Int32, None);
+        let uint32_type = create_diag_coded_type(DataType::UInt32, None);
+
         let expected = Ok(vec![0x00, 0x01, 0x80, 0x00]);
         assert_eq!(
-            super::json_value_to_uds_data(DataType::ByteField, None, &json_value),
+            super::json_value_to_uds_data(&bytefield_type, None, &json_value),
             expected
         );
         assert_eq!(
-            super::json_value_to_uds_data(DataType::Float64, None, &json_value),
+            super::json_value_to_uds_data(&float64_type, None, &json_value),
             expected
         );
         assert_eq!(
-            super::json_value_to_uds_data(DataType::Float32, None, &json_value),
+            super::json_value_to_uds_data(&float32_type, None, &json_value),
             expected
         );
         assert_eq!(
-            super::json_value_to_uds_data(DataType::Int32, None, &json_value),
+            super::json_value_to_uds_data(&int32_type, None, &json_value),
             expected
         );
         assert_eq!(
-            super::json_value_to_uds_data(DataType::UInt32, None, &json_value),
+            super::json_value_to_uds_data(&uint32_type, None, &json_value),
             expected
         );
     }
@@ -630,7 +765,8 @@ mod tests {
     #[test]
     fn test_mixed_values() {
         let json_value = serde_json::json!("ff 0a 128 deadbeef ca7");
-        let result = super::json_value_to_uds_data(DataType::ByteField, None, &json_value);
+        let diag_type = create_diag_coded_type(DataType::ByteField, None);
+        let result = super::json_value_to_uds_data(&diag_type, None, &json_value);
         assert_eq!(
             result,
             Ok(vec![255, 10, 128, 0xde, 0xad, 0xbe, 0xef, 0xca, 0x07])
@@ -640,21 +776,24 @@ mod tests {
     #[test]
     fn test_hex_long() {
         let json_value = serde_json::json!("c0ffeca7");
-        let result = super::json_value_to_uds_data(DataType::ByteField, None, &json_value);
+        let diag_type = create_diag_coded_type(DataType::ByteField, None);
+        let result = super::json_value_to_uds_data(&diag_type, None, &json_value);
         assert_eq!(result, Ok(vec![0xc0, 0xff, 0xec, 0xa7]));
     }
 
     #[test]
     fn test_invalid_hex_value() {
         let json_value = serde_json::json!("0xZZ");
-        let result = super::json_value_to_uds_data(DataType::ByteField, None, &json_value);
+        let diag_type = create_diag_coded_type(DataType::ByteField, None);
+        let result = super::json_value_to_uds_data(&diag_type, None, &json_value);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_long_byte_value() {
         let json_value = serde_json::json!("256");
-        let result = super::json_value_to_uds_data(DataType::ByteField, None, &json_value);
+        let diag_type = create_diag_coded_type(DataType::ByteField, Some(9));
+        let result = super::json_value_to_uds_data(&diag_type, None, &json_value);
         assert_eq!(result, Ok(vec![0x01, 0x00]));
     }
 
@@ -662,26 +801,32 @@ mod tests {
     fn test_float_string() {
         let json_value = serde_json::json!("10.42");
 
+        let int32_type = create_diag_coded_type(DataType::Int32, None);
+        let uint32_type = create_diag_coded_type(DataType::UInt32, None);
+        let bytefield_type = create_diag_coded_type(DataType::ByteField, None);
+        let float32_type = create_diag_coded_type(DataType::Float32, None);
+        let float64_type = create_diag_coded_type(DataType::Float64, None);
+
         let int_result = Ok(vec![0x00, 0x00, 0x00, 0x0a]);
         assert_eq!(
-            super::json_value_to_uds_data(DataType::Int32, None, &json_value),
+            super::json_value_to_uds_data(&int32_type, None, &json_value),
             int_result
         );
         assert_eq!(
-            super::json_value_to_uds_data(DataType::UInt32, None, &json_value),
+            super::json_value_to_uds_data(&uint32_type, None, &json_value),
             int_result
         );
         assert_eq!(
-            super::json_value_to_uds_data(DataType::ByteField, None, &json_value),
+            super::json_value_to_uds_data(&bytefield_type, None, &json_value),
             Ok(vec![0x0a])
         );
 
         assert_eq!(
-            super::json_value_to_uds_data(DataType::Float32, None, &json_value),
+            super::json_value_to_uds_data(&float32_type, None, &json_value),
             Ok(vec![65, 38, 184, 82])
         );
         assert_eq!(
-            super::json_value_to_uds_data(DataType::Float64, None, &json_value),
+            super::json_value_to_uds_data(&float64_type, None, &json_value),
             Ok(vec![64, 36, 215, 10, 61, 112, 163, 215])
         );
     }
@@ -690,16 +835,22 @@ mod tests {
     fn test_float() {
         let json_value = serde_json::json!(10.42);
 
-        assert!(super::json_value_to_uds_data(DataType::Int32, None, &json_value).is_err());
-        assert!(super::json_value_to_uds_data(DataType::UInt32, None, &json_value).is_err());
-        assert!(super::json_value_to_uds_data(DataType::ByteField, None, &json_value).is_err());
+        let int32_type = create_diag_coded_type(DataType::Int32, None);
+        let uint32_type = create_diag_coded_type(DataType::UInt32, None);
+        let bytefield_type = create_diag_coded_type(DataType::ByteField, None);
+        let float32_type = create_diag_coded_type(DataType::Float32, None);
+        let float64_type = create_diag_coded_type(DataType::Float64, None);
+
+        assert!(super::json_value_to_uds_data(&int32_type, None, &json_value).is_err());
+        assert!(super::json_value_to_uds_data(&uint32_type, None, &json_value).is_err());
+        assert!(super::json_value_to_uds_data(&bytefield_type, None, &json_value).is_err());
 
         assert_eq!(
-            super::json_value_to_uds_data(DataType::Float32, None, &json_value),
+            super::json_value_to_uds_data(&float32_type, None, &json_value),
             Ok(vec![65, 38, 184, 82])
         );
         assert_eq!(
-            super::json_value_to_uds_data(DataType::Float64, None, &json_value),
+            super::json_value_to_uds_data(&float64_type, None, &json_value),
             Ok(vec![64, 36, 215, 10, 61, 112, 163, 215])
         );
     }
@@ -862,5 +1013,108 @@ mod tests {
             &value,
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_numeric_type_str_to_byte_vec_invalid_bit_values() {
+        // Test ByteField with 8-bit length - value 256 exceeds 8 bits
+        let bytefield_8bit = DiagCodedType::new(
+            DataType::ByteField,
+            DiagCodedTypeVariant::StandardLength(StandardLengthType {
+                bit_length: 8,
+                bit_mask: None,
+                condensed: false,
+            }),
+            true,
+        )
+        .unwrap();
+        super::numeric_type_str_to_byte_vec(&bytefield_8bit, "256").unwrap_err();
+
+        // Test UInt32 with 16-bit length - value 65536 exceeds 16 bits
+        let uint32_16bit = DiagCodedType::new(
+            DataType::UInt32,
+            DiagCodedTypeVariant::StandardLength(StandardLengthType {
+                bit_length: 16,
+                bit_mask: None,
+                condensed: false,
+            }),
+            true,
+        )
+        .unwrap();
+        super::numeric_type_str_to_byte_vec(&uint32_16bit, "65536").unwrap_err();
+
+        // Test Int32 with 8-bit length - value 128 exceeds signed 8-bit range (-128 to 127)
+        let int32_8bit = DiagCodedType::new(
+            DataType::Int32,
+            DiagCodedTypeVariant::StandardLength(StandardLengthType {
+                bit_length: 8,
+                bit_mask: None,
+                condensed: false,
+            }),
+            true,
+        )
+        .unwrap();
+        super::numeric_type_str_to_byte_vec(&int32_8bit, "128").unwrap_err();
+        super::numeric_type_str_to_byte_vec(&int32_8bit, "-129").unwrap_err();
+    }
+
+    #[test]
+    fn test_validate_bit_len_signed() {
+        // Test with bit len = 0 (invalid)
+        assert!(super::validate_bit_len_signed(0i16, 0).is_err());
+
+        // Test with bit_len = 8 (range: -128 to 127)
+        assert!(super::validate_bit_len_signed(-128i16, 8).is_ok());
+        assert!(super::validate_bit_len_signed(127i16, 8).is_ok());
+        assert!(super::validate_bit_len_signed(0i16, 8).is_ok());
+        assert!(super::validate_bit_len_signed(-129i16, 8).is_err());
+        assert!(super::validate_bit_len_signed(128i16, 8).is_err());
+
+        // Test boundary values for bit_len = 7 (range: -64 to 63)
+        assert!(super::validate_bit_len_signed(-64i16, 7).is_ok());
+        assert!(super::validate_bit_len_signed(63i16, 7).is_ok());
+        assert!(super::validate_bit_len_signed(-65i16, 7).is_err());
+        assert!(super::validate_bit_len_signed(64i16, 7).is_err());
+
+        // Test edge case: bit_len equal to type size
+        assert!(super::validate_bit_len_signed(i8::MIN, 7).is_err());
+        assert!(super::validate_bit_len_signed(i8::MIN, 8).is_ok());
+        assert!(super::validate_bit_len_signed(i8::MAX, 8).is_ok());
+        assert!(super::validate_bit_len_signed(i16::MIN, 16).is_ok());
+        assert!(super::validate_bit_len_signed(i16::MAX, 16).is_ok());
+    }
+
+    #[test]
+    fn test_validate_bit_len_unsigned() {
+        // Test with bit_len = 0 (invalid)
+        assert!(super::validate_bit_len_unsigned(0u8, 0).is_err());
+
+        // Test with bit_len = 8 (range: 0 to 255)
+        assert!(super::validate_bit_len_unsigned(0u16, 8).is_ok());
+        assert!(super::validate_bit_len_unsigned(255u16, 8).is_ok());
+        assert!(super::validate_bit_len_unsigned(128u16, 8).is_ok());
+        assert!(super::validate_bit_len_unsigned(256u16, 8).is_err());
+
+        // Test with bit_len = 16 (range: 0 to 65535)
+        assert!(super::validate_bit_len_unsigned(0u32, 16).is_ok());
+        assert!(super::validate_bit_len_unsigned(65535u32, 16).is_ok());
+        assert!(super::validate_bit_len_unsigned(32768u32, 16).is_ok());
+        assert!(super::validate_bit_len_unsigned(65536u32, 16).is_err());
+
+        // Test boundary values for u8 with bit_len = 7 (range: 0 to 127)
+        assert!(super::validate_bit_len_unsigned(0u8, 7).is_ok());
+        assert!(super::validate_bit_len_unsigned(127u8, 7).is_ok());
+        assert!(super::validate_bit_len_unsigned(128u8, 7).is_err());
+
+        // Test edge case: bit_len equal to type size
+        assert!(super::validate_bit_len_unsigned(u8::MIN, 8).is_ok());
+        assert!(super::validate_bit_len_unsigned(u8::MAX, 8).is_ok());
+        assert!(super::validate_bit_len_unsigned(u16::MIN, 16).is_ok());
+        assert!(super::validate_bit_len_unsigned(u16::MAX, 16).is_ok());
+
+        // Test middle values
+        assert!(super::validate_bit_len_unsigned(5u8, 4).is_ok());
+        assert!(super::validate_bit_len_unsigned(15u8, 4).is_ok());
+        assert!(super::validate_bit_len_unsigned(16u8, 4).is_err());
     }
 }

--- a/cda-database/src/datatypes/diag_coded_type.rs
+++ b/cda-database/src/datatypes/diag_coded_type.rs
@@ -184,6 +184,17 @@ impl DiagCodedType {
     }
 
     #[must_use]
+    pub fn bit_len(&self) -> Option<BitLength> {
+        match &self.type_ {
+            DiagCodedTypeVariant::LeadingLengthInfo(bit_len) => Some(*bit_len),
+            DiagCodedTypeVariant::MinMaxLength(_min_max) => None,
+            DiagCodedTypeVariant::StandardLength(standard_length) => {
+                Some(standard_length.bit_length)
+            }
+        }
+    }
+
+    #[must_use]
     pub fn type_(&self) -> &DiagCodedTypeVariant {
         &self.type_
     }
@@ -551,6 +562,13 @@ impl DiagCodedType {
 
                 let (packed, len) =
                     pack_data(slt.bit_length as usize, 0, mask.as_ref(), &input_data)?;
+                if len > slt.bit_length as usize {
+                    return Err(DiagServiceError::BadPayload(format!(
+                        "StandardLengthType input data length {len} bits exceeds allowed length \
+                         {} bits",
+                        slt.bit_length
+                    )));
+                }
                 (packed, len, mask)
             }
         };


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

This commit introduces validation for bit lenghts. Prior to this commit the below example would have been passed to the ECU, although it is not valid per ODX.
* Bit length 3
* No limits set on datatypes
* Value is 0x42

This value exceeds the maximum value, but was accepted. In this commit validation is added, and an error is returned.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers


--- 

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
