### PR TITLE
ci-cd: Add nightly stage without pinned version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,18 @@ concurrency:
 
 jobs:
   format_and_clippy_nightly_toolchain:
+    concurrency:
+      group: format_and_clippy_nightly_toolchain-${{ github.ref }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - toolchain: nightly-2025-07-14
+            allow-failure: false
+          - toolchain: nightly
+            allow-failure: true
+    continue-on-error: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -36,10 +47,12 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2025-07-14
+          toolchain: ${{ matrix.toolchain }}
           components: clippy, rustfmt
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.toolchain }}
       - name: Formating - check for long lines
         run: cargo fmt -- --check --config error_on_unformatted=true,error_on_line_overflow=true,format_strings=true
       - name: Formatting - check import order
@@ -48,8 +61,14 @@ jobs:
         run: cargo fmt -- --check --config imports_granularity=Crate
       - name: Formatting - check hex literals
         run: cargo fmt -- --check --config hex_literal_case=Upper
-      - name: run clippy nightly
-        run: cargo clippy --locked --all-targets -- -D warnings
+      - name: Clippy
+        uses: giraffate/clippy-action@v1
+        with:
+          reporter: 'github-check'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          clippy_flags: --locked --all-targets --features integration-tests ${{ matrix.allow-failure == false && '-- -D warnings' || '' }}
+          filter_mode: 'nofilter'
+          fail_on_error: ${{ !matrix.allow-failure }}
 
   features:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Improves the clippy output.
Hints are now annoated at the line they occur.
Nightly findings as warning, nightly-2025.. pinned as error.

<img width="630" height="878" alt="image" src="https://github.com/user-attachments/assets/dcdc1732-a422-44f1-971b-3707d83a0bc2" />


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->


Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)