### PR TITLE
ci: use cicd workflow action for rust lint and format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,55 +19,51 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write # Grants permission to post review comments
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  format_and_clippy_nightly_toolchain:
+  format_and_clippy_nightly_toolchain_pinned:
     concurrency:
-      group: format_and_clippy_nightly_toolchain-${{ github.ref }}
+      group: format_and_clippy_nightly_toolchain_pinned-${{ github.ref }}
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - toolchain: nightly-2025-07-14
-            allow-failure: false
-          - toolchain: nightly
-            allow-failure: true
     continue-on-error: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: false
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+      - name: Format and Clippy
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@3c3da34839e9692d5ca4db226c28926809d9ad6e
         with:
-          toolchain: ${{ matrix.toolchain }}
-          components: clippy, rustfmt
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+          toolchain: nightly-2025-07-14
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-format-error: 'true'
+          fail-on-clippy-error: 'true'
+          clippy-deny-warnings: 'true'
+
+  format_and_clippy_nightly_toolchain_latest:
+    needs: format_and_clippy_nightly_toolchain_pinned
+    concurrency:
+      group: format_and_clippy_nightly_toolchain_latest-${{ github.ref }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
-          shared-key: ${{ matrix.toolchain }}
-      - name: Formating - check for long lines
-        run: cargo fmt -- --check --config error_on_unformatted=true,error_on_line_overflow=true,format_strings=true
-      - name: Formatting - check import order
-        run: cargo fmt -- --check --config group_imports=StdExternalCrate
-      - name: Formatting - check imports granularity
-        run: cargo fmt -- --check --config imports_granularity=Crate
-      - name: Formatting - check hex literals
-        run: cargo fmt -- --check --config hex_literal_case=Upper
-      - name: Clippy
-        uses: giraffate/clippy-action@v1
+          submodules: false
+      - name: Format and Clippy
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@3c3da34839e9692d5ca4db226c28926809d9ad6e
         with:
-          reporter: 'github-check'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          clippy_flags: --locked --all-targets --features integration-tests ${{ matrix.allow-failure == false && '-- -D warnings' || '' }}
-          filter_mode: 'nofilter'
-          fail_on_error: ${{ !matrix.allow-failure }}
+          toolchain: nightly
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-format-error: 'false'
+          fail-on-clippy-error: 'false'
+          clippy-deny-warnings: 'false'
 
   features:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

The action is using the common rules and reviewdog to
apply linting and formatting errors / warnings
as review comments

**New and improved --> using PR review style now** 


<img width="666" height="322" alt="image" src="https://github.com/user-attachments/assets/9e39fbc4-fb2b-4d5c-beed-cc3394c74a50" />


<img width="765" height="403" alt="image" src="https://github.com/user-attachments/assets/fe107c75-7c46-4c1a-a4d3-eeeb248f54fe" />


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests



## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->



---- 

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)