### PR TITLE
ci: use all-features in clippy stage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2025-07-14
-          components: clippy
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
       - name: Install Protoc
@@ -48,10 +47,8 @@ jobs:
           # The action queries the GitHub API to fetch releases data,
           # to avoid rate limiting, passing the default token.
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup DLT
+      - name: Setup DLT tracing lib
         uses: eclipse-opensovd/dlt-tracing-lib/.github/actions/setup-dlt@main
-      - name: Clippy
-        run: cargo clippy --locked --all-targets --all-features -- -D warnings
       - name: Build all features
         run: cargo build --locked --verbose --all-features
       - name: Build minimal features

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -36,6 +36,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+      - name: Setup DLT tracing lib
+        uses: eclipse-opensovd/dlt-tracing-lib/.github/actions/setup-dlt@main
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          # The action queries the GitHub API to fetch releases data,
+          # to avoid rate limiting, passing the default token.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Format and Clippy - Nightly toolchain pinned
         uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@41c531349e9d7e7852455c35682cd200519fb81b
         with:
@@ -44,7 +52,7 @@ jobs:
           fail-on-format-error: "true"
           fail-on-clippy-error: "true"
           clippy-deny-warnings: "true"
-          clippy-features: "integration-tests"
+          clippy-features: "all-features"
           reporter: ${{ env.IS_FORK == 'true' && 'github-pr-annotations' || 'github-pr-review' }}
       - name: Format and Clippy - Nightly toolchain latest
         id: nightly-clippy
@@ -56,7 +64,7 @@ jobs:
           fail-on-format-error: "false"
           fail-on-clippy-error: "false"
           clippy-deny-warnings: "false"
-          clippy-features: "integration-tests"
+          clippy-features: "all-features"
           # For nightly, we also want to see files not touched by
           # the PR, to detect if there are any new warnings introduced by the latest nightly toolchain.
           reporter: ${{ env.IS_FORK == 'true' && 'github-annotations' || 'github-pr-check' }}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
Remove clippy from all features build and
add all-features to the existing clippy stage.
This de-duplicates running clippy and makes sure
that reviewdog complains about all possible clippy finds.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->


Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
