### PR TITLE
[#27] Support GET for ECU configurations

### DIFF
--- a/cda-sovd-interfaces/src/components/ecu/mod.rs
+++ b/cda-sovd-interfaces/src/components/ecu/mod.rs
@@ -141,9 +141,25 @@ pub mod configurations {
 
     pub type ConfigurationsQuery = crate::IncludeSchemaQuery;
 
+    /// Response returned when querying a service configuration.
+    #[derive(Deserialize, Serialize, Debug, schemars::JsonSchema)]
+    pub struct ServiceResponse {
+        /// Identifier of the service.
+        pub id: String,
+        /// Configuration data for the service.
+        pub data: serde_json::Value,
+    }
+
     pub mod get {
         use super::Components;
         pub type Response = Components;
+    }
+
+    /// Module for the `GET /configurations/{service}` endpoint.
+    pub mod get_service {
+        use super::ServiceResponse;
+        /// Response type returned by this endpoint.
+        pub type Response = ServiceResponse;
     }
 }
 

--- a/cda-sovd/src/sovd/mod.rs
+++ b/cda-sovd/src/sovd/mod.rs
@@ -358,7 +358,8 @@ fn ecu_route<
             routing::put_with(
                 configurations::diag_service::put,
                 configurations::diag_service::docs_put,
-            ),
+            )
+            .get_with(data::diag_service::get, data::diag_service::docs_get),
         )
         .api_route("/data", routing::get_with(data::get, data::docs_get))
         .api_route(


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

- Added support for GET /components/{ECU}/configurations/{service} by routing requests to UDS ReadDataByIdentifier (0x22).

- Existing PUT behavior remains unchanged (WriteDataByIdentifier 0x2E).

- Added integration tests for the GET configuration flow.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ * ] I have tested my changes locally
- [ * ] I have linked related issues or discussions
- [ * ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
