### PR TITLE
fix: handle SendKey level names with multiple underscores

### DIFF
--- a/cda-sovd/src/sovd/components/ecu/modes.rs
+++ b/cda-sovd/src/sovd/components/ecu/modes.rs
@@ -421,17 +421,15 @@ pub(crate) mod security {
         >,
     ) -> Response {
         fn split_at_last_underscore(input: &str) -> (String, Option<String>) {
-            let parts: Vec<&str> = input.split('_').collect();
-
-            if parts.len() > 2 {
-                let last_part = parts.last().map(|s| (*s).to_string());
-                let remaining = parts
-                    .get(..parts.len().saturating_sub(1))
-                    .map_or_else(|| input.to_string(), |slice| slice.join("_"));
-                (remaining, last_part)
-            } else {
-                (input.to_string(), None)
+            if let Some((level, suffix)) = input.rsplit_once('_') {
+                return match suffix {
+                    "RequestSeed" => (level.to_string(), Some(suffix.to_string())),
+                    "SendKey" => (level.to_string(), None),
+                    _ => (input.to_string(), None),
+                };
             }
+
+            (input.to_string(), None)
         }
 
         let claims = security_plugin.as_auth_plugin().claims();


### PR DESCRIPTION
## Bug
https://github.com/eclipse-opensovd/classic-diagnostic-adapter/issues/260 — security mode parsing treated any value with more than two underscore-separated segments as if a service suffix was present, which made valid SendKey requests fail with a mixed RequestSeed/SendKey error.

## Fix
This change now only treats `_RequestSeed` and `_SendKey` as explicit service suffixes. Other underscore segments stay part of the level name. `_SendKey` is normalized to a regular SendKey flow, so key-based requests no longer conflict with suffix parsing.

## Testing
Unable to run Rust tests in this environment because `cargo` is not installed. Verified the parser logic change in `cda-sovd/src/sovd/components/ecu/modes.rs` to ensure only known service suffixes are interpreted.

Happy to address any feedback.

Greetings, saschabuehrle
