### PR TITLE
docs: fix rebuild_docs.sh on macos

### DIFF
--- a/docs/rebuild_docs.sh
+++ b/docs/rebuild_docs.sh
@@ -14,11 +14,11 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 rm -rf "${SCRIPT_DIR}/_build"
 
-UID=$(id -u)
-GID=$(id -g)
+SCRIPT_UID=$(id -u)
+SCRIPT_GID=$(id -g)
 
 docker build -f Dockerfile . -t sovdsphinx:latest
-docker run --rm --user "${UID}:${GID}" \
+docker run --rm --user "${SCRIPT_UID}:${SCRIPT_GID}" \
 		-e _JAVA_OPTIONS="-Djava.io.tmpdir=/tmp -Duser.home=/tmp" \
 		-v "${SCRIPT_DIR}:/docs" \
 		-v "${SCRIPT_DIR}/..:/project" \


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Fixes rebuild_docs.sh script on macos, by renaming UID/GID variables

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

-- 

Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
