### PR TITLE
datatypes: treat empty mask as None

### DIFF
--- a/cda-database/src/datatypes/diag_coded_type.rs
+++ b/cda-database/src/datatypes/diag_coded_type.rs
@@ -553,10 +553,15 @@ impl DiagCodedType {
             }
             DiagCodedTypeVariant::StandardLength(slt) => {
                 self.base_datatype.validate_bit_len(slt.bit_length)?;
-                let mask = slt.bit_mask.as_ref().map(|m| Mask {
-                    data: m.clone(),
-                    condensed: slt.condensed,
-                });
+                // Treat an empty bit_mask as no mask (None)
+                let mask = slt
+                    .bit_mask
+                    .as_ref()
+                    .filter(|m| !m.is_empty())
+                    .map(|m| Mask {
+                        data: m.clone(),
+                        condensed: slt.condensed,
+                    });
 
                 let (packed, len) =
                     pack_data(slt.bit_length as usize, 0, mask.as_ref(), &input_data)?;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

During encoding of standard length types,
empty masks where not filtered out.
If a database is using an empty vector instead of None, this leads to applying all zeroed mask to all bytes, which leads to wiping the payload.
This commit changes this, so empty masks are treated the same as 'None' masks.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Found while playing around with https://github.com/bburda42dot/diag-converter fyi @bburda42dot 

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)