### PR TITLE
functional-groups: support /data GET endpoint for functional

### DIFF
--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -1348,6 +1348,16 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
         Ok(items)
     }
 
+    async fn get_functional_group_data_info(
+        &self,
+        functional_group_name: &str,
+    ) -> Result<Vec<cda_interfaces::datatypes::ComponentDataInfo>, DiagServiceError> {
+        self.ecu_manager(&self.functional_description_database)?
+            .read()
+            .await
+            .get_functional_group_data_info(functional_group_name)
+    }
+
     async fn get_components_configuration_info(
         &self,
         ecu: &str,

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -834,6 +834,24 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
         .collect()
     }
 
+    fn get_functional_group_data_info(
+        &self,
+        functional_group_name: &str,
+    ) -> Result<Vec<ComponentDataInfo>, DiagServiceError> {
+        Ok(self
+            .get_services_from_functional_group_and_parent_refs(functional_group_name, |service| {
+                service
+                    .request_id()
+                    .is_some_and(|id| id == service_ids::READ_DATA_BY_IDENTIFIER)
+            })?
+            .into_iter()
+            .filter_map(|service| {
+                let diag_comm = service.diag_comm()?;
+                Some(self.diag_comm_to_component_data_info(&(diag_comm.into())))
+            })
+            .collect())
+    }
+
     fn get_components_single_ecu_jobs_info(&self) -> Vec<ComponentDataInfo> {
         self.get_single_ecu_jobs_from_variant_and_parent_refs(|_| true)
             .into_iter()
@@ -2175,6 +2193,68 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     service_filter,
                 )
             })
+    }
+
+    /// Retrieves diagnostic services from a given functional group and its parent
+    /// references, filtered by the provided predicate.
+    ///
+    /// # Errors
+    /// Will return `Err` if the database has no functional groups or the specified
+    /// group is not found.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let read_services = ecu_manager.get_services_from_functional_group_and_parent_refs(
+    ///     "FunctionalGroupName",
+    ///     |service| {
+    ///         service
+    ///             .request_id()
+    ///             .is_some_and(|id| id == service_ids::READ_DATA_BY_IDENTIFIER)
+    ///     },
+    /// )?;
+    /// for service in &read_services {
+    ///     println!("{:?}", service.diag_comm().and_then(|dc| dc.short_name()));
+    /// }
+    /// ```
+    fn get_services_from_functional_group_and_parent_refs<F>(
+        &self,
+        group_name: &str,
+        service_filter: F,
+    ) -> Result<Vec<datatypes::DiagService<'_>>, DiagServiceError>
+    where
+        F: Fn(&datatypes::DiagService) -> bool,
+    {
+        let Ok(groups) = self.diag_database.functional_groups() else {
+            return Err(DiagServiceError::InvalidDatabase(
+                "Database has no functional groups".to_owned(),
+            ));
+        };
+
+        let matching_group = groups
+            .into_iter()
+            .find(|group| {
+                group
+                    .diag_layer()
+                    .and_then(|dl| dl.short_name())
+                    .is_some_and(|name| name.eq_ignore_ascii_case(group_name))
+            })
+            .ok_or_else(|| {
+                DiagServiceError::NotFound(Some(format!(
+                    "Functional group '{group_name}' not found"
+                )))
+            })?;
+
+        Ok(matching_group
+            .diag_layer()
+            .map(|dl| (dl, matching_group.parent_refs()))
+            .map_or(<_>::default(), |(diag_layer, parent_refs)| {
+                Self::get_services_from_diag_layer_and_parent_refs(
+                    &(diag_layer.into()),
+                    parent_refs.into_iter().flatten().map(datatypes::ParentRef),
+                    service_filter,
+                )
+            }))
     }
 
     /// Retrieves single ECU jobs from the current variants `DiagLayer` and its parent
@@ -4706,6 +4786,35 @@ mod tests {
         };
     }
 
+    /// Helper: build a database with a single variant and functional groups.
+    macro_rules! finish_db_with_functional_groups {
+        ($builder:expr, $protocol:expr, $variant_services:expr, $functional_groups:expr) => {{
+            let cp_ref = $builder.create_com_param_ref(None, None, None, Some($protocol), None);
+            let diag_layer = $builder.create_diag_layer(DiagLayerParams {
+                short_name: TEST_DIAG_LAYER,
+                com_param_refs: Some(vec![cp_ref]),
+                diag_services: {
+                    let services: Vec<_> = $variant_services;
+                    if services.is_empty() {
+                        None
+                    } else {
+                        Some(services)
+                    }
+                },
+                ..Default::default()
+            });
+            let variant = $builder.create_variant(diag_layer, true, None, None);
+            $builder.finish(EcuDataParams {
+                ecu_name: "TestEcu",
+                revision: "1",
+                version: "1.0.0",
+                variants: Some(vec![variant]),
+                functional_groups: Some($functional_groups),
+                ..Default::default()
+            })
+        }};
+    }
+
     /// Helper: build a `DiagComm` flatbuffer node with test-default fields.
     macro_rules! new_diag_comm {
         ($builder:expr, $name:expr, $protocol:expr) => {
@@ -4851,6 +4960,51 @@ mod tests {
             false,
         )
         .unwrap()
+    }
+
+    /// Creates an ECU manager whose database contains a functional group named `"MixedGroup"`
+    /// with one `ReadDataByIdentifier` service (`"ReadService"`) and one
+    /// `WriteDataByIdentifier` service (`"WriteService"`).
+    fn create_ecu_manager_with_mixed_functional_group()
+    -> super::EcuManager<DefaultSecurityPluginData> {
+        let mut db_builder = EcuDataBuilder::new();
+        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+
+        // Create a READ_DATA_BY_IDENTIFIER service
+        let read_diag_comm = db_builder.create_diag_comm(DiagCommParams {
+            short_name: "ReadService",
+            long_name: Some("Read Service"),
+            semantic: Some("DATA"),
+            protocols: Some(vec![protocol]),
+            ..Default::default()
+        });
+        let read_request =
+            create_sid_only_request!(db_builder, service_ids::READ_DATA_BY_IDENTIFIER);
+        let read_service =
+            new_diag_service!(db_builder, read_diag_comm, read_request, vec![], vec![]);
+
+        // Create a WRITE_DATA_BY_IDENTIFIER service
+        let write_diag_comm = db_builder.create_diag_comm(DiagCommParams {
+            short_name: "WriteService",
+            long_name: Some("Write Service"),
+            semantic: Some("DATA"),
+            protocols: Some(vec![protocol]),
+            ..Default::default()
+        });
+        let write_request =
+            create_sid_only_request!(db_builder, service_ids::WRITE_DATA_BY_IDENTIFIER);
+        let write_service =
+            new_diag_service!(db_builder, write_diag_comm, write_request, vec![], vec![]);
+
+        let fg_diag_layer = db_builder.create_diag_layer(DiagLayerParams {
+            short_name: "MixedGroup",
+            diag_services: Some(vec![read_service, write_service]),
+            ..Default::default()
+        });
+        let fg = db_builder.create_functional_group(fg_diag_layer, None);
+
+        let db = finish_db_with_functional_groups!(db_builder, protocol, vec![], vec![fg]);
+        new_ecu_manager(db)
     }
 
     /// Creates an ECU manager with a diagnostic service containing a `DynamicLengthField` DOP.
@@ -7979,6 +8133,42 @@ mod tests {
             Some(&json!(500)),
             "suffix must be decoded from bytes after var_data, not from the (absent) static byte \
              position"
+        );
+    }
+
+    #[test]
+    fn test_get_functional_group_data_info_filters_non_read_services() {
+        let ecu_manager = create_ecu_manager_with_mixed_functional_group();
+
+        let result = ecu_manager
+            .get_functional_group_data_info("MixedGroup")
+            .expect("should return Ok");
+
+        assert_eq!(result.len(), 1, "only read services should be returned");
+        assert_eq!(
+            result.first().expect("Expected element at index 0").id,
+            "ReadService"
+        );
+    }
+
+    #[test]
+    fn test_get_functional_group_data_info_no_functional_groups() {
+        let mut db_builder = EcuDataBuilder::new();
+        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+
+        // Build a database with no functional groups
+        let db = finish_db!(db_builder, protocol, vec![]);
+        let ecu_manager = new_ecu_manager(db);
+
+        let result = ecu_manager.get_functional_group_data_info("AnyGroup");
+
+        assert!(
+            result.is_err(),
+            "should fail when database has no functional groups"
+        );
+        assert!(
+            matches!(result, Err(DiagServiceError::InvalidDatabase(_))),
+            "expected InvalidDatabase error"
         );
     }
 

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -365,6 +365,13 @@ pub trait EcuManager:
 
     /// Retrieve all `read` services for the current ECU variant.
     fn get_components_data_info(&self) -> Vec<ComponentDataInfo>;
+    /// Retrieve all `read` services for a specific functional group's diag layer.
+    /// # Errors
+    /// Will return `Err` if the functional group cannot be found.
+    fn get_functional_group_data_info(
+        &self,
+        functional_group_name: &str,
+    ) -> Result<Vec<ComponentDataInfo>, DiagServiceError>;
     /// Retrieve all configuration type services for the current ECU variant.
     /// # Errors
     /// Returns `DiagServiceError` if the lookup failed.

--- a/cda-interfaces/src/ecuuds.rs
+++ b/cda-interfaces/src/ecuuds.rs
@@ -357,6 +357,14 @@ pub trait UdsEcu: Send + Sync + 'static {
         fault_code: Option<String>,
     ) -> Result<Self::Response, DiagServiceError>;
 
+    /// Retrieve all `read` services for a specific functional group.
+    /// # Errors
+    /// Will return `Err` if the description database ECU does not exist.
+    async fn get_functional_group_data_info(
+        &self,
+        functional_group_name: &str,
+    ) -> Result<Vec<ComponentDataInfo>, DiagServiceError>;
+
     /// Get the functional groups an ECU belongs to.
     /// # Errors
     /// Returns `DiagServiceError::NotFound` if the ECU is not found.
@@ -674,6 +682,10 @@ pub mod mock {
                 security_plugin: &DynamicPlugin,
                 fault_code: Option<String>,
             ) -> Result<<MockUdsEcu as UdsEcu>::Response, DiagServiceError>;
+            async fn get_functional_group_data_info(
+                &self,
+                functional_group_name: &str,
+            ) -> Result<Vec<ComponentDataInfo>, DiagServiceError>;
             async fn ecu_functional_groups(
                 &self,
                 ecu_name: &str,

--- a/cda-sovd-interfaces/src/functions/functional_groups/data.rs
+++ b/cda-sovd-interfaces/src/functions/functional_groups/data.rs
@@ -54,4 +54,5 @@ pub mod service {
 
 pub mod get {
     pub type Query = crate::IncludeSchemaQuery;
+    pub type Response = crate::Items<crate::components::ecu::ComponentDataInfo>;
 }

--- a/cda-sovd/src/sovd/functions/functional_groups/mod.rs
+++ b/cda-sovd/src/sovd/functions/functional_groups/mod.rs
@@ -159,6 +159,7 @@ fn create_functional_group_route<T: UdsEcu + Clone>(fg_state: WebserverFgState<T
                 .put_with(locks::lock::put, locks::lock::docs_put)
                 .delete_with(locks::lock::delete, locks::lock::docs_delete),
         )
+        .api_route("/data", routing::get_with(data::get, data::docs_get))
         .api_route(
             "/data/{diag_service}",
             routing::get_with(data::diag_service::get, data::diag_service::docs_get)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Add /data GET for functional group and a unit test to
validate the functionality.


```json
{
  "items": [
    {
      "category": "IDENTIFICATION",
      "id": "ActiveDiagnosticInformation_",
      "name": "Active Diagnostic Information"
    },
    {
      "category": "IDENTIFICATION",
      "id": "HardwareSupplier_",
      "name": "Hardware Supplier Identification"
    }
  ]
```

NOTE: The underscore _is_ part of the response because the default naming convention does not filter the underscore. This is addressed in https://github.com/eclipse-opensovd/classic-diagnostic-adapter/pull/217/

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Depends on #221 
----

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)