### PR TITLE
feat(cda-core): add get_response_parameter_metadata and fix PhysConst coded-value resolution

### DIFF
--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -1436,48 +1436,13 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
             response_type,
         })
     }
-    fn get_service_parameter_metadata(
+    fn get_request_parameter_metadata(
         &self,
         service_name: &str,
     ) -> Result<Vec<cda_interfaces::ServiceParameterMetadata>, DiagServiceError> {
         use cda_interfaces::ServiceParameterMetadata;
-        fn extract_param_type_metadata(
-            param: &datatypes::Parameter<'_>,
-            service_name: &str,
-            name: &str,
-        ) -> Result<cda_interfaces::ParameterTypeMetadata, DiagServiceError> {
-            use cda_interfaces::ParameterTypeMetadata;
 
-            let param_type = match param.param_type()? {
-                datatypes::ParamType::CodedConst => param
-                    .specific_data_as_coded_const()
-                    .and_then(|cc| cc.coded_value())
-                    .map_or(ParameterTypeMetadata::Value, |v| {
-                        ParameterTypeMetadata::CodedConst {
-                            coded_value: v.to_owned(),
-                        }
-                    }),
-                datatypes::ParamType::PhysConst => param
-                    .specific_data_as_phys_const()
-                    .and_then(|pc| pc.phys_constant_value())
-                    .map_or_else(
-                        || {
-                            tracing::warn!(
-                                "Service '{}' param '{}' PHYS-CONST has no value",
-                                service_name,
-                                name
-                            );
-                            ParameterTypeMetadata::Value
-                        },
-                        |v| ParameterTypeMetadata::PhysConst {
-                            phys_constant_value: v.to_owned(),
-                        },
-                    ),
-                _ => ParameterTypeMetadata::Value,
-            };
-
-            Ok(param_type)
-        }
+        use crate::diag_kernel::param_metadata::extract_request_param_type;
 
         let service = self.get_meta_data_service(service_name)?;
         let Some(request) = service.request() else {
@@ -1508,7 +1473,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
                 })?;
 
                 let semantic = param.semantic().map(ToOwned::to_owned);
-                let param_type = extract_param_type_metadata(&param, service_name, &name).ok()?;
+                let param_type = extract_request_param_type(&param, service_name, &name).ok()?;
 
                 Some(ServiceParameterMetadata {
                     name,
@@ -1518,6 +1483,81 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
             })
             .collect();
 
+        Ok(metadata)
+    }
+
+    /// Get parameter metadata for the POS-RESPONSE of a service.
+    ///
+    /// Returns one [`ResponseParameterInfo`] per parameter in the first positive
+    /// response definition, including byte layout (position, size) and type
+    /// information. This is the response-side counterpart of
+    /// [`get_request_parameter_metadata`] (which returns request parameters).
+    ///
+    /// For MUX DOP parameters, the MUX cases are expanded: each case's inner
+    /// structure parameters are returned with their names prefixed by the case
+    /// short name
+    fn get_response_parameter_metadata(
+        &self,
+        service_name: &str,
+    ) -> Result<Vec<cda_interfaces::ResponseParameterInfo>, DiagServiceError> {
+        use cda_interfaces::ResponseParameterInfo;
+
+        use crate::diag_kernel::param_metadata::{
+            byte_size_from_coded_const, byte_size_from_value_param, expand_mux_cases,
+            extract_response_param_type,
+        };
+
+        let service = self.get_meta_data_service(service_name)?;
+        let pos_responses = match service.pos_responses() {
+            Some(r) if !r.is_empty() => r,
+            _ => return Ok(Vec::new()),
+        };
+
+        let Some(params) = pos_responses.iter().next().and_then(|r| r.params()) else {
+            return Ok(Vec::new());
+        };
+
+        let mut metadata: Vec<ResponseParameterInfo> = Vec::new();
+        for raw_param in params {
+            let param = datatypes::Parameter(raw_param);
+            let Some(name) = param.short_name().map(ToOwned::to_owned) else {
+                continue;
+            };
+            let semantic = param.semantic().map(ToOwned::to_owned);
+            let param_type = extract_response_param_type(&param);
+
+            let byte_size = match &param_type {
+                cda_interfaces::ParameterTypeMetadata::Value { .. } => {
+                    let (size, is_mux) = byte_size_from_value_param(&param);
+                    if is_mux {
+                        metadata.extend(expand_mux_cases(&param, param.byte_position()));
+                        continue;
+                    }
+                    size
+                }
+                cda_interfaces::ParameterTypeMetadata::CodedConst { .. } => {
+                    byte_size_from_coded_const(&param)
+                }
+                cda_interfaces::ParameterTypeMetadata::MatchingRequestParam { byte_length } => {
+                    Some(*byte_length)
+                }
+                cda_interfaces::ParameterTypeMetadata::PhysConst { .. } => None,
+            };
+            metadata.push(ResponseParameterInfo {
+                name,
+                semantic,
+                param_type,
+                byte_position: param.byte_position(),
+                bit_position: param.bit_position(),
+                byte_size,
+            });
+        }
+
+        tracing::debug!(
+            "Service '{}' has {} positive-response parameters (MUX-expanded)",
+            service_name,
+            metadata.len()
+        );
         Ok(metadata)
     }
 
@@ -7627,13 +7667,13 @@ mod tests {
     }
 
     #[test]
-    fn test_get_service_parameter_metadata_success() {
+    fn test_get_request_parameter_metadata_success() {
         use cda_interfaces::ParameterTypeMetadata;
 
         let ecu_manager = create_ecu_manager_with_parameter_metadata();
 
         // Get parameter metadata for the test service
-        let result = ecu_manager.get_service_parameter_metadata("RDBI_TestService");
+        let result = ecu_manager.get_request_parameter_metadata("RDBI_TestService");
         assert!(result.is_ok());
 
         let metadata = result.unwrap();
@@ -7661,16 +7701,16 @@ mod tests {
         let data_param = metadata.iter().find(|m| m.name == "data").unwrap();
         assert!(matches!(
             data_param.param_type,
-            ParameterTypeMetadata::Value
+            ParameterTypeMetadata::Value { .. }
         ));
     }
 
     #[test]
-    fn test_get_service_parameter_metadata_service_not_found() {
+    fn test_get_request_parameter_metadata_service_not_found() {
         let ecu_manager = create_ecu_manager_with_parameter_metadata();
 
         // Try to get metadata for a non-existent service
-        let result = ecu_manager.get_service_parameter_metadata("NonExistentService");
+        let result = ecu_manager.get_request_parameter_metadata("NonExistentService");
         assert!(result.is_err());
 
         // Should return NotFound error for non-existent service
@@ -7734,13 +7774,13 @@ mod tests {
     }
 
     #[test]
-    fn test_get_service_parameter_metadata_extracts_coded_const_did_value() {
+    fn test_get_request_parameter_metadata_extracts_coded_const_did_value() {
         use cda_interfaces::ParameterTypeMetadata;
 
         let ecu_manager = create_ecu_manager_with_parameter_metadata();
 
         // Get parameter metadata
-        let result = ecu_manager.get_service_parameter_metadata("RDBI_TestService");
+        let result = ecu_manager.get_request_parameter_metadata("RDBI_TestService");
         assert!(result.is_ok());
 
         let metadata = result.unwrap();
@@ -7765,6 +7805,256 @@ mod tests {
         } else {
             panic!("Expected CODED-CONST parameter type");
         }
+    }
+
+    /// Verifies that `get_request_parameter_metadata` resolves `coded_value` for a
+    /// PHYS-CONST parameter backed by a `NormalDOP` with an Identical `CompuMethod`.
+    #[test]
+    fn test_get_request_parameter_metadata_phys_const_coded_value_resolved() {
+        use cda_interfaces::ParameterTypeMetadata;
+
+        let (ecu_manager, _dc, _sid) = create_ecu_manager_with_phys_const_normal_dop_service();
+
+        let result = ecu_manager.get_request_parameter_metadata("TestPhysConstNormalService");
+        assert!(result.is_ok());
+
+        let metadata = result.unwrap();
+
+        let did_param = metadata
+            .iter()
+            .find(|m| m.name == "DID")
+            .expect("DID parameter should be present");
+
+        if let ParameterTypeMetadata::PhysConst {
+            phys_constant_value,
+            coded_value,
+        } = &did_param.param_type
+        {
+            assert_eq!(phys_constant_value, "61840");
+            // Identical CompuMethod: phys string parses directly to coded integer
+            assert_eq!(
+                *coded_value,
+                Some(61840u64),
+                "PHYS-CONST with Identical CompuMethod must resolve coded_value"
+            );
+        } else {
+            panic!(
+                "Expected PhysConst parameter type for DID, got {:?}",
+                did_param.param_type
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_response_parameter_metadata_service_not_found() {
+        let (ecu_manager, _dc, _sid) = create_ecu_manager_with_phys_const_normal_dop_service();
+
+        let result = ecu_manager.get_response_parameter_metadata("NonExistentService");
+        assert!(result.is_err());
+        assert!(matches!(result, Err(DiagServiceError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_get_response_parameter_metadata_empty_for_no_pos_response() {
+        let (ecu_manager, _dc, _sid, _) = create_ecu_manager_with_struct_service(1);
+
+        // TestStructService has no positive-response definition
+        let result = ecu_manager.get_response_parameter_metadata("TestStructService");
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    /// Covers `CodedConst` (SID), `PhysConst` (DID), and `Value` (data) response parameters.
+    ///
+    /// Fixture layout (`pos_response` of `TestPhysConstNormalService`):
+    ///   byte 0: `sid`       – CODED-CONST (1 byte)
+    ///   byte 1: `DID`       – PHYS-CONST  (u16, `coded_value` = None in response metadata)
+    ///   byte 3: `data_param`– VALUE        (u8, 1 byte)
+    #[test]
+    fn test_get_response_parameter_metadata_phys_const_and_value_params() {
+        use cda_interfaces::ParameterTypeMetadata;
+
+        let (ecu_manager, _dc, _sid) = create_ecu_manager_with_phys_const_normal_dop_service();
+
+        let result = ecu_manager.get_response_parameter_metadata("TestPhysConstNormalService");
+        assert!(result.is_ok());
+
+        let metadata = result.unwrap();
+        assert_eq!(metadata.len(), 3, "Expected sid, DID, data_param");
+
+        // SID: CODED-CONST at byte 0
+        let sid_param = metadata
+            .iter()
+            .find(|m| m.name == "sid")
+            .expect("sid param should be present");
+        assert!(matches!(
+            sid_param.param_type,
+            ParameterTypeMetadata::CodedConst { .. }
+        ));
+        assert_eq!(sid_param.byte_position, 0);
+        assert_eq!(sid_param.byte_size, Some(1)); // 8 bits
+
+        // DID: PHYS-CONST at byte 1; response metadata does not resolve coded_value
+        let did_param = metadata
+            .iter()
+            .find(|m| m.name == "DID")
+            .expect("DID param should be present");
+        if let ParameterTypeMetadata::PhysConst {
+            phys_constant_value,
+            coded_value,
+        } = &did_param.param_type
+        {
+            assert_eq!(phys_constant_value, "61840");
+            assert!(
+                coded_value.is_none(),
+                "get_response_parameter_metadata does not resolve PhysConst coded_value"
+            );
+        } else {
+            panic!(
+                "Expected PhysConst type for DID, got {:?}",
+                did_param.param_type
+            );
+        }
+        assert_eq!(did_param.byte_position, 1);
+        assert!(did_param.byte_size.is_none());
+
+        // data_param: VALUE at byte 3, u8 = 1 byte
+        let data_param = metadata
+            .iter()
+            .find(|m| m.name == "data_param")
+            .expect("data_param should be present");
+        assert!(matches!(
+            data_param.param_type,
+            ParameterTypeMetadata::Value { .. }
+        ));
+        assert_eq!(data_param.byte_position, 3);
+        assert_eq!(data_param.byte_size, Some(1)); // u8 = 8 bits
+    }
+
+    /// Verifies MUX expansion: each case's inner parameters appear as
+    /// `"case_name/param_name"` entries, and each case produces a
+    /// `"__mux_case__/case_name"` marker.
+    ///
+    /// Fixture layout (`pos_response` of `TestMuxService`):
+    ///   byte 0: `test_service_pos_sid` – CODED-CONST (1 byte, SID = 0x22)
+    ///   byte 2: `mux_1_param`          – MUX DOP (expanded into case entries)
+    ///     switch key: u16 at offset 0 within mux (size = 2 bytes)
+    ///     case 1 abs pos = mux(2) + key(2) + `inner_offset`
+    ///       `mux_1_case_1_param_1`: f32 → byte 4, size 4
+    ///       `mux_1_case_1_param_2`: u8  → byte 8, size 1
+    ///       marker __`mux_case`__/`mux_1_case_1`: byte 4, size = structure (7)
+    ///     case 2 abs pos = 2 + 2 + `inner_offset`
+    ///       `mux_1_case_2_param_1`: i16  → byte 5, size 2
+    ///       `mux_1_case_2_param_2`: ascii 32 bits → byte 8, size 4
+    ///       marker __`mux_case`__/`mux_1_case_2`: byte 4, size = structure (7)
+    ///     case 3: no structure → produces no entries
+    #[test]
+    fn test_get_response_parameter_metadata_mux_expansion() {
+        use cda_interfaces::ParameterTypeMetadata;
+
+        let (ecu_manager, _, _) = create_ecu_manager_with_mux_service(None, None, None);
+
+        let result = ecu_manager.get_response_parameter_metadata("TestMuxService");
+        assert!(result.is_ok());
+
+        let metadata = result.unwrap();
+        // SID (1) + case-1 (2 inner + 1 marker) + case-2 (2 inner + 1 marker) = 7
+        assert_eq!(
+            metadata.len(),
+            7,
+            "Expected SID + case-1 entries (2+marker) + case-2 entries (2+marker)"
+        );
+
+        // SID coded-const is preserved unchanged
+        let sid_param = metadata
+            .iter()
+            .find(|m| m.name == "test_service_pos_sid")
+            .expect("test_service_pos_sid should be present");
+        assert!(matches!(
+            sid_param.param_type,
+            ParameterTypeMetadata::CodedConst { .. }
+        ));
+        assert_eq!(sid_param.byte_position, 0);
+
+        // Case 1 inner params (mux byte_pos=2, switch_key_size=2)
+        let c1p1 = metadata
+            .iter()
+            .find(|m| m.name == "mux_1_case_1/mux_1_case_1_param_1")
+            .expect("mux_1_case_1/mux_1_case_1_param_1 should be present");
+        assert!(matches!(
+            c1p1.param_type,
+            ParameterTypeMetadata::Value { .. }
+        ));
+        // mux_byte_pos(2) + switch_key_size(2) + inner_byte_pos(0)
+        assert_eq!(c1p1.byte_position, 4);
+        assert_eq!(c1p1.byte_size, Some(4)); // f32 = 32 bits / 8
+
+        let c1p2 = metadata
+            .iter()
+            .find(|m| m.name == "mux_1_case_1/mux_1_case_1_param_2")
+            .expect("mux_1_case_1/mux_1_case_1_param_2 should be present");
+        assert!(matches!(
+            c1p2.param_type,
+            ParameterTypeMetadata::Value { .. }
+        ));
+        // mux_byte_pos(2) + switch_key_size(2) + inner_byte_pos(4)
+        assert_eq!(c1p2.byte_position, 8);
+        assert_eq!(c1p2.byte_size, Some(1)); // u8 = 8 bits / 8
+
+        let marker_1 = metadata
+            .iter()
+            .find(|m| m.name == "__mux_case__/mux_1_case_1")
+            .expect("__mux_case__/mux_1_case_1 marker should be present");
+        assert!(matches!(
+            marker_1.param_type,
+            ParameterTypeMetadata::CodedConst { .. }
+        ));
+        assert_eq!(marker_1.byte_position, 4); // mux_byte_pos(2) + switch_key_size(2)
+        assert_eq!(marker_1.byte_size, Some(7)); // structure byte_size
+
+        // Case 2 inner params
+        let c2p1 = metadata
+            .iter()
+            .find(|m| m.name == "mux_1_case_2/mux_1_case_2_param_1")
+            .expect("mux_1_case_2/mux_1_case_2_param_1 should be present");
+        assert!(matches!(
+            c2p1.param_type,
+            ParameterTypeMetadata::Value { .. }
+        ));
+        // mux_byte_pos(2) + switch_key_size(2) + inner_byte_pos(1)
+        assert_eq!(c2p1.byte_position, 5);
+        assert_eq!(c2p1.byte_size, Some(2)); // i16 = 16 bits / 8
+
+        let c2p2 = metadata
+            .iter()
+            .find(|m| m.name == "mux_1_case_2/mux_1_case_2_param_2")
+            .expect("mux_1_case_2/mux_1_case_2_param_2 should be present");
+        assert!(matches!(
+            c2p2.param_type,
+            ParameterTypeMetadata::Value { .. }
+        ));
+        // mux_byte_pos(2) + switch_key_size(2) + inner_byte_pos(4)
+        assert_eq!(c2p2.byte_position, 8);
+        assert_eq!(c2p2.byte_size, Some(4)); // ascii 32 bits / 8
+
+        let marker_2 = metadata
+            .iter()
+            .find(|m| m.name == "__mux_case__/mux_1_case_2")
+            .expect("__mux_case__/mux_1_case_2 marker should be present");
+        assert!(matches!(
+            marker_2.param_type,
+            ParameterTypeMetadata::CodedConst { .. }
+        ));
+        assert_eq!(marker_2.byte_position, 4); // mux_byte_pos(2) + switch_key_size(2)
+        assert_eq!(marker_2.byte_size, Some(7)); // structure byte_size
+
+        // Case 3 has no structure — must produce no entries at all
+        assert!(
+            metadata
+                .iter()
+                .all(|m| !m.name.starts_with("mux_1_case_3/")),
+            "mux_1_case_3 has no structure and must not produce entries"
+        );
     }
 
     #[tokio::test]

--- a/cda-core/src/diag_kernel/mod.rs
+++ b/cda-core/src/diag_kernel/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod diagservices;
 pub(crate) mod ecumanager;
 pub(crate) mod iso_14229_nrc;
 mod operations;
+pub(crate) mod param_metadata;
 mod payload;
 mod schema;
 mod variant_detection;

--- a/cda-core/src/diag_kernel/param_metadata.rs
+++ b/cda-core/src/diag_kernel/param_metadata.rs
@@ -1,0 +1,923 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+//! Standalone helpers for extracting parameter type metadata from MDD
+//! diagnostic descriptions.
+//!
+//! These functions operate on individual [`datatypes::Parameter`] values
+//! without requiring access to `EcuManager` state, which keeps the main
+//! `ecumanager` module shorter and avoids duplication between the request-
+//! and response-side metadata extraction paths.
+
+use cda_database::datatypes;
+use cda_interfaces::{
+    CompuScaleInfo, DiagServiceError, ParameterTypeMetadata, ResponseParameterInfo,
+};
+
+/// Parse a limit value string as a `u64`.
+///
+/// Tries integer parsing first; falls back to `f64` parsing with
+/// truncation for values like `"3.0"` that ODX databases occasionally use.
+// f64->u64 cast is intentional: ODX limit values are expected to fit
+// within u64; fractional parts are truncated by design.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn parse_limit_as_u64(value: &str) -> Option<u64> {
+    value
+        .parse::<u64>()
+        .ok()
+        .or_else(|| value.parse::<f64>().ok().map(|f| f as u64))
+}
+
+/// Resolve a PHYS-CONST text value to its coded integer via the
+/// parameter's DOP -> `NormalDOP` -> `CompuMethod` chain.
+///
+/// Supported compu-method categories:
+/// - `TextTable`: scans `internal_to_phys` scales for a `CompuValues`
+///   entry whose `vt` or `vt_ti` matches `phys_value`, then returns the
+///   scale's `lower_limit` value.  Only `CLOSED` lower and upper bounds are
+///   accepted; `OPEN` or `INFINITE` bounds indicate a genuine range rather
+///   than an exact point value, and are skipped.
+/// - `Identical`: the physical text IS the coded value; the string is
+///   parsed directly as a `u64`.
+///
+/// Returns `None` for unsupported categories (`Linear`, `ScaleLinear`, …) or
+/// when no matching scale entry is found.
+pub(crate) fn resolve_phys_const_coded_value(
+    param: &datatypes::Parameter<'_>,
+    phys_value: &str,
+) -> Option<u64> {
+    let pc = param.specific_data_as_phys_const()?;
+    let dop = pc.dop()?;
+    let normal_dop = dop.specific_data_as_normal_dop()?;
+    let cm = normal_dop.compu_method()?;
+    let category: datatypes::CompuCategory = cm.category().into();
+
+    match category {
+        datatypes::CompuCategory::TextTable => {
+            let scales = cm.internal_to_phys()?.compu_scales()?;
+            for scale in scales {
+                let text_match = scale.consts().is_some_and(|cv| {
+                    cv.vt().is_some_and(|vt| vt == phys_value)
+                        || cv.vt_ti().is_some_and(|ti| ti == phys_value)
+                });
+                if !text_match {
+                    continue;
+                }
+                let limit = scale.lower_limit()?;
+                // Only accept scales where both bounds are CLOSED and equal,
+                // meaning a single point value. An OPEN or INFINITE upper
+                // bound means the scale covers a range, not an exact match.
+                let lower_interval: datatypes::IntervalType = limit.interval_type().into();
+                if !matches!(lower_interval, datatypes::IntervalType::Closed) {
+                    continue;
+                }
+                let upper_interval: datatypes::IntervalType = scale
+                    .upper_limit()
+                    .map_or(datatypes::IntervalType::Infinite, |ul| {
+                        ul.interval_type().into()
+                    });
+                if !matches!(upper_interval, datatypes::IntervalType::Closed) {
+                    continue;
+                }
+                return limit.value().and_then(parse_limit_as_u64);
+            }
+            None
+        }
+        datatypes::CompuCategory::Identical => {
+            // For IDENTICAL the physical string is also the coded value.
+            parse_limit_as_u64(phys_value)
+        }
+        _ => None,
+    }
+}
+
+/// Extract `CompuScaleInfo` entries from a Value param's DOP `CompuMethod`.
+///
+/// Returns `(physical_default_value, coded_default_value, compu_scales)`.
+/// Used by both request-side and response-side metadata extraction.
+pub(crate) fn extract_value_dop_info(
+    param: &datatypes::Parameter<'_>,
+) -> (Option<String>, Option<u64>, Vec<CompuScaleInfo>) {
+    let Some(value_data) = param.specific_data_as_value() else {
+        return (None, None, Vec::new());
+    };
+
+    let physical_default = value_data.physical_default_value().map(ToOwned::to_owned);
+
+    let Some(dop) = value_data.dop() else {
+        return (physical_default, None, Vec::new());
+    };
+    let Some(normal_dop) = dop.specific_data_as_normal_dop() else {
+        return (physical_default, None, Vec::new());
+    };
+    let Some(cm) = normal_dop.compu_method() else {
+        return (physical_default, None, Vec::new());
+    };
+
+    let category: datatypes::CompuCategory = cm.category().into();
+    let mut scales = Vec::new();
+
+    if matches!(category, datatypes::CompuCategory::TextTable)
+        && let Some(itp) = cm.internal_to_phys()
+        && let Some(compu_scales) = itp.compu_scales()
+    {
+        for scale in compu_scales {
+            let short_label = scale
+                .short_label()
+                .and_then(|t| t.value())
+                .map(ToOwned::to_owned);
+            let compu_const_vt = scale
+                .consts()
+                .and_then(|cv| cv.vt().or_else(|| cv.vt_ti()).map(ToOwned::to_owned));
+            let lower = scale
+                .lower_limit()
+                .and_then(|l| l.value().and_then(parse_limit_as_u64));
+            let upper = scale
+                .upper_limit()
+                .and_then(|l| l.value().and_then(parse_limit_as_u64));
+            scales.push(CompuScaleInfo {
+                short_label,
+                lower_limit: lower,
+                upper_limit: upper.or(lower),
+                compu_const_vt,
+            });
+        }
+    }
+
+    // Resolve coded default from physical default via the CompuMethod
+    let coded_default = physical_default.as_deref().and_then(|pd| match category {
+        datatypes::CompuCategory::TextTable => scales.iter().find_map(|s| {
+            if s.compu_const_vt.as_deref() == Some(pd) {
+                s.lower_limit
+            } else {
+                None
+            }
+        }),
+        datatypes::CompuCategory::Identical => parse_limit_as_u64(pd),
+        _ => None,
+    });
+
+    (physical_default, coded_default, scales)
+}
+
+/// Extract `CodedConst` metadata from a parameter, falling back to the
+/// default `Value` variant when no coded value is present.
+fn extract_coded_const_metadata(param: &datatypes::Parameter<'_>) -> ParameterTypeMetadata {
+    param
+        .specific_data_as_coded_const()
+        .and_then(|cc| cc.coded_value())
+        .map_or(ParameterTypeMetadata::default(), |v| {
+            ParameterTypeMetadata::CodedConst {
+                coded_value: v.to_owned(),
+            }
+        })
+}
+
+/// Extract [`ParameterTypeMetadata`] for a request-side parameter.
+///
+/// Resolves `CodedConst`, `PhysConst` (with coded-value resolution through
+/// the DOP chain), and `Value` (with DOP-derived scales and defaults).
+pub(crate) fn extract_request_param_type(
+    param: &datatypes::Parameter<'_>,
+    service_name: &str,
+    name: &str,
+) -> Result<ParameterTypeMetadata, DiagServiceError> {
+    let param_type = match param.param_type()? {
+        datatypes::ParamType::CodedConst => extract_coded_const_metadata(param),
+        datatypes::ParamType::PhysConst => {
+            let phys_value = param
+                .specific_data_as_phys_const()
+                .and_then(|pc| pc.phys_constant_value());
+
+            if let Some(pv) = phys_value {
+                let coded = resolve_phys_const_coded_value(param, pv);
+                if coded.is_none() {
+                    tracing::debug!(
+                        "Service '{}' param '{}' PHYS-CONST '{}' coded value unresolved \
+                         (unsupported DOP category or no matching scale)",
+                        service_name,
+                        name,
+                        pv,
+                    );
+                }
+                ParameterTypeMetadata::PhysConst {
+                    phys_constant_value: pv.to_owned(),
+                    coded_value: coded,
+                }
+            } else {
+                tracing::warn!(
+                    "Service '{}' param '{}' PHYS-CONST has no value",
+                    service_name,
+                    name
+                );
+                ParameterTypeMetadata::default()
+            }
+        }
+        _ => {
+            let (phys_default, coded_default, compu_scales) = extract_value_dop_info(param);
+            ParameterTypeMetadata::Value {
+                physical_default_value: phys_default,
+                coded_default_value: coded_default,
+                compu_scales,
+            }
+        }
+    };
+
+    Ok(param_type)
+}
+
+/// Extract [`ParameterTypeMetadata`] for a response-side parameter.
+///
+/// Unlike the request-side variant, this also handles `MatchingRequestParam`
+/// and does not resolve `PhysConst` coded values (they are not needed for
+/// response decoding).
+pub(crate) fn extract_response_param_type(
+    param: &datatypes::Parameter<'_>,
+) -> ParameterTypeMetadata {
+    let Ok(pt) = param.param_type() else {
+        return ParameterTypeMetadata::default();
+    };
+
+    match pt {
+        datatypes::ParamType::CodedConst => extract_coded_const_metadata(param),
+        datatypes::ParamType::MatchingRequestParam => {
+            let byte_length = param
+                .specific_data_as_matching_request_param()
+                .map_or(0, |m| m.byte_length());
+            ParameterTypeMetadata::MatchingRequestParam { byte_length }
+        }
+        datatypes::ParamType::PhysConst => {
+            let phys_value = param
+                .specific_data_as_phys_const()
+                .and_then(|p| p.phys_constant_value().map(ToOwned::to_owned));
+            match phys_value {
+                Some(v) => ParameterTypeMetadata::PhysConst {
+                    phys_constant_value: v,
+                    coded_value: None,
+                },
+                None => ParameterTypeMetadata::default(),
+            }
+        }
+        _ => {
+            let (phys_default, coded_default, compu_scales) = extract_value_dop_info(param);
+            ParameterTypeMetadata::Value {
+                physical_default_value: phys_default,
+                coded_default_value: coded_default,
+                compu_scales,
+            }
+        }
+    }
+}
+
+pub(crate) fn byte_size_from_diag_coded_type(
+    dct: Result<datatypes::DiagCodedType, DiagServiceError>,
+) -> Option<u32> {
+    dct.ok()
+        .and_then(|dt| dt.bit_len())
+        .map(|bits| bits.div_ceil(8))
+}
+
+pub(crate) fn byte_size_from_value_param(param: &datatypes::Parameter<'_>) -> (Option<u32>, bool) {
+    let Some(dop) = param.specific_data_as_value().and_then(|v| v.dop()) else {
+        return (None, false);
+    };
+    let data_op = datatypes::DataOperation(dop);
+    match data_op.variant() {
+        Ok(datatypes::DataOperationVariant::Normal(n)) => {
+            (byte_size_from_diag_coded_type(n.diag_coded_type()), false)
+        }
+        Ok(datatypes::DataOperationVariant::Mux(_)) => (None, true),
+        _ => (None, false),
+    }
+}
+
+pub(crate) fn byte_size_from_coded_const(param: &datatypes::Parameter<'_>) -> Option<u32> {
+    let cc = param.specific_data_as_coded_const()?;
+    let dct = cc.diag_coded_type()?;
+    let dct: Result<datatypes::DiagCodedType, _> = dct.try_into();
+    byte_size_from_diag_coded_type(dct)
+}
+
+/// Expand MUX DOP cases into a flat list of [`ResponseParameterInfo`].
+///
+/// Each MUX case's inner structure parameters are returned with their names
+/// prefixed by the case short name (e.g. `"CaseName/ParamName"`).
+pub(crate) fn expand_mux_cases(
+    param: &datatypes::Parameter<'_>,
+    mux_byte_position: u32,
+) -> Vec<ResponseParameterInfo> {
+    let Some(value_data) = param.specific_data_as_value() else {
+        return Vec::new();
+    };
+    let Some(dop) = value_data.dop() else {
+        return Vec::new();
+    };
+    let data_op = datatypes::DataOperation(dop);
+    let Ok(datatypes::DataOperationVariant::Mux(mux_dop)) = data_op.variant() else {
+        return Vec::new();
+    };
+
+    let switch_key_size = mux_dop
+        .switch_key()
+        .and_then(|sk| sk.dop())
+        .and_then(|dop| {
+            let data_op = datatypes::DataOperation(dop);
+            if let Ok(datatypes::DataOperationVariant::Normal(n)) = data_op.variant() {
+                byte_size_from_diag_coded_type(n.diag_coded_type())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| {
+            tracing::warn!("MUX DOP switch-key size could not be determined; assuming 0");
+            0
+        });
+
+    let Some(cases) = mux_dop.cases() else {
+        return Vec::new();
+    };
+
+    let mut result = Vec::new();
+    for case in cases {
+        let case_name = case.short_name().unwrap_or_default();
+        let lower_limit = case
+            .lower_limit()
+            .and_then(|ll| ll.value())
+            .map(ToOwned::to_owned);
+
+        let Some(case_dop) = case.structure() else {
+            continue;
+        };
+        let Some(structure) = case_dop.specific_data_as_structure() else {
+            continue;
+        };
+        let Some(inner_params) = structure.params() else {
+            continue;
+        };
+
+        for inner_param in inner_params {
+            let inner = datatypes::Parameter(inner_param);
+            let Some(inner_name) = inner.short_name() else {
+                continue;
+            };
+            let inner_type = extract_response_param_type(&inner);
+            let (inner_byte_size, _) = match &inner_type {
+                ParameterTypeMetadata::CodedConst { .. } => {
+                    (byte_size_from_coded_const(&inner), false)
+                }
+                ParameterTypeMetadata::Value { .. } => byte_size_from_value_param(&inner),
+                _ => (None, false),
+            };
+
+            let byte_position = mux_byte_position
+                .checked_add(switch_key_size)
+                .and_then(|v| v.checked_add(inner.byte_position()))
+                .unwrap_or(mux_byte_position);
+
+            result.push(ResponseParameterInfo {
+                name: format!("{case_name}/{inner_name}"),
+                semantic: inner.semantic().map(ToOwned::to_owned),
+                param_type: inner_type,
+                byte_position,
+                bit_position: inner.bit_position(),
+                byte_size: inner_byte_size,
+            });
+        }
+
+        let marker_position = mux_byte_position
+            .checked_add(switch_key_size)
+            .unwrap_or(mux_byte_position);
+
+        result.push(ResponseParameterInfo {
+            name: format!("__mux_case__/{case_name}"),
+            semantic: Some("MUX-CASE".to_owned()),
+            param_type: ParameterTypeMetadata::CodedConst {
+                coded_value: lower_limit.unwrap_or_default(),
+            },
+            byte_position: marker_position,
+            bit_position: 0,
+            byte_size: structure.byte_size(),
+        });
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use cda_database::datatypes::{
+        self, CompuCategory, DataType, IntervalType, Limit, ResponseType,
+        database_builder::{DiagCommParams, DiagServiceParams, EcuDataBuilder},
+    };
+    use cda_interfaces::{ParameterTypeMetadata, Protocol};
+
+    use super::{
+        byte_size_from_coded_const, byte_size_from_value_param, expand_mux_cases,
+        extract_request_param_type, extract_response_param_type, extract_value_dop_info,
+        resolve_phys_const_coded_value,
+    };
+
+    /// Wraps a finished database and provides access to individual parameters
+    /// from the first service's request or response.
+    struct TestDb {
+        db: datatypes::DiagnosticDatabase,
+    }
+
+    impl TestDb {
+        fn param(&self, idx: usize) -> datatypes::Parameter<'_> {
+            let variant = self.db.base_variant().expect("no base variant");
+            let services = variant.diag_layer().unwrap().diag_services().unwrap();
+            let service = datatypes::DiagService(services.get(0));
+            let params = service.request().unwrap().params().unwrap();
+            datatypes::Parameter(params.get(idx))
+        }
+
+        fn response_param(&self, idx: usize) -> datatypes::Parameter<'_> {
+            let variant = self.db.base_variant().expect("no base variant");
+            let services = variant.diag_layer().unwrap().diag_services().unwrap();
+            let service = datatypes::DiagService(services.get(0));
+            let responses = service.pos_responses().unwrap();
+            let params = responses.iter().next().unwrap().params().unwrap();
+            datatypes::Parameter(params.get(idx))
+        }
+    }
+
+    /// Wrap builder, protocol, request, and optional responses into a
+    /// single-service `TestDb`. Mirrors the `finish_db!` / `new_diag_comm!` /
+    /// `new_diag_service!` macros from the ecumanager.rs test module.
+    macro_rules! finish_test_db {
+        ($db:expr, $protocol:expr, $request:expr) => {
+            finish_test_db!($db, $protocol, $request, vec![])
+        };
+        ($db:expr, $protocol:expr, $request:expr, $pos_responses:expr) => {{
+            let dc = $db.create_diag_comm(DiagCommParams {
+                short_name: "TestSvc",
+                protocols: Some(vec![$protocol]),
+                ..Default::default()
+            });
+            let svc = $db.create_diag_service(DiagServiceParams {
+                diag_comm: Some(dc),
+                request: Some($request),
+                pos_responses: $pos_responses,
+                ..Default::default()
+            });
+            TestDb {
+                db: $db.finish_with_single_variant($protocol, vec![svc], "L", "E", "1", "1.0"),
+            }
+        }};
+    }
+
+    /// Build a database with a single request-parameter for PHYS-CONST tests.
+    fn build_phys_const_db(
+        scales: &[(&str, u64, IntervalType, IntervalType)],
+        phys_value: &str,
+        bit_len: u32,
+        identical: bool,
+    ) -> TestDb {
+        let mut db = EcuDataBuilder::new();
+        let protocol = db.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let diag_type = db.create_diag_coded_type_standard_length(bit_len, DataType::UInt32);
+        let compu_method = if identical {
+            db.create_compu_method(CompuCategory::Identical, None, None)
+        } else {
+            db.create_text_table_compu_method(scales)
+        };
+        let dop = db.create_regular_normal_dop("test_dop", diag_type, compu_method);
+        let param = db.create_phys_const_param("test_param", Some(phys_value), dop, 0, 0);
+        let request = db.create_request(Some(vec![param]), None);
+        finish_test_db!(db, protocol, request)
+    }
+
+    /// Build a database with a VALUE parameter backed by a DOP.
+    fn build_value_db(
+        bit_len: u32,
+        text_table_scales: &[(&str, u64, IntervalType, IntervalType)],
+        identical: bool,
+        physical_default_value: Option<&str>,
+    ) -> TestDb {
+        let mut db = EcuDataBuilder::new();
+        let protocol = db.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let diag_type = db.create_diag_coded_type_standard_length(bit_len, DataType::UInt32);
+        let compu_method = if identical {
+            db.create_compu_method(CompuCategory::Identical, None, None)
+        } else {
+            db.create_text_table_compu_method(text_table_scales)
+        };
+        let dop = db.create_regular_normal_dop("test_dop", diag_type, compu_method);
+        let param =
+            db.create_value_param_with_default("test_param", dop, 0, 0, physical_default_value);
+        let request = db.create_request(Some(vec![param]), None);
+        finish_test_db!(db, protocol, request)
+    }
+
+    /// Build a database with a CODED-CONST parameter.
+    fn build_coded_const_db(coded_value: &str, bit_len: u32) -> TestDb {
+        let mut db = EcuDataBuilder::new();
+        let protocol = db.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let param =
+            db.create_coded_const_param("test_param", coded_value, 0, 0, bit_len, DataType::UInt32);
+        let request = db.create_request(Some(vec![param]), None);
+        finish_test_db!(db, protocol, request)
+    }
+
+    /// Build a database with a response containing multiple parameter types.
+    fn build_response_db() -> TestDb {
+        let mut db = EcuDataBuilder::new();
+        let protocol = db.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let diag_type = db.create_diag_coded_type_standard_length(16, DataType::UInt32);
+        let compu = db.create_compu_method(CompuCategory::Identical, None, None);
+        let dop = db.create_regular_normal_dop("resp_dop", diag_type, compu);
+
+        let coded_param = db.create_coded_const_param("sid_resp", "34", 0, 0, 8, DataType::UInt32);
+        let value_param = db.create_value_param("resp_value", dop, 1, 0);
+        let phys_param = db.create_phys_const_param("resp_phys", Some("ON"), dop, 3, 0);
+
+        let request = db.create_request(None, None);
+        let pos_response = db.create_response(
+            ResponseType::Positive,
+            Some(vec![coded_param, value_param, phys_param]),
+            None,
+        );
+        finish_test_db!(db, protocol, request, vec![pos_response])
+    }
+
+    /// Build a database with a MUX parameter in the response.
+    fn build_mux_response_db() -> TestDb {
+        let mut db = EcuDataBuilder::new();
+        let protocol = db.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let u8_diag = db.create_diag_coded_type_standard_length(8, DataType::UInt32);
+        let u16_diag = db.create_diag_coded_type_standard_length(16, DataType::UInt32);
+        let compu = db.create_compu_method(CompuCategory::Identical, None, None);
+
+        let case_param_dop = db.create_regular_normal_dop("case_dop", u8_diag, compu);
+        let case_param = db.create_value_param("inner_param", case_param_dop, 0, 0);
+        let structure = db.create_structure(Some(vec![case_param]), Some(1), true);
+        let case = db.create_case(
+            "case_1",
+            Some(Limit {
+                value: "1".to_owned(),
+                interval_type: IntervalType::Closed,
+            }),
+            Some(Limit {
+                value: "1".to_owned(),
+                interval_type: IntervalType::Closed,
+            }),
+            Some(structure),
+        );
+
+        let switch_key_dop = db.create_regular_normal_dop("sk_dop", u16_diag, compu);
+        let switch_key = db.create_switch_key(0, Some(0), Some(switch_key_dop));
+        let mux_dop = db.create_mux_dop(
+            "test_mux",
+            1,
+            Some(switch_key),
+            None,
+            Some(vec![case]),
+            true,
+        );
+        let mux_param = db.create_value_param("mux_param", mux_dop, 1, 0);
+
+        let request = db.create_request(None, None);
+        let pos_response = db.create_response(ResponseType::Positive, Some(vec![mux_param]), None);
+        finish_test_db!(db, protocol, request, vec![pos_response])
+    }
+
+    #[test]
+    fn text_table_resolves_exact_closed_closed_scale() {
+        let tdb = build_phys_const_db(
+            &[("ACTIVE", 1, IntervalType::Closed, IntervalType::Closed)],
+            "ACTIVE",
+            8,
+            false,
+        );
+        assert_eq!(
+            resolve_phys_const_coded_value(&tdb.param(0), "ACTIVE"),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn text_table_picks_correct_entry_among_multiple_scales() {
+        let tdb = build_phys_const_db(
+            &[
+                ("OFF", 0, IntervalType::Closed, IntervalType::Closed),
+                ("ON", 1, IntervalType::Closed, IntervalType::Closed),
+                ("STANDBY", 2, IntervalType::Closed, IntervalType::Closed),
+            ],
+            "ON",
+            8,
+            false,
+        );
+        assert_eq!(resolve_phys_const_coded_value(&tdb.param(0), "ON"), Some(1));
+    }
+
+    #[test]
+    fn text_table_skips_open_lower_bound() {
+        let tdb = build_phys_const_db(
+            &[("RANGE_VALUE", 5, IntervalType::Open, IntervalType::Closed)],
+            "RANGE_VALUE",
+            8,
+            false,
+        );
+        assert_eq!(
+            resolve_phys_const_coded_value(&tdb.param(0), "RANGE_VALUE"),
+            None
+        );
+    }
+
+    #[test]
+    fn text_table_skips_open_upper_bound() {
+        let tdb = build_phys_const_db(
+            &[("RANGE_VALUE", 5, IntervalType::Closed, IntervalType::Open)],
+            "RANGE_VALUE",
+            8,
+            false,
+        );
+        assert_eq!(
+            resolve_phys_const_coded_value(&tdb.param(0), "RANGE_VALUE"),
+            None
+        );
+    }
+
+    #[test]
+    fn text_table_no_matching_entry_returns_none() {
+        let tdb = build_phys_const_db(
+            &[("ACTIVE", 1, IntervalType::Closed, IntervalType::Closed)],
+            "ACTIVE",
+            8,
+            false,
+        );
+        assert_eq!(
+            resolve_phys_const_coded_value(&tdb.param(0), "UNKNOWN"),
+            None
+        );
+    }
+
+    #[test]
+    fn text_table_empty_scales_returns_none() {
+        let tdb = build_phys_const_db(&[], "ACTIVE", 8, false);
+        assert_eq!(
+            resolve_phys_const_coded_value(&tdb.param(0), "ACTIVE"),
+            None
+        );
+    }
+
+    #[test]
+    fn identical_parses_integer_string() {
+        let tdb = build_phys_const_db(&[], "61840", 16, true);
+        assert_eq!(
+            resolve_phys_const_coded_value(&tdb.param(0), "61840"),
+            Some(61840)
+        );
+    }
+
+    #[test]
+    fn identical_parses_float_string_truncates() {
+        let tdb = build_phys_const_db(&[], "3.0", 8, true);
+        assert_eq!(
+            resolve_phys_const_coded_value(&tdb.param(0), "3.0"),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn identical_non_numeric_returns_none() {
+        let tdb = build_phys_const_db(&[], "not_a_number", 8, true);
+        assert_eq!(
+            resolve_phys_const_coded_value(&tdb.param(0), "not_a_number"),
+            None
+        );
+    }
+
+    #[test]
+    fn value_dop_info_identical_no_scales() {
+        let tdb = build_value_db(16, &[], true, None);
+        let (phys_default, coded_default, scales) = extract_value_dop_info(&tdb.param(0));
+        assert_eq!(phys_default, None);
+        assert_eq!(coded_default, None);
+        assert!(scales.is_empty());
+    }
+
+    #[test]
+    fn value_dop_info_text_table_returns_scales() {
+        let tdb = build_value_db(
+            8,
+            &[
+                ("OFF", 0, IntervalType::Closed, IntervalType::Closed),
+                ("ON", 1, IntervalType::Closed, IntervalType::Closed),
+            ],
+            false,
+            None,
+        );
+        let (_, _, scales) = extract_value_dop_info(&tdb.param(0));
+        assert_eq!(scales.len(), 2);
+        let s0 = scales.first().unwrap();
+        let s1 = scales.get(1).unwrap();
+        assert_eq!(s0.compu_const_vt.as_deref(), Some("OFF"));
+        assert_eq!(s0.lower_limit, Some(0));
+        assert_eq!(s1.compu_const_vt.as_deref(), Some("ON"));
+        assert_eq!(s1.lower_limit, Some(1));
+    }
+
+    #[test]
+    fn value_dop_info_with_physical_default_resolves_coded() {
+        let tdb = build_value_db(
+            8,
+            &[("ON", 1, IntervalType::Closed, IntervalType::Closed)],
+            false,
+            Some("ON"),
+        );
+        let (phys_default, coded_default, _) = extract_value_dop_info(&tdb.param(0));
+        assert_eq!(phys_default.as_deref(), Some("ON"));
+        assert_eq!(coded_default, Some(1));
+    }
+
+    #[test]
+    fn value_dop_info_with_identical_default_resolves_coded() {
+        let tdb = build_value_db(16, &[], true, Some("42"));
+        let (phys_default, coded_default, scales) = extract_value_dop_info(&tdb.param(0));
+        assert_eq!(phys_default.as_deref(), Some("42"));
+        assert_eq!(coded_default, Some(42));
+        assert!(scales.is_empty());
+    }
+
+    #[test]
+    fn value_dop_info_non_value_param_returns_defaults() {
+        let tdb = build_coded_const_db("34", 8);
+        let (phys_default, coded_default, scales) = extract_value_dop_info(&tdb.param(0));
+        assert_eq!(phys_default, None);
+        assert_eq!(coded_default, None);
+        assert!(scales.is_empty());
+    }
+
+    #[test]
+    fn request_param_coded_const() {
+        let tdb = build_coded_const_db("34", 8);
+        let result = extract_request_param_type(&tdb.param(0), "Svc", "p").unwrap();
+        assert!(matches!(
+            result,
+            ParameterTypeMetadata::CodedConst { coded_value } if coded_value == "34"
+        ));
+    }
+
+    #[test]
+    fn request_param_phys_const_with_text_table() {
+        let tdb = build_phys_const_db(
+            &[("ACTIVE", 1, IntervalType::Closed, IntervalType::Closed)],
+            "ACTIVE",
+            8,
+            false,
+        );
+        let result = extract_request_param_type(&tdb.param(0), "Svc", "p").unwrap();
+        match result {
+            ParameterTypeMetadata::PhysConst {
+                phys_constant_value,
+                coded_value,
+            } => {
+                assert_eq!(phys_constant_value, "ACTIVE");
+                assert_eq!(coded_value, Some(1));
+            }
+            other => panic!("expected PhysConst, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn request_param_phys_const_unresolvable() {
+        let tdb = build_phys_const_db(
+            &[("ACTIVE", 1, IntervalType::Open, IntervalType::Open)],
+            "ACTIVE",
+            8,
+            false,
+        );
+        let result = extract_request_param_type(&tdb.param(0), "Svc", "p").unwrap();
+        match result {
+            ParameterTypeMetadata::PhysConst { coded_value, .. } => {
+                assert_eq!(coded_value, None);
+            }
+            other => panic!("expected PhysConst, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn request_param_value_with_scales() {
+        let tdb = build_value_db(
+            8,
+            &[("A", 0, IntervalType::Closed, IntervalType::Closed)],
+            false,
+            None,
+        );
+        let result = extract_request_param_type(&tdb.param(0), "Svc", "p").unwrap();
+        match result {
+            ParameterTypeMetadata::Value { compu_scales, .. } => {
+                assert_eq!(compu_scales.len(), 1);
+                let s0 = compu_scales.first().unwrap();
+                assert_eq!(s0.compu_const_vt.as_deref(), Some("A"));
+            }
+            other => panic!("expected Value, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn response_param_coded_const() {
+        let tdb = build_response_db();
+        let result = extract_response_param_type(&tdb.response_param(0));
+        assert!(matches!(
+            result,
+            ParameterTypeMetadata::CodedConst { coded_value } if coded_value == "34"
+        ));
+    }
+
+    #[test]
+    fn response_param_value() {
+        let tdb = build_response_db();
+        let result = extract_response_param_type(&tdb.response_param(1));
+        assert!(matches!(result, ParameterTypeMetadata::Value { .. }));
+    }
+
+    #[test]
+    fn response_param_phys_const_no_coded_resolution() {
+        let tdb = build_response_db();
+        let result = extract_response_param_type(&tdb.response_param(2));
+        match result {
+            ParameterTypeMetadata::PhysConst {
+                phys_constant_value,
+                coded_value,
+            } => {
+                assert_eq!(phys_constant_value, "ON");
+                assert_eq!(coded_value, None);
+            }
+            other => panic!("expected PhysConst, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn byte_size_coded_const_8_bit() {
+        let tdb = build_coded_const_db("34", 8);
+        assert_eq!(byte_size_from_coded_const(&tdb.param(0)), Some(1));
+    }
+
+    #[test]
+    fn byte_size_coded_const_16_bit() {
+        let tdb = build_coded_const_db("256", 16);
+        assert_eq!(byte_size_from_coded_const(&tdb.param(0)), Some(2));
+    }
+
+    #[test]
+    fn byte_size_coded_const_non_aligned() {
+        let tdb = build_coded_const_db("1", 12);
+        assert_eq!(byte_size_from_coded_const(&tdb.param(0)), Some(2));
+    }
+
+    #[test]
+    fn byte_size_value_param_returns_size() {
+        let tdb = build_value_db(32, &[], true, None);
+        let (size, is_mux) = byte_size_from_value_param(&tdb.param(0));
+        assert_eq!(size, Some(4));
+        assert!(!is_mux);
+    }
+
+    #[test]
+    fn byte_size_value_param_mux_returns_none_and_flag() {
+        let tdb = build_mux_response_db();
+        let (size, is_mux) = byte_size_from_value_param(&tdb.response_param(0));
+        assert_eq!(size, None);
+        assert!(is_mux);
+    }
+
+    #[test]
+    fn byte_size_from_coded_const_on_value_param_returns_none() {
+        let tdb = build_value_db(16, &[], true, None);
+        assert_eq!(byte_size_from_coded_const(&tdb.param(0)), None);
+    }
+
+    #[test]
+    fn mux_cases_expand_inner_params() {
+        let tdb = build_mux_response_db();
+        let result = expand_mux_cases(&tdb.response_param(0), 1);
+
+        assert_eq!(result.len(), 2);
+        let r0 = result.first().unwrap();
+        let r1 = result.get(1).unwrap();
+        assert_eq!(r0.name, "case_1/inner_param");
+        // mux_byte_pos(1) + switch_key_size(2) + inner_byte_pos(0)
+        assert_eq!(r0.byte_position, 3);
+        assert_eq!(r1.name, "__mux_case__/case_1");
+        assert_eq!(r1.semantic.as_deref(), Some("MUX-CASE"));
+    }
+
+    #[test]
+    fn mux_cases_non_mux_param_returns_empty() {
+        let tdb = build_value_db(16, &[], true, None);
+        let result = expand_mux_cases(&tdb.param(0), 0);
+        assert!(result.is_empty());
+    }
+}

--- a/cda-database/src/datatypes/database_builder.rs
+++ b/cda-database/src/datatypes/database_builder.rs
@@ -698,11 +698,28 @@ impl<'a> EcuDataBuilder<'a> {
         byte_pos: u32,
         bit_pos: u32,
     ) -> WIPOffset<dataformat::Param<'a>> {
+        self.create_value_param_with_default(name, dop, byte_pos, bit_pos, None)
+    }
+
+    /// Like [`create_value_param`] but populates `PHYSICAL-DEFAULT-VALUE`.
+    ///
+    /// `PHYSICAL-DEFAULT-VALUE` is a free-text string in the physical
+    /// domain, e.g. `"service_XX_HO"` for a testerServiceIdentifier parameter
+    /// (PARAM xsi:type="VALUE").
+    pub fn create_value_param_with_default(
+        &mut self,
+        name: &'a str,
+        dop: WIPOffset<dataformat::DOP>,
+        byte_pos: u32,
+        bit_pos: u32,
+        physical_default_value: Option<&'a str>,
+    ) -> WIPOffset<dataformat::Param<'a>> {
+        let pdv_offset = physical_default_value.map(|v| self.fbb.create_string(v));
         let specific_data = Some(
             dataformat::ParamSpecificData::tag_as_value(dataformat::Value::create(
                 &mut self.fbb,
                 &dataformat::ValueArgs {
-                    physical_default_value: None,
+                    physical_default_value: pdv_offset,
                     dop: Some(dop),
                 },
             ))
@@ -1187,6 +1204,79 @@ impl<'a> EcuDataBuilder<'a> {
         };
 
         dataformat::CompuMethod::create(&mut self.fbb, &compu_method_args)
+    }
+
+    /// Build a `TEXTTABLE` `CompuMethod` from a slice of scale entries.
+    ///
+    /// Each entry is `(vt, coded_value, lower_interval, upper_interval)` where:
+    /// - `vt` - the physical text label (`COMPU-CONST/VT` in ODX)
+    /// - `coded_value` - the integer coded value stored in both `LOWER-LIMIT`
+    ///   and `UPPER-LIMIT` (point-value scale)
+    /// - `lower_interval` / `upper_interval` - interval type for the respective
+    ///   limit; use `Closed`/`Closed` for an exact point, `Open` to represent a
+    ///   genuine range so that `resolve_phys_const_coded_value` will skip it
+    ///
+    /// The resulting `CompuMethod` mirrors the ODX `CATEGORY="TEXTTABLE"` structure
+    /// used for enumeration-style DOPs (e.g. state parameters, mode identifiers).
+    pub fn create_text_table_compu_method(
+        &mut self,
+        entries: &[(&str, u64, IntervalType, IntervalType)],
+    ) -> WIPOffset<dataformat::CompuMethod<'a>> {
+        let scales: Vec<_> = entries
+            .iter()
+            .map(|(vt, coded, lower_interval, upper_interval)| {
+                let vt_str = self.fbb.create_string(vt);
+                let consts = dataformat::CompuValues::create(
+                    &mut self.fbb,
+                    &dataformat::CompuValuesArgs {
+                        vt: Some(vt_str),
+                        ..Default::default()
+                    },
+                );
+                let coded_str = self.fbb.create_string(&coded.to_string());
+                let lower = dataformat::Limit::create(
+                    &mut self.fbb,
+                    &dataformat::LimitArgs {
+                        value: Some(coded_str),
+                        interval_type: match lower_interval {
+                            IntervalType::Open => dataformat::IntervalType::OPEN,
+                            IntervalType::Closed => dataformat::IntervalType::CLOSED,
+                            IntervalType::Infinite => dataformat::IntervalType::INFINITE,
+                        },
+                    },
+                );
+                let coded_str2 = self.fbb.create_string(&coded.to_string());
+                let upper = dataformat::Limit::create(
+                    &mut self.fbb,
+                    &dataformat::LimitArgs {
+                        value: Some(coded_str2),
+                        interval_type: match upper_interval {
+                            IntervalType::Open => dataformat::IntervalType::OPEN,
+                            IntervalType::Closed => dataformat::IntervalType::CLOSED,
+                            IntervalType::Infinite => dataformat::IntervalType::INFINITE,
+                        },
+                    },
+                );
+                dataformat::CompuScale::create(
+                    &mut self.fbb,
+                    &dataformat::CompuScaleArgs {
+                        consts: Some(consts),
+                        lower_limit: Some(lower),
+                        upper_limit: Some(upper),
+                        ..Default::default()
+                    },
+                )
+            })
+            .collect();
+        let scales_vec = self.fbb.create_vector(&scales);
+        let itp = dataformat::CompuInternalToPhys::create(
+            &mut self.fbb,
+            &dataformat::CompuInternalToPhysArgs {
+                compu_scales: Some(scales_vec),
+                ..Default::default()
+            },
+        );
+        self.create_compu_method(CompuCategory::TextTable, Some(itp), None)
     }
 
     pub fn create_case(

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -33,15 +33,79 @@ pub struct ServiceParameterMetadata {
     pub param_type: ParameterTypeMetadata,
 }
 
+/// Metadata for a POS-RESPONSE parameter, including byte layout information
+/// needed for encoding response payloads.
+#[derive(Debug, Clone, Serialize)]
+pub struct ResponseParameterInfo {
+    /// Parameter short name
+    pub name: String,
+    /// Parameter semantic (e.g., "DATA", "SERVICEIDRQ", "DATA-IDENTIFIER")
+    pub semantic: Option<String>,
+    /// Parameter type and constant value
+    pub param_type: ParameterTypeMetadata,
+    /// Byte offset in the response payload (0-based)
+    pub byte_position: u32,
+    /// Bit offset within the byte (0-based)
+    pub bit_position: u32,
+    /// Fixed byte size for `StandardLength` parameters, `None` for variable-length
+    pub byte_size: Option<u32>,
+}
+
+/// Information about a single scale in a DOP `CompuMethod`.
+///
+/// For TEXTTABLE DOPs the lower/upper limits define the coded (internal)
+/// value range that maps to the label in `compu_const_vt`.
+#[derive(Debug, Clone, Serialize)]
+pub struct CompuScaleInfo {
+    /// Short label for this scale
+    pub short_label: Option<String>,
+    /// Lower coded limit (closed bound)
+    pub lower_limit: Option<u64>,
+    /// Upper coded limit (closed bound); equals `lower_limit` for single-value scales.
+    pub upper_limit: Option<u64>,
+    /// COMPU-CONST textual value (VT or VT-TI)
+    pub compu_const_vt: Option<String>,
+}
+
 /// Parameter type with constant value metadata
 #[derive(Debug, Clone, Serialize)]
 pub enum ParameterTypeMetadata {
     /// CODED-CONST parameter with fixed value from MDD
     CodedConst { coded_value: String },
-    /// PHYS-CONST parameter with constant value from MDD
-    PhysConst { phys_constant_value: String },
-    /// VALUE or other dynamic parameter types
-    Value,
+    /// PHYS-CONST parameter with constant value from MDD.
+    /// If the DOP uses a TEXTTABLE `CompuMethod`, `coded_value` contains
+    /// the numeric (internal/coded) value resolved from the text table.
+    PhysConst {
+        phys_constant_value: String,
+        coded_value: Option<u64>,
+    },
+    /// MATCHING-REQUEST-PARAM: value copied from the corresponding request parameter.
+    /// `byte_length` is the number of bytes to copy from the request.
+    MatchingRequestParam { byte_length: u32 },
+    /// VALUE or other dynamic parameter types.
+    ///
+    /// When the DOP is available, `physical_default_value` carries the ODX
+    /// default, `coded_default_value` is its resolved coded equivalent, and
+    /// `compu_scales` lists the TEXTTABLE / LINEAR scales from the DOP
+    /// `CompuMethod` (empty for IDENTICAL DOPs).
+    Value {
+        /// ODX `PHYSICAL-DEFAULT-VALUE` (textual)
+        physical_default_value: Option<String>,
+        /// Coded (internal) form of the default value, resolved via the DOP
+        coded_default_value: Option<u64>,
+        /// Scales from the DOP `CompuMethod` (TEXTTABLE entries with limits)
+        compu_scales: Vec<CompuScaleInfo>,
+    },
+}
+
+impl Default for ParameterTypeMetadata {
+    fn default() -> Self {
+        Self::Value {
+            physical_default_value: None,
+            coded_default_value: None,
+            compu_scales: Vec::new(),
+        }
+    }
 }
 
 /// MUX case information for service response routing
@@ -386,10 +450,18 @@ pub trait EcuManager:
     /// This is useful for discovering which DIDs are handled by which services.
     /// # Errors
     /// Will return `Err` if the service cannot be found or parameter metadata cannot be extracted.
-    fn get_service_parameter_metadata(
+    fn get_request_parameter_metadata(
         &self,
         service_name: &str,
     ) -> Result<Vec<ServiceParameterMetadata>, DiagServiceError>;
+    /// Get parameter metadata for the POS-RESPONSE of a service.
+    /// Includes byte layout and type information for response payload construction.
+    /// # Errors
+    /// Will return `Err` if the service cannot be found or metadata cannot be extracted.
+    fn get_response_parameter_metadata(
+        &self,
+        service_name: &str,
+    ) -> Result<Vec<ResponseParameterInfo>, DiagServiceError>;
     /// Get MUX case information for services using multiplexed responses
     /// (e.g., `ReadDataByIdentifier` with different DIDs).
     /// The MUX cases contain the actual DID values in their `lower_limit/upper_limit` fields.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
Added get_response_parameter_metadata() to expose POS-RESPONSE layout introspection (byte positions, sizes, MUX structure),  This is the response-side counterpart of `get_service_parameter_metadata` (which returns request parameters).
Also fixes get_service_parameter_metadata() to correctly resolve PhysConst coded values through the DOP → CompuMethod chain.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests
