### PR TITLE
sovd: add mode to ecu response

### DIFF
--- a/cda-sovd-interfaces/src/components/ecu/mod.rs
+++ b/cda-sovd-interfaces/src/components/ecu/mod.rs
@@ -51,6 +51,7 @@ pub struct Ecu {
     #[serde(rename = "x-single-ecu-jobs")]
     pub single_ecu_jobs: String,
     pub faults: String,
+    pub modes: String,
     #[schemars(skip)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<schemars::Schema>,

--- a/cda-sovd/src/sovd/components/ecu/mod.rs
+++ b/cda-sovd/src/sovd/components/ecu/mod.rs
@@ -108,6 +108,7 @@ pub(crate) async fn get<R: DiagServiceResponse, T: UdsEcu + Clone, U: FileManage
             sdgs,
             single_ecu_jobs: format!("{base_path}/x-single-ecu-jobs"),
             faults: format!("{base_path}/faults"),
+            modes: format!("{base_path}/modes"),
             schema,
         }),
     )
@@ -138,6 +139,7 @@ pub(crate) fn docs_get(op: TransformOperation) -> TransformOperation {
                     "http://localhost:20002/vehicle/v15/components/my_ecu/x-single-ecu-jobs"
                         .to_string(),
                 faults: "http://localhost:20002/vehicle/v15/components/my_ecu/faults".to_string(),
+                modes: "http://localhost:20002/vehicle/v15/components/my_ecu/modes".to_string(),
                 schema: None,
             })
             .description("Response with ECU information (i.e. detected variant) and service URLs")


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

/vehicle/v15/components/<ecu> was missing 'modes'
as part of the response.
This trivial fix is adding the missing endpoint to the response
```json
{
  "id": "my_ecu",
  "name": "my_ecu",
  "variant": {
    "name": "my_variant",
    "is_base_variant": false,
    "state": "Online",
    "logical_address": "0x42"
  },
  "locks": "http://localhost:20002/vehicle/v15/components/my_ecu/locks",
  "operations": "http://localhost:20002/vehicle/v15/components/my_ecu/operations",
  "data": "http://localhost:20002/vehicle/v15/components/my_ecu/data",
  "configurations": "http://localhost:20002/vehicle/v15/components/my_ecu/configurations",
  "x-single-ecu-jobs": "http://localhost:20002/vehicle/v15/components/my_ecu/x-single-ecu-jobs",
  "faults": "http://localhost:20002/vehicle/v15/components/my_ecu/faults",
  "modes": "http://localhost:20002/vehicle/v15/components/my_ecu/modes" <--- new
}
```


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
---

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)