### PR TITLE
chore: pin cicd workflows to SHA 7005336

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -31,6 +31,7 @@ concurrency:
 
 jobs:
   checks:
-    uses: eclipse-opensovd/cicd-workflows/.github/workflows/checks.yml@main
+    # GitHub is not executing the action, when a short SHA is used.
+    uses: eclipse-opensovd/cicd-workflows/.github/workflows/checks.yml@70053360006eacf5c8bf5a0e8d0dfadd6e384e88
     with:
-      license-config-path: ".licenserc.yaml" # Optional, uses action's default config if not specified
+      license-config-path: ".licenserc.yaml"


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

this is in preparation to update the cicd workflow repository.
To prevent breaking the build here the version of the workflow is pinned.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->


----

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)