### PR TITLE
Support implementation of security plugin in separate crate

### DIFF
--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -25,7 +25,7 @@ use cda_interfaces::{
     dlt_ctx,
     file_manager::{Chunk, ChunkType},
 };
-use cda_plugin_security::SecurityPlugin;
+use cda_plugin_security::{SecurityPlugin, SecurityPluginLoader};
 use cda_sovd::Locks;
 use cda_tracing::{OtelGuard, TracingSetupError, TracingWorkerGuard};
 use tokio::{
@@ -35,9 +35,12 @@ use tokio::{
 use tracing::Instrument;
 use tracing_subscriber::layer::SubscriberExt;
 
-use crate::config::configfile::Configuration;
+use crate::config::configfile::{ConfigSanity, Configuration};
 
 pub mod config;
+
+#[cfg(feature = "health")]
+const MAIN_HEALTH_COMPONENT_KEY: &str = "main";
 
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
@@ -775,4 +778,154 @@ pub fn setup_tracing(config: &Configuration) -> Result<TracingGuards, TracingSet
 #[must_use]
 pub fn cda_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
+}
+
+/// Starts the CDA server using a pre-built security plugin instance.
+///
+/// This is the primary entry point for integrating a custom security plugin.
+/// The plugin is created once before calling this function; all requests share
+/// the same instance, so expensive initialisation (key loading, policy engine
+/// setup, connection pooling, etc.) only happens once.
+///
+/// Tracing must be set up by the caller before invoking this function.
+///
+/// # Errors
+/// Returns `AppError` if the server cannot start or encounters a fatal error.
+pub async fn run_server<F, S>(
+    config: &Configuration,
+    security_plugin: Arc<S>,
+    shutdown_signal: F,
+) -> Result<(), AppError>
+where
+    F: Future<Output = ()> + Clone + Send + 'static,
+    S: SecurityPluginLoader,
+{
+    let webserver_config = cda_sovd::WebServerConfig {
+        host: config.server.address.clone(),
+        port: config.server.port,
+    };
+
+    let (dynamic_router, webserver_task) =
+        cda_sovd::launch_webserver(webserver_config.clone(), shutdown_signal.clone()).await?;
+
+    #[cfg(feature = "health")]
+    let (health_state, main_health_provider) = if config.health.enabled {
+        let health_state =
+            cda_health::add_health_routes(&dynamic_router, cda_version().to_owned()).await;
+        let main_health_provider = Arc::new(cda_health::StatusHealthProvider::new(
+            cda_health::Status::Starting,
+        ));
+        if let Err(e) = health_state
+            .register_provider(
+                MAIN_HEALTH_COMPONENT_KEY,
+                Arc::clone(&main_health_provider) as Arc<dyn cda_health::HealthProvider>,
+            )
+            .await
+        {
+            tracing::warn!(error = %e, "Failed to register main health provider");
+        }
+        (Some(health_state), Some(main_health_provider))
+    } else {
+        (None, None)
+    };
+
+    #[cfg(not(feature = "health"))]
+    let (health_state, main_health_provider): (
+        Option<cda_health::HealthState>,
+        Option<Arc<cda_health::StatusHealthProvider>>,
+    ) = (None, None);
+
+    tracing::debug!("Webserver is running. Loading sovd routes...");
+
+    let vehicle_data = load_vehicle_data::<_, S::PluginData>(
+        config,
+        shutdown_signal.clone(),
+        health_state.as_ref(),
+    )
+    .await?;
+
+    if vehicle_data.databases.is_empty() && config.database.exit_no_database_loaded {
+        return Err(AppError::ResourceError(
+            "No database loaded, exiting as configured".to_string(),
+        ));
+    }
+
+    cda_sovd::add_vehicle_routes::<DiagServiceResponseStruct, _, _, S>(
+        &dynamic_router,
+        vehicle_data.uds_manager,
+        config.flash_files_path.clone(),
+        vehicle_data.file_managers,
+        vehicle_data.locks,
+        config.functional_description.clone(),
+        config.components.clone(),
+        Arc::clone(&security_plugin),
+    )
+    .await?;
+
+    if let serde_json::Value::Object(version_info) = serde_json::json!({
+        "id": "version",
+        "data": {
+            "name": "Eclipse OpenSOVD Classic Diagnostic Adapter",
+            "api": {
+                // 1.1 to match the sovd standard version
+                "version": "1.1"
+            },
+            "implementation": {
+                "version": cda_version(),
+                "commit": env!("GIT_COMMIT_HASH").to_owned(),
+                "build_date": env!("BUILD_DATE").to_owned(),
+            }
+        }
+    }) {
+        cda_sovd::add_static_data_endpoint(
+            &dynamic_router,
+            version_info.clone(),
+            "/vehicle/v15/apps/sovd2uds/data/version",
+        )
+        .await;
+        cda_sovd::add_static_data_endpoint(
+            &dynamic_router,
+            version_info,
+            "/vehicle/v15/data/version",
+        )
+        .await;
+    } else {
+        tracing::error!("Failed to build version information");
+    }
+
+    cda_sovd::add_openapi_routes(&dynamic_router, &webserver_config).await;
+
+    tracing::info!("CDA fully initialized and ready to serve requests");
+    if let Some(provider) = main_health_provider {
+        provider.update_status(cda_health::Status::Up).await;
+    }
+
+    shutdown_signal.await;
+    tracing::info!("Shutting down...");
+    webserver_task
+        .await
+        .map_err(|e| AppError::RuntimeError(format!("Webserver task join error: {e}")))?;
+
+    Ok(())
+}
+
+/// Minimal entry point: loads configuration, sets up tracing, then starts the server.
+///
+/// This is the simplest way to run the CDA with a custom security plugin. CLI argument
+/// overrides are not applied; use [`run_server`] directly if you need those.
+///
+/// # Errors
+/// Returns `AppError` if configuration, tracing setup, or the server itself fails.
+pub async fn start_cda<S: SecurityPluginLoader>(security_plugin: Arc<S>) -> Result<(), AppError> {
+    let config = config::load_config().unwrap_or_else(|e| {
+        println!("Failed to load configuration: {e}");
+        println!("Using default values");
+        config::default_config()
+    });
+    config.validate_sanity()?;
+    let _tracing_guards = setup_tracing(&config)?;
+    tracing::info!("Starting CDA - version {}", cda_version());
+    use futures::FutureExt as _;
+    let shutdown = shutdown_signal().shared();
+    run_server(&config, security_plugin, shutdown).await
 }

--- a/cda-main/src/main.rs
+++ b/cda-main/src/main.rs
@@ -12,19 +12,15 @@
 
 use std::sync::Arc;
 
-use cda_core::DiagServiceResponseStruct;
 use cda_interfaces::dlt_ctx;
-use cda_plugin_security::{DefaultSecurityPlugin, DefaultSecurityPluginData};
+use cda_plugin_security::DefaultSecurityPlugin;
 use clap::Parser;
 use futures::future::FutureExt;
 use opensovd_cda_lib::{
     AppError, cda_version,
     config::configfile::{ConfigSanity, Configuration},
-    setup_tracing, shutdown_signal,
+    run_server, setup_tracing, shutdown_signal,
 };
-
-#[cfg(feature = "health")]
-const MAIN_HEALTH_COMPONENT_KEY: &str = "main";
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -91,118 +87,9 @@ async fn main() -> Result<(), AppError> {
     let _tracing_guards = setup_tracing(&config)?;
     tracing::info!("Starting CDA - version {}", cda_version());
 
-    let webserver_config = cda_sovd::WebServerConfig {
-        host: config.server.address.clone(),
-        port: config.server.port,
-    };
-
-    let clonable_shutdown_signal = shutdown_signal().shared();
-
-    let (dynamic_router, webserver_task) =
-        cda_sovd::launch_webserver(webserver_config.clone(), clonable_shutdown_signal.clone())
-            .await?;
-
-    #[cfg(feature = "health")]
-    let (health_state, main_health_provider) = if config.health.enabled {
-        let health_state =
-            cda_health::add_health_routes(&dynamic_router, cda_version().to_owned()).await;
-        let main_health_provider = Arc::new(cda_health::StatusHealthProvider::new(
-            cda_health::Status::Starting,
-        ));
-
-        if let Err(e) = health_state
-            .register_provider(
-                MAIN_HEALTH_COMPONENT_KEY,
-                Arc::clone(&main_health_provider) as Arc<dyn cda_health::HealthProvider>,
-            )
-            .await
-        {
-            tracing::warn!(error = %e, "Failed to register main health provider");
-        }
-        (Some(health_state), Some(main_health_provider))
-    } else {
-        (None, None)
-    };
-
-    #[cfg(not(feature = "health"))]
-    let (health_state, main_health_provider): (
-        Option<cda_health::HealthState>,
-        Option<Arc<cda_health::StatusHealthProvider>>,
-    ) = (None, None);
-
-    tracing::debug!("Webserver is running. Loading sovd routes...");
-
-    let vehicle_data = opensovd_cda_lib::load_vehicle_data::<_, DefaultSecurityPluginData>(
-        &config,
-        clonable_shutdown_signal.clone(),
-        health_state.as_ref(),
-    )
-    .await?;
-
-    if vehicle_data.databases.is_empty() && config.database.exit_no_database_loaded {
-        return Err(AppError::ResourceError(
-            "No database loaded, exiting as configured".to_string(),
-        ));
-    }
-
-    cda_sovd::add_vehicle_routes::<DiagServiceResponseStruct, _, _, DefaultSecurityPlugin>(
-        &dynamic_router,
-        vehicle_data.uds_manager,
-        config.flash_files_path.clone(),
-        vehicle_data.file_managers,
-        vehicle_data.locks,
-        config.functional_description,
-        config.components,
-    )
-    .await?;
-
-    if let serde_json::Value::Object(version_info) = serde_json::json!({
-        "id": "version",
-        "data": {
-            "name": "Eclipse OpenSOVD Classic Diagnostic Adapter",
-            "api": {
-                // 1.1 to match the sovd standard version
-                "version": "1.1"
-            },
-            "implementation": {
-                "version": cda_version(),
-                "commit": env!("GIT_COMMIT_HASH").to_owned(),
-                "build_date": env!("BUILD_DATE").to_owned(),
-            }
-        }
-    }) {
-        cda_sovd::add_static_data_endpoint(
-            &dynamic_router,
-            version_info.clone(),
-            "/vehicle/v15/apps/sovd2uds/data/version",
-        )
-        .await;
-        // For now, both version endpoints serve the same data. This might change in the future.
-        cda_sovd::add_static_data_endpoint(
-            &dynamic_router,
-            version_info,
-            "/vehicle/v15/data/version",
-        )
-        .await;
-    } else {
-        tracing::error!("Failed to build version information");
-    }
-
-    cda_sovd::add_openapi_routes(&dynamic_router, &webserver_config).await;
-
-    tracing::info!("CDA fully initialized and ready to serve requests");
-    if let Some(provider) = main_health_provider {
-        provider.update_status(cda_health::Status::Up).await;
-    }
-
-    // Wait for shutdown signal
-    clonable_shutdown_signal.await;
-    tracing::info!("Shutting down...");
-    webserver_task
-        .await
-        .map_err(|e| AppError::RuntimeError(format!("Webserver task join error: {e}")))?;
-
-    Ok(())
+    let security_plugin = Arc::new(DefaultSecurityPlugin::default());
+    let shutdown = shutdown_signal().shared();
+    run_server(&config, security_plugin, shutdown).await
 }
 
 impl AppArgs {

--- a/cda-plugin-security/src/default_security_plugin.rs
+++ b/cda-plugin-security/src/default_security_plugin.rs
@@ -47,9 +47,13 @@
 
 use std::sync::LazyLock;
 
-use aide::axum::IntoApiResponse;
 use async_trait::async_trait;
-use axum::{Json, RequestPartsExt, body::Bytes, http::StatusCode, response::IntoResponse};
+use axum::{
+    Json, RequestPartsExt,
+    body::Bytes,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
 use axum_extra::{
     TypedHeader,
     headers::{Authorization, authorization::Bearer},
@@ -166,11 +170,13 @@ pub struct DefaultSecurityPluginData {
 ///
 #[derive(Default)]
 pub struct DefaultSecurityPlugin;
-impl SecurityPluginLoader for DefaultSecurityPlugin {}
+impl SecurityPluginLoader for DefaultSecurityPlugin {
+    type PluginData = DefaultSecurityPluginData;
+}
 
 #[async_trait]
 impl AuthorizationRequestHandler for DefaultSecurityPlugin {
-    async fn authorize(_headers: HeaderMap, body_bytes: Bytes) -> impl IntoApiResponse {
+    async fn authorize(&self, _headers: HeaderMap, body_bytes: Bytes) -> Response {
         let payload = match axum::extract::Json::<AuthPayload>::from_bytes(&body_bytes) {
             Ok(payload) => payload.0,
             Err(e) => {

--- a/cda-plugin-security/src/lib.rs
+++ b/cda-plugin-security/src/lib.rs
@@ -18,36 +18,14 @@
 //!
 //! ## Middleware Integration
 //!
-//! The security plugin integrates with the Axum web framework through middleware.
-//! The [`security_plugin_middleware`] function:
-//! - Creates a plugin initializer instance
-//! - Injects it into the request extensions
-//! - Passes control to the next middleware/handler
-//! - Ensures plugin availability throughout the request lifecycle
-//!
-//! The middleware is applied to protected routes in the SOVD module:
-//!
-//! ```rust,ignore
-//! .layer(middleware::from_fn(security_plugin_middleware::<S>))
-//! ```
+//! Security plugins are registered with the Axum web framework as _mmiddleware_ components
+//! by means of the [`security_plugin_middleware`] function as part of configuring Axum's
+//! request handling pipeline.
 //!
 //! ## Authorization Endpoint
 //!
 //! The plugin system allows for providing a standardized authorization endpoint
 //! at `/vehicle/v15/authorize` through the [`AuthorizationRequestHandler`] trait.
-//!
-//! ## Configuration
-//!
-//! ### Runtime Integration
-//! Security plugins are integrated into the main application through a type parameter:
-//!
-//! ```rust,ignore
-//! pub async fn launch_webserver<F, R, T, M, S>(
-//!     // ... other parameters
-//! ) -> Result<(), String>
-//! where
-//!     S: SecurityPluginLoader,
-//! ```
 //!
 //! ## Default Implementation
 //!
@@ -106,12 +84,11 @@
 
 use std::{any::Any, ops::Deref, sync::Arc};
 
-use aide::axum::IntoApiResponse;
 use async_trait::async_trait;
 use axum::{
     Json,
     body::Bytes,
-    extract::{FromRequestParts, Request},
+    extract::{FromRequestParts, Request, State},
     middleware::Next,
     response::{IntoResponse, Response},
 };
@@ -291,7 +268,7 @@ pub trait AuthorizationRequestHandler: Send + Sync {
     /// An HTTP response containing either:
     /// - Success: An access token or other authentication data of some form
     /// - Error: SOVD-compliant error response with appropriate status code
-    async fn authorize(headers: HeaderMap, body_bytes: Bytes) -> impl IntoApiResponse;
+    async fn authorize(&self, headers: HeaderMap, body_bytes: Bytes) -> Response;
 }
 
 /// Complete security plugin loader that combines initialization and authorization capabilities.
@@ -300,9 +277,15 @@ pub trait AuthorizationRequestHandler: Send + Sync {
 /// initialize plugin instances from requests and handle authorization requests.
 /// It is used as the main interface for integrating security plugins into the
 /// web server framework.
+///
+/// The associated type `PluginData` ties the loader to the per-request data struct
+/// it produces, so callers only need a single type parameter.
 pub trait SecurityPluginLoader:
-    SecurityPluginInitializer + AuthorizationRequestHandler + Default + 'static
+    SecurityPluginInitializer + AuthorizationRequestHandler + 'static
 {
+    /// The per-request security context produced by
+    /// [`SecurityPluginInitializer::initialize_from_request_parts`].
+    type PluginData: SecurityPlugin;
 }
 
 type SecurityPluginInitializerType = Arc<dyn SecurityPluginInitializer>;
@@ -313,37 +296,33 @@ type SecurityPluginInitializerType = Arc<dyn SecurityPluginInitializer>;
 /// and handles the plugin lifecycle during request processing. It is applied to
 /// protected routes to ensure authentication and authorization are enforced.
 ///
-/// ## Middleware Behavior
-///
-/// The middleware:
-/// - Creates a plugin initializer instance
-/// - Injects it into the request extensions
-/// - Passes control to the next middleware/handler
-/// - Ensures plugin availability throughout the request lifecycle
+/// The pre-created plugin instance is forwarded via Axum state, so it is instantiated
+/// exactly once at startup and shared across all requests.
 ///
 /// ## Usage
 ///
-/// Apply this middleware to protected routes:
+/// Apply this middleware to protected routes using Axum's `from_fn_with_state`:
 ///
 /// ```rust,ignore
-/// .layer(middleware::from_fn(security_plugin_middleware::<S>))
+/// .layer(middleware::from_fn_with_state(
+///     Arc::clone(&plugin) as Arc<dyn SecurityPluginInitializer>,
+///     security_plugin_middleware,
+/// ))
 /// ```
 ///
-/// # Type Parameters
-/// * `A` - The security plugin loader type that implements [`SecurityPluginLoader`]
-///
 /// # Arguments
+/// * `initializer` - The shared, startup-initialized plugin instance
 /// * `req` - The incoming HTTP request
 /// * `next` - The next middleware or handler in the chain
 ///
 /// # Returns
 /// The HTTP response from the downstream middleware/handler
-pub async fn security_plugin_middleware<A: SecurityPluginLoader>(
+pub async fn security_plugin_middleware(
+    State(initializer): State<SecurityPluginInitializerType>,
     mut req: Request,
     next: Next,
 ) -> Response {
-    let security_plugin = Arc::new(A::default()) as SecurityPluginInitializerType;
-    req.extensions_mut().insert(security_plugin);
+    req.extensions_mut().insert(initializer);
     next.run(req).await
 }
 
@@ -454,9 +433,13 @@ impl IntoResponse for AuthError {
 
 #[cfg(feature = "test-utils")]
 pub mod mock {
-    use aide::axum::IntoApiResponse;
     use async_trait::async_trait;
-    use axum::{Json, body::Bytes, http::StatusCode};
+    use axum::{
+        Json,
+        body::Bytes,
+        http::StatusCode,
+        response::{IntoResponse, Response},
+    };
     use cda_interfaces::DiagServiceError;
     use http::{HeaderMap, request::Parts};
 
@@ -575,7 +558,7 @@ pub mod mock {
 
     #[async_trait]
     impl AuthorizationRequestHandler for TestSecurityPlugin {
-        async fn authorize(_headers: HeaderMap, _body_bytes: Bytes) -> impl IntoApiResponse {
+        async fn authorize(&self, _headers: HeaderMap, _body_bytes: Bytes) -> Response {
             (
                 StatusCode::OK,
                 Json(serde_json::json!({
@@ -584,8 +567,11 @@ pub mod mock {
                     "expires_in": 3600
                 })),
             )
+                .into_response()
         }
     }
 
-    impl SecurityPluginLoader for TestSecurityPlugin {}
+    impl SecurityPluginLoader for TestSecurityPlugin {
+        type PluginData = TestSecurityPlugin;
+    }
 }

--- a/cda-sovd/src/lib.rs
+++ b/cda-sovd/src/lib.rs
@@ -113,7 +113,7 @@ where
 // type alias does not allow specifying hasher, we set the hasher globally.
 #[allow(clippy::implicit_hasher)]
 #[tracing::instrument(
-    skip(dynamic_router, ecu_uds, file_manager, locks),
+    skip(dynamic_router, ecu_uds, file_manager, locks, security_plugin),
     fields(
         flash_files_path = %flash_files_path
     )
@@ -126,6 +126,7 @@ pub async fn add_vehicle_routes<R, T, M, S>(
     locks: Arc<Locks>,
     functional_group_config: FunctionalDescriptionConfig,
     components_config: ComponentsConfig,
+    security_plugin: std::sync::Arc<S>,
 ) -> Result<(), DoipGatewaySetupError>
 where
     R: DiagServiceResponse,
@@ -140,6 +141,7 @@ where
         flash_files_path,
         file_manager,
         locks,
+        security_plugin,
     )
     .await;
 

--- a/cda-sovd/src/sovd/mod.rs
+++ b/cda-sovd/src/sovd/mod.rs
@@ -34,7 +34,9 @@ use cda_interfaces::{
     diagservices::{DiagServiceResponse, UdsPayloadData},
     file_manager::FileManager,
 };
-use cda_plugin_security::{SecurityPluginLoader, security_plugin_middleware};
+use cda_plugin_security::{
+    SecurityPluginInitializer, SecurityPluginLoader, security_plugin_middleware,
+};
 use error::{ApiError, api_error_from_diag_response};
 use http::{Uri, header};
 use indexmap::IndexMap;
@@ -175,6 +177,7 @@ pub async fn route<
     flash_files_path: String,
     mut file_manager: HashMap<String, U>,
     locks: Arc<Locks>,
+    security_plugin: Arc<S>,
 ) -> Router {
     let flash_data = Arc::new(RwLock::new(sovd_interfaces::sovd2uds::FileList {
         files: Vec::new(),
@@ -190,16 +193,25 @@ pub async fn route<
 
     let router = components_route::<R, T, U>(state.clone(), &mut file_manager).await;
 
-    vehicle_route::<T, S>(state, router, functional_group_config)
-        .await
-        .layer(middleware::from_fn(security_plugin_middleware::<S>))
-        .with_state(uds.clone())
+    vehicle_route::<T, S>(
+        state,
+        router,
+        functional_group_config,
+        Arc::clone(&security_plugin),
+    )
+    .await
+    .layer(middleware::from_fn_with_state(
+        Arc::clone(&security_plugin) as Arc<dyn SecurityPluginInitializer>,
+        security_plugin_middleware,
+    ))
+    .with_state(uds.clone())
 }
 
 async fn vehicle_route<T: UdsEcu + SchemaProvider + Clone, S: SecurityPluginLoader>(
     state: WebserverState<T>,
     router: Router<WebserverState<T>>,
     functional_group_config: FunctionalDescriptionConfig,
+    security_plugin: Arc<S>,
 ) -> Router<T> {
     let router = router.nest_api_service(
         "/vehicle/v15/functions",
@@ -240,7 +252,16 @@ async fn vehicle_route<T: UdsEcu + SchemaProvider + Clone, S: SecurityPluginLoad
                 apps::sovd2uds::bulk_data::flash_files::docs_get,
             ),
         )
-        .route("/vehicle/v15/authorize", routing::post(S::authorize))
+        .route(
+            "/vehicle/v15/authorize",
+            routing::post({
+                let security_plugin = Arc::clone(&security_plugin);
+                move |headers: HeaderMap, body_bytes: Bytes| {
+                    let security_plugin = Arc::clone(&security_plugin);
+                    async move { security_plugin.authorize(headers, body_bytes).await }
+                }
+            }),
+        )
         .with_state(state)
         .api_route(
             "/vehicle/v15/apps/sovd2uds/data/networkstructure",

--- a/integration-tests/tests/sovd/custom_routes.rs
+++ b/integration-tests/tests/sovd/custom_routes.rs
@@ -181,6 +181,7 @@ async fn test_custom_demo_endpoint() {
         ComponentsConfig {
             additional_fields: HashMap::new(),
         },
+        Arc::new(cda_plugin_security::DefaultSecurityPlugin::default()),
     )
     .await
     .expect("Failed to add vehicle routes");

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -259,6 +259,7 @@ fn start_cda(config: Configuration) {
             vehicle_data.locks,
             config.functional_description,
             config.components,
+            Arc::new(DefaultSecurityPlugin::default()),
         )
         .await
         .map_err(|e| {


### PR DESCRIPTION
## Summary

The current architecture of the CDA runtime requires the type of the security plugin to be known at compile time, which limits our ability to support multiple implementations or to load the plugin dynamically.

This commit refactors the code to allow for a more flexible architecture where the security plugin can be created once and passed as a parameter to a generic startup function. This way we can afford more sophisticated initialization like loading configuration files, connecting to external services, or setting up dependencies, which would be inefficient to do for each request.

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have added or updated tests

## Related

Fixes #255

## Notes for Reviewers

This PR has been created with the help of generative AI, which was used to analyze the existing codebase, identify areas for improvement, and generate the necessary changes to support the new architecture.

I have manually reviewed and tested all generated code to ensure it meets requirements and maintains the existing functionality (as far as the existing test suite is concerned). The changes include modifications to the main runtime, the security plugin implementation, and the integration tests to reflect the new architecture.
