### PR TITLE
improve state lookup and integration tests

### DIFF
--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -1378,7 +1378,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
         let current_session = ecu_diag_service.read().await.session().await?;
 
         if current_session == default_session {
-            tracing::debug!("Already in default session, nothing to do");
+            tracing::info!("Already in default session, nothing to do");
             return Ok(());
         }
 

--- a/integration-tests/tests/sovd/ecu.rs
+++ b/integration-tests/tests/sovd/ecu.rs
@@ -733,8 +733,8 @@ async fn test_ecu_session_reset_on_lock_reacquire() {
     let lock_id =
         extract_field_from_json::<String>(&response_to_json(&ecu_lock).unwrap(), "id").unwrap();
 
-    // Set session with 3s expiry
-    let session_expiration = 3u64;
+    // Set session with 2s expiry
+    let session_expiration = 2u64;
     let switch_session_result: modes::security_and_session::put::Response<String> = put_mode(
         &runtime.config,
         &auth,
@@ -769,6 +769,7 @@ async fn test_ecu_session_reset_on_lock_reacquire() {
     let ecu_state_after_expiry = ecusim::get_ecu_state(&runtime.ecu_sim, "flxc1000")
         .await
         .expect("Failed to get ECU sim state after session expiry");
+
     assert_eq!(
         ecu_state_after_expiry.session_state,
         Some(ecusim::SessionState::Default),

--- a/integration-tests/tests/sovd/mod.rs
+++ b/integration-tests/tests/sovd/mod.rs
@@ -15,5 +15,5 @@ mod custom_routes;
 mod ecu;
 mod locks;
 
-pub(crate) const ECU_FLXC1000_ENDPOINT: &str = "components/flxc1000/";
-pub(crate) const ECU_FLXCNG1000_ENDPOINT: &str = "components/flxcng1000/";
+pub(crate) const ECU_FLXC1000_ENDPOINT: &str = "components/flxc1000";
+pub(crate) const ECU_FLXCNG1000_ENDPOINT: &str = "components/flxcng1000";

--- a/testcontainer/docker-compose.yml
+++ b/testcontainer/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       ecu-sim:
         condition: service_healthy
     environment:
-      - RUST_LOG=info
+      - RUST_LOG=debug
     command: ["-d", "/app/odx"]
     restart: unless-stopped
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

* ecumanager: improve state lookup, to prevent confusing sessions with security access.
* tests: add a custom panic handler to print logs. this makes debugging easier as the CDA and ecu manager logs will be available.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers

At the time of creating this there was an [issue with GH actions](https://www.githubstatus.com/incidents/xwn6hjps36ty)


Setting this to ready for review anyway, as it is working locally. 

-----

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)