### PR TITLE
Improvement: Add error message to DiagServiceError::ConnectionClosed

### DIFF
--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -69,10 +69,16 @@ impl From<EcuError> for DiagServiceError {
                 }
                 ConnectionError::Timeout(_) => DiagServiceError::Timeout,
                 // map arbitrary connection errors to connection closed
-                ConnectionError::ConnectionFailed(_)
-                | ConnectionError::RoutingError(_)
-                | ConnectionError::SendFailed(_)
-                | ConnectionError::Closed => DiagServiceError::ConnectionClosed,
+                ConnectionError::ConnectionFailed(msg) => {
+                    DiagServiceError::ConnectionClosed(format!("ConnectionFailed {msg}"))
+                }
+                ConnectionError::RoutingError(msg) => {
+                    DiagServiceError::ConnectionClosed(format!("RoutingError {msg}"))
+                }
+                ConnectionError::SendFailed(msg) => {
+                    DiagServiceError::ConnectionClosed(format!("SendFailed {msg}"))
+                }
+                ConnectionError::Closed => DiagServiceError::ConnectionClosed(String::new()),
             },
         }
     }

--- a/cda-comm-doip/src/ecu_connection.rs
+++ b/cda-comm-doip/src/ecu_connection.rs
@@ -395,7 +395,9 @@ async fn try_read_routing_activation_response(
         Ok(Some(Err(e))) => Err(DiagServiceError::UnexpectedResponse(Some(format!(
             "Error reading from gateway: {e:?}"
         )))),
-        Ok(None) => Err(DiagServiceError::ConnectionClosed),
+        Ok(None) => Err(DiagServiceError::ConnectionClosed(
+            "Incomplete routing activation response due to connection closure or error".to_owned(),
+        )),
         Err(_) => Err(DiagServiceError::Timeout),
     }
 }

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -238,12 +238,26 @@ impl<T: EcuAddressProvider + DoipComParamProvider> DoipDiagGateway<T> {
 
     async fn get_doip_connection(
         &self,
-        conn_idx: usize,
+        logical_address: u16,
     ) -> Result<Arc<DoipConnection>, DiagServiceError> {
+        let conn_idx = *self
+            .logical_address_to_connection
+            .read()
+            .await
+            .get(&logical_address)
+            .ok_or_else(|| {
+                DiagServiceError::EcuOffline(format!(
+                    "Connection not found for logical address {logical_address}"
+                ))
+            })?;
+
         let lock = self.doip_connections.read().await;
         let conn = lock
             .get(conn_idx)
-            .ok_or(DiagServiceError::ConnectionClosed)?;
+            .ok_or(DiagServiceError::ConnectionClosed(format!(
+                "Connection entry for address {logical_address} found, but it was already closed"
+            )))?;
+
         Ok(Arc::clone(conn))
     }
 
@@ -300,18 +314,10 @@ impl<T: EcuAddressProvider + DoipComParamProvider> EcuGateway for DoipDiagGatewa
         expect_uds_reply: bool,
     ) -> Result<(), DiagServiceError> {
         let start = Instant::now();
-        let conn_idx = *self
-            .logical_address_to_connection
-            .read()
-            .await
-            .get(&transmission_params.gateway_address)
-            .ok_or_else(|| DiagServiceError::EcuOffline(transmission_params.ecu_name.clone()))?;
 
-        if conn_idx >= self.doip_connections.read().await.len() {
-            return Err(DiagServiceError::ConnectionClosed);
-        }
-
-        let doip_conn = self.get_doip_connection(conn_idx).await?;
+        let doip_conn = self
+            .get_doip_connection(transmission_params.gateway_address)
+            .await?;
         let ecu_mtx = self
             .get_ecu_mtx(&doip_conn, &message, &transmission_params)
             .await?;
@@ -529,13 +535,10 @@ impl<T: EcuAddressProvider + DoipComParamProvider> EcuGateway for DoipDiagGatewa
         ecu_db: &RwLock<E>,
     ) -> Result<(), DiagServiceError> {
         let ecu_lock = ecu_db.read().await;
-        let conn_idx = *self
-            .logical_address_to_connection
-            .read()
-            .await
-            .get(&ecu_lock.logical_gateway_address())
-            .ok_or_else(|| DiagServiceError::EcuOffline(ecu_name.to_owned()))?;
-        let doip_conn = self.get_doip_connection(conn_idx).await?;
+
+        let doip_conn = self
+            .get_doip_connection(ecu_lock.logical_gateway_address())
+            .await?;
         doip_conn
             .ecus
             .get(&ecu_lock.logical_address())
@@ -550,18 +553,9 @@ impl<T: EcuAddressProvider + DoipComParamProvider> EcuGateway for DoipDiagGatewa
         expected_ecu_logical_addrs: HashMap<u16, String>,
         timeout: Duration,
     ) -> Result<HashMap<String, Result<UdsResponse, DiagServiceError>>, DiagServiceError> {
-        let conn_idx = *self
-            .logical_address_to_connection
-            .read()
-            .await
-            .get(&transmission_params.gateway_address)
-            .ok_or_else(|| DiagServiceError::EcuOffline("Gateway not found".to_string()))?;
-
-        if conn_idx >= self.doip_connections.read().await.len() {
-            return Err(DiagServiceError::ConnectionClosed);
-        }
-
-        let doip_conn = self.get_doip_connection(conn_idx).await?;
+        let doip_conn = self
+            .get_doip_connection(transmission_params.gateway_address)
+            .await?;
 
         // Get the gateway ECU for sending the functional request
         let gateway_ecu = doip_conn

--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -73,7 +73,9 @@ where
                     Ok(Some(Err(e))) => return Err(DiagServiceError::UnexpectedResponse(Some(
                         format!("Failed to receive VAMs: {e:?}"))
                     )),
-                    Ok(None) => return Err(DiagServiceError::ConnectionClosed),
+                    Ok(None) => return Err(DiagServiceError::ConnectionClosed(
+                        "Incomplete VAM due to connection closure/error".to_owned()
+                    )),
                     Err(_) => {
                         // no VAM received within timeout
                         break;

--- a/cda-interfaces/src/lib.rs
+++ b/cda-interfaces/src/lib.rs
@@ -291,8 +291,8 @@ pub enum DiagServiceError {
     UnexpectedResponse(Option<String>),
     #[error("No response {0}")]
     NoResponse(String),
-    #[error("Connection closed")]
-    ConnectionClosed,
+    #[error("Connection closed {0}")]
+    ConnectionClosed(String),
     #[error("Ecu {0} offline")]
     EcuOffline(String),
     #[error("Timeout")]

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -91,7 +91,7 @@ impl From<DiagServiceError> for AppError {
         match value {
             DiagServiceError::RequestNotSupported(_)
             | DiagServiceError::BadPayload(_)
-            | DiagServiceError::ConnectionClosed
+            | DiagServiceError::ConnectionClosed(_)
             | DiagServiceError::UnexpectedResponse(_)
             | DiagServiceError::EcuOffline(_)
             | DiagServiceError::NoResponse(_)

--- a/cda-sovd/src/sovd/error.rs
+++ b/cda-sovd/src/sovd/error.rs
@@ -73,7 +73,7 @@ impl From<DiagServiceError> for ApiError {
             | DiagServiceError::VariantDetectionError(_)
             | DiagServiceError::EcuOffline(_)
             | DiagServiceError::ResourceError(_)
-            | DiagServiceError::ConnectionClosed
+            | DiagServiceError::ConnectionClosed(_)
             | DiagServiceError::InvalidRequest(_)
             | DiagServiceError::SendFailed(_)
             | DiagServiceError::InvalidAddress(_)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
Added error message to DiagServiceError::ConnectionClosed for a better understanding of why the error occured.
Additionally, some duplicate code has been consolidated under `get_doip_connection()`

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
This PR solves [Issue #145](https://github.com/eclipse-opensovd/classic-diagnostic-adapter/issues/145)

## Notes for Reviewers
Of course, let me know if I have missed something! Thank you!