### PR TITLE
TesterPresent: check ecu state before sending

### DIFF
--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -755,6 +755,19 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
                         schedule.set_missed_tick_behavior(MissedTickBehavior::Delay);
                         loop {
                             let _ = schedule.tick().await;
+                            // Skip sending if the ECU is not online; the loop will
+                            // naturally resume once the ECU is detected online again.
+                            if let Ok(ecu) = uds.ecu_manager(&control_msg.ecu) {
+                                let ecu_state = ecu.read().await.variant().state;
+                                if ecu_state != EcuState::Online {
+                                    tracing::debug!(
+                                        ecu = %control_msg.ecu,
+                                        ecu_state = %ecu_state,
+                                        "Skipping tester present for ECU that is not online"
+                                    );
+                                    continue;
+                                }
+                            }
                             // abort sending if it takes longer than `interval` and log an
                             // error, but try to continue sending tester present afterwards.
                             if let Ok(r) = tokio::time::timeout(


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
This PR add a check for the ECU status in the tester present loop.
In case the ECU is not online, skip sending and recheck on the next iteration if the ECU is online.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)