### PR TITLE
variant-detection: split diagnostic service name before last delimiter

### DIFF
--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -18,9 +18,9 @@ use std::{
 
 use async_trait::async_trait;
 use cda_interfaces::{
-    DiagComm, DiagCommType, DiagServiceError, DynamicPlugin, EcuGateway, EcuManager, EcuState,
-    EcuVariant, FlashTransferStartParams, FunctionalDescriptionConfig, HashMap, HashMapExtensions,
-    HashSet, HashSetExtensions, SchemaDescription, SchemaProvider, SecurityAccess, ServicePayload,
+    DiagComm, DiagServiceError, DynamicPlugin, EcuGateway, EcuManager, EcuState, EcuVariant,
+    FlashTransferStartParams, FunctionalDescriptionConfig, HashMap, HashMapExtensions, HashSet,
+    HashSetExtensions, SchemaDescription, SchemaProvider, SecurityAccess, ServicePayload,
     TesterPresentControlMessage, TesterPresentMode, TesterPresentType, TransmissionParameters,
     UDS_ID_RESPONSE_BITMASK, UdsEcu, UdsResponse,
     datatypes::{
@@ -1808,19 +1808,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
             .await
             .get_variant_detection_requests()
             .iter()
-            .map(|req| {
-                let name = req
-                    .split_once('_')
-                    .map_or(req.as_str(), |(name, _)| name)
-                    .to_owned();
-
-                let service = DiagComm {
-                    name: name.clone(),
-                    type_: DiagCommType::Data,
-                    lookup_name: None,
-                };
-                Ok((req.to_owned(), service))
-            })
+            .map(|(name, service)| Ok((name.to_owned(), service.clone())))
             .collect::<Result<Vec<(String, DiagComm)>, DiagServiceError>>()?;
 
         if !ecu.read().await.is_loaded() {

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -289,7 +289,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
         }
     }
 
-    fn get_variant_detection_requests(&self) -> &HashSet<String> {
+    fn get_variant_detection_requests(&self) -> &HashMap<String, DiagComm> {
         &self.variant_detection.diag_service_requests
     }
 
@@ -1660,7 +1660,8 @@ impl<S: SecurityPlugin> EcuManager<S> {
         func_description_config: &cda_interfaces::FunctionalDescriptionConfig,
         fallback_to_base_variant: bool,
     ) -> Result<Self, DiagServiceError> {
-        let variant_detection = variant_detection::prepare_variant_detection(&database)?;
+        let variant_detection =
+            variant_detection::prepare_variant_detection(&database, &database_naming_convention)?;
 
         let data_protocol = into_db_protocol(&database, protocol)?;
 
@@ -1854,7 +1855,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
             connection_retry_delay: com_params.doip.connection_retry_delay.default,
             connection_retry_attempts: com_params.doip.connection_retry_attempts.default,
             variant_detection: VariantDetection {
-                diag_service_requests: HashSet::new(),
+                diag_service_requests: HashMap::new(),
             },
             variant_index: None,
             variant: EcuVariant {

--- a/cda-core/src/diag_kernel/variant_detection.rs
+++ b/cda-core/src/diag_kernel/variant_detection.rs
@@ -12,18 +12,20 @@
 
 use cda_database::datatypes;
 use cda_interfaces::{
-    DiagServiceError, HashMap, HashSet, diagservices::DiagServiceResponse, dlt_ctx,
+    DiagComm, DiagCommType, DiagServiceError, HashMap, datatypes::DatabaseNamingConvention,
+    diagservices::DiagServiceResponse, dlt_ctx,
 };
 pub(super) type DiagServiceId = String;
 
 pub(super) struct VariantDetection {
-    pub(crate) diag_service_requests: HashSet<DiagServiceId>,
+    pub(crate) diag_service_requests: HashMap<DiagServiceId, DiagComm>,
 }
 
 pub(super) fn prepare_variant_detection(
     diagnostic_database: &datatypes::DiagnosticDatabase,
+    db_naming_convention: &DatabaseNamingConvention,
 ) -> Result<VariantDetection, DiagServiceError> {
-    let diag_service_requests: HashSet<_> = diagnostic_database
+    let diag_service_requests: HashMap<_, _> = diagnostic_database
         .ecu_data()?
         .variants()
         .map(|variants| {
@@ -38,7 +40,17 @@ pub(super) fn prepare_variant_detection(
                                     mp.diag_service()
                                         .and_then(|ds| ds.diag_comm())
                                         .and_then(|dc| dc.short_name())
-                                        .map(ToOwned::to_owned)
+                                        .map(|sn| {
+                                            (
+                                                sn.to_owned(),
+                                                DiagComm {
+                                                    name: db_naming_convention
+                                                        .trim_short_name_affixes(sn),
+                                                    type_: DiagCommType::Data,
+                                                    lookup_name: Some(sn.to_owned()),
+                                                },
+                                            )
+                                        })
                                 })
                             })
                         })

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -171,7 +171,7 @@ pub trait EcuManager:
         &mut self,
         service_responses: HashMap<String, T>,
     ) -> impl Future<Output = Result<(), DiagServiceError>> + Send;
-    fn get_variant_detection_requests(&self) -> &HashSet<String>;
+    fn get_variant_detection_requests(&self) -> &HashMap<String, DiagComm>;
     /// Communication parameters for the ECU.
     /// # Errors
     /// Will return `DiagServiceError` if the communication


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
Diagnostic service name is split after first _ delimiter determining a failure in the variant identication because of the name mismatch between processed name and database name

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->
Fixes https://github.com/eclipse-opensovd/classic-diagnostic-adapter/issues/226
## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
