### PR TITLE
feature: allow using system allocator

### DIFF
--- a/cda-main/Cargo.toml
+++ b/cda-main/Cargo.toml
@@ -85,5 +85,8 @@ openssl-vendored = [
 ]
 dlt-tracing = ["cda-tracing/dlt-tracing"]
 integration-tests = []
-
 health = []
+
+
+# ~65% less virtual memory usage but ~30% slower
+system-alloc = []

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -39,6 +39,12 @@ use crate::config::configfile::Configuration;
 
 pub mod config;
 
+
+#[cfg(feature = "system-alloc")]
+#[global_allocator]
+static GLOBAL: std::alloc::System = std::alloc::System;
+
+#[cfg(not(feature = "system-alloc"))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary


I also did some measurements to compare the two, to evaluate if it's worth to remove mimalloc entirely. 
Profiled on macOS / Apple Silicon (arm64) using Xcode Instruments.
Both allocators have advantages, so it makes sense to keep mimalloc as the default. 


## Comparison

| Metric                 | mimalloc         | System (macOS)   | Winner       |
|------------------------|------------------|------------------|--------------|
| **CPU Time**           | 3.35 s           | 4.33 s           |  mimalloc (29% faster) |
| **Real Memory**        | 400.22 MiB       | 329.78 MiB       | System (17% less) |
| **Heap & Anon VM**     | 1.24 GiB         | 434.01 MiB       |  System (65% less) |
| **Total Allocated**    | 4.29 GiB         | 3.19 GiB         |  System (26% less) |
| **Allocation Count**   | 7,896            | 2,273,227        |  mimalloc (287× fewer) |
| **Persistent Allocs**  | 1,084            | 202,138          |  mimalloc (186× fewer) |
| **Dirty Memory**       | 60.73 MiB        | 60.01 MiB        | ≈ Tie        |
| **Thread Count**       | 15               | 15               | Tie          |
| **Fragmentation Ratio**| 0.34% / 0.83%   | 0.16% / 1.02%   | Mixed        |

## mimalloc Advantages

- **\~29% faster execution** - fewer, larger allocations with arena-based pooling reduce per-allocation overhead.
- **Drastically fewer allocation syscalls** (\~8K vs \~2.3M) - batches allocations into large arenas, reducing kernel interaction.


## System Allocator Advantages

- **\~65% less virtual memory usage** - does not pre-reserve large arenas; allocates only what is needed.
- **\~17% lower resident memory** - more conservative memory footprint
- **\~26% less total bytes allocated** - tighter lifetime tracking, faster release to OS.


## Takeaway

mimalloc trades **memory for speed** it pre-allocates large areas leading to faster throughput but higher memory overhead. The system allocator is more **memory-efficient** but pays for it with more frequent, fine-grained allocations and \~1 second slower total runtime.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

This is a draft because the feature is not needed after all, so probably going to close this w/o merging.
