### PR TITLE
fix: additional_fields filtering for components without DoIP connectivity

### DIFF
--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -363,6 +363,15 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
             self.get_diag_layers_from_variant_and_parent_refs()
                 .into_iter()
                 .find_map(|dl| dl.sdgs())
+                .or_else(|| {
+                    // Fall back to the base variant's DiagLayer SDGs when no
+                    // variant has been detected yet (e.g. ECU is offline).
+                    self.diag_database
+                        .base_variant()
+                        .ok()
+                        .and_then(|v| v.diag_layer())
+                        .and_then(|dl| dl.sdgs())
+                })
                 .map(datatypes::Sdgs)
         }
         .ok_or_else(|| DiagServiceError::InvalidDatabase("No SDG found in DB".to_owned()))?;

--- a/cda-interfaces/src/datatypes/sdg.rs
+++ b/cda-interfaces/src/datatypes/sdg.rs
@@ -50,10 +50,30 @@ pub enum SdSdg {
 /// A config value to specify which Strings are to be interpreted
 /// as truthy and which as falsey
 /// `ignore_case` can be set to compare the SD values case-insensitively
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Serialize, Clone, Debug)]
 pub struct SdMappingsTruthyValue {
     values: HashSet<String>,
     ignore_case: bool,
+}
+
+/// Custom `Deserialize` impl that routes through `Self::new()` so that
+/// `ignore_case = true` lowercases the stored values at parse time.
+/// A derived `Deserialize` would set fields directly, bypassing `new()`,
+/// and `contains()` (which lowercases the lookup) would never match the
+/// un-lowercased stored values.
+impl<'de> Deserialize<'de> for SdMappingsTruthyValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Raw {
+            values: HashSet<String>,
+            ignore_case: bool,
+        }
+        let raw = Raw::deserialize(deserializer)?;
+        Ok(Self::new(raw.values, raw.ignore_case))
+    }
 }
 
 impl SdMappingsTruthyValue {
@@ -85,3 +105,50 @@ impl SdMappingsTruthyValue {
 
 /// A mapping of an SD.si to their truthy values
 pub type SdBoolMappings = HashMap<String, SdMappingsTruthyValue>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialized_ignore_case_lowercases_values() {
+        let json = r#"{"values": ["Flux Capacitor Mark II", "Enabled"], "ignore_case": true}"#;
+        let mapping: SdMappingsTruthyValue = serde_json::from_str(json).unwrap();
+        // Values should have been lowercased during deserialization
+        assert!(mapping.values.contains("flux capacitor mark ii"));
+        assert!(mapping.values.contains("enabled"));
+        assert!(!mapping.values.contains("Flux Capacitor Mark II"));
+        assert!(!mapping.values.contains("Enabled"));
+    }
+
+    #[test]
+    fn deserialized_case_sensitive_preserves_values() {
+        let json = r#"{"values": ["Flux Capacitor Mark II", "Enabled"], "ignore_case": false}"#;
+        let mapping: SdMappingsTruthyValue = serde_json::from_str(json).unwrap();
+        assert!(mapping.values.contains("Flux Capacitor Mark II"));
+        assert!(mapping.values.contains("Enabled"));
+    }
+
+    #[test]
+    fn contains_matches_case_insensitive_after_deserialization() {
+        let json = r#"{"values": ["Flux Capacitor Mark II", "Plutonium"], "ignore_case": true}"#;
+        let mapping: SdMappingsTruthyValue = serde_json::from_str(json).unwrap();
+        // Should match regardless of input case
+        assert!(mapping.contains("flux capacitor mark ii"));
+        assert!(mapping.contains("Flux Capacitor Mark II"));
+        assert!(mapping.contains("FLUX CAPACITOR MARK II"));
+        assert!(mapping.contains("plutonium"));
+        assert!(mapping.contains("Plutonium"));
+        assert!(!mapping.contains("Mr. Fusion"));
+    }
+
+    #[test]
+    fn contains_matches_case_sensitive_after_deserialization() {
+        let json = r#"{"values": ["Plutonium", "Mr. Fusion"], "ignore_case": false}"#;
+        let mapping: SdMappingsTruthyValue = serde_json::from_str(json).unwrap();
+        assert!(mapping.contains("Plutonium"));
+        assert!(!mapping.contains("plutonium"));
+        assert!(mapping.contains("Mr. Fusion"));
+        assert!(!mapping.contains("mr. fusion"));
+    }
+}

--- a/cda-main/src/config/configfile.rs
+++ b/cda-main/src/config/configfile.rs
@@ -314,4 +314,61 @@ long_name_affixes = [ "Read ", "Write_ " ]
         assert!(config.validate_sanity().is_err());
         Ok(())
     }
+
+    #[tokio::test]
+    async fn load_config_toml_additional_fields_ignore_case_lowercases_values()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let config_str = r#"
+[components.additional_fields.x-sovd2uds-time-travel-ecus.FluxCapacitor]
+values = ["Flux Capacitor Mark II", "Flux Capacitor Mark III", "yes"]
+ignore_case = true
+
+[components.additional_fields.x-sovd2uds-power-source-ecus.PowerSource]
+values = ["Plutonium", "Mr. Fusion"]
+ignore_case = true
+"#;
+        let figment = Figment::from(Serialized::defaults(Configuration::default()))
+            .merge(Toml::string(config_str));
+        let config: Configuration = figment.extract()?;
+
+        // Verify the FluxCapacitor additional field was loaded and values match case-insensitively
+        let flux_field = config
+            .components
+            .additional_fields
+            .get("x-sovd2uds-time-travel-ecus")
+            .expect("x-sovd2uds-time-travel-ecus should exist");
+        let flux_mapping = flux_field
+            .get("FluxCapacitor")
+            .expect("FluxCapacitor mapping should exist");
+        assert!(
+            flux_mapping.contains("flux capacitor mark ii"),
+            "Should match lowercase"
+        );
+        assert!(
+            flux_mapping.contains("Flux Capacitor Mark II"),
+            "Should match original case"
+        );
+        assert!(
+            flux_mapping.contains("FLUX CAPACITOR MARK II"),
+            "Should match uppercase"
+        );
+        assert!(flux_mapping.contains("yes"), "Should match lowercase 'yes'");
+        assert!(flux_mapping.contains("YES"), "Should match uppercase 'YES'");
+
+        // Verify the PowerSource additional field
+        let power_field = config
+            .components
+            .additional_fields
+            .get("x-sovd2uds-power-source-ecus")
+            .expect("x-sovd2uds-power-source-ecus should exist");
+        let power_mapping = power_field
+            .get("PowerSource")
+            .expect("PowerSource mapping should exist");
+        assert!(power_mapping.contains("Plutonium"));
+        assert!(power_mapping.contains("plutonium"));
+        assert!(power_mapping.contains("Mr. Fusion"));
+        assert!(power_mapping.contains("mr. fusion"));
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Fix SDG lookup to fall back to base variant when no variant is detected, and fix SdMappingsTruthyValue deserialization to normalize case via new().


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
