### PR TITLE
bugfix: use vehicle route for 2nd version endpoint

### DIFF
--- a/cda-main/src/main.rs
+++ b/cda-main/src/main.rs
@@ -175,7 +175,12 @@ async fn main() -> Result<(), AppError> {
         )
         .await;
         // For now, both version endpoints serve the same data. This might change in the future.
-        cda_sovd::add_static_data_endpoint(&dynamic_router, version_info, "/data/version").await;
+        cda_sovd::add_static_data_endpoint(
+            &dynamic_router,
+            version_info,
+            "/vehicle/v15/data/version",
+        )
+        .await;
     } else {
         tracing::error!("Failed to build version information");
     }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Use the correct url for the data version endpoint

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)

