### PR TITLE
Extend DoIP config to allow setting the TLS port

### DIFF
--- a/cda-comm-doip/src/config.rs
+++ b/cda-comm-doip/src/config.rs
@@ -18,6 +18,7 @@ pub struct DoipConfig {
     pub tester_address: String,
     pub tester_subnet: String,
     pub gateway_port: u16,
+    pub tls_port: u16,
     pub send_timeout_ms: u64,
     pub send_diagnostic_message_ack: bool,
 }
@@ -29,6 +30,7 @@ impl Default for DoipConfig {
             tester_address: "127.0.0.1".to_owned(),
             tester_subnet: "255.255.0.0".to_owned(),
             gateway_port: 13400,
+            tls_port: 3496,
             send_timeout_ms: 1000,
             send_diagnostic_message_ack: true,
         }

--- a/cda-comm-doip/src/socket.rs
+++ b/cda-comm-doip/src/socket.rs
@@ -29,18 +29,18 @@ use tokio_util::{
 use crate::ConnectionError;
 
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct DoIPConnectionConfig {
+pub(crate) struct DoIPConfig {
     pub protocol_version: ProtocolVersion,
     pub send_diagnostic_message_ack: bool,
 }
 
 pub(crate) struct DoIPConnection<T: AsyncRead + AsyncWrite + Unpin> {
     io: Framed<T, DoipCodec>,
-    config: DoIPConnectionConfig,
+    config: DoIPConfig,
 }
 
 impl<T: AsyncRead + AsyncWrite + Unpin> DoIPConnection<T> {
-    pub fn new(io: T, config: DoIPConnectionConfig) -> Self {
+    pub fn new(io: T, config: DoIPConfig) -> Self {
         Self {
             io: Framed::new(io, DoipCodec {}),
             config,


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
This PR adds a field to the config that can set the default TLS port used for DoIP connections and does some minor refractoring regarding how parameters are passed through in the doip layer.
This is related to #5 but does NOT fully solve it, as we still want to define a com parameter to be able to overwrite it on a component basis!

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->
#5 

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

--- 
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)