### PR TITLE
memory-map FlatBuffers data to reduce RSS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,15 +400,18 @@ dependencies = [
 name = "cda-database"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "cargo_toml",
  "cda-build",
  "cda-interfaces",
  "flatbuffers",
+ "memmap2",
  "ouroboros",
  "prost",
  "prost-build",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "toml 0.9.8",
  "tracing",
@@ -438,6 +441,7 @@ name = "cda-interfaces"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "foldhash",
  "hex",
  "mockall",
@@ -1971,6 +1975,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mimalloc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ tokio-util = { version = "0.7.3", default-features = false }
 futures = "0.3"
 regex = "1.12.2"
 uuid = "1.18.1"
+bytes = "1"
 prost = "0.14"
 flatbuffers = "25.9.23"
 xz2 = "0.1.7"
@@ -86,7 +87,9 @@ toml = "0.9.8"
 cargo_toml = "0.22.3"
 libc = "0.2.177"
 foldhash = "0.2.0"
+memmap2 = "0.9"
 mockall = "0.14.0"
+sha2 = "0.10"
 
 # ---- tracing & logging crates ----
 tracing = "0.1.41"

--- a/cda-database/Cargo.toml
+++ b/cda-database/Cargo.toml
@@ -27,13 +27,16 @@ path = "src/lib.rs"
 # internal dependencies
 cda-interfaces = { workspace = true }
 # external
+bytes = { workspace = true }
 prost = { workspace = true }
 flatbuffers = { workspace = true }
+memmap2 = { workspace = true }
 ouroboros = { workspace = true }
 # tokio
 tokio = { workspace = true, features = ["rt", "sync", "io-util", "time"] }
 # v4 - Version 4 UUIDs with random data.
 uuid = { workspace = true, features = ["v4"] }
+sha2 = { workspace = true }
 xz2 = { workspace = true, features = ["static"] }
 
 # logging

--- a/cda-database/build.rs
+++ b/cda-database/build.rs
@@ -39,7 +39,12 @@ fn prepend_copyright(file_path: &str) -> std::io::Result<()> {
 /// so they can be checked into the repository.
 #[cfg(feature = "gen-protos")]
 fn generate_protos() -> std::io::Result<()> {
-    prost_build::compile_protos(&["proto/file_format.proto"], &["proto/"])?;
+    let mut config = prost_build::Config::new();
+    // Emit `bytes::Bytes` instead of `Vec<u8>` for the chunk data field so that
+    // protobuf decoding from an mmap-backed `Bytes` buffer produces zero-copy
+    // sub-slices rather than heap-allocated copies.
+    config.bytes([".fileformat.Chunk.data"]);
+    config.compile_protos(&["proto/file_format.proto"], &["proto/"])?;
 
     let out_dir = out_dir()?;
 

--- a/cda-database/src/datatypes/database_builder.rs
+++ b/cda-database/src/datatypes/database_builder.rs
@@ -240,7 +240,7 @@ impl<'a> EcuDataBuilder<'a> {
         self.fbb.finish(ecu_data, None);
         let blob = self.fbb.finished_data().to_vec();
 
-        super::DiagnosticDatabase::new(
+        super::DiagnosticDatabase::new_from_vec(
             String::default(),
             blob,
             cda_interfaces::datatypes::FlatbBufConfig::default(),

--- a/cda-database/src/datatypes/mod.rs
+++ b/cda-database/src/datatypes/mod.rs
@@ -27,7 +27,7 @@ pub use service::*;
 use crate::{
     datatypes,
     flatbuf::diagnostic_description::dataformat,
-    mdd_data::{load_ecudata, read_ecudata},
+    mdd_data::{self, read_ecudata},
 };
 
 #[cfg(feature = "database-builder")]
@@ -439,16 +439,14 @@ impl From<dataformat::LongName<'_>> for LongName {
 }
 
 #[self_referencing]
-#[derive(Debug)]
 struct EcuData {
-    blob: Vec<u8>,
+    blob: bytes::Bytes,
 
     #[borrows(blob)]
     #[covariant]
     pub data: dataformat::EcuData<'this>,
 }
 
-#[derive(Debug)]
 pub struct DiagnosticDatabase {
     ecu_database_path: String,
     ecu_data: Option<EcuData>,
@@ -477,20 +475,42 @@ pub struct LongName {
 }
 
 impl DiagnosticDatabase {
-    /// Create a new `DiagnosticDatabase` from the given ECU database path and ECU data blob.
+    /// Create a new `DiagnosticDatabase` from a `FlatBuffers` blob in memory.
+    ///
+    /// Converts the `Vec<u8>` into `bytes::Bytes` (zero-copy move) and
+    /// delegates to [`Self::new_from_bytes`].
+    ///
     /// # Errors
-    /// Returns an error if the ECU data blob cannot be read.
-    /// # Panics
-    /// When `FlatBufConfig::verify` is disabled and an invalid ECU data blob is provided.
-    pub fn new(
+    /// Returns an error if the blob cannot be parsed as valid `FlatBuffers` data.
+    pub fn new_from_vec(
         ecu_database_path: String,
         ecu_data_blob: Vec<u8>,
         flatbuf_config: FlatbBufConfig,
     ) -> Result<Self, DiagServiceError> {
+        Self::new_from_bytes(
+            ecu_database_path,
+            bytes::Bytes::from(ecu_data_blob),
+            flatbuf_config,
+        )
+    }
+
+    /// Create a new `DiagnosticDatabase` from a `Bytes` buffer.
+    ///
+    /// This is usually a zero-copy sub-slice of a mmap-backed protobuf decode,
+    /// so the underlying memory is file-backed
+    /// and can be evicted by the kernel under memory pressure.
+    ///
+    /// # Errors
+    /// Returns an error if the blob cannot be parsed as valid `FlatBuffers` data.
+    pub fn new_from_bytes(
+        ecu_database_path: String,
+        ecu_data_blob: bytes::Bytes,
+        flatbuf_config: FlatbBufConfig,
+    ) -> Result<Self, DiagServiceError> {
         let ecu_data = EcuDataTryBuilder {
             blob: ecu_data_blob,
-            data_builder: |ecu_data_blob| {
-                read_ecudata(ecu_data_blob, &flatbuf_config).map_err(|e| {
+            data_builder: |blob| {
+                read_ecudata(blob.as_ref(), &flatbuf_config).map_err(|e| {
                     DiagServiceError::InvalidDatabase(format!(
                         "Failed to read ECU data from blob: {e}"
                     ))
@@ -521,11 +541,13 @@ impl DiagnosticDatabase {
     /// # Panics
     /// If the ECU data is invalid and `FlatbBufConfig::verify` is disabled.
     pub fn load(&mut self) -> Result<(), DiagServiceError> {
-        let ecu_data = load_ecudata(&self.ecu_database_path)
+        // If the decompress feature is enabled, decompression already happened
+        // before 'new' of DiagnosticDatabase, so we can just load the data from the path.
+        let (_ecu_name, blob) = mdd_data::load_ecudata(&self.ecu_database_path)
             .map_err(|e| DiagServiceError::InvalidDatabase(e.to_string()))?;
-        *self = DiagnosticDatabase::new(
+        *self = DiagnosticDatabase::new_from_bytes(
             self.ecu_database_path.clone(),
-            ecu_data.1,
+            blob,
             self.flatbuf_config.clone(),
         )?;
         Ok(())

--- a/cda-database/src/lib.rs
+++ b/cda-database/src/lib.rs
@@ -17,4 +17,5 @@ pub(crate) mod proto;
 
 pub use mdd_data::{
     ProtoLoadConfig, files::FileManager, load_chunk, load_ecudata, load_proto_data,
+    update_mdd_uncompressed,
 };

--- a/cda-database/src/mdd_data/files.rs
+++ b/cda-database/src/mdd_data/files.rs
@@ -129,7 +129,7 @@ impl cda_interfaces::file_manager::FileManager for FileManager {
                 cache.last_accessed = Some(Instant::now());
                 Ok((
                     cache.chunk.meta_data.clone(),
-                    load_chunk(&mut cache.chunk, &self.mdd_path).cloned()?,
+                    load_chunk(&mut cache.chunk, &self.mdd_path)?.to_vec(),
                 ))
             },
         )

--- a/cda-database/src/mdd_data/mod.rs
+++ b/cda-database/src/mdd_data/mod.rs
@@ -421,12 +421,24 @@ pub fn update_mdd_uncompressed(mdd_path: &str) -> Result<bool, MddError> {
     })?;
 
     verify_mdd_chunk_checksums(&tmp_path, &expected_hashes).inspect_err(|_| {
-        let _ = std::fs::remove_file(&tmp_path);
+        if let Err(e) = std::fs::remove_file(&tmp_path) {
+            tracing::error!(
+                error = %e,
+                filename = %tmp_path,
+                "Failed to remove temporary MDD file after checksum verification failure"
+            );
+        }
     })?;
 
     std::fs::rename(&tmp_path, mdd_path).map_err(|e| {
         // Clean up the temp file on rename failure.
-        let _ = std::fs::remove_file(&tmp_path);
+        if let Err(e) = std::fs::remove_file(&tmp_path) {
+            tracing::error!(
+                error = %e,
+                filename = %tmp_path,
+                "Failed to remove temporary MDD file after rename failure"
+            );
+        }
         MddError::Io(format!(
             "Failed to rename temporary MDD file to '{mdd_path}': {e}"
         ))

--- a/cda-database/src/mdd_data/mod.rs
+++ b/cda-database/src/mdd_data/mod.rs
@@ -12,6 +12,7 @@
 
 use std::{io::Read, time::Instant};
 
+use bytes::Bytes;
 use cda_interfaces::{
     HashMap,
     datatypes::FlatbBufConfig,
@@ -20,6 +21,7 @@ use cda_interfaces::{
 };
 use flatbuffers::VerifierOptions;
 use prost::Message;
+use sha2::Digest;
 
 use crate::{
     flatbuf::diagnostic_description::dataformat,
@@ -55,6 +57,78 @@ const fn file_magic_bytes() -> [u8; FILE_MAGIC_BYTES_LEN] {
     bytes
 }
 
+/// Decompress chunk data based on the compression algorithm.
+///
+/// # Errors
+/// Returns an error if the compression algorithm is unsupported or if
+/// LZMA decompression fails.
+fn decompress_chunk_data(
+    data: Bytes,
+    compression_algorithm: Option<&str>,
+    chunk_name: &str,
+) -> Result<Bytes, MddError> {
+    match compression_algorithm.map(str::to_lowercase).as_deref() {
+        Some("lzma") => {
+            let decompressor = xz2::stream::Stream::new_lzma_decoder(u64::MAX)
+                .map_err(|e| MddError::Io(format!("Failed to create LZMA decoder: {e}")))?;
+            let mut decoder = xz2::bufread::XzDecoder::new_stream(
+                std::io::BufReader::new(data.as_ref()),
+                decompressor,
+            );
+            let mut decoded = Vec::new();
+            decoder
+                .read_to_end(&mut decoded)
+                .map_err(|e| MddError::Io(format!("Failed to decompress chunk data: {e}")))?;
+            Ok(Bytes::from(decoded))
+        }
+        None => Ok(data),
+        Some(algorithm) => Err(MddError::Parsing(format!(
+            "Unsupported compression algorithm '{algorithm}' for chunk '{chunk_name}'"
+        ))),
+    }
+}
+
+/// Memory-map an MDD file, validate its magic bytes, and decode the protobuf.
+///
+/// Returns the decoded `MddFile` backed by zero-copy `Bytes` sub-slices of
+/// the memory-mapped region.
+///
+/// # Errors
+/// Returns an error if the file cannot be opened, memory-mapped, has invalid
+/// magic bytes, or cannot be parsed as a protobuf.
+fn mmap_and_decode_mdd(mdd_path: &str) -> Result<fileformat::MddFile, MddError> {
+    let mdd_file = std::fs::File::open(mdd_path)
+        .map_err(|e| MddError::Io(format!("Failed to open MDD file '{mdd_path}': {e}")))?;
+
+    // SAFETY: The file is opened read-only, and we only hold a shared reference to the mapping.
+    // The caller must ensure the file is not modified or truncated while mapped.
+    let mmap = unsafe { memmap2::Mmap::map(&mdd_file) }
+        .map_err(|e| MddError::Io(format!("Failed to mmap MDD file '{mdd_path}': {e}")))?;
+
+    #[cfg(unix)]
+    // Hint to the kernel, that the access pattern is random, so no read-ahead is needed.
+    if let Err(e) = mmap.advise(memmap2::Advice::Random) {
+        tracing::warn!(error = %e, "Failed to set mmap advice, memory usage might be higher");
+    }
+
+    let magic_slice = mmap
+        .get(..FILE_MAGIC_BYTES_LEN)
+        .ok_or_else(|| MddError::Parsing("Invalid file format: file too small".to_owned()))?;
+    if *magic_slice != file_magic_bytes() {
+        return Err(MddError::Parsing(
+            "Invalid file format: Magic Byte mismatch".to_owned(),
+        ));
+    }
+
+    // Wrap the mmap as `Bytes` so that prost decoding produces zero-copy
+    // sub-slices for `bytes` fields instead of heap-allocated `Vec<u8>`.
+    // The resulting `Bytes` sub-slices keep the mmap alive via refcount.
+    let mmap_bytes = Bytes::from_owner(mmap);
+    let payload = mmap_bytes.slice(FILE_MAGIC_BYTES_LEN..);
+    fileformat::MddFile::decode(payload)
+        .map_err(|e| MddError::Parsing(format!("Failed to parse MDD file: {e}")))
+}
+
 #[derive(Debug)]
 pub struct ProtoLoadConfig {
     pub load_data: bool,
@@ -88,7 +162,7 @@ impl From<&ChunkType> for ChunkDataType {
         dlt_context = dlt_ctx!("DB"),
     )
 )]
-pub fn load_chunk<'a>(chunk: &'a mut Chunk, mdd_file: &str) -> Result<&'a Vec<u8>, MddError> {
+pub fn load_chunk<'a>(chunk: &'a mut Chunk, mdd_file: &str) -> Result<&'a Bytes, MddError> {
     if chunk.payload.is_none() {
         tracing::debug!("Loading data from file");
         let chunk_data = load_chunk_data(mdd_file, chunk)?;
@@ -103,7 +177,7 @@ pub fn load_chunk<'a>(chunk: &'a mut Chunk, mdd_file: &str) -> Result<&'a Vec<u8
 /// Load the ECU data from the given MDD file.
 /// # Errors
 /// See `load_proto_data` for details on possible errors.
-pub fn load_ecudata(mdd_file: &str) -> Result<(String, Vec<u8>), MddError> {
+pub fn load_ecudata(mdd_file: &str) -> Result<(String, Bytes), MddError> {
     load_proto_data(
         mdd_file,
         &[ProtoLoadConfig {
@@ -135,7 +209,7 @@ pub fn load_ecudata(mdd_file: &str) -> Result<(String, Vec<u8>), MddError> {
 /// Load the data for a chunk from the mdd file.
 /// # Errors
 /// See `load_proto_data` for details on possible errors.
-fn load_chunk_data(mdd_file: &str, chunk: &Chunk) -> Result<Vec<u8>, MddError> {
+fn load_chunk_data(mdd_file: &str, chunk: &Chunk) -> Result<Bytes, MddError> {
     load_proto_data(
         mdd_file,
         &[ProtoLoadConfig {
@@ -171,96 +245,69 @@ fn load_chunk_data(mdd_file: &str, chunk: &Chunk) -> Result<Vec<u8>, MddError> {
     )
 )]
 pub fn load_proto_data(
-    mdd_file: &str,
+    mdd_file_path: &str,
     load_info: &[ProtoLoadConfig],
 ) -> Result<(String, HashMap<ChunkType, Vec<Chunk>>), MddError> {
     tracing::trace!("Loading ECU data from file");
     let start = Instant::now();
-    let mut filein = std::fs::File::open(mdd_file)
-        .map_err(|e| MddError::Io(format!("Failed to open mdd file: {e}")))?;
-    let magic = file_magic_bytes();
-    for b in magic {
-        let mut buf = [0; 1];
-        filein.read_exact(&mut buf).map_err(|e| {
-            MddError::Parsing(format!("Failed to read magic byte from mdd file: {e}"))
-        })?;
-        if buf[0] != b {
-            return Err(MddError::Parsing(
-                "Invalid file format: Magic Byte mismatch".to_owned(),
-            ));
-        }
-    }
-    let mut filebuf = Vec::new();
-    filein
-        .read_to_end(&mut filebuf)
-        .map_err(|e| MddError::Io(format!("Failed to read file: {e}")))?;
-    let proto_file = fileformat::MddFile::decode(&mut std::io::Cursor::new(filebuf))
-        .map_err(|e| MddError::Parsing(format!("Failed to parse MDD file: {e}")))?;
+    let mdd_file = mmap_and_decode_mdd(mdd_file_path)?;
 
     let proto_data: HashMap<ChunkType, Vec<Chunk>> = load_info
         .iter()
         .map(|chunk_info| {
-            let chunks: Vec<Chunk> = proto_file
+            let chunks: Vec<Chunk> = mdd_file
                 .chunks
                 .iter()
-                .filter_map(|proto_chunk| {
-                    if ChunkDataType::try_from(proto_chunk.r#type) == Ok((&chunk_info.type_).into())
+                .filter(|proto_chunk| {
+                    ChunkDataType::try_from(proto_chunk.r#type) == Ok((&chunk_info.type_).into())
                         && chunk_info
                             .name
                             .as_ref()
                             .is_none_or(|name| Some(name) == proto_chunk.name.as_ref())
-                    {
-                        let data = if chunk_info.load_data {
-                            let Some(proto_chunk_data) = &proto_chunk.data else {
-                                return None;
-                            };
-                            let decompressor =
-                                xz2::stream::Stream::new_lzma_decoder(u64::MAX).ok()?;
-                            let mut decoder = xz2::bufread::XzDecoder::new_stream(
-                                std::io::BufReader::new(proto_chunk_data.as_slice()),
-                                decompressor,
-                            );
-
-                            let mut decoded = Vec::new();
-                            decoder.read_to_end(&mut decoded).ok()?;
-
-                            Some(decoded)
-                        } else {
-                            None
+                })
+                .map(|proto_chunk| {
+                    let data = if chunk_info.load_data {
+                        let Some(proto_chunk_data) = &proto_chunk.data else {
+                            return Ok(None);
                         };
 
-                        Some(Chunk {
-                            payload: data,
-                            meta_data: ChunkMetaData {
-                                type_: chunk_info.type_.clone(),
-                                name: proto_chunk
-                                    .name
-                                    .as_ref()
-                                    .map_or(String::new(), std::clone::Clone::clone),
-                                uncompressed_size: proto_chunk
-                                    .uncompressed_size
-                                    .unwrap_or_default(),
-                                content_type: proto_chunk.mime_type.clone(),
-                            },
-                        })
+                        Some(decompress_chunk_data(
+                            proto_chunk_data.clone(),
+                            proto_chunk.compression_algorithm.as_deref(),
+                            proto_chunk.name.as_deref().unwrap_or("unknown"),
+                        )?)
                     } else {
                         None
-                    }
+                    };
+
+                    Ok(Some(Chunk {
+                        payload: data,
+                        meta_data: ChunkMetaData {
+                            type_: chunk_info.type_.clone(),
+                            name: proto_chunk
+                                .name
+                                .as_ref()
+                                .map_or(String::new(), std::clone::Clone::clone),
+                            uncompressed_size: proto_chunk.uncompressed_size.unwrap_or_default(),
+                            content_type: proto_chunk.mime_type.clone(),
+                        },
+                    }))
                 })
-                .collect();
-            (chunk_info.type_.clone(), chunks)
+                .filter_map(Result::transpose)
+                .collect::<Result<Vec<_>, MddError>>()?;
+            Ok((chunk_info.type_.clone(), chunks))
         })
-        .collect();
+        .collect::<Result<HashMap<_, _>, MddError>>()?;
 
     let end = Instant::now();
 
     tracing::trace!(
-        ecu_name = %proto_file.ecu_name,
+        ecu_name = %mdd_file.ecu_name,
         duration = ?end.saturating_duration_since(start),
         chunks_loaded = proto_data.len(),
         "Loaded ECU data"
     );
-    Ok((proto_file.ecu_name.clone(), proto_data))
+    Ok((mdd_file.ecu_name.clone(), proto_data))
 }
 
 pub(crate) fn read_ecudata<'a>(
@@ -295,4 +342,131 @@ pub(crate) fn read_ecudata<'a>(
         "Parsed flatbuff data"
     );
     ecu_data
+}
+
+/// Rewrite the MDD file with  uncompressed data, if it is not already uncompressed.
+/// If the chunks are already uncompressed this is a no-op and returns
+/// `Ok(false)`. Otherwise, the chunk is decompressed, written back into
+/// the protobuf, and the file is replaced atomically (write-to-tmp + rename).
+///
+/// Returns `Ok(true)` when the file was rewritten.
+///
+/// # Errors
+/// Returns an error if the file cannot be read, parsed, decompressed, or
+/// written back.
+pub fn update_mdd_uncompressed(mdd_path: &str) -> Result<bool, MddError> {
+    // Use mmap + zero-copy decode to check whether any chunks are
+    // compressed.  This avoids heap-allocating the file contents on the
+    // common path (already decompressed) the mmap is dropped and the kernel
+    // reclaims the pages with zero RSS residue.
+    let needs_decompression = {
+        let proto_file = mmap_and_decode_mdd(mdd_path)?;
+        proto_file
+            .chunks
+            .iter()
+            .any(|c| c.compression_algorithm.is_some())
+    };
+
+    if !needs_decompression {
+        return Ok(false);
+    }
+
+    // At least one chunk is compressed — read into heap, decompress,
+    // and rewrite. This path only runs once per MDD file.
+    let data = std::fs::read(mdd_path)
+        .map_err(|e| MddError::Io(format!("Failed to read MDD file '{mdd_path}': {e}")))?;
+
+    let payload = data
+        .get(FILE_MAGIC_BYTES_LEN..)
+        .ok_or_else(|| MddError::Parsing("Invalid file format: no data after magic".to_owned()))?;
+    let mut proto_file = fileformat::MddFile::decode(payload)
+        .map_err(|e| MddError::Parsing(format!("Failed to parse MDD file: {e}")))?;
+
+    for chunk in &mut proto_file.chunks {
+        let Some(chunk_data) = chunk.data.take() else {
+            continue;
+        };
+
+        let chunk_name = chunk.name.as_deref().unwrap_or("unknown");
+        let decompressed = decompress_chunk_data(
+            chunk_data,
+            chunk.compression_algorithm.as_deref(),
+            chunk_name,
+        )?;
+        chunk.data = Some(decompressed);
+        chunk.compression_algorithm = None;
+        chunk.uncompressed_size = None;
+    }
+
+    // Compute expected SHA-512 digests of the decompressed chunk data
+    // *before* encoding so we can verify the written file.
+    let expected_hashes: Vec<Option<[u8; 64]>> = proto_file
+        .chunks
+        .iter()
+        .map(|c| c.data.as_ref().map(|d| sha2::Sha512::digest(d).into()))
+        .collect();
+
+    let mut out = Vec::with_capacity(FILE_MAGIC_BYTES_LEN.saturating_add(proto_file.encoded_len()));
+    out.extend_from_slice(&file_magic_bytes());
+    proto_file
+        .encode(&mut out)
+        .map_err(|e| MddError::Io(format!("Failed to encode updated MDD: {e}")))?;
+
+    // Atomic write: temp file + rename.
+    let tmp_path = format!("{mdd_path}.tmp");
+    std::fs::write(&tmp_path, &out).map_err(|e| {
+        MddError::Io(format!(
+            "Failed to write temporary MDD file '{tmp_path}': {e}"
+        ))
+    })?;
+
+    verify_mdd_chunk_checksums(&tmp_path, &expected_hashes).inspect_err(|_| {
+        let _ = std::fs::remove_file(&tmp_path);
+    })?;
+
+    std::fs::rename(&tmp_path, mdd_path).map_err(|e| {
+        // Clean up the temp file on rename failure.
+        let _ = std::fs::remove_file(&tmp_path);
+        MddError::Io(format!(
+            "Failed to rename temporary MDD file to '{mdd_path}': {e}"
+        ))
+    })?;
+
+    tracing::info!(
+        mdd_file = %mdd_path,
+        "Rewrote MDD file with uncompressed chunk data"
+    );
+
+    Ok(true)
+}
+
+/// Read back a written MDD temp file, re-parse the protobuf and compare the
+/// SHA-512 digest of every chunk's `data` field against the `expected_hashes`.
+///
+/// # Errors
+/// On checksum mismatch an error is returned. The caller is responsible for cleaning up
+/// the temp file.
+fn verify_mdd_chunk_checksums(
+    mdd_file_path: &str,
+    expected_hashes: &[Option<[u8; 64]>],
+) -> Result<(), MddError> {
+    let mdd_file = mmap_and_decode_mdd(mdd_file_path)?;
+    if mdd_file.chunks.len() != expected_hashes.len() {
+        return Err(MddError::Parsing(format!(
+            "Verification failed: chunk count mismatch (expected {}, got {})",
+            expected_hashes.len(),
+            mdd_file.chunks.len()
+        )));
+    }
+
+    for (i, (chunk, expected)) in mdd_file.chunks.iter().zip(expected_hashes).enumerate() {
+        let actual: Option<[u8; 64]> = chunk.data.as_ref().map(|d| sha2::Sha512::digest(d).into());
+        if actual != *expected {
+            return Err(MddError::Parsing(format!(
+                "Verification failed: SHA-512 mismatch for chunk {i} in '{mdd_file_path}'"
+            )));
+        }
+    }
+
+    Ok(())
 }

--- a/cda-database/src/proto/fileformat.rs
+++ b/cda-database/src/proto/fileformat.rs
@@ -53,8 +53,8 @@ pub struct Chunk {
     #[prost(string, optional, tag = "9")]
     pub mime_type: ::core::option::Option<::prost::alloc::string::String>,
     /// chunk data - optional in case the metadata is the actual data for this chunk
-    #[prost(bytes = "vec", optional, tag = "8")]
-    pub data: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes = "bytes", optional, tag = "8")]
+    pub data: ::core::option::Option<::prost::bytes::Bytes>,
 }
 /// Nested message and enum types in `Chunk`.
 pub mod chunk {

--- a/cda-interfaces/Cargo.toml
+++ b/cda-interfaces/Cargo.toml
@@ -25,6 +25,7 @@ path = "src/lib.rs"
 
 [dependencies]
 # internal dependencies
+bytes = { workspace = true }
 foldhash = { workspace = true }
 
 parking_lot = { workspace = true }

--- a/cda-interfaces/src/datatypes/flatbuf_config.rs
+++ b/cda-interfaces/src/datatypes/flatbuf_config.rs
@@ -19,6 +19,7 @@ pub struct FlatbBufConfig {
     pub max_tables: usize,
     pub max_apparent_size: usize,
     pub ignore_missing_null_terminator: bool,
+    pub mdd_decompress: bool,
 }
 
 impl Default for FlatbBufConfig {
@@ -37,6 +38,7 @@ impl Default for FlatbBufConfig {
             #[allow(clippy::cast_possible_truncation)]
             max_apparent_size: i64::MAX as usize,
             ignore_missing_null_terminator: false,
+            mdd_decompress: false,
         }
     }
 }

--- a/cda-interfaces/src/file_manager.rs
+++ b/cda-interfaces/src/file_manager.rs
@@ -30,7 +30,7 @@ pub struct ChunkMetaData {
 }
 
 pub struct Chunk {
-    pub payload: Option<Vec<u8>>,
+    pub payload: Option<bytes::Bytes>,
     pub meta_data: ChunkMetaData,
 }
 

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -15,7 +15,7 @@ use std::{future::Future, path::PathBuf, sync::Arc};
 use cda_comm_doip::{DoipDiagGateway, config::DoipConfig};
 use cda_comm_uds::UdsManager;
 use cda_core::{DiagServiceResponseStruct, EcuManager};
-use cda_database::{FileManager, ProtoLoadConfig};
+use cda_database::{FileManager, ProtoLoadConfig, update_mdd_uncompressed};
 use cda_health::{HealthState, StatusHealthProvider};
 use cda_interfaces::{
     DiagServiceError, DoipGatewaySetupError, EcuAddressProvider, EcuManager as EcuManagerTrait,
@@ -155,6 +155,29 @@ impl From<TracingSetupError> for AppError {
         }
     }
 }
+
+pub const PROTO_LOAD_CONFIG: &[ProtoLoadConfig; 4] = &[
+    ProtoLoadConfig {
+        type_: ChunkType::DiagnosticDescription,
+        load_data: true,
+        name: None,
+    },
+    ProtoLoadConfig {
+        type_: ChunkType::CodeFile,
+        load_data: false,
+        name: None,
+    },
+    ProtoLoadConfig {
+        type_: ChunkType::CodeFilePartial,
+        load_data: false,
+        name: None,
+    },
+    ProtoLoadConfig {
+        type_: ChunkType::EmbeddedFile,
+        load_data: false,
+        name: None,
+    },
+];
 
 /// Loads vehicle databases and sets up SOVD routes in the webserver.
 /// # Errors
@@ -443,66 +466,55 @@ async fn load_database<S: SecurityPlugin>(
             continue;
         };
 
-        match cda_database::load_proto_data(
-            &mdd_path,
-            &[
-                ProtoLoadConfig {
-                    type_: ChunkType::DiagnosticDescription,
-                    load_data: true,
-                    name: None,
-                },
-                ProtoLoadConfig {
-                    type_: ChunkType::CodeFile,
-                    load_data: false,
-                    name: None,
-                },
-                ProtoLoadConfig {
-                    type_: ChunkType::CodeFilePartial,
-                    load_data: false,
-                    name: None,
-                },
-                ProtoLoadConfig {
-                    type_: ChunkType::EmbeddedFile,
-                    load_data: false,
-                    name: None,
-                },
-            ],
-        ) {
+        // Ensure the MDD file contains uncompressed data (rewrite on first
+        // use), so that subsequent loads skip LZMA decompression.
+        if flat_buf_settings.mdd_decompress
+            && let Err(e) = update_mdd_uncompressed(&mdd_path)
+        {
+            tracing::error!(
+                mdd_file = %mddfile.display(),
+                error = %e,
+                "Failed to update MDD file with uncompressed data");
+        }
+
+        match cda_database::load_proto_data(&mdd_path, PROTO_LOAD_CONFIG) {
             Ok((ecu_name, mut proto_data)) => {
-                let Some(ecu_data) = proto_data.remove(&ChunkType::DiagnosticDescription) else {
-                    tracing::error!(
-                        mdd_file = %mddfile.display(),
-                        "No diagnostic description found in MDD file");
-                    continue;
+                let database_payload = proto_data
+                    .remove(&ChunkType::DiagnosticDescription)
+                    .and_then(|mut chunks| chunks.pop())
+                    .and_then(|c| c.payload);
+
+                // Build DiagnosticDatabase from the diagnostic database payload.
+                let diag_data_base = {
+                    let Some(payload) = database_payload else {
+                        tracing::error!(
+                            mdd_file = %mddfile.display(),
+                            ecu_name = %ecu_name,
+                            "No payload found in diagnostic description for ECU");
+                        continue;
+                    };
+
+                    match cda_database::datatypes::DiagnosticDatabase::new_from_bytes(
+                        mdd_path.clone(),
+                        payload,
+                        flat_buf_settings.clone(),
+                    ) {
+                        Ok(db) => db,
+                        Err(e) => {
+                            tracing::error!(
+                                mdd_file = %mddfile.display(),
+                                ecu_name = %ecu_name,
+                                error = %e,
+                                "Failed to create database from MDD payload");
+                            continue;
+                        }
+                    }
                 };
+
                 let ecu_type = if func_description_cfg.description_database == ecu_name {
                     EcuManagerType::FunctionalDescription
                 } else {
                     EcuManagerType::Ecu
-                };
-
-                let ecu_payload: Vec<u8> =
-                    if let Some(payload) = ecu_data.into_iter().next().and_then(|c| c.payload) {
-                        payload
-                    } else {
-                        tracing::error!(
-                        ecu_name = %ecu_name,
-                        "No payload found in diagnostic description for ECU");
-                        continue;
-                    };
-
-                let diag_data_base = match cda_database::datatypes::DiagnosticDatabase::new(
-                    mdd_path.clone(),
-                    ecu_payload,
-                    flat_buf_settings.clone(),
-                ) {
-                    Ok(db) => db,
-                    Err(e) => {
-                        tracing::error!(
-                            mdd_file = %mddfile.display(),
-                            error = %e, "Failed to create database from MDD file");
-                        continue;
-                    }
                 };
                 let diag_service_manager = match EcuManager::new(
                     diag_data_base,

--- a/cda-main/src/main.rs
+++ b/cda-main/src/main.rs
@@ -69,6 +69,13 @@ struct AppArgs {
 
     #[arg(long)]
     fallback_to_base_variant: Option<bool>,
+
+    /// Set to true, to rewrite mdd files without compression, which
+    /// reduces memory usage due to mmap significantly.
+    // Could use Action::SetFalse here, as the default is false but then we would have
+    // two different ways to set booleans (with and without `true`)
+    #[arg(long)]
+    mdd_decompress: Option<bool>,
 }
 
 #[tokio::main]
@@ -250,6 +257,9 @@ impl AppArgs {
         }
         if let Some(log_file_name) = self.log_file_name {
             config.logging.log_file_config.name = log_file_name;
+        }
+        if let Some(mdd_decompress) = self.mdd_decompress {
+            config.flat_buf.mdd_decompress = mdd_decompress;
         }
     }
 }

--- a/docs/04_adr/03_mmap_strategy.rst
+++ b/docs/04_adr/03_mmap_strategy.rst
@@ -1,0 +1,294 @@
+.. SPDX-License-Identifier: Apache-2.0
+.. SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+..
+.. See the NOTICE file(s) distributed with this work for additional
+.. information regarding copyright ownership.
+..
+.. This program and the accompanying materials are made available under the
+.. terms of the Apache License Version 2.0 which is available at
+.. https://www.apache.org/licenses/LICENSE-2.0
+
+ADR-003: Memory-Map Uncompressed MDD Files for FlatBuffers Access
+=================================================================
+
+Status
+------
+
+**Accepted**
+
+Date: 2026-03-10
+
+Context
+-------
+
+The Classic Diagnostic Adapter loads ECU diagnostic databases stored as MDD
+files.  Each MDD file is a protobuf container whose chunks hold FlatBuffers
+data compressed with LZMA.  At startup every MDD file must be read, the
+protobuf parsed, the FlatBuffers payload decompressed, and the resulting data
+kept available for the lifetime of the process.
+
+The main target platform is **Linux** (onboard automotive ECUs), where RAM is
+limited and the system may reclaim memory aggressively under pressure via the
+kernel page cache.
+
+Three strategies were evaluated:
+
+1. **Heap** — decompress into heap-allocated ``Vec<u8>`` buffers.
+2. **MmapSidecar** — decompress into separate ``.fb`` sidecar files next to the
+   MDD files, then memory-map those sidecar files.
+3. **MmapMdd (in-place)** — decompress the MDD files themselves once (i.e. during a
+   software update), rewriting them with uncompressed chunk data, then
+   memory-map the MDD files directly with zero-copy protobuf decoding.
+
+Decision
+--------
+
+We will use the **MmapMdd (in-place)** strategy: MDD files are decompressed
+once and are subsequently used **read-only** via
+``mmap``.  The protobuf layer uses prost's ``Bytes`` support
+(``Bytes::from_owner(mmap)``) so that chunk data fields are zero-copy slices
+into the memory-mapped file — no heap allocation is required for the
+FlatBuffers payload.
+
+Before the atomic rename of a rewritten MDD file, the written data is verified
+by re-parsing the temporary file and comparing SHA-512 checksums of every chunk
+against the expected values.
+
+Rationale
+---------
+
+Performance Comparison
+^^^^^^^^^^^^^^^^^^^^^^
+
+Benchmarking was conducted on **Linux 6.18.2-arch2-1** (x86_64, i5-7200U CPU)
+with 32 GB RAM using 68 MDD files (~47 MB compressed, 242 MB uncompressed),
+Rust 1.92.0, ``--release`` profile, ~3 minutes idle warm-up, and swap disabled.
+
+.. list-table:: RSS Comparison (KB)
+   :header-rows: 1
+   :widths: 30 20 20 20
+
+   * - Strategy
+     - Idle
+     - Under Pressure
+     - Disk Usage
+   * - Heap (baseline)
+     - 486,900
+     - 469,320
+     - 47 MB
+   * - MmapSidecar
+     - 307,552
+     - 171,904
+     - ~282 MB
+   * - **MmapMdd (in-place)**
+     - **152,780**
+     - **118,988**
+     - **242 MB**
+
+.. note::
+   The MmapMdd implementation uses ``memmap2::Advice::Random``
+   (``MADV_RANDOM``) immediately after ``mmap()`` to disable read-ahead for
+   the sparse FlatBuffers vtable lookups that dominate runtime access.  This
+   avoids a ``libc`` dependency — the hint is set directly via ``memmap2``
+   before ownership is transferred to ``Bytes::from_owner()``.
+
+MmapMdd Advantages over Heap
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. **RSS under pressure: −75 %** (119 MB vs 469 MB)
+
+   All FlatBuffers data is backed by the MDD file on disk.  Under memory
+   pressure the kernel cleanly drops those pages and re-reads them on demand —
+   no swap I/O required.  On the heap strategy, anonymous pages can only be
+   compressed or swapped, incurring significant I/O overhead with a modest
+   −3.7 % reduction.
+
+2. **Idle RSS: −69 %** (153 MB vs 487 MB)
+
+   The zero-copy protobuf decode (``Bytes::from_owner(mmap)``) avoids copying
+   every ``bytes`` field to the heap.  Chunk data fields are slices into the
+   mmap, so there is no second copy of the decompressed data in memory.
+
+   Setting ``MADV_RANDOM`` via ``memmap2`` prevents the kernel from
+   prefetching adjacent pages during random-access FlatBuffers queries,
+   keeping idle RSS well below the heap baseline.
+
+MmapMdd Advantages over MmapSidecar
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. **Simpler file management**
+
+   No additional ``.fb`` sidecar files to create, track, or clean up.  The MDD
+   files are the single source of truth.  This eliminates an entire class of
+   consistency bugs (stale sidecar, missing sidecar, partial write).
+
+2. **Lower RSS under pressure** (119 MB vs 172 MB)
+
+   The in-place strategy benefits from zero-copy protobuf decoding
+   (``Bytes::from_owner``) which the sidecar approach did not use.  All data —
+   protobuf metadata and FlatBuffers payloads — lives in the single mmap,
+   giving the kernel a unified region to evict.
+
+3. **Lower idle RSS** (153 MB vs 308 MB)
+
+   Zero-copy decoding avoids duplicating chunk data on the heap, resulting in
+   50 % lower idle RSS than the sidecar approach.
+
+4. **Less extra disk space** (+195 MB vs +235 MB)
+
+   Sidecar files duplicated the FlatBuffers payload alongside the original
+   compressed MDD.  In-place rewriting replaces the compressed data, so the
+   growth is only the difference between compressed and uncompressed sizes.
+
+Runtime CPU Performance (``perf`` Profiling)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In addition to the RSS benchmarks above, ``perf`` profiling was conducted under
+a realistic end-to-end workload on the target Linux system to compare the
+**MmapMdd** implementation against the ``main`` (heap/compressed) branch.
+
+**Test setup**
+
+- Platform: Linux target (i5-7200U), Release build
+- Workload: CDA started, 20s idle warm-up, then ``perf`` attached for
+  profiling, followed by filling ~54 GB of memory with garbage data (two
+  27 GB ``bytearray`` allocations in parallel to induce memory pressure), then
+  a full ECU flash session via DoIP.
+- Tool: ``perf stat`` attached to the running process (after warm-up) with
+  events: ``cycles``, ``instructions``, ``faults``, ``cache-references``,
+  ``cache-misses``.
+
+.. list-table:: ``perf stat`` Results — Main vs MmapMdd (under load)
+   :header-rows: 1
+   :widths: 32 22 22 24
+
+   * - Metric
+     - Main (compressed)
+     - MmapMdd (decompressed)
+     - Δ
+   * - cycles
+     - 448,473,942
+     - 437,102,422
+     - **−2.5 %**
+   * - instructions
+     - 194,934,031
+     - 194,316,925
+     - −0.3 %
+   * - IPC (insn/cycle)
+     - 0.43
+     - 0.44
+     - +2.3 %
+   * - page faults
+     - 340
+     - 1,206
+     - +255 % (see note)
+   * - cache-references
+     - 25,838,457
+     - 26,031,415
+     - +0.7 %
+   * - cache-misses
+     - 18,142,040 (70.21 %)
+     - 18,478,329 (70.98 %)
+     - −0.77 pp
+   * - wall time
+     - 42.19 s
+     - 42.19 s
+     - negligible
+
+.. note::
+   The higher page-fault count in MmapMdd (1,206 vs 340) reflects the
+   kernel mapping mmap pages on first access rather than heap pages already
+   loaded in at startup.  The absolute numbers are negligible (< 1,500
+   faults over ~42 s) and have no measurable impact on wall time.
+
+**Runtime profiling conclusions**
+
+Under realistic ECU-flash load with concurrent memory pressure both
+implementations are effectively equivalent in CPU efficiency (within 2.5 %
+of each other) and identical in wall time.  The workload is dominated by
+network I/O (DoIP) rather than database access, so the expected RSS savings
+of MmapMdd (−75 % under pressure) are realized without any runtime CPU
+regression.
+
+``perf report`` call-graph analysis confirmed that the top hotspots
+(``alloc::vec::in_place_collect``, ``flatbuffers::vtable::VTable::get``,
+``cda_database::datatypes::DiagService::find_request``, mimalloc
+internals) are present in both branches with similar weights, confirming
+that no new hot paths were introduced by the MmapMdd implementation.
+
+Trade-offs
+^^^^^^^^^^
+
+- **Disk usage increases**: MDD files grow from ~47 MB to 242 MB (~5.1×).  This
+  is a one-time cost during the software update and is acceptable on the target
+  platform where storage is less constrained than RAM.
+
+- **MDD files are modified**: The original compressed MDD files are replaced
+  with uncompressed versions.  This is acceptable because:
+
+  - Decompression happens once during a controlled update step, not at runtime.
+    - This will be implemented at a later point in time in the update plugin, for now the CDA does this at runtime.
+  - SHA-512 verification ensures data integrity before the atomic rename.
+
+
+Consequences
+------------
+
+Positive
+^^^^^^^^
+
+- **75 % RSS reduction under memory pressure** compared to the heap baseline
+  (119 MB vs 469 MB), critical for embedded Linux targets with limited RAM.
+- **69 % lower idle RSS** (153 MB vs 487 MB) due to zero-copy protobuf
+  decoding and ``MADV_RANDOM`` via ``memmap2`` to suppress wasteful
+  read-ahead during sparse FlatBuffers lookups.
+- **Zero-copy data path**: mmap → ``Bytes`` → FlatBuffers — no intermediate
+  heap allocations for the diagnostic payload.
+- **Single file, single source of truth**: no sidecar files to manage,
+  eliminating consistency and cleanup issues.
+- **Atomic, verified writes**: SHA-512 checksums and temp-file + rename ensure
+  data integrity even if the update is interrupted.
+- **Read-only at runtime**: after the initial update, MDD files are opened
+  read-only, compatible with read-only filesystems or integrity-checked
+  partitions.
+- **No libc dependency**: ``MADV_RANDOM`` is set via ``memmap2`` before
+  ownership transfer, avoiding the need for direct ``libc::madvise()`` calls.
+
+Negative
+^^^^^^^^
+
+- **5.1× disk usage increase** for the MDD database directory.
+- **One-time decompression cost** i.e. during software update or first startup
+- **Platform dependency**: relies on OS-level mmap, page cache behaviour, and
+  ``madvise(2)`` support (POSIX systems), although the latter is guarded by a cfg flag, so the CDA still
+  works on platforms without ``MADV_RANDOM`` support (e.g. Windows) possibly with higher idle RSS.
+
+Alternatives Considered
+-----------------------
+
+Heap (Baseline)
+^^^^^^^^^^^^^^^
+
+Decompress FlatBuffers data into heap-allocated ``Vec<u8>`` buffers.  Simplest
+implementation but RSS remains high (~487 MB idle, ~469 MB under pressure).
+Anonymous heap pages cannot be cleanly evicted by the kernel — they must be
+compressed or swapped, incurring I/O overhead.  Unsuitable for
+memory-constrained targets.
+
+Separate Flatbuffer file (Sidecar)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Decompress into separate ``.fb`` files and memory-map those.  Achieves good
+pressure behaviour (~172 MB) but introduces additional file management
+complexity: sidecar files must be created, kept in sync with MDD files, and
+cleaned up on updates.  Uses more disk space (+235 MB) because both compressed
+MDD and uncompressed sidecar exist side by side.  The sidecar approach was
+prototyped and benchmarked but rejected in favour of the simpler in-place
+strategy.
+
+References
+----------
+
+- `memmap2 crate <https://crates.io/crates/memmap2>`_
+- `bytes crate — Bytes::from_owner <https://docs.rs/bytes/latest/bytes/struct.Bytes.html#method.from_owner>`_
+- `prost Bytes support <https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.bytes>`_

--- a/docs/04_adr/index.rst
+++ b/docs/04_adr/index.rst
@@ -15,3 +15,4 @@ Architecture Decision Records
 .. include:: 01_mimalloc.rst
 
 .. include:: 02_mbedtls_tls_backend.rst
+.. include:: 03_mmap_strategy.rst


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
Memory-map FlatBuffers data to reduce RSS by \~75% under memory pressure via zero-copy mmap with two-phase `madvise` hints. MDD files are memory-mapped directly and decompressed chunks are rewritten in-place as uncompressed, allowing the OS to page out unused regions automatically. Resident memory becomes proportional to the working set rather than total database size.

### Implementation Details

**Zero-Copy Memory Mapping:**
- MDD files are memory-mapped directly (no heap allocation) 
- First access to each MDD triggers in-place rewrite: compressed chunks (defaults to 'off')

### Measurements

#### RAM

**Setup:**
- 68 loaded databases, \~47 MB compressed on disk
- Linux 6.18.2-arch2-1, 32GB RAM, i5-7200U CPU
- Rust 1.92.0, `--release` profile
- No Simulation running
- Idle measured after \~3m runtime
- Swap disabled

**Results:**

| Configuration | Strategy | RSS (Idle) | RSS (Under Pressure) | Disk Usage | Reduction vs Baseline |
| --- | --- | --- | --- | --- | --- |
| **Baseline** | Heap allocation | 486,900 KB | 469,320 KB | 47 MB | — |
| **Decompressed MDD Data** | **In-place rewrite** | **152,780 KB** | **118,988 KB** | **242 MB** | Idle: −334,120 KB (−68.6%), Pressure: −350,332 KB (−74.7%) |
| Sidecar files | Persistent `.fb` files | 307,552 KB | 171,904 KB | \~282 MB (47 MB + 235 MB) | Idle: −179,348 KB (−36.8%), Pressure: −297,416 KB (−63.4%) |


### CPU

**Setup:**
* Start CDA, loaded 68 databases
* Wait 20s
* Attach perf
* Wait 10s 
* Fill memory with garbage data
* Flash an ECU

**Results:**

| Metric | Main | MMap | Change | Winner |
|--------|------|------|--------|--------|
| **cycles** | 448.5M | 437.1M | **-2.5%** | MMap |
| **instructions** | 194.9M | 194.3M | **-0.3%** | MMap |
| **faults** | 340 | 1,206 | **+255%**  | Main |
| **cache-refs** | 25.8M | 26.0M | +0.7% | Main |
| **cache-misses** | 18.1M (70.21%) | 18.5M (70.98%) | **-7% miss rate** | Main |
| **wall time** | 42.19s | 42.19s | negligible | tie |

**Analysis:**

*Both implementations are essentially equivalent under realistic load
* 2.5% difference is negligible as only a few runs where conducted. 
* 340 faults vs 1,206 (255% more for MMap, to be expected and doesn't have an impact on performance at the scale of the test)


### Architecture Decision Record

Full analysis documented in ADR-002: MDD Memory-Mapping Strategy
- Decision rationale: In-place rewrite vs sidecar files vs two-phase madvise
- Benchmarks showing around 75% RSS reduction under pressure

## Checklist

- [x] I have tested my changes locally (benchmarks run, RSS verified)
- [x] I have added or updated documentation (ADR-002)
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Notes for Reviewers

For anyone who read the PR already:
I redid the tests on Linux and disabled swap, because MacOS is just too good at compressing memory and swapping, so it is not representative at all (except you're running your onboard system on a Mac I guess).
The new measurements yields numbers way closer to reality.
Although they a reduction by \~75% isn't as amazing as 90%, it's still a great improvement.
History is squashed the sidecar impl can be found on https://github.com/eclipse-opensovd/classic-diagnostic-adapter/commit/d37f213d350a0bbffb673bf955688654d8639da9

### Todo
- [x] Cleanup code
- [x] Performance tests
- [x] Cleanup weirdness for some measurements, re-do for current impl and base line

**Safety:**
- SHA-512 verification ensures integrity after rewrite
- Atomic write (temp file + rename) prevents corruption
- Mmap safety: FlatBuffers never mutates mapped data

**Trade-offs:**
- First load per MDD writes file -> Should be moved to MDD update plugin eventually
- Positive: Loading uncompressed MDDs files is slightly faster, so startup is sped up.
