### PR TITLE
ecu-manager: improve payload parsing

### DIFF
--- a/cda-core/src/diag_kernel/operations.rs
+++ b/cda-core/src/diag_kernel/operations.rs
@@ -311,6 +311,14 @@ pub(in crate::diag_kernel) fn extract_diag_data_container(
     let byte_pos = param.byte_position() as usize;
     let uds_payload = payload.data()?;
     let (data, bit_len) = diag_type.decode(uds_payload, byte_pos, param.bit_position() as usize)?;
+    if data.is_empty() {
+        // at least 1 byte expected, we are using NotEnoughData error here, because
+        // this might happen when parsing end of pdu and leftover bytes can be ignored
+        return Err(DiagServiceError::NotEnoughData {
+            expected: 1,
+            actual: 0,
+        });
+    }
 
     let data_type = diag_type.base_datatype();
     payload.set_last_read_byte_pos(byte_pos.saturating_add(data.len()));

--- a/cda-core/src/diag_kernel/payload.rs
+++ b/cda-core/src/diag_kernel/payload.rs
@@ -72,7 +72,7 @@ impl<'a> Payload<'a> {
         }
     }
 
-    pub(in crate::diag_kernel) fn consume(&mut self) {
+    pub(in crate::diag_kernel) fn consume(&mut self) -> usize {
         let advance_len = self.last_read_byte_pos.saturating_add(self.bytes_to_skip);
         if self.pos().saturating_add(advance_len) > self.data.len() {
             self.current_index = self.data.len(); // Move to the end if we exceed
@@ -81,6 +81,7 @@ impl<'a> Payload<'a> {
         }
         self.last_read_byte_pos = 0;
         self.bytes_to_skip = 0;
+        advance_len
     }
 
     pub(in crate::diag_kernel) fn len(&self) -> usize {

--- a/cda-database/src/datatypes/diag_coded_type.rs
+++ b/cda-database/src/datatypes/diag_coded_type.rs
@@ -410,11 +410,10 @@ impl DiagCodedType {
         let start_pos = byte_pos.saturating_add(length_info_bytes.len());
         let end_pos = start_pos.saturating_add(len);
         if end_pos > uds_payload.len() {
-            return Err(DiagServiceError::BadPayload(format!(
-                "Not enough data in payload: need {} bytes, but only {} bytes available",
-                end_pos,
-                uds_payload.len()
-            )));
+            return Err(DiagServiceError::NotEnoughData {
+                expected: end_pos,
+                actual: uds_payload.len(),
+            });
         }
         Ok((
             end_pos.saturating_sub(start_pos).saturating_mul(8),


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
* ignore garbage bytes at end of pdu
* catch edge case where no data was consumed at end of pdu causing infinite loop.

This was noticed when a simulated ECU returned garbage bytes at end of PDU, which is okay according to the spec, but was not properly handled. 

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->


---


Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
