### PR TITLE
security: filter services through the security plugin

### DIFF
--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -1338,34 +1338,37 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
     async fn get_components_data_info(
         &self,
         ecu: &str,
+        security_plugin: &DynamicPlugin,
     ) -> Result<Vec<cda_interfaces::datatypes::ComponentDataInfo>, DiagServiceError> {
         let items = self
             .ecu_manager(ecu)?
             .read()
             .await
-            .get_components_data_info();
+            .get_components_data_info(security_plugin);
 
         Ok(items)
     }
 
     async fn get_functional_group_data_info(
         &self,
+        security_plugin: &DynamicPlugin,
         functional_group_name: &str,
     ) -> Result<Vec<cda_interfaces::datatypes::ComponentDataInfo>, DiagServiceError> {
         self.ecu_manager(&self.functional_description_database)?
             .read()
             .await
-            .get_functional_group_data_info(functional_group_name)
+            .get_functional_group_data_info(security_plugin, functional_group_name)
     }
 
     async fn get_components_configuration_info(
         &self,
         ecu: &str,
+        security_plugin: &DynamicPlugin,
     ) -> Result<Vec<ComponentConfigurationsInfo>, DiagServiceError> {
         self.ecu_manager(ecu)?
             .read()
             .await
-            .get_components_configurations_info()
+            .get_components_configurations_info(security_plugin)
     }
 
     async fn get_components_single_ecu_jobs_info(

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -820,13 +820,14 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
         }
     }
 
-    fn get_components_data_info(&self) -> Vec<ComponentDataInfo> {
+    fn get_components_data_info(&self, security_plugin: &DynamicPlugin) -> Vec<ComponentDataInfo> {
         self.get_services_from_variant_and_parent_refs(|service| {
             service
                 .request_id()
                 .is_some_and(|id| id == service_ids::READ_DATA_BY_IDENTIFIER)
         })
         .into_iter()
+        .filter(|service| Self::is_service_visible(security_plugin, service))
         .filter_map(|service| {
             let diag_comm = service.diag_comm()?;
             Some(self.diag_comm_to_component_data_info(&(diag_comm.into())))
@@ -836,6 +837,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
 
     fn get_functional_group_data_info(
         &self,
+        security_plugin: &DynamicPlugin,
         functional_group_name: &str,
     ) -> Result<Vec<ComponentDataInfo>, DiagServiceError> {
         Ok(self
@@ -845,6 +847,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
                     .is_some_and(|id| id == service_ids::READ_DATA_BY_IDENTIFIER)
             })?
             .into_iter()
+            .filter(|service| Self::is_service_visible(security_plugin, service))
             .filter_map(|service| {
                 let diag_comm = service.diag_comm()?;
                 Some(self.diag_comm_to_component_data_info(&(diag_comm.into())))
@@ -1035,6 +1038,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
     /// that are in the functional group varcoding.
     fn get_components_configurations_info(
         &self,
+        security_plugin: &DynamicPlugin,
     ) -> Result<Vec<ComponentConfigurationsInfo>, DiagServiceError> {
         let diag_layers = self.get_diag_layers_from_variant_and_parent_refs();
         let var_coding_func_class_short_name = diag_layers
@@ -1068,6 +1072,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
             .filter_map(|dl| dl.diag_services())
             .flat_map(|services| services.iter())
             .map(datatypes::DiagService)
+            .filter(|service| Self::is_service_visible(security_plugin, service))
             .filter(|service| {
                 service
                     .request_id()
@@ -4425,6 +4430,16 @@ impl<S: SecurityPlugin> EcuManager<S> {
             .map(SecurityPlugin::as_security_plugin)?;
 
         security_plugin.validate_service(service)
+    }
+
+    /// Returns true if the security plugin allows the user to see this service.
+    /// Reuses [`Self::check_security_plugin`] which handles void plugins (always allowed)
+    /// and real plugins (delegates to [`SecurityApi::validate_service`]).
+    fn is_service_visible(
+        security_plugin: &DynamicPlugin,
+        service: &datatypes::DiagService<'_>,
+    ) -> bool {
+        Self::check_security_plugin(security_plugin, service).is_ok()
     }
 
     fn get_meta_data_service(
@@ -8141,7 +8156,7 @@ mod tests {
         let ecu_manager = create_ecu_manager_with_mixed_functional_group();
 
         let result = ecu_manager
-            .get_functional_group_data_info("MixedGroup")
+            .get_functional_group_data_info(&skip_sec_plugin!(), "MixedGroup")
             .expect("should return Ok");
 
         assert_eq!(result.len(), 1, "only read services should be returned");
@@ -8160,7 +8175,7 @@ mod tests {
         let db = finish_db!(db_builder, protocol, vec![]);
         let ecu_manager = new_ecu_manager(db);
 
-        let result = ecu_manager.get_functional_group_data_info("AnyGroup");
+        let result = ecu_manager.get_functional_group_data_info(&skip_sec_plugin!(), "AnyGroup");
 
         assert!(
             result.is_err(),

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -364,12 +364,13 @@ pub trait EcuManager:
     ) -> Result<Vec<MuxCaseInfo>, DiagServiceError>;
 
     /// Retrieve all `read` services for the current ECU variant.
-    fn get_components_data_info(&self) -> Vec<ComponentDataInfo>;
+    fn get_components_data_info(&self, security_plugin: &DynamicPlugin) -> Vec<ComponentDataInfo>;
     /// Retrieve all `read` services for a specific functional group's diag layer.
     /// # Errors
     /// Will return `Err` if the functional group cannot be found.
     fn get_functional_group_data_info(
         &self,
+        security_plugin: &DynamicPlugin,
         functional_group_name: &str,
     ) -> Result<Vec<ComponentDataInfo>, DiagServiceError>;
     /// Retrieve all configuration type services for the current ECU variant.
@@ -377,6 +378,7 @@ pub trait EcuManager:
     /// Returns `DiagServiceError` if the lookup failed.
     fn get_components_configurations_info(
         &self,
+        security_plugin: &DynamicPlugin,
     ) -> Result<Vec<ComponentConfigurationsInfo>, DiagServiceError>;
     /// Retrieve all 'single ecu' jobs for the current ECU variant.
     fn get_components_single_ecu_jobs_info(&self) -> Vec<ComponentDataInfo>;

--- a/cda-interfaces/src/ecuuds.rs
+++ b/cda-interfaces/src/ecuuds.rs
@@ -68,18 +68,22 @@ pub trait UdsEcu: Send + Sync + 'static {
     /// Will return `Err` if the ECU does not exist.
     async fn get_comparams(&self, ecu: &str) -> Result<ComplexComParamValue, DiagServiceError>;
     /// Retrieve all `read` services for the given ECU on the detected variant.
+    /// Services are filtered through the security plugin.
     /// # Errors
     /// Will return `Err` if the ECU does not exist.
     async fn get_components_data_info(
         &self,
         ecu: &str,
+        security_plugin: &DynamicPlugin,
     ) -> Result<Vec<ComponentDataInfo>, DiagServiceError>;
     /// Retrieve all configuration type services for the given ECU on the detected variant.
+    /// Services are filtered through the security plugin.
     /// # Errors
     /// Will return `Err` if the ECU does not exist
     async fn get_components_configuration_info(
         &self,
         ecu: &str,
+        security_plugin: &DynamicPlugin,
     ) -> Result<Vec<ComponentConfigurationsInfo>, DiagServiceError>;
     /// Retrieve all single ecu jobs for the given ECU on the detected variant.
     /// # Errors
@@ -362,6 +366,7 @@ pub trait UdsEcu: Send + Sync + 'static {
     /// Will return `Err` if the description database ECU does not exist.
     async fn get_functional_group_data_info(
         &self,
+        security_plugin: &DynamicPlugin,
         functional_group_name: &str,
     ) -> Result<Vec<ComponentDataInfo>, DiagServiceError>;
 
@@ -523,10 +528,12 @@ pub mod mock {
             async fn get_components_data_info(
                 &self,
                 ecu: &str,
+                security_plugin: &DynamicPlugin,
             ) -> Result<Vec<ComponentDataInfo>, DiagServiceError>;
             async fn get_components_configuration_info(
                 &self,
                 ecu: &str,
+                security_plugin: &DynamicPlugin,
             ) -> Result<Vec<ComponentConfigurationsInfo>, DiagServiceError>;
             async fn get_components_single_ecu_jobs_info(
                 &self,
@@ -684,6 +691,7 @@ pub mod mock {
             ) -> Result<<MockUdsEcu as UdsEcu>::Response, DiagServiceError>;
             async fn get_functional_group_data_info(
                 &self,
+                security_plugin: &DynamicPlugin,
                 functional_group_name: &str,
             ) -> Result<Vec<ComponentDataInfo>, DiagServiceError>;
             async fn ecu_functional_groups(

--- a/cda-sovd/src/sovd/functions/functional_groups/data.rs
+++ b/cda-sovd/src/sovd/functions/functional_groups/data.rs
@@ -10,14 +10,15 @@
  * https://www.apache.org/licenses/LICENSE-2.0
  */
 
-use aide::transform::TransformOperation;
+use aide::{UseApi, transform::TransformOperation};
 use axum::{
     Json,
     extract::{Query, State},
     response::{IntoResponse, Response},
 };
 use axum_extra::extract::WithRejection;
-use cda_interfaces::UdsEcu;
+use cda_interfaces::{DynamicPlugin, UdsEcu};
+use cda_plugin_security::Secured;
 use http::StatusCode;
 
 use super::WebserverFgState;
@@ -27,6 +28,7 @@ use crate::sovd::{
 };
 
 pub(crate) async fn get<T: UdsEcu + Clone>(
+    UseApi(Secured(security_plugin), _): UseApi<Secured, ()>,
     WithRejection(Query(query), _): WithRejection<
         Query<sovd_interfaces::functions::functional_groups::data::get::Query>,
         ApiError,
@@ -45,7 +47,7 @@ pub(crate) async fn get<T: UdsEcu + Clone>(
         None
     };
     match uds
-        .get_functional_group_data_info(&functional_group_name)
+        .get_functional_group_data_info(&(security_plugin as DynamicPlugin), &functional_group_name)
         .await
     {
         Ok(mut items) => {


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
Only show services in 'get' functions a user is allowed to see based on the response of the security plugin. For example this can be used to prevent user Bob from seeing services which are only meant for special use cases like production, which are only visible to user Alice.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->


Ready for review but depends on https://github.com/eclipse-opensovd/classic-diagnostic-adapter/pull/218

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
