### PR TITLE
dtc: add parameter to define fault memory

### DIFF
--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -827,10 +827,11 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
         security_plugin: &DynamicPlugin,
         dtc_code: DtcCode,
         service_types: Vec<DtcReadInformationFunction>,
+        memory_selection: Option<u8>,
         include_schema: bool,
     ) -> Result<(R, String, Option<SchemaDescription>), DiagServiceError> {
         let ecu = self.ecu_manager(ecu_name)?;
-        let (_, extended_data_lookup) = ecu
+        let (read_func, extended_data_lookup) = ecu
             .read()
             .await
             .lookup_dtc_services(service_types)?
@@ -846,6 +847,11 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
             &dtc_code.to_be_bytes(),
         )?;
         raw_payload.push(0xFF); // record number, 0xFF means all records or all memory
+
+        if read_func.is_user_scope() {
+            raw_payload.push(memory_selection.unwrap_or(0x00));
+        }
+
         let uds_payload = UdsPayloadData::Raw(raw_payload);
 
         let schema = if include_schema {
@@ -876,6 +882,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
         security_plugin: &DynamicPlugin,
         dtc_code: DtcCode,
         include_schema: bool,
+        memory_selection: Option<u8>,
     ) -> Result<(Option<ExtendedDataRecords>, Option<serde_json::Value>), DiagServiceError> {
         fn extract_schema_properties(schema_desc: &SchemaDescription) -> Option<serde_json::Value> {
             // todo after solving #54: we are missing the 'Selector' and the case name here
@@ -897,6 +904,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
                     DtcReadInformationFunction::FaultMemoryExtDataRecordByDtcNumber,
                     DtcReadInformationFunction::UserMemoryDtcExtDataRecordByDtcNumber,
                 ],
+                memory_selection,
                 include_schema,
             )
             .await?;
@@ -962,6 +970,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
         security_plugin: &DynamicPlugin,
         dtc_code: DtcCode,
         include_schema: bool,
+        memory_selection: Option<u8>,
     ) -> Result<(Option<ExtendedSnapshots>, Option<serde_json::Value>), DiagServiceError> {
         fn extract_schema_properties(schema_desc: &SchemaDescription) -> Option<serde_json::Value> {
             let param_properties = schema_desc.get_param_properties()?;
@@ -990,6 +999,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
                     DtcReadInformationFunction::FaultMemorySnapshotRecordByDtcNumber,
                     DtcReadInformationFunction::UserMemoryDtcSnapshotRecordByDtcNumber,
                 ],
+                memory_selection,
                 include_schema,
             )
             .await?;
@@ -2029,6 +2039,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
         status: Option<HashMap<String, serde_json::Value>>,
         severity: Option<u32>,
         scope: Option<String>,
+        memory_selection: Option<u8>,
     ) -> Result<HashMap<DtcCode, DtcRecordAndStatus>, DiagServiceError> {
         let ecu = self.ecu_manager(ecu_name)?;
         let mut all_dtcs = HashMap::new();
@@ -2075,8 +2086,12 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
             u8::MAX
         };
 
-        for (_, lookup) in scoped_services {
-            let payload = UdsPayloadData::Raw(vec![mask]);
+        for (read_info, lookup) in scoped_services {
+            let mut payload = vec![mask];
+            if read_info.is_user_scope() {
+                payload.push(memory_selection.unwrap_or(0));
+            }
+            let payload = UdsPayloadData::Raw(payload);
             let response = self
                 .send(
                     ecu_name,
@@ -2141,25 +2156,45 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
         include_extended_data: bool,
         include_snapshot: bool,
         include_schema: bool,
+        memory_selection: Option<u8>,
     ) -> Result<DtcExtendedInfo, DiagServiceError> {
         let dtc_code = decode_dtc_from_str(sae_dtc)?;
 
         let (snapshots, snapshot_schema) = if include_snapshot {
-            self.map_snapshots(ecu_name, security_plugin, dtc_code, include_schema)
-                .await?
+            self.map_snapshots(
+                ecu_name,
+                security_plugin,
+                dtc_code,
+                include_schema,
+                memory_selection,
+            )
+            .await?
         } else {
             (None, None)
         };
 
         let (extended_records, extended_schema) = if include_extended_data {
-            self.map_extended_data(ecu_name, security_plugin, dtc_code, include_schema)
-                .await?
+            self.map_extended_data(
+                ecu_name,
+                security_plugin,
+                dtc_code,
+                include_schema,
+                memory_selection,
+            )
+            .await?
         } else {
             (None, None)
         };
 
         let mut dtc_by_mask = self
-            .ecu_dtc_by_mask(ecu_name, security_plugin, None, None, None)
+            .ecu_dtc_by_mask(
+                ecu_name,
+                security_plugin,
+                None,
+                None,
+                None,
+                memory_selection,
+            )
             .await?;
 
         let record_and_status =

--- a/cda-interfaces/src/datatypes/faults.rs
+++ b/cda-interfaces/src/datatypes/faults.rs
@@ -55,6 +55,16 @@ impl DtcReadInformationFunction {
     pub fn all() -> Vec<Self> {
         Self::iter().collect()
     }
+
+    #[must_use]
+    pub fn is_user_scope(&self) -> bool {
+        matches!(
+            self,
+            Self::UserMemoryDtcByStatusMask
+                | Self::UserMemoryDtcSnapshotRecordByDtcNumber
+                | Self::UserMemoryDtcExtDataRecordByDtcNumber
+        )
+    }
 }
 
 #[repr(u8)]

--- a/cda-interfaces/src/ecuuds.rs
+++ b/cda-interfaces/src/ecuuds.rs
@@ -335,8 +335,12 @@ pub trait UdsEcu: Send + Sync + 'static {
         status: Option<HashMap<String, serde_json::Value>>,
         severity: Option<u32>,
         scope: Option<String>,
+        memory_selection: Option<u8>,
     ) -> Result<HashMap<DtcCode, DtcRecordAndStatus>, DiagServiceError>;
 
+    // alternative of passing a struct DtcOptions containing
+    // the include_ and memory_selection parameters isn't better for readability.
+    #[allow(clippy::too_many_arguments)]
     async fn ecu_dtc_extended(
         &self,
         ecu_name: &str,
@@ -345,6 +349,7 @@ pub trait UdsEcu: Send + Sync + 'static {
         include_extended_data: bool,
         include_snapshot: bool,
         include_schema: bool,
+        memory_selection: Option<u8>,
     ) -> Result<DtcExtendedInfo, DiagServiceError>;
 
     /// Clear the faults for the given ECU
@@ -658,6 +663,7 @@ pub mod mock {
                 status: Option<HashMap<String, serde_json::Value>>,
                 severity: Option<u32>,
                 scope: Option<String>,
+                memory_selection: Option<u8>,
             ) -> Result<HashMap<DtcCode, DtcRecordAndStatus>, DiagServiceError>;
             async fn ecu_dtc_extended(
                 &self,
@@ -667,6 +673,7 @@ pub mod mock {
                 include_extended_data: bool,
                 include_snapshot: bool,
                 include_schema: bool,
+                memory_selection: Option<u8>,
             ) -> Result<DtcExtendedInfo, DiagServiceError>;
             async fn delete_dtcs(
                 &self,

--- a/cda-sovd-interfaces/src/components/ecu/mod.rs
+++ b/cda-sovd-interfaces/src/components/ecu/mod.rs
@@ -474,6 +474,10 @@ pub mod faults {
             pub scope: Option<String>,
             #[serde(rename = "include-schema", default)]
             pub include_schema: bool,
+            /// Value for the memory selection in user defined memory.
+            /// Only used for user defined memory, defaults to 0
+            #[serde(default)]
+            pub memory_selection: Option<u8>,
         }
 
         #[derive(Serialize, Deserialize, schemars::JsonSchema)]
@@ -513,6 +517,10 @@ pub mod faults {
                 pub include_snapshot_data: bool,
                 #[serde(default)]
                 pub include_schema: bool,
+                /// Value for the memory selection in user defined memory.
+                /// Only used for user defined memory, defaults to 0
+                #[serde(default)]
+                pub memory_selection: Option<u8>,
             }
 
             #[derive(Serialize, schemars::JsonSchema)]

--- a/cda-sovd/src/sovd/components/ecu/faults.rs
+++ b/cda-sovd/src/sovd/components/ecu/faults.rs
@@ -89,6 +89,7 @@ pub(crate) async fn get<
             query.status,
             query.severity,
             query.scope,
+            query.memory_selection,
         )
         .await
     {
@@ -340,6 +341,7 @@ pub(crate) mod id {
                 query.include_extended_data,
                 query.include_snapshot_data,
                 query.include_schema,
+                query.memory_selection,
             )
             .await
         {
@@ -462,11 +464,15 @@ mod tests {
         // Setup mock expectations
         mock_uds
             .expect_ecu_dtc_by_mask()
-            .withf(|name, _, status, severity, scope| {
-                name == "TestECU" && status.is_none() && severity.is_none() && scope.is_none()
+            .withf(|name, _, status, severity, scope, memory_selection| {
+                name == "TestECU"
+                    && status.is_none()
+                    && severity.is_none()
+                    && scope.is_none()
+                    && memory_selection.is_none()
             })
             .times(1)
-            .returning(move |_, _, _, _, _| {
+            .returning(move |_, _, _, _, _, _| {
                 let dtcs = expected_dtcs.clone();
                 Ok(dtcs)
             });
@@ -483,6 +489,7 @@ mod tests {
             severity: None,
             scope: None,
             include_schema: false,
+            memory_selection: None,
         };
 
         // Create security plugin using test utility


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

0x1918 needs a parameter to define the user scope memory. It can be set via memory-scope=4 as query parameter. If not set, it defaults to 0


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->



Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)