### PR TITLE
Fix clippy findings

### DIFF
--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -81,7 +81,6 @@ where
                         }
                         Some(Err(e)) => {
                             tracing::warn!("Failed to receive VAMs: {e:?}");
-                            continue;
                         },
                         None => {
                             tracing::warn!("Incomplete VAM due to connection closure/error");

--- a/cda-sovd/src/sovd/error.rs
+++ b/cda-sovd/src/sovd/error.rs
@@ -89,7 +89,8 @@ impl From<DiagServiceError> for ApiError {
             | DiagServiceError::InvalidAddress(_)
             | DiagServiceError::NotEnoughData { .. }
             | DiagServiceError::UnexpectedResponse(_)
-            | DiagServiceError::DataError(_) => {
+            | DiagServiceError::DataError(_)
+            | DiagServiceError::InvalidSecurityPlugin => {
                 ApiError::InternalServerError(Some(value.to_string()))
             }
             DiagServiceError::InvalidRequest(_)
@@ -103,9 +104,6 @@ impl From<DiagServiceError> for ApiError {
                 ApiError::BadRequest(value.to_string())
             }
             DiagServiceError::AccessDenied(_) => ApiError::Forbidden(Some(value.to_string())),
-            DiagServiceError::InvalidSecurityPlugin => {
-                ApiError::InternalServerError(Some(value.to_string()))
-            }
         }
     }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
Fix clippy lints reported by `cargo clippy --all-targets`

```bash
cargo clippy --all-targets --fix --allow-dirty
    Checking cda-interfaces v0.1.0 (/Users/EGANTNE/dev/inhouse_cda/classic-diagnostic-adapter/cda-interfaces)
   Compiling cda-database v0.1.0 (/Users/EGANTNE/dev/inhouse_cda/classic-diagnostic-adapter/cda-database)
    Checking cda-tracing v0.1.0 (/Users/EGANTNE/dev/inhouse_cda/classic-diagnostic-adapter/cda-tracing)
   Compiling opensovd-cda v0.1.0 (/Users/EGANTNE/dev/inhouse_cda/classic-diagnostic-adapter/cda-main)
    Checking sovd-interfaces v0.1.0 (/Users/EGANTNE/dev/inhouse_cda/classic-diagnostic-adapter/cda-sovd-interfaces)
    Checking cda-comm-uds v0.1.0 (/Users/EGANTNE/dev/inhouse_cda/classic-diagnostic-adapter/cda-comm-uds)
    Checking cda-comm-doip v0.1.0 (/Users/EGANTNE/dev/inhouse_cda/classic-diagnostic-adapter/cda-comm-doip)
warning: this `continue` expression is redundant
  --> cda-comm-doip/src/vir_vam.rs:84:29
   |
84 | ...                   continue;
   |                       ^^^^^^^^
   |
   = help: consider dropping the `continue` expression
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_continue
   = note: `-W clippy::needless-continue` implied by `-W clippy::pedantic`
   = help: to override `-W clippy::pedantic` add `#[allow(clippy::needless_continue)]`

warning: `cda-comm-doip` (lib) generated 1 warning
warning: `cda-comm-doip` (lib test) generated 1 warning (1 duplicate)
    Checking cda-plugin-security v0.1.0 (/Users/EGANTNE/dev/inhouse_cda/classic-diagnostic-adapter/cda-plugin-security)
    Checking cda-sovd v0.1.0 (/Users/EGANTNE/dev/inhouse_cda/classic-diagnostic-adapter/cda-sovd)
    Checking cda-core v0.1.0 (/Users/EGANTNE/dev/inhouse_cda/classic-diagnostic-adapter/cda-core)
warning: this match arm has an identical body to another arm
  --> cda-sovd/src/sovd/error.rs:84:13
   |
84 | /             DiagServiceError::InvalidDatabase(_)
85 | |             | DiagServiceError::VariantDetectionError(_)
86 | |             | DiagServiceError::ResourceError(_)
87 | |             | DiagServiceError::ConnectionClosed(_)
...  |
93 | |                 ApiError::InternalServerError(Some(value.to_string()))
94 | |             }
   | |_____________^
   |
   = help: try changing either arm body
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_same_arms
   = note: `-W clippy::match-same-arms` implied by `-W clippy::pedantic`
   = help: to override `-W clippy::pedantic` add `#[allow(clippy::match_same_arms)]`
help: or try merging the arm patterns and removing the obsolete arm
   |
92 |             DiagServiceError::InvalidDatabase(_)
...
99 |             | DiagServiceError::UnexpectedResponse(_)
100~             | DiagServiceError::DataError(_) | DiagServiceError::InvalidSecurityPlugin => {
101|                 ApiError::InternalServerError(Some(value.to_string()))
...
113|             DiagServiceError::AccessDenied(_) => ApiError::Forbidden(Some(value.to_string())),
114~             }
   |

warning: `cda-sovd` (lib) generated 1 warning
    Checking cda-health v0.1.0 (/Users/EGANTNE/dev/inhouse_cda/classic-diagnostic-adapter/cda-health)
warning: `cda-sovd` (lib test) generated 1 warning (1 duplicate)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 22.27s
```

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)