### PR TITLE
database: allow bitmask to be empty for SID

### DIFF
--- a/cda-database/src/datatypes/mod.rs
+++ b/cda-database/src/datatypes/mod.rs
@@ -198,7 +198,11 @@ impl DiagService<'_> {
             let standard_length_type = diag_coded_type.specific_data_as_standard_length_type()?;
 
             // SIDRQ validation
-            if standard_length_type.condensed() || standard_length_type.bit_mask().is_some() {
+            if standard_length_type.condensed()
+                || standard_length_type
+                    .bit_mask()
+                    .is_some_and(|mask| !mask.is_empty())
+            {
                 return None;
             }
 


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

This makes detecting the SID a bit more flexible,
as prior to this commit the mask for the SID had to be None. Using an empty mask is as good as None, though a
database writer implementation should prefer None
over an empty vector.


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

While is not _strictly_ necessary I fell into this issue while playing around with https://github.com/bburda42dot/diag-converter which uses an empty vector instead of None. 
I did raise this issue also in the diag-converter, so None should be prefered but this makes the CDA a little bit more resilient against non perfect databases. 


Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
