### PR TITLE
core: Add public APIs to EcuManager for service parameter introspection, MUX case discovery and UDS request parsing

### DIFF
--- a/cda-interfaces/src/lib.rs
+++ b/cda-interfaces/src/lib.rs
@@ -211,6 +211,12 @@ const OPERATIONS_PREFIXES: [u8; 5] = [
     service_ids::REQUEST_TRANSFER_EXIT,
 ];
 
+pub const SERVICE_IDS_PARAMETER_META_DATA: [u8; 3] = [
+    service_ids::READ_DATA_BY_IDENTIFIER,
+    service_ids::WRITE_DATA_BY_IDENTIFIER,
+    service_ids::ROUTINE_CONTROL,
+];
+
 impl TesterPresentType {
     #[must_use]
     pub fn is_functional(&self) -> bool {


### PR DESCRIPTION
Adding 3 new public APIs to EcuManager for service parameter introspection, MUX case discovery (discover service capabilities at runtime without parsing MDD files directly.) and parsing UDS request required for uds2sovdproxy.

1. get_service_parameter_metadata()
Purpose: Extract parameter metadata (CODED-CONST, PHYS-CONST, VALUE) from service definitions.

2. get_mux_cases_for_service()
Purpose: Retrieve MUX case information from service positive responses.

3. convert_request_from_uds()
Purpose: Parses incoming **REQUEST** payloads (not responses) using MDD REQUEST structure definitions.
- Takes raw UDS request bytes [SID, DID/Param..., DATA...]
- Parses according to MDD REQUEST definition
- Extracts all parameters with their types and values
- Returns JSON-mapped structure

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
