### PR TITLE
cda-health: make query_all_providers accessible

### DIFF
--- a/cda-health/src/lib.rs
+++ b/cda-health/src/lib.rs
@@ -102,7 +102,7 @@ impl HealthState {
     }
 
     /// Query all registered health providers and return their current status.
-    async fn query_all_providers(&self) -> HashMap<String, Status> {
+    pub async fn query_all_providers(&self) -> HashMap<String, Status> {
         let providers = self.providers.read().await;
 
         let futures = providers.iter().map(|(name, provider)| async move {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
This PR  changes query_all_providers to `pub` to allow OEMs to use the healthstate directly without querying the endpoint for additional functionality like watchdogs etc.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)