### PR TITLE
consider security state transition for precondition allowed

### DIFF
--- a/cda-database/src/datatypes/database_builder.rs
+++ b/cda-database/src/datatypes/database_builder.rs
@@ -1219,4 +1219,49 @@ impl<'a> EcuDataBuilder<'a> {
             Some(dataformat::SpecificDOPData::tag_as_dtcdop(dtc_dop_specific_data).value_offset()),
         )
     }
+
+    pub fn create_state_transition(
+        &mut self,
+        short_name: &str,
+        source_short_name_ref: Option<&str>,
+        target_short_name_ref: Option<&str>,
+    ) -> WIPOffset<dataformat::StateTransition<'a>> {
+        let short_name_offset = self.fbb.create_string(short_name);
+        let source_offset = source_short_name_ref.map(|s| self.fbb.create_string(s));
+        let target_offset = target_short_name_ref.map(|s| self.fbb.create_string(s));
+
+        let args = dataformat::StateTransitionArgs {
+            short_name: Some(short_name_offset),
+            source_short_name_ref: source_offset,
+            target_short_name_ref: target_offset,
+        };
+
+        dataformat::StateTransition::create(&mut self.fbb, &args)
+    }
+
+    pub fn create_state_transition_ref(
+        &mut self,
+        state_transition: WIPOffset<dataformat::StateTransition<'a>>,
+    ) -> WIPOffset<dataformat::StateTransitionRef<'a>> {
+        let args = dataformat::StateTransitionRefArgs {
+            value: None,
+            state_transition: Some(state_transition),
+        };
+
+        dataformat::StateTransitionRef::create(&mut self.fbb, &args)
+    }
+
+    pub fn create_pre_condition_state_ref(
+        &mut self,
+        state: WIPOffset<dataformat::State<'a>>,
+    ) -> WIPOffset<dataformat::PreConditionStateRef<'a>> {
+        let args = dataformat::PreConditionStateRefArgs {
+            value: None,
+            in_param_if_short_name: None,
+            in_param_path_short_name: None,
+            state: Some(state),
+        };
+
+        dataformat::PreConditionStateRef::create(&mut self.fbb, &args)
+    }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
if a service is transitioning a security state,
aside from the states defined in the precondition states, the source state of the state transition must be taken into account.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->



----

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)