### PR TITLE
Functional: implement session change for fg

### DIFF
--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -2390,6 +2390,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
         sid: u8,
         service_name: &str,
         params: Option<HashMap<String, serde_json::Value>>,
+        mode_expiration: Option<Duration>,
         map_to_json: bool,
     ) -> Result<HashMap<String, Result<Self::Response, DiagServiceError>>, DiagServiceError> {
         let func_group = self.ecu_manager(&self.functional_description_database)?;
@@ -2418,6 +2419,10 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
                     .await
                     .set_service_state(sid, service_name.to_owned())
                     .await;
+                if let Some(ref expiration) = mode_expiration {
+                    self.start_reset_task(ecu, Some(*expiration), ResetType::Session)
+                        .await;
+                }
             }
         }
 

--- a/cda-interfaces/src/ecuuds.rs
+++ b/cda-interfaces/src/ecuuds.rs
@@ -433,6 +433,7 @@ pub trait UdsEcu: Send + Sync + 'static {
     ///
     /// # Errors
     /// Returns error if the functional group doesn't exist or if the request cannot be sent
+    #[allow(clippy::too_many_arguments)] // there is not much benefit in passing a structure here
     async fn set_functional_state(
         &self,
         group_name: &str,
@@ -440,6 +441,7 @@ pub trait UdsEcu: Send + Sync + 'static {
         sid: u8,
         service_name: &str,
         params: Option<HashMap<String, serde_json::Value>>,
+        mode_expiration: Option<Duration>,
         map_to_json: bool,
     ) -> Result<HashMap<String, Result<Self::Response, DiagServiceError>>, DiagServiceError>;
 }
@@ -677,6 +679,7 @@ pub mod mock {
                 sid: u8,
                 service_name: &str,
                 params: Option<HashMap<String, serde_json::Value>>,
+                mode_expiration: Option<Duration>,
                 map_to_json: bool,
             ) -> Result<HashMap<String, Result<<MockUdsEcu as UdsEcu>::Response,
                     DiagServiceError>>, DiagServiceError>;

--- a/cda-sovd-interfaces/src/functions/functional_groups/mod.rs
+++ b/cda-sovd-interfaces/src/functions/functional_groups/mod.rs
@@ -32,6 +32,7 @@ pub struct FunctionalGroup {
     pub locks: String,
     pub operations: String,
     pub data: String,
+    pub modes: String,
     #[schemars(skip)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<schemars::Schema>,

--- a/cda-sovd-interfaces/src/functions/functional_groups/modes.rs
+++ b/cda-sovd-interfaces/src/functions/functional_groups/modes.rs
@@ -68,3 +68,41 @@ pub mod dtcsetting {
         pub type Response<T> = DataResponse<T, ResponseElement>;
     }
 }
+
+pub mod session {
+    pub mod get {
+        use crate::functions::functional_groups::modes::DataResponse;
+
+        pub type ResponseElement = crate::common::modes::get::Mode<String>;
+        pub type Response<T> = DataResponse<T, ResponseElement>;
+    }
+    pub mod put {
+        use cda_interfaces::HashMap;
+        use serde::{Deserialize, Serialize};
+
+        use crate::error::ApiErrorResponse;
+
+        #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
+        #[schemars(rename = "FunctionalModesSessionRequest")]
+        #[rustfmt::skip] // skip formatting due to the reference to the other module
+        pub struct Request {
+            pub value: String,
+            /// Defines the expiration in seconds for the given mode
+            /// see [`components::ecu::modes::security_and_session::put::Request`](crate::components::ecu::modes::security_and_session::put::Request)
+            pub mode_expiration: Option<u64>,
+        }
+
+        pub type ResponseElement = crate::common::modes::put::Response<String>;
+
+        #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
+        pub struct Response<T> {
+            pub modes: HashMap<String, ResponseElement>,
+            /// Errors that occurred during the operation
+            #[serde(skip_serializing_if = "Vec::is_empty")]
+            pub errors: Vec<ApiErrorResponse<T>>,
+            #[schemars(skip)]
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub schema: Option<schemars::Schema>,
+        }
+    }
+}

--- a/cda-sovd/src/sovd/functions/functional_groups/mod.rs
+++ b/cda-sovd/src/sovd/functions/functional_groups/mod.rs
@@ -183,6 +183,11 @@ fn create_functional_group_route<T: UdsEcu + Clone>(fg_state: WebserverFgState<T
             routing::get_with(modes::dtcsetting::get, modes::dtcsetting::docs_get)
                 .put_with(modes::dtcsetting::put, modes::dtcsetting::docs_put),
         )
+        .api_route(
+            &format!("/modes/{}", sovd_interfaces::common::modes::SESSION_ID),
+            routing::get_with(modes::session::get, modes::session::docs_get)
+                .put_with(modes::session::put, modes::session::docs_put),
+        )
         .with_state(fg_state)
 }
 
@@ -302,6 +307,7 @@ async fn functional_group_description<T: UdsEcu + Clone>(
                 locks: format!("{base_path}/locks"),
                 operations: format!("{base_path}/operations"),
                 data: format!("{base_path}/data"),
+                modes: format!("{base_path}/modes"),
                 schema,
             },
         ),
@@ -325,6 +331,9 @@ fn docs_functional_group(op: TransformOperation) -> TransformOperation {
                         functionalgroups/group_a/operations".into(),
                 data:
                 "http://localhost:20002/vehicle/v15/functions/functionalgroups/group_a/data"
+                    .into(),
+                modes:
+                "http://localhost:20002/vehicle/v15/functions/functionalgroups/group_a/modes"
                     .into(),
                 schema: None,
             })


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

This PR introduces the functional session query and change.
Note: To initiate the functional session change the ECUs in the functional group need to already be authenticated!


## Example

GET /vehicle/v15/functions/functionalgroups/group_1/modes/session
response:
```json
{
  "modes": {
    "ecu_a": {
      "name": "Diagnostic session",
      "value": "Default"
    }
  }
}
```

PUT /vehicle/v15/functions/functionalgroups/group_1/modes/session
request:
```json
{
  "value": "Extended",
  "mode_expiration": 60
}
```
response:
```json
{
  "modes": {
    "ecu_a": {
      "name": "Diagnostic session",
      "value": "Extended"
    }
  }
}
```
---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)