### PR TITLE
security: Validate vehicle lock

### DIFF
--- a/integration-tests/tests/sovd/mod.rs
+++ b/integration-tests/tests/sovd/mod.rs
@@ -10,6 +10,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+use http::{HeaderMap, Method, StatusCode};
+use opensovd_cda_lib::config::configfile::Configuration;
+use serde::{Serialize, de::DeserializeOwned};
+use sovd_interfaces::components::ecu::modes::dtcsetting;
+
+use crate::util::{
+    TestingError,
+    http::{response_to_t, send_cda_request},
+};
 
 mod custom_routes;
 mod ecu;
@@ -17,3 +26,50 @@ mod locks;
 
 pub(crate) const ECU_FLXC1000_ENDPOINT: &str = "components/flxc1000";
 pub(crate) const ECU_FLXCNG1000_ENDPOINT: &str = "components/flxcng1000";
+
+pub(crate) async fn put_mode<T: DeserializeOwned, S: Serialize>(
+    config: &Configuration,
+    headers: &HeaderMap,
+    ecu_endpoint: &str,
+    sub_path: &str,
+    request: S,
+    excepted_status: StatusCode,
+) -> Result<Option<T>, TestingError> {
+    let request_body = serde_json::to_string(&request)
+        .map_err(|e| TestingError::InvalidData(format!("Failed to serialize request body: {e}")))?;
+    let http_response = send_cda_request(
+        config,
+        &format!("{ecu_endpoint}/modes/{sub_path}"),
+        excepted_status,
+        Method::PUT,
+        Some(&request_body),
+        Some(headers),
+    )
+    .await?;
+    if excepted_status == StatusCode::OK {
+        Ok(Some(response_to_t(&http_response)?))
+    } else {
+        Ok(None)
+    }
+}
+
+pub(crate) async fn set_dtc_setting(
+    value: &str,
+    config: &Configuration,
+    headers: &HeaderMap,
+    ecu_endpoint: &str,
+    expected_status: StatusCode,
+) -> Result<Option<dtcsetting::put::Response>, TestingError> {
+    put_mode(
+        config,
+        headers,
+        ecu_endpoint,
+        "dtcsetting",
+        dtcsetting::put::Request {
+            value: value.to_owned(),
+            parameters: None,
+        },
+        expected_status,
+    )
+    .await
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

This fixes a security issue, breaking the vehicle lock. When an authenticated user locked the vehicle only and no ECU lock was set another authenticated user was able to do operations which require a vehicle lock.
The validate_lock function was not checking if the vehicle lock is actually owned by the user and only validated the ECU locks.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
--


Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)