### PR TITLE
tests: improve ecu manager tests

### DIFF
--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -23,7 +23,7 @@ use cda_interfaces::{
     EcuVariant, FlashTransferStartParams, FunctionalDescriptionConfig, HashMap, HashMapExtensions,
     HashSet, HashSetExtensions, SchemaDescription, SchemaProvider, SecurityAccess, ServicePayload,
     TesterPresentControlMessage, TesterPresentMode, TesterPresentType, TransmissionParameters,
-    UdsEcu, UdsResponse,
+    UDS_ID_RESPONSE_BITMASK, UdsEcu, UdsResponse,
     datatypes::{
         self, ComponentConfigurationsInfo, DTC_CODE_BIT_LEN, DataTransferError,
         DataTransferMetaData, DataTransferStatus, DtcCode, DtcExtendedInfo, DtcMask,
@@ -42,8 +42,6 @@ use tokio::{
 };
 
 type EcuIdentifier = String;
-
-const UDS_RESPONSE_OFFSET: u8 = 0x40;
 
 #[derive(Copy, Clone, Display)]
 enum ResetType {
@@ -379,7 +377,9 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
                                         && msg.data.get(1) == sent_sid)
                                         || (msg.data.first()
                                             == sent_sid
-                                                .map(|sid| sid.saturating_add(UDS_RESPONSE_OFFSET))
+                                                .map(|sid| {
+                                                    sid.saturating_add(UDS_ID_RESPONSE_BITMASK)
+                                                })
                                                 .as_ref()))
                                 {
                                     tracing::debug!("Received expected UDS message: {:?}", msg);

--- a/cda-interfaces/src/lib.rs
+++ b/cda-interfaces/src/lib.rs
@@ -75,6 +75,16 @@ pub struct DiagComm {
 
 impl DiagComm {
     #[must_use]
+    pub fn new(name: impl Into<String>, type_: DiagCommType) -> Self {
+        let name = name.into();
+        Self {
+            lookup_name: Some(name.clone()),
+            name,
+            type_,
+        }
+    }
+
+    #[must_use]
     pub fn action(&self) -> DiagCommAction {
         self.type_.clone().into()
     }
@@ -184,6 +194,8 @@ pub mod service_ids {
     pub const CONTROL_DTC_SETTING: u8 = 0x85;
     pub const NEGATIVE_RESPONSE: u8 = 0x7F;
 }
+
+pub const UDS_ID_RESPONSE_BITMASK: u8 = 0x40;
 
 const CONFIGURATIONS_PREFIXES: [u8; 1] = [service_ids::WRITE_DATA_BY_IDENTIFIER];
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

This adds a few macros into the ecumanager
tests to deduplicate code.
Uses macros so the opaque `WIPOffset<dataformat::…>` types are inferred without needing access to the cda-database internal types.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Consider reviewing this before #191 
So #191 can be adjusted to use the macros.

Reasoning for this: Writing tests in the ecu manager became unmangable with a lot of duplicated code throughout the tests. I didn't had the idea just to use a macro for the opaque types when implementing this in the first place.

----

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)