### PR TITLE
modes: improve error message with possible parameters.

### DIFF
--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -756,35 +756,56 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
         service_id: u8,
         name: &str,
     ) -> Result<DiagComm, DiagServiceError> {
-        self.lookup_services_by_sid(service_id)?
-            .into_iter()
-            .find_map(|service| {
-                let diag_comm = service.diag_comm()?;
-                let short_name = diag_comm.short_name()?;
+        let services = self.lookup_services_by_sid(service_id)?;
+        let result = services.iter().find_map(|service| {
+            let diag_comm = service.diag_comm()?;
+            let short_name = diag_comm.short_name()?;
 
-                let short_name_no_affix = self
-                    .database_naming_convention
-                    .trim_service_name_affixes(service_id, short_name.to_owned());
-                let matches = match self.database_naming_convention.short_name_affix_position {
-                    DiagnosticServiceAffixPosition::Suffix => {
-                        starts_with_ignore_ascii_case(&short_name_no_affix, name)
-                    }
-                    DiagnosticServiceAffixPosition::Prefix => {
-                        ends_with_ignore_ascii_case(&short_name_no_affix, name)
-                    }
-                };
-
-                if !matches {
-                    return None;
+            let short_name_no_affix = self
+                .database_naming_convention
+                .trim_service_name_affixes(service_id, short_name.to_owned());
+            let matches = match self.database_naming_convention.short_name_affix_position {
+                DiagnosticServiceAffixPosition::Suffix => {
+                    starts_with_ignore_ascii_case(&short_name_no_affix, name)
                 }
+                DiagnosticServiceAffixPosition::Prefix => {
+                    ends_with_ignore_ascii_case(&short_name_no_affix, name)
+                }
+            };
 
-                Some(DiagComm {
-                    name: short_name.to_owned(),
-                    type_: DiagCommType::try_from(service_id).ok()?,
-                    lookup_name: Some(short_name.to_owned()),
-                })
+            if !matches {
+                return None;
+            }
+
+            Some(DiagComm {
+                name: short_name.to_owned(),
+                type_: DiagCommType::try_from(service_id).ok()?,
+                lookup_name: Some(short_name.to_owned()),
             })
-            .ok_or_else(|| DiagServiceError::NotFound(Some(name.to_owned())))
+        });
+
+        if let Some(diag_comm) = result {
+            Ok(diag_comm)
+        } else {
+            let alternatives: HashSet<String> = services
+                .iter()
+                .filter_map(|service| {
+                    let diag_comm = service.diag_comm()?;
+                    let short_name = diag_comm.short_name()?;
+                    let short_name_no_affix =
+                        self.database_naming_convention.trim_short_name_affixes(
+                            &self
+                                .database_naming_convention
+                                .trim_service_name_affixes(service_id, short_name.to_owned()),
+                        );
+                    Some(short_name_no_affix)
+                })
+                .collect();
+
+            Err(DiagServiceError::InvalidParameter {
+                possible_values: alternatives,
+            })
+        }
     }
 
     fn get_components_data_info(&self) -> Vec<ComponentDataInfo> {

--- a/cda-interfaces/src/lib.rs
+++ b/cda-interfaces/src/lib.rs
@@ -332,6 +332,8 @@ pub enum DiagServiceError {
         name: String,
         candidates: Vec<String>,
     },
+    #[error("No value found with the given parameters. Possible values are: {possible_values:?}")]
+    InvalidParameter { possible_values: HashSet<String> },
 }
 
 #[derive(Error, Debug)]

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -121,6 +121,7 @@ impl From<DiagServiceError> for AppError {
             | DiagServiceError::InvalidDatabase(_)
             | DiagServiceError::DatabaseEntryNotFound(_)
             | DiagServiceError::AmbiguousParameters { .. }
+            | DiagServiceError::InvalidParameter { .. }
             | DiagServiceError::NotEnoughData { .. } => Self::DataError(value.to_string()),
         }
     }

--- a/cda-sovd/src/lib.rs
+++ b/cda-sovd/src/lib.rs
@@ -32,7 +32,9 @@ use tokio::net::TcpListener;
 use tower::{Layer, ServiceExt as TowerServiceExt};
 use tower_http::{normalize_path::NormalizePathLayer, trace::TraceLayer};
 
-pub use crate::sovd::{locks::Locks, static_data::add_static_data_endpoint};
+pub use crate::sovd::{
+    error::VendorErrorCode, locks::Locks, static_data::add_static_data_endpoint,
+};
 
 pub mod dynamic_router;
 mod openapi;

--- a/cda-sovd/src/sovd/error.rs
+++ b/cda-sovd/src/sovd/error.rs
@@ -23,7 +23,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use cda_interfaces::{
-    DiagServiceError, HashMap, HashMapExtensions, diagservices::DiagServiceResponse,
+    DiagServiceError, HashMap, HashMapExtensions, HashSet, diagservices::DiagServiceResponse,
     file_manager::MddError,
 };
 use serde::{Deserialize, Serialize};
@@ -45,6 +45,8 @@ pub enum ApiError {
     Conflict(String),
     #[error("Not Responding: {0}")]
     NotResponding(String),
+    #[error("The value of the parameter is not of the allowed values")]
+    InvalidParameter { possible_values: HashSet<String> },
 }
 
 impl ApiError {
@@ -58,6 +60,10 @@ impl ApiError {
                 Some(VendorErrorCode::BadRequest),
             ),
             ApiError::Forbidden(_) => (ErrorCode::InsufficientAccessRights, None),
+            ApiError::InvalidParameter { .. } => (
+                ErrorCode::VendorSpecific,
+                Some(VendorErrorCode::InvalidParameter),
+            ),
             _ => (ErrorCode::SovdServerFailure, None),
         }
     }
@@ -65,11 +71,13 @@ impl ApiError {
 
 impl From<DiagServiceError> for ApiError {
     fn from(value: DiagServiceError) -> Self {
-        match &value {
+        match value {
             DiagServiceError::UdsLookupError(_) | DiagServiceError::NotFound(_) => {
                 ApiError::NotFound(Some(value.to_string()))
             }
-
+            DiagServiceError::InvalidParameter { possible_values } => {
+                ApiError::InvalidParameter { possible_values }
+            }
             DiagServiceError::InvalidDatabase(_)
             | DiagServiceError::DatabaseEntryNotFound(_)
             | DiagServiceError::VariantDetectionError(_)
@@ -151,7 +159,7 @@ pub struct ErrorWrapper {
     pub include_schema: bool,
 }
 
-#[derive(Serialize, schemars::JsonSchema)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum VendorErrorCode {
     /// The requested resource was not found.
@@ -167,6 +175,8 @@ pub enum VendorErrorCode {
     ///
     /// eg. A Value received by the ECU was outside of the expected range
     ErrorInterpretingMessage,
+    /// The given parameter is not valid.
+    InvalidParameter,
 }
 
 impl OperationOutput for ErrorWrapper {
@@ -252,6 +262,35 @@ impl IntoResponse for ErrorWrapper {
                     },
                 ),
             ),
+            ApiError::InvalidParameter { possible_values } => {
+                let mut parameters = HashMap::new();
+                parameters.insert(
+                    "details".to_owned(),
+                    serde_json::Value::String("value".to_owned()),
+                );
+                parameters.insert(
+                    "possiblevalues".to_owned(),
+                    serde_json::Value::Array(
+                        possible_values
+                            .into_iter()
+                            .map(|v| serde_json::Value::String(v.to_lowercase()))
+                            .collect(),
+                    ),
+                );
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(
+                        sovd_interfaces::error::ApiErrorResponse::<VendorErrorCode> {
+                            message: "The parameter value is not valid".to_owned(),
+                            error_code: ErrorCode::VendorSpecific,
+                            vendor_code: Some(VendorErrorCode::InvalidParameter),
+                            parameters: Some(parameters),
+                            error_source: None,
+                            schema,
+                        },
+                    ),
+                )
+            }
             ApiError::NotResponding(message) => (
                 StatusCode::GATEWAY_TIMEOUT,
                 Json(

--- a/integration-tests/tests/sovd/ecu.rs
+++ b/integration-tests/tests/sovd/ecu.rs
@@ -413,6 +413,29 @@ async fn test_communication_control() {
     let lock_id =
         extract_field_from_json::<String>(&response_to_json(&ecu_lock).unwrap(), "id").unwrap();
 
+    // Sending an invalid value should return BAD_REQUEST with possible values
+    sovd::validate_invalid_parameter_error(
+        &runtime.config,
+        &auth,
+        ecu_endpoint,
+        "commctrl",
+        modes::commctrl::put::Request {
+            value: "invalid-value".to_owned(),
+            parameters: None,
+        },
+        &[
+            "enablerxandenabletx",
+            "enablerxanddisabletx",
+            "disablerxandenabletx",
+            "disablerxanddisabletx",
+            "enablerxanddisabletxwithenhancedaddressinformation",
+            "enablerxandtxwithenhancedaddressinformation",
+            "temporalsync",
+        ],
+    )
+    .await
+    .unwrap();
+
     let enable_rx_and_enable_tx = "enablerxandenabletx";
     let result = set_comm_control(
         "EnableRxAndEnableTx",

--- a/integration-tests/tests/sovd/faults.rs
+++ b/integration-tests/tests/sovd/faults.rs
@@ -12,7 +12,7 @@
 use std::time::Duration;
 
 use http::{Method, StatusCode};
-use sovd_interfaces::components::ecu::faults::Fault;
+use sovd_interfaces::components::ecu::{faults::Fault, modes::dtcsetting};
 
 use crate::{
     sovd::{
@@ -78,6 +78,21 @@ async fn test_dtc_setting() {
         &auth,
         ecu_endpoint,
         StatusCode::OK,
+    )
+    .await
+    .unwrap();
+
+    // Sending an invalid value should return BAD_REQUEST with possible values
+    sovd::validate_invalid_parameter_error(
+        &runtime.config,
+        &auth,
+        ecu_endpoint,
+        "dtcsetting",
+        dtcsetting::put::Request {
+            value: "invalid-value".to_owned(),
+            parameters: None,
+        },
+        &["on", "off", "timetraveldtcson"],
     )
     .await
     .unwrap();

--- a/integration-tests/tests/sovd/mod.rs
+++ b/integration-tests/tests/sovd/mod.rs
@@ -9,10 +9,16 @@
  * terms of the Apache License Version 2.0 which is available at
  * https://www.apache.org/licenses/LICENSE-2.0
  */
+use std::collections::HashSet;
+
+use cda_sovd::VendorErrorCode;
 use http::{HeaderMap, Method, StatusCode};
 use opensovd_cda_lib::config::configfile::Configuration;
-use serde::{Serialize, de::DeserializeOwned};
-use sovd_interfaces::components::ecu::{faults::Fault, modes::dtcsetting};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use sovd_interfaces::{
+    components::ecu::{faults::Fault, modes::dtcsetting},
+    error::{ApiErrorResponse, ErrorCode},
+};
 
 use crate::util::{
     TestingError,
@@ -46,11 +52,86 @@ pub(crate) async fn put_mode<T: DeserializeOwned, S: Serialize>(
         Some(headers),
     )
     .await?;
-    if excepted_status == StatusCode::OK {
-        Ok(Some(response_to_t(&http_response)?))
-    } else {
-        Ok(None)
+    match response_to_t(&http_response) {
+        Ok(v) => Ok(Some(v)),
+        Err(_) if excepted_status != StatusCode::OK => Ok(None),
+        Err(e) => Err(e),
     }
+}
+
+/// Sends a mode PUT request with the given body and validates that the response
+/// is a `400 Bad Request` with an `invalid-parameter` vendor code and that
+/// the `possiblevalues` field contains exactly the expected values.
+pub(crate) async fn validate_invalid_parameter_error<S: Serialize>(
+    config: &Configuration,
+    headers: &HeaderMap,
+    ecu_endpoint: &str,
+    sub_path: &str,
+    request: S,
+    expected_possible_values: &[&str],
+) -> Result<(), TestingError> {
+    #[derive(Deserialize)]
+    struct InvalidParameterDetails {
+        details: String,
+        possiblevalues: Vec<String>,
+    }
+
+    let error_response: ApiErrorResponse<VendorErrorCode> = put_mode(
+        config,
+        headers,
+        ecu_endpoint,
+        sub_path,
+        request,
+        StatusCode::BAD_REQUEST,
+    )
+    .await?
+    .expect("Expected error response body for BAD_REQUEST");
+
+    assert_eq!(
+        error_response.message, "The parameter value is not valid",
+        "Unexpected error message: {}",
+        error_response.message
+    );
+    assert_eq!(
+        error_response.error_code,
+        ErrorCode::VendorSpecific,
+        "Unexpected error_code: {:?}",
+        error_response.error_code
+    );
+    assert_eq!(
+        error_response.vendor_code,
+        Some(VendorErrorCode::InvalidParameter),
+        "Unexpected vendor_code: {:?}",
+        error_response.vendor_code
+    );
+
+    let params: InvalidParameterDetails = serde_json::from_value(
+        serde_json::to_value(
+            error_response
+                .parameters
+                .expect("Expected 'parameters' in error response"),
+        )
+        .expect("Invalid parameters structure"),
+    )
+    .expect("Failed to parse InvalidParameterDetails from parameters");
+
+    assert_eq!(params.details, "value", "Unexpected details value");
+
+    let actual_values: HashSet<String> = params
+        .possiblevalues
+        .iter()
+        .map(|s| s.to_lowercase())
+        .collect();
+    let expected_values: HashSet<String> = expected_possible_values
+        .iter()
+        .map(|s| s.to_lowercase())
+        .collect();
+    assert_eq!(
+        actual_values, expected_values,
+        "Possible values mismatch, Expected: {expected_values:?}, Actual: {actual_values:?}"
+    );
+
+    Ok(())
 }
 
 pub(crate) async fn set_dtc_setting(


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
Prior to this commit /modes/commctrl and /modes/dtcsetting returned a 404 if an unknown value was passed.
This commit introduces a new error type that lists the possible values for the function.

### Example
```json
{
  "message": "The parameter value is not valid",
  "error_code": "vendor-specific",
  "vendor_code": "invalid-parameter",
  "parameters": {
    "details": "value",
    "possiblevalues": [
      "enablerxandenabletx",
      "enablerxanddisabletx"
    ]
  }
}
```

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)