### PR TITLE
core: BYTE-SIZE optional & Extended PHYS-CONST to support all DOP var…

### DIFF
--- a/cda-database/src/datatypes/database_builder.rs
+++ b/cda-database/src/datatypes/database_builder.rs
@@ -679,6 +679,38 @@ impl<'a> EcuDataBuilder<'a> {
             specific_data,
         })
     }
+    pub fn create_phys_const_param(
+        &mut self,
+        name: &'a str,
+        phys_constant_value: Option<&str>,
+        dop: WIPOffset<dataformat::DOP<'a>>,
+        byte_pos: u32,
+        bit_pos: u32,
+    ) -> WIPOffset<dataformat::Param<'a>> {
+        let phys_value = phys_constant_value.map(|v| self.fbb.create_string(v));
+        let specific_data = Some(
+            dataformat::ParamSpecificData::tag_as_phys_const(dataformat::PhysConst::create(
+                &mut self.fbb,
+                &dataformat::PhysConstArgs {
+                    phys_constant_value: phys_value,
+                    dop: Some(dop),
+                },
+            ))
+            .value_offset(),
+        );
+
+        self.create_param(&ParameterParams {
+            param_type: dataformat::ParamType::PHYS_CONST,
+            short_name: Some(name),
+            semantic: None,
+            sdgs: None,
+            physical_default_value: None,
+            byte_position: Some(byte_pos),
+            bit_position: Some(bit_pos),
+            specific_data_type: dataformat::ParamSpecificData::PhysConst,
+            specific_data,
+        })
+    }
 
     pub fn create_structure(
         &mut self,


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
**Fix 1**: Made Structure `BYTE-SIZE` optional (per ODX XSD 2.2.0 spec)
**Fix 2**: Extended PHYS-CONST to support all DOP variants (Structure, Mux, etc.), not just Normal DOPs

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
