### PR TITLE
Improvement: Add error message to DiagService::NotFound errors

### DIFF
--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -148,9 +148,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
     fn ecu_manager(&self, ecu_name: &str) -> Result<&RwLock<T>, DiagServiceError> {
         self.ecus
             .get(ecu_name)
-            .ok_or(DiagServiceError::NotFound(Some(format!(
-                "ECU {ecu_name} not found"
-            ))))
+            .ok_or_else(|| DiagServiceError::NotFound(format!("ECU {ecu_name} not found")))
     }
 
     async fn start_reset_task(
@@ -1099,7 +1097,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
                     let Some(ecu_manager) = self.ecus.get(&ecu_name) else {
                         result_map.insert(
                             ecu_name.clone(),
-                            Err(DiagServiceError::NotFound(Some(ecu_name.clone()))),
+                            Err(DiagServiceError::NotFound(ecu_name.clone())),
                         );
                         continue;
                     };
@@ -1402,7 +1400,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
         let items = self
             .ecus
             .get(ecu)
-            .ok_or_else(|| DiagServiceError::NotFound(Some(format!("Unknown ECU: {ecu}"))))?
+            .ok_or_else(|| DiagServiceError::NotFound(format!("Unknown ECU: {ecu}")))?
             .read()
             .await
             .get_components_single_ecu_jobs_info();
@@ -1621,10 +1619,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
         ecu_name: &str,
         level: &str,
     ) -> Result<String, DiagServiceError> {
-        let ecu_diag_service = self
-            .ecus
-            .get(ecu_name)
-            .ok_or(DiagServiceError::NotFound(None))?;
+        let ecu_diag_service = self.ecu_manager(ecu_name)?;
         let security_access = ecu_diag_service
             .read()
             .await
@@ -1666,10 +1661,9 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
         diag_manager
             .get_service_state(service)
             .await
-            .ok_or(DiagServiceError::NotFound(
-                format!("Service state for service ID {service:02X} not found in ECU {ecu_name}")
-                    .into(),
-            ))
+            .ok_or(DiagServiceError::NotFound(format!(
+                "Service state for service ID {service:02X} not found in ECU {ecu_name}"
+            )))
     }
 
     async fn ecu_exec_service_from_function_class(
@@ -1787,10 +1781,9 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
         id: &str,
     ) -> Result<(), DiagServiceError> {
         let mut lock = self.data_transfers.lock().await;
-        let transfer = lock.get(ecu_name).ok_or(DiagServiceError::NotFound(None))?;
-        if transfer.meta_data.id != id {
-            return Err(DiagServiceError::NotFound(None));
-        }
+        let transfer = lock.get(ecu_name).ok_or_else(|| {
+            DiagServiceError::NotFound(format!("Data transfer for ECU {ecu_name} not found"))
+        })?;
 
         if !matches!(
             transfer.meta_data.status,
@@ -1802,9 +1795,12 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
             )));
         }
 
-        let mut transfer = lock
-            .remove(ecu_name)
-            .ok_or(DiagServiceError::NotFound(None))?;
+        // Now it is safe to remove the transfer from the map
+        let mut transfer = lock.remove(ecu_name).ok_or_else(|| {
+            DiagServiceError::NotFound(format!(
+                "Data transfer for ECU {ecu_name} not found during exit"
+            ))
+        })?;
 
         if let Err(e) = transfer.status_receiver.changed().await {
             return Err(DiagServiceError::InvalidRequest(format!(
@@ -1829,7 +1825,9 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
             .await
             .get(ecu_name)
             .map(|transfer| transfer.meta_data.clone())
-            .ok_or(DiagServiceError::NotFound(None))?;
+            .ok_or_else(|| {
+                DiagServiceError::NotFound(format!("No data transfer running for ECU {ecu_name}"))
+            })?;
 
         Ok(vec![meta_data.clone()])
     }
@@ -1843,7 +1841,11 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
             .await?
             .into_iter()
             .find(|transfer| transfer.id == id)
-            .ok_or(DiagServiceError::NotFound(None))
+            .ok_or_else(|| {
+                DiagServiceError::NotFound(format!(
+                    "Data transfer with id {id} not found for ECU {ecu_name}"
+                ))
+            })
     }
 
     #[tracing::instrument(skip(self), err,
@@ -2449,13 +2451,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
     }
 
     async fn ecu_functional_groups(&self, ecu_name: &str) -> Result<Vec<String>, DiagServiceError> {
-        let groups = self
-            .ecus
-            .get(ecu_name)
-            .ok_or(DiagServiceError::NotFound(None))?
-            .read()
-            .await
-            .functional_groups();
+        let groups = self.ecu_manager(ecu_name)?.read().await.functional_groups();
         Ok(groups)
     }
 

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -410,9 +410,11 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
                 .request_id()
                 .is_some_and(|service_id| raw_data_sid == service_id)
         });
-        let mapped_service = matched_services
-            .first()
-            .ok_or(DiagServiceError::NotFound(None))?;
+        let mapped_service = matched_services.first().ok_or_else(|| {
+            DiagServiceError::NotFound(format!(
+                "No matching generic service found for SID {raw_data_sid:#04X}"
+            ))
+        })?;
         let mapped_dc = mapped_service.diag_comm().map(datatypes::DiagComm).ok_or(
             DiagServiceError::InvalidDatabase("Service is missing DiagComm".to_owned()),
         )?;
@@ -709,9 +711,9 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
         .into_iter()
         .next()
         .map(|job| (*job).into())
-        .ok_or(DiagServiceError::NotFound(Some(format!(
+        .ok_or(DiagServiceError::NotFound(format!(
             "Single ECU job with name '{job_name}' not found"
-        ))))
+        )))
     }
 
     /// Lookup a service by a given function class name and service id.
@@ -740,10 +742,10 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
         .next()
         .and_then(|service| service.try_into().ok())
         .ok_or_else(|| {
-            DiagServiceError::NotFound(Some(format!(
+            DiagServiceError::NotFound(format!(
                 "Service with functional class '{func_class_name}' and SID 0x{service_id:02X} not \
                  found"
-            )))
+            ))
         })
     }
 
@@ -770,11 +772,9 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
         &self,
         request_bytes: &[u8],
     ) -> Result<Vec<DiagComm>, DiagServiceError> {
-        let service_id = *request_bytes
-            .first()
-            .ok_or(DiagServiceError::NotFound(Some(
-                "cannot lookup service by empty prefix".to_owned(),
-            )))?;
+        let service_id = *request_bytes.first().ok_or(DiagServiceError::NotFound(
+            "cannot lookup service by empty prefix".to_owned(),
+        ))?;
         let services: Vec<_> = self
             .lookup_services_by_sid(service_id)?
             .iter()
@@ -833,9 +833,9 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
             .collect();
 
         if services.is_empty() {
-            Err(DiagServiceError::NotFound(Some(format!(
+            Err(DiagServiceError::NotFound(format!(
                 "No service found matching request prefix: {request_bytes:02X?}"
-            ))))
+            )))
         } else {
             Ok(services)
         }
@@ -1045,7 +1045,16 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
                             .is_some_and(|r| r.params().is_some_and(|p| p.len() == 2))
                         && name_matches
                 })
-                .ok_or(DiagServiceError::NotFound(None))?;
+                .ok_or_else(|| {
+                    DiagServiceError::NotFound(format!(
+                        "No matching 'request seed' SecurityAccess service found for level \
+                         '{level}'{}",
+                        seed_service
+                            .as_ref()
+                            .map(|s| format!(" and seed service '{s}'"))
+                            .unwrap_or_default()
+                    ))
+                })?;
 
             let request_seed_service = request_seed_service.try_into()?;
 
@@ -1130,7 +1139,12 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
                     )
                 })
             })
-            .ok_or(DiagServiceError::NotFound(None))?;
+            .ok_or_else(|| {
+                DiagServiceError::NotFound(format!(
+                    "Functional class '{}' for varcoding not found in any diagnostic layer",
+                    self.database_naming_convention.functional_class_varcoding
+                ))
+            })?;
 
         let configuration_sids = [
             service_ids::READ_DATA_BY_IDENTIFIER,
@@ -2114,7 +2128,9 @@ impl<S: SecurityPlugin> EcuManager<S> {
         if let Some(Some(location)) = self.db_cache.diag_services.read().await.get(&lookup_id) {
             return match self.get_service_by_location(location) {
                 Some(service) => Ok(service),
-                None => Err(DiagServiceError::NotFound(None)), // cached negative result
+                None => Err(DiagServiceError::NotFound(format!(
+                    "Cached diagnostic service '{lookup_name}' not found at stored location"
+                ))),
             };
         }
 
@@ -2144,9 +2160,10 @@ impl<S: SecurityPlugin> EcuManager<S> {
             .await
             .insert(lookup_id, None);
 
-        Err(DiagServiceError::NotFound(Some(format!(
-            "Diagnostic service '{lookup_name}' not found in variant or parent refs"
-        ))))
+        Err(DiagServiceError::NotFound(format!(
+            "Diagnostic service '{lookup_name}' not found in variant, base variant, or ECU shared \
+             data"
+        )))
     }
 
     fn search_with_location<F>(
@@ -2323,9 +2340,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     .is_some_and(|name| name.eq_ignore_ascii_case(group_name))
             })
             .ok_or_else(|| {
-                DiagServiceError::NotFound(Some(format!(
-                    "Functional group '{group_name}' not found"
-                )))
+                DiagServiceError::NotFound(format!("Functional group '{group_name}' not found"))
             })?;
 
         Ok(matching_group
@@ -4327,7 +4342,9 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     semantic = %semantic,
                     "State chart with given semantic not found in base variant"
                 );
-                DiagServiceError::NotFound(None)
+                DiagServiceError::NotFound(format!(
+                    "State chart with semantic '{semantic}' not found in base variant"
+                ))
             })?;
 
         let service = self
@@ -4356,7 +4373,10 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     semantic,
                     "Failed to find service for state transition"
                 );
-                DiagServiceError::NotFound(None)
+                DiagServiceError::NotFound(format!(
+                    "No service found for state transition {current_state} -> {target_state} \
+                     ({semantic})"
+                ))
             })?;
 
         service.try_into()
@@ -4372,7 +4392,11 @@ impl<S: SecurityPlugin> EcuManager<S> {
             .flat_map(|sc| sc.iter())
             .find(|sc| sc.semantic().is_some_and(|sem| sem == semantic))
             .map(datatypes::StateChart)
-            .ok_or(DiagServiceError::NotFound(None))
+            .ok_or_else(|| {
+                DiagServiceError::NotFound(format!(
+                    "State chart with semantic '{semantic}' not found in base variant"
+                ))
+            })
     }
 
     fn default_state(&self, semantic: &str) -> Result<String, DiagServiceError> {
@@ -4395,7 +4419,10 @@ impl<S: SecurityPlugin> EcuManager<S> {
         });
 
         if services.is_empty() {
-            Err(DiagServiceError::NotFound(None))
+            Err(DiagServiceError::NotFound(format!(
+                "No services with SID {service_id:#04X} found in variant, base variant, or ECU \
+                 shared data"
+            )))
         } else {
             Ok(services)
         }
@@ -4528,7 +4555,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     })
             })
             .ok_or_else(|| {
-                DiagServiceError::NotFound(Some(format!("Service '{service_name}' not found")))
+                DiagServiceError::NotFound(format!("Service '{service_name}' not found"))
             })
     }
 

--- a/cda-database/src/datatypes/comparam.rs
+++ b/cda-database/src/datatypes/comparam.rs
@@ -42,9 +42,9 @@ pub(super) fn lookup(
                         .is_some_and(|n| n == param_name)
             })
         })
-        .ok_or(DiagServiceError::NotFound(Some(format!(
+        .ok_or(DiagServiceError::NotFound(format!(
             "No ComParamRef found for {param_name} in protocol {protocol_name}"
-        ))))?;
+        )))?;
 
     let cp = cp_ref.com_param().ok_or(DiagServiceError::InvalidDatabase(
         "ComParamRef has no ComParam".to_owned(),

--- a/cda-database/src/datatypes/mod.rs
+++ b/cda-database/src/datatypes/mod.rs
@@ -679,7 +679,7 @@ impl DiagnosticDatabase {
                 com_param.default.clone()
             }
             Err(e) => {
-                if let DiagServiceError::NotFound(Some(e)) = &e {
+                if let DiagServiceError::NotFound(e) = &e {
                     tracing::debug!(
                         param_name = %com_param.name,
                         error = %e,

--- a/cda-interfaces/src/lib.rs
+++ b/cda-interfaces/src/lib.rs
@@ -272,7 +272,7 @@ pub struct FunctionalDescriptionConfig {
 pub enum DiagServiceError {
     /// Returned in case a resource can not be found
     #[error("Not found: {0:?}")]
-    NotFound(Option<String>),
+    NotFound(String),
     #[error("Request not supported: {0}")]
     RequestNotSupported(String),
     #[error("Invalid database: {0}")]

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -114,11 +114,8 @@ impl From<DiagServiceError> for AppError {
 
             DiagServiceError::ResourceError(_) => Self::ResourceError(value.to_string()),
 
-            DiagServiceError::NotFound(Some(_)) => Self::NotFound(value.to_string()),
+            DiagServiceError::NotFound(_) => Self::NotFound(value.to_string()),
 
-            DiagServiceError::NotFound(None) => {
-                Self::NotFound("Resource could not be found.".to_owned())
-            }
             DiagServiceError::DataError(_)
             | DiagServiceError::InvalidDatabase(_)
             | DiagServiceError::AmbiguousParameters { .. }


### PR DESCRIPTION
## Summary

This PR is adding error messages to all DiagService::NotFound errors. This makes it easier to find out what went wrong and which lookup failed. There was already a PR (https://github.com/eclipse-opensovd/classic-diagnostic-adapter/pull/154) for this, but I closed it due to Git issues. This PR is now replacing the old one.


- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions

Implements https://github.com/eclipse-opensovd/classic-diagnostic-adapter/issues/97
