### PR TITLE
Fix Denial-of-service on DoIP Gateway discovery process

### DIFF
--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -265,11 +265,7 @@ impl<T: EcuAddressProvider + DoipComParamProvider> DoipDiagGateway<T> {
             .read()
             .await
             .get(&logical_address)
-            .ok_or_else(|| {
-                DiagServiceError::EcuOffline(format!(
-                    "Connection not found for logical address {logical_address}"
-                ))
-            })?;
+            .ok_or_else(|| DiagServiceError::EcuOffline(format!("[{logical_address}]")))?;
 
         let lock = self.doip_connections.read().await;
         let conn = lock

--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -53,39 +53,44 @@ where
     let mut gateways = Vec::new();
 
     let vam_timeout = Duration::from_secs(1); // not the actual timeout from the spec ...
-    loop {
-        tokio::select! {
-            () = shutdown_signal.clone() => {
-                break
-            },
-            res = tokio::time::timeout(vam_timeout, socket.recv()) => {
-                match res {
-                    Ok(Some(Ok((doip_msg, source_addr)))) => {
-                        if let PayloadType::VehicleIdentificationRequest =
-                            doip_msg.header.payload_type {
-                            // skip our own VIR
-                            continue;
+
+    tokio::select! {
+        () = shutdown_signal.clone() => {
+            tracing::info!("Shutdown signal received");
+        },
+        () = tokio::time::sleep(vam_timeout) => {
+            tracing::info!("Finished waiting for VIRs");
+        },
+        () = async { // loop until timeout is exceeded or shutdown signal is received
+                loop {
+                    tracing::info!("Started loop");
+                    match socket.recv().await {
+                        Some(Ok((doip_msg, source_addr))) => {
+                            if let PayloadType::VehicleIdentificationRequest =
+                                doip_msg.header.payload_type {
+                                // skip our own VIR
+                                tracing::info!("Skipping own VIR");
+                                continue;
+                            }
+                            match handle_vam::<T>(ecus, doip_msg, source_addr, netmask).await {
+                                Ok(Some(gateway)) => gateways.push(gateway),
+                                Ok(None) => { /* ignore non-matching VAMs */ }
+                                Err(e) => tracing::error!(error = ?e, "Failed to handle VAM"),
+                            }
                         }
-                        match handle_vam::<T>(ecus, doip_msg, source_addr, netmask).await {
-                            Ok(Some(gateway)) => gateways.push(gateway),
-                            Ok(None) => { /* ignore non-matching VAMs */ }
-                            Err(e) => tracing::error!(error = ?e, "Failed to handle VAM"),
+                        Some(Err(e)) => {
+                            tracing::warn!("Failed to receive VAMs: {e:?}");
+                            break;
+                        },
+                        None => {
+                            tracing::warn!("Incomplete VAM due to connection closure/error");
+                            break;
                         }
-                    }
-                    Ok(Some(Err(e))) => return Err(DiagServiceError::UnexpectedResponse(Some(
-                        format!("Failed to receive VAMs: {e:?}"))
-                    )),
-                    Ok(None) => return Err(DiagServiceError::ConnectionClosed(
-                        "Incomplete VAM due to connection closure/error".to_owned()
-                    )),
-                    Err(_) => {
-                        // no VAM received within timeout
-                        break;
                     }
                 }
-            }
-        }
+            } => { /* nothing else to do once finished */ }
     }
+
     Ok(gateways)
 }
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
Fix Denial of Service in DoIP Gateway discovery by using `tokio::select!` over all 3 conditions: shutdown signal, timeout and VIR processing.
Also fixed `DiagServiceError::EcuOffline` log which expects the ECU name/address.

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
Fixes Issue #8

## Notes for Reviewers
I have confirmed the issue initially by periodically sending a VIR while the function was running, which prevented the function from ever returning. With the fix, the function will return once one of the above futures are done.