### PR TITLE
TCP-Connection: ensure connecting from tester IP

### DIFF
--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -199,6 +199,7 @@ impl<T: EcuAddressProvider + DoipComParamProvider> DoipDiagGateway<T> {
 
             for gateway in gateways {
                 if let Ok(logical_address) = connections::handle_gateway_connection::<T>(
+                    &doip_config.tester_address,
                     gateway,
                     &doip_connections,
                     &ecus,

--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -111,6 +111,7 @@ pub(crate) async fn listen_for_vams<T, F>(
         )
     )]
     async fn handle_doip_response<T: EcuAddressProvider + DoipComParamProvider>(
+        tester_ip: &str,
         gateway: &DoipDiagGateway<T>,
         send_timeout: Duration,
         doip_msg_ctx: DoipMessageContext,
@@ -149,6 +150,7 @@ pub(crate) async fn listen_for_vams<T, F>(
                     tracing::info!(ecu_name = %doip_target.ecu, "New Gateway ECU detected");
 
                     match handle_gateway_connection::<T>(
+                        tester_ip,
                         doip_target,
                         &gateway.doip_connections,
                         &gateway.ecus,
@@ -262,6 +264,7 @@ pub(crate) async fn listen_for_vams<T, F>(
                     Some(Ok((doip_msg, source_addr))) = socket.recv() => {
                         if let DoipPayload::VehicleAnnouncementMessage(_) = &doip_msg.payload {
                             handle_doip_response(
+                                &tester_ip,
                                 &gateway,
                                 send_timeout,
                                 DoipMessageContext { doip_msg, source_addr, netmask },


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
Instead of relying on `connect` with target IP only, the socket is created and bound to the configured Tester IP. This ensures that on systems where an interface has multiple IPs defined the correct one is picked when creating the connection.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
To reproduce you will need to create an interface with 2 IPs. Put the secondary IP as tester IP in the launch command. Before the change the ECU Connections will be made from the primary IP, after the change they will correctly be established from the secondary.

---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)