### PR TITLE
ci: remove clippy and format from rust build stage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,14 +81,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Install cargo-deny
         run: cargo install --locked --version 0.18.9 cargo-deny
-      - name: Install taplo toml toolkit
-        run: cargo install --locked --version 0.10.0 taplo-cli
-      - name: check fmt
-        run: cargo fmt --all -- --check
-      - name: check toml fmt
-        run: taplo fmt --check --diff
-      - name: Run Clippy
-        run: cargo clippy --locked --all-targets -- -D warnings
       - name: Build
         run: cargo build --locked --verbose
       - name: Check licenses


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Foramtting and clippy is already validated by the PR checks stage, no need to do it again.
Saves a bit of CI time and allows tests to run even when there are clippy warnings, so the author of a PR can get as much feedback as possible out of a single PR run.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

----

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)