### PR TITLE
Improve recovery from corrupted UDP DoIP frames

### DIFF
--- a/cda-comm-doip/src/socket.rs
+++ b/cda-comm-doip/src/socket.rs
@@ -22,6 +22,7 @@ use doip_definitions::{
 use futures::{SinkExt, StreamExt};
 use tokio::io::{AsyncRead, AsyncWrite, ReadHalf, WriteHalf};
 use tokio_util::{
+    bytes::Buf,
     codec::{Framed, FramedRead, FramedWrite},
     udp::UdpFramed,
 };
@@ -142,7 +143,14 @@ impl DoIPUdpSocket {
 
     pub async fn recv(&mut self) -> Option<Result<(DoipMessage, SocketAddr), ConnectionError>> {
         self.io.next().await.map(|opt| {
-            opt.map_err(|e| ConnectionError::Decoding(format!("Failed to read message: {e:?}")))
+            opt.map_err(|e| {
+                // In case of error (remaining bytes, corrupted DoIP message, etc...),
+                // the current UDP frame needs to be disposed of to be able to receive new frames
+                let remaining_bytes = self.io.read_buffer().len();
+                self.io.read_buffer_mut().advance(remaining_bytes);
+
+                ConnectionError::Decoding(format!("Failed to read message: {e:?}"))
+            })
         })
     }
 }

--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -64,7 +64,7 @@ where
         },
         () = async { // loop until timeout is exceeded or shutdown signal is received
                 loop {
-                    tracing::info!("Started loop");
+                    tracing::info!("Waiting for VIRs...");
                     match socket.recv().await {
                         Some(Ok((doip_msg, source_addr))) => {
                             if let PayloadType::VehicleIdentificationRequest =
@@ -81,7 +81,7 @@ where
                         }
                         Some(Err(e)) => {
                             tracing::warn!("Failed to receive VAMs: {e:?}");
-                            break;
+                            continue;
                         },
                         None => {
                             tracing::warn!("Incomplete VAM due to connection closure/error");


### PR DESCRIPTION
## Summary
In this PR, `DoIPUdpSocket` can now recover from corrupted or invalid DoIP messages so listening to VIRs is no longer abruptly stopped earlier than expected.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
Relates to Issue #8 and continues PR #205

## Notes for Reviewers
❌Before the improvement, a corrupted UDP DoIP message would lock the `UdpFramed` instance by trying to continuously decode the same corrupted UDP frame, leading, in one case, to an early exit of looking for VIRs at startup (leading to potentially missed ECU's)
<img width="1451" height="244" alt="udp_recovery_improvement_before" src="https://github.com/user-attachments/assets/3bd2d9d4-e5ae-4adc-bd37-663279e0a29f" />
`Finished waiting for VIRs` log is missing indicating that the function exited early due to the decoding error.

✅ After the fix, corrupt UDP frames are discarded so new frames can be processed.
<img width="1886" height="466" alt="udp_recovery_improvement_after" src="https://github.com/user-attachments/assets/042114ba-9135-492f-8488-7acd52377c2b" />
It can be seen that the search now ends due to timeout even with the 2 corrupted frames previously received (and not because of the decoding error)