### PR TITLE
version: make the version endpoint SOVD compliant

### DIFF
--- a/cda-main/src/main.rs
+++ b/cda-main/src/main.rs
@@ -153,14 +153,21 @@ async fn main() -> Result<(), AppError> {
     )
     .await?;
 
-    if let serde_json::Value::Object(version_info) = serde_json::json!(
-    {
-        "server_version": cda_version(),
-        "server_type": "Eclipse OpenSOVD Classic Diagnostics Adapter",
-        "commit": env!("GIT_COMMIT_HASH").to_owned(),
-        "build_date": env!("BUILD_DATE").to_owned(),
-    }
-    ) {
+    if let serde_json::Value::Object(version_info) = serde_json::json!({
+        "id": "version",
+        "data": {
+            "name": "Eclipse OpenSOVD Classic Diagnostics Adapter",
+            "api": {
+                // 1.1 to match the sovd standard version
+                "version": "1.1"
+            },
+            "implementation": {
+                "version": cda_version(),
+                "commit": env!("GIT_COMMIT_HASH").to_owned(),
+                "build_date": env!("BUILD_DATE").to_owned(),
+            }
+        }
+    }) {
         cda_sovd::add_version_endpoint(&dynamic_router, version_info).await;
     } else {
         tracing::error!("Failed to build version information");


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
data endpoints should contain 'id' and data.
This change makes the version endpoint compliant with this

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers


Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
