### PR TITLE
sovd: introduce not responding error code and fix mapping

### DIFF
--- a/cda-sovd/src/sovd/error.rs
+++ b/cda-sovd/src/sovd/error.rs
@@ -44,13 +44,16 @@ pub enum ApiError {
     InternalServerError(Option<String>),
     #[error("Conflict: {0}")]
     Conflict(String),
+    #[error("Not Responding: {0}")]
+    NotResponding(String),
 }
 
 impl ApiError {
     #[must_use]
     pub fn error_and_vendor_code(&self) -> (ErrorCode, Option<VendorErrorCode>) {
         match &self {
-            ApiError::NotFound(_) => (ErrorCode::NotResponding, None),
+            ApiError::NotResponding(_) => (ErrorCode::NotResponding, None),
+            ApiError::NotFound(_) => (ErrorCode::VendorSpecific, Some(VendorErrorCode::NotFound)),
             ApiError::BadRequest(_) => (
                 ErrorCode::InvalidResponseContent,
                 Some(VendorErrorCode::BadRequest),
@@ -244,6 +247,19 @@ impl IntoResponse for ErrorWrapper {
                         message,
                         error_code: ErrorCode::VendorSpecific,
                         vendor_code: Some(VendorErrorCode::BadRequest),
+                        parameters: None,
+                        error_source: None,
+                        schema,
+                    },
+                ),
+            ),
+            ApiError::NotResponding(message) => (
+                StatusCode::GATEWAY_TIMEOUT,
+                Json(
+                    sovd_interfaces::error::ApiErrorResponse::<VendorErrorCode> {
+                        message,
+                        error_code: ErrorCode::NotResponding,
+                        vendor_code: None,
                         parameters: None,
                         error_source: None,
                         schema,


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
ApiError not found was mapped onto Error Code not responding. Not found had no Vendor error code.
This leads to confusing error messages.
In this commit a new error code is introduced to fix this.

### Example:

This for example happens when a functional group is used to set commctrl or dtcsettings.
The errors block was mapped not correct in this case.

#### Now
```json
{
  "modes": {
 // redacted, not releveant
  },
  "errors": [
    {
      "message": "Not Found: : Not found: Some(\"Service state for service ID 85 not found in ECU MY_ECU\")",
      "error_code": "vendor-specific",
      "vendor_code": "not-found", <--- Expected, the Service is not found
      "x-errorsource": "MY_ECU"
    }
 ]
}
```

#### Before

```json
{
  "modes": {
 // redacted, not releveant
  },
  "errors": [
    {
      "message": "Not Found: : Not found: Some(\"Service state for service ID 85 not found in ECU MY_ECU\")",
      "error_code": "vendor-specific",
      "vendor_code": "not-responding", <--- Wrong and confusing mapping.
      "x-errorsource": "MY_ECU"
    }
 ]
}
```

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
