### PR TITLE
chore: fix clippy lints for nightly 1.93

### DIFF
--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -699,7 +699,7 @@ async fn send_alive_request(conn: &EcuConnectionTarget) -> Result<(), ()> {
                 return;
             };
             let reader = reader_mtx.get_reader();
-            match try_read(Duration::from_millis(1000), reader).await {
+            match try_read(Duration::from_secs(1), reader).await {
                 Some(Ok(DiagnosticResponse::AliveCheckResponse)) => {
                     tracing::debug!("Alive check OK");
                 }

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -33,7 +33,7 @@ mod connections;
 mod ecu_connection;
 mod vir_vam;
 
-const SLEEP_INTERVAL: Duration = Duration::from_millis(30000);
+const SLEEP_INTERVAL: Duration = Duration::from_secs(30);
 
 const NRC_BUSY_REPEAT_REQUEST: u8 = 0x21;
 const NRC_RESPONSE_PENDING: u8 = 0x78;

--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -50,7 +50,7 @@ where
 
     let mut gateways = Vec::new();
 
-    let vam_timeout = Duration::from_millis(1000); // not the actual timeout from the spec ...
+    let vam_timeout = Duration::from_secs(1); // not the actual timeout from the spec ...
     loop {
         tokio::select! {
             () = shutdown_signal.clone() => {

--- a/cda-database/src/mdd_data/files.rs
+++ b/cda-database/src/mdd_data/files.rs
@@ -44,6 +44,8 @@ impl FileManager {
     #[must_use]
     pub fn new(mdd_path: String, files: Vec<Chunk>) -> Self {
         let mdd_name = mdd_path.split('/').next_back().unwrap_or("mdd").to_string();
+        // Duration::from_mins is only available in rust >= 1.91.0, we want to support 1.88.0
+        #[allow(unknown_lints, clippy::duration_suboptimal_units)]
         let cache_lifetime = Duration::from_secs(60 * 5);
 
         let files = Arc::new(RwLock::new(

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -287,7 +287,7 @@ pub async fn load_databases<S: SecurityPlugin>(
             })
             .collect::<Vec<_>>();
 
-        files.sort_by(|a, b| b.1.cmp(&a.1));
+        files.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         let chunk_size = files
             .len()

--- a/cda-sovd/src/sovd/locks.rs
+++ b/cda-sovd/src/sovd/locks.rs
@@ -1135,8 +1135,7 @@ fn schedule_token_deletion(
 
     let secs = duration_until_target
         .to_std()
-        .map(|std_duration| std_duration.as_secs())
-        .unwrap_or(0);
+        .map_or(0, |std_duration| std_duration.as_secs());
 
     let target_instant = Instant::now()
         .checked_add(Duration::from_secs(secs))
@@ -1228,6 +1227,8 @@ mod tests {
     #[tokio::test]
     async fn test_ecu_lock_cleanup_calls_reset() {
         let (mock_uds, ecu_name, locks) = setup_ecu_lock_test();
+        // Duration::from_mins is only available in rust >= 1.91.0, we want to support 1.88.0
+        #[allow(unknown_lints, clippy::duration_suboptimal_units)]
         let lock_id = create_ecu_lock(&mock_uds, &locks, &ecu_name, Duration::from_secs(60)).await;
 
         let delete_response = delete_handler(
@@ -1283,6 +1284,8 @@ mod tests {
     #[tokio::test]
     async fn test_vehicle_lock_cleanup_calls_reset_for_all_ecus() {
         let (mock_uds, locks) = setup_vehicle_lock_test();
+        // Duration::from_mins is only available in rust >= 1.91.0, we want to support 1.88.0
+        #[allow(unknown_lints, clippy::duration_suboptimal_units)]
         let lock_id = create_vehicle_lock(&mock_uds, &locks, Duration::from_secs(60)).await;
 
         let delete_response = delete_handler(

--- a/integration-tests/tests/sovd/ecu.rs
+++ b/integration-tests/tests/sovd/ecu.rs
@@ -50,6 +50,8 @@ async fn test_ecu_session_switching() {
     .await
     .unwrap();
 
+    // Duration::from_mins is only available in rust >= 1.91.0, we want to support 1.88.0
+    #[allow(unknown_lints, clippy::duration_suboptimal_units)]
     let expiration_timeout = Duration::from_secs(60);
     let ecu_lock = create_lock(
         expiration_timeout,
@@ -354,6 +356,8 @@ async fn test_communication_control() {
     .unwrap();
 
     // Create and acquire lock
+    // Duration::from_mins is only available in rust >= 1.91.0, we want to support 1.88.0
+    #[allow(unknown_lints, clippy::duration_suboptimal_units)]
     let expiration_timeout = Duration::from_secs(60);
     let ecu_lock = create_lock(
         expiration_timeout,

--- a/integration-tests/tests/sovd/locks.rs
+++ b/integration-tests/tests/sovd/locks.rs
@@ -556,6 +556,8 @@ pub(crate) async fn create_lock(
 }
 
 fn default_timeout() -> Duration {
+    // Duration::from_hours is only available in rust >= 1.91.0, we want to support 1.88.0
+    #[allow(unknown_lints, clippy::duration_suboptimal_units)]
     Duration::from_secs(3600)
 }
 

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -431,9 +431,7 @@ pub(crate) async fn restart_cda(config: &Configuration) -> Result<(), TestingErr
 }
 
 fn use_docker() -> bool {
-    std::env::var(CDA_INTEGRATION_TEST_USE_DOCKER)
-        .map(|s| s == "true")
-        .unwrap_or(true)
+    std::env::var(CDA_INTEGRATION_TEST_USE_DOCKER).map_or(true, |s| s == "true")
 }
 
 async fn wait_for_http_ready(
@@ -538,9 +536,8 @@ fn test_container_dir() -> Result<std::path::PathBuf, TestingError> {
 
 fn register_cleanup() {
     extern "C" fn cleanup_handler() {
-        let use_docker = std::env::var(CDA_INTEGRATION_TEST_USE_DOCKER)
-            .map(|s| s == "true")
-            .unwrap_or(true);
+        let use_docker =
+            std::env::var(CDA_INTEGRATION_TEST_USE_DOCKER).map_or(true, |s| s == "true");
 
         if use_docker {
             if let Err(e) = docker_compose_down(None) {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

This commit fixes the clippy lints for rust nightly 1.93. Many of the lints are about the newish duration_suboptimal_units. This lint had to be disabled as the new durations are not available on 1.88.0.
To do this unknown_lints has to be used together
with clippy::duration_suboptimal_units as the lint as well isn't available on 1.88.0.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers

Although our primary target is 1.88.0, for local development I am usually just using the latest nightly release, as it comes with further linting improvements.
This new lints had to be disabled though due to missing support.


---

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)