### PR TITLE
diag-kernel: thread base offset through structure DOP decoding

### DIFF
--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -912,6 +912,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
         dtc_code: DtcCode,
         include_schema: bool,
         memory_selection: Option<u8>,
+        scope: &str,
     ) -> Result<(Option<ExtendedDataRecords>, Option<serde_json::Value>), DiagServiceError> {
         fn extract_schema_properties(schema_desc: &SchemaDescription) -> Option<serde_json::Value> {
             // todo after solving #54: we are missing the 'Selector' and the case name here
@@ -924,15 +925,20 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
             schema.map(|schema| serde_json::Value::Object(schema.clone()))
         }
 
+        let ext_data_service_type = if DtcReadInformationFunction::UserMemoryDtcByStatusMask
+            .default_scope()
+            .eq_ignore_ascii_case(scope)
+        {
+            DtcReadInformationFunction::UserMemoryDtcExtDataRecordByDtcNumber
+        } else {
+            DtcReadInformationFunction::FaultMemoryExtDataRecordByDtcNumber
+        };
         let (extended_data_response, _scope, schema_desc) = self
             .request_extended_data(
                 ecu_name,
                 security_plugin,
                 dtc_code,
-                vec![
-                    DtcReadInformationFunction::FaultMemoryExtDataRecordByDtcNumber,
-                    DtcReadInformationFunction::UserMemoryDtcExtDataRecordByDtcNumber,
-                ],
+                vec![ext_data_service_type],
                 memory_selection,
                 include_schema,
             )
@@ -1000,6 +1006,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
         dtc_code: DtcCode,
         include_schema: bool,
         memory_selection: Option<u8>,
+        scope: &str,
     ) -> Result<(Option<ExtendedSnapshots>, Option<serde_json::Value>), DiagServiceError> {
         fn extract_schema_properties(schema_desc: &SchemaDescription) -> Option<serde_json::Value> {
             let param_properties = schema_desc.get_param_properties()?;
@@ -1018,16 +1025,20 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
                 Some(serde_json::Value::Object(schema))
             }
         }
-
+        let snapshot_service_type = if DtcReadInformationFunction::UserMemoryDtcByStatusMask
+            .default_scope()
+            .eq_ignore_ascii_case(scope)
+        {
+            DtcReadInformationFunction::UserMemoryDtcSnapshotRecordByDtcNumber
+        } else {
+            DtcReadInformationFunction::FaultMemorySnapshotRecordByDtcNumber
+        };
         let (snapshot_data_response, _scope, schema_desc) = self
             .request_extended_data(
                 ecu_name,
                 security_plugin,
                 dtc_code,
-                vec![
-                    DtcReadInformationFunction::FaultMemorySnapshotRecordByDtcNumber,
-                    DtcReadInformationFunction::UserMemoryDtcSnapshotRecordByDtcNumber,
-                ],
+                vec![snapshot_service_type],
                 memory_selection,
                 include_schema,
             )
@@ -2278,33 +2289,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
     ) -> Result<DtcExtendedInfo, DiagServiceError> {
         let dtc_code = decode_dtc_from_str(sae_dtc)?;
 
-        let (snapshots, snapshot_schema) = if include_snapshot {
-            self.map_snapshots(
-                ecu_name,
-                security_plugin,
-                dtc_code,
-                include_schema,
-                memory_selection,
-            )
-            .await?
-        } else {
-            (None, None)
-        };
-
-        let (extended_records, extended_schema) = if include_extended_data {
-            self.map_extended_data(
-                ecu_name,
-                security_plugin,
-                dtc_code,
-                include_schema,
-                memory_selection,
-            )
-            .await?
-        } else {
-            (None, None)
-        };
-
-        let mut dtc_by_mask = self
+        let mut dtc_by_mask: HashMap<DtcCode, DtcRecordAndStatus> = self
             .ecu_dtc_by_mask(
                 ecu_name,
                 security_plugin,
@@ -2321,6 +2306,35 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
                 .ok_or(DiagServiceError::InvalidRequest(format!(
                     "DTC {sae_dtc} not found in ECU {ecu_name}"
                 )))?;
+
+        let scope = &record_and_status.scope.clone();
+        let (snapshots, snapshot_schema) = if include_snapshot {
+            self.map_snapshots(
+                ecu_name,
+                security_plugin,
+                dtc_code,
+                include_schema,
+                memory_selection,
+                scope,
+            )
+            .await?
+        } else {
+            (None, None)
+        };
+
+        let (extended_records, extended_schema) = if include_extended_data {
+            self.map_extended_data(
+                ecu_name,
+                security_plugin,
+                dtc_code,
+                include_schema,
+                memory_selection,
+                scope,
+            )
+            .await?
+        } else {
+            (None, None)
+        };
 
         Ok(DtcExtendedInfo {
             record_and_status,

--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -858,7 +858,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
         service_types: Vec<DtcReadInformationFunction>,
         memory_selection: Option<u8>,
         include_schema: bool,
-    ) -> Result<(R, String, Option<SchemaDescription>), DiagServiceError> {
+    ) -> Result<(R, DtcReadInformationFunction, Option<SchemaDescription>), DiagServiceError> {
         let ecu = self.ecu_manager(ecu_name)?;
         let (read_func, extended_data_lookup) = ecu
             .read()
@@ -912,7 +912,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
         dtc_code: DtcCode,
         include_schema: bool,
         memory_selection: Option<u8>,
-        scope: &str,
+        scope: DtcReadInformationFunction,
     ) -> Result<(Option<ExtendedDataRecords>, Option<serde_json::Value>), DiagServiceError> {
         fn extract_schema_properties(schema_desc: &SchemaDescription) -> Option<serde_json::Value> {
             // todo after solving #54: we are missing the 'Selector' and the case name here
@@ -925,10 +925,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
             schema.map(|schema| serde_json::Value::Object(schema.clone()))
         }
 
-        let ext_data_service_type = if DtcReadInformationFunction::UserMemoryDtcByStatusMask
-            .default_scope()
-            .eq_ignore_ascii_case(scope)
-        {
+        let ext_data_service_type = if scope.is_user_scope() {
             DtcReadInformationFunction::UserMemoryDtcExtDataRecordByDtcNumber
         } else {
             DtcReadInformationFunction::FaultMemoryExtDataRecordByDtcNumber
@@ -1006,7 +1003,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
         dtc_code: DtcCode,
         include_schema: bool,
         memory_selection: Option<u8>,
-        scope: &str,
+        scope: DtcReadInformationFunction,
     ) -> Result<(Option<ExtendedSnapshots>, Option<serde_json::Value>), DiagServiceError> {
         fn extract_schema_properties(schema_desc: &SchemaDescription) -> Option<serde_json::Value> {
             let param_properties = schema_desc.get_param_properties()?;
@@ -1025,10 +1022,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
                 Some(serde_json::Value::Object(schema))
             }
         }
-        let snapshot_service_type = if DtcReadInformationFunction::UserMemoryDtcByStatusMask
-            .default_scope()
-            .eq_ignore_ascii_case(scope)
-        {
+        let snapshot_service_type = if scope.is_user_scope() {
             DtcReadInformationFunction::UserMemoryDtcSnapshotRecordByDtcNumber
         } else {
             DtcReadInformationFunction::FaultMemorySnapshotRecordByDtcNumber
@@ -2183,7 +2177,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
             .filter(|(_, lookup)| {
                 scope
                     .as_ref()
-                    .is_none_or(|scope| scope.to_lowercase() == lookup.scope.to_lowercase())
+                    .is_none_or(|scope| scope.eq_ignore_ascii_case(lookup.scope.default_scope()))
             })
             .collect();
         if scoped_services.is_empty() {
@@ -2254,7 +2248,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
                     record.code,
                     DtcRecordAndStatus {
                         record,
-                        scope: lookup.scope.clone(),
+                        scope: lookup.scope,
                         status: get_dtc_status_for_mask(status_byte),
                     },
                 );
@@ -2264,7 +2258,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
                 for record in lookup.dtcs {
                     all_dtcs.entry(record.code).or_insert(DtcRecordAndStatus {
                         record,
-                        scope: lookup.scope.clone(),
+                        scope: lookup.scope,
                         status: get_dtc_status_for_mask(0),
                     });
                 }
@@ -2307,7 +2301,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
                     "DTC {sae_dtc} not found in ECU {ecu_name}"
                 )))?;
 
-        let scope = &record_and_status.scope.clone();
+        let scope = record_and_status.scope;
         let (snapshots, snapshot_schema) = if include_snapshot {
             self.map_snapshots(
                 ecu_name,

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -57,6 +57,38 @@ struct VariantData {
     is_fallback: bool,
 }
 
+#[derive(Clone, Copy)]
+struct ParamContext<'a> {
+    parameter: &'a datatypes::Parameter<'a>,
+    base_offset: usize,
+    outer_context: Option<&'a MappedDiagServiceResponsePayload>,
+}
+
+impl<'a> ParamContext<'a> {
+    fn new(parameter: &'a datatypes::Parameter<'a>, base_offset: usize) -> Self {
+        Self {
+            parameter,
+            base_offset,
+            outer_context: None,
+        }
+    }
+
+    fn with_outer_context(
+        self,
+        outer_context: Option<&'a MappedDiagServiceResponsePayload>,
+    ) -> Self {
+        Self {
+            outer_context,
+            ..self
+        }
+    }
+
+    fn abs_byte_pos(self) -> usize {
+        self.base_offset
+            .saturating_add(self.parameter.byte_position() as usize)
+    }
+}
+
 impl VariantData {
     fn from_variant_and_fallback(v: &datatypes::Variant<'_>, is_fallback: bool) -> Self {
         Self {
@@ -462,6 +494,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
         ),
         err
     )]
+    #[allow(clippy::too_many_lines)]
     async fn convert_from_uds(
         &self,
         diag_service: &cda_interfaces::DiagComm,
@@ -549,7 +582,23 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
                 });
             }
             let mut mapping_errors = Vec::new();
-            for param in params {
+            let mut sorted_params = params;
+            sorted_params.sort_by(|a, b| {
+                match (a.has_byte_position(), b.has_byte_position()) {
+                    // Both have a position → normal comparison
+                    (true, true) => a
+                        .byte_position()
+                        .cmp(&b.byte_position())
+                        .then(a.bit_position().cmp(&b.bit_position())),
+                    // Only a has no position → a goes after b
+                    (false, true) => std::cmp::Ordering::Greater,
+                    // Only b has no position → b goes after a
+                    (true, false) => std::cmp::Ordering::Less,
+                    // Neither has a position → preserve order
+                    (false, false) => std::cmp::Ordering::Equal,
+                }
+            });
+            for param in sorted_params {
                 let semantic = param.semantic();
                 if semantic.is_some_and(|semantic| {
                     semantic != semantics::DATA && semantic != semantics::SERVICEIDRQ
@@ -567,11 +616,10 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
                 }
                 match self.map_param_from_uds(
                     &mapped_service,
-                    &param,
                     short_name,
                     &mut uds_payload,
                     &mut data,
-                    0,
+                    ParamContext::new(&param, 0),
                 ) {
                     Ok(()) => {}
                     Err(DiagServiceError::DataError(error)) => {
@@ -1806,11 +1854,10 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
             });
             match self.map_param_from_uds(
                 &mapped_service,
-                &param,
                 short_name,
                 &mut uds_payload,
                 &mut data,
-                0,
+                ParamContext::new(&param, 0),
             ) {
                 Ok(()) => {}
                 Err(DiagServiceError::DataError(error)) => {
@@ -2437,7 +2484,32 @@ impl<S: SecurityPlugin> EcuManager<S> {
         let predicate = |service: &datatypes::DiagService<'_>| {
             service.diag_comm().is_some_and(|dc| {
                 dc.short_name()
-                    .is_some_and(|name| starts_with_ignore_ascii_case(name, &lookup_name))
+                    .is_some_and(|name| name.eq_ignore_ascii_case(&lookup_name))
+            }) && service
+                .request_id()
+                .is_some_and(|sid| prefixes.contains(&sid))
+        };
+
+        if let Some(fg_name) = functional_group_name {
+            return self
+                .get_services_from_functional_group_and_parent_refs(fg_name, predicate)?
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    DiagServiceError::NotFound(format!(
+                        "Diagnostic service '{lookup_name}' not found in functional group \
+                         '{fg_name}'"
+                    ))
+                });
+        }
+
+        let lookup_id = STRINGS.get_or_insert(&lookup_name);
+
+        let prefixes = diag_comm.type_.service_prefixes();
+        let predicate = |service: &datatypes::DiagService<'_>| {
+            service.diag_comm().is_some_and(|dc| {
+                dc.short_name()
+                    .is_some_and(|name| name.eq_ignore_ascii_case(&lookup_name))
             }) && service
                 .request_id()
                 .is_some_and(|sid| prefixes.contains(&sid))
@@ -2989,49 +3061,29 @@ impl<S: SecurityPlugin> EcuManager<S> {
     fn map_param_from_uds(
         &self,
         mapped_service: &datatypes::DiagService,
-        param: &datatypes::Parameter,
         param_name: &str,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
-        base_offset: usize,
+        param_ctx: ParamContext<'_>,
     ) -> Result<(), DiagServiceError> {
-        match param.param_type()? {
+        match param_ctx.parameter.param_type()? {
             datatypes::ParamType::CodedConst => {
-                Self::map_param_coded_const_from_uds(
-                    param,
-                    param_name,
-                    uds_payload,
-                    data,
-                    base_offset,
-                )?;
+                Self::map_param_coded_const_from_uds(param_name, uds_payload, data, param_ctx)?;
             }
             datatypes::ParamType::MatchingRequestParam => {
                 self.map_param_matching_request_from_uds(
                     mapped_service,
-                    param,
                     param_name,
                     uds_payload,
                     data,
-                    base_offset,
+                    param_ctx,
                 )?;
             }
             datatypes::ParamType::Value => {
-                self.map_param_value_from_uds(
-                    mapped_service,
-                    param,
-                    uds_payload,
-                    data,
-                    base_offset,
-                )?;
+                self.map_param_value_from_uds(mapped_service, uds_payload, data, param_ctx)?;
             }
             datatypes::ParamType::Reserved => {
-                Self::map_param_reserved_from_uds(
-                    param,
-                    param_name,
-                    uds_payload,
-                    data,
-                    base_offset,
-                )?;
+                Self::map_param_reserved_from_uds(param_name, uds_payload, data, param_ctx)?;
             }
             datatypes::ParamType::TableEntry => {
                 tracing::error!("TableStructParam not implemented.");
@@ -3040,13 +3092,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 tracing::error!("Dynamic ParamType not implemented.");
             }
             datatypes::ParamType::LengthKey => {
-                self.map_param_length_key_from_uds(
-                    mapped_service,
-                    param,
-                    uds_payload,
-                    data,
-                    base_offset,
-                )?;
+                self.map_param_length_key_from_uds(mapped_service, uds_payload, data, param_ctx)?;
             }
             datatypes::ParamType::NrcConst => {
                 tracing::error!("NrcConst ParamType not implemented.");
@@ -3054,11 +3100,10 @@ impl<S: SecurityPlugin> EcuManager<S> {
             datatypes::ParamType::PhysConst => {
                 self.map_param_phys_const_from_uds(
                     mapped_service,
-                    param,
                     param_name,
                     uds_payload,
                     data,
-                    base_offset,
+                    param_ctx,
                 )?;
             }
             datatypes::ParamType::System => {
@@ -3075,17 +3120,14 @@ impl<S: SecurityPlugin> EcuManager<S> {
     }
 
     fn map_param_reserved_from_uds(
-        param: &datatypes::Parameter,
         param_name: &str,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
-        base_offset: usize,
+        param_ctx: ParamContext<'_>,
     ) -> Result<(), DiagServiceError> {
-        let r = param
-            .specific_data_as_reserved()
-            .ok_or(DiagServiceError::InvalidDatabase(
-                "Expected Reserved specific data".to_owned(),
-            ))?;
+        let r = param_ctx.parameter.specific_data_as_reserved().ok_or(
+            DiagServiceError::InvalidDatabase("Expected Reserved specific data".to_owned()),
+        )?;
 
         let coded_type = datatypes::DiagCodedType::new_high_low_byte_order(
             datatypes::DataType::UInt32,
@@ -3098,8 +3140,8 @@ impl<S: SecurityPlugin> EcuManager<S> {
 
         let (param_data, bit_len) = coded_type.decode(
             uds_payload.data()?,
-            base_offset.saturating_add(param.byte_position() as usize),
-            param.bit_position() as usize,
+            param_ctx.abs_byte_pos(),
+            param_ctx.parameter.bit_position() as usize,
         )?;
 
         data.insert(
@@ -3117,16 +3159,13 @@ impl<S: SecurityPlugin> EcuManager<S> {
     fn map_param_value_from_uds(
         &self,
         mapped_service: &datatypes::DiagService,
-        param: &datatypes::Parameter,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
-        base_offset: usize,
+        param_ctx: ParamContext<'_>,
     ) -> Result<(), DiagServiceError> {
-        let v = param
-            .specific_data_as_value()
-            .ok_or(DiagServiceError::InvalidDatabase(
-                "Expected Value specific data".to_owned(),
-            ))?;
+        let v = param_ctx.parameter.specific_data_as_value().ok_or(
+            DiagServiceError::InvalidDatabase("Expected Value specific data".to_owned()),
+        )?;
 
         let dop =
             v.dop()
@@ -3134,46 +3173,45 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 .ok_or(DiagServiceError::InvalidDatabase(
                     "Value DoP is None".to_owned(),
                 ))?;
-        self.map_dop_from_uds(mapped_service, &dop, param, uds_payload, data, base_offset)?;
+        self.map_dop_from_uds(mapped_service, &dop, uds_payload, data, param_ctx)?;
         Ok(())
     }
 
     fn map_param_length_key_from_uds(
         &self,
         mapped_service: &datatypes::DiagService,
-        param: &datatypes::Parameter,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
-        base_offset: usize,
+        param_ctx: ParamContext<'_>,
     ) -> Result<(), DiagServiceError> {
-        let length_key =
-            param
-                .specific_data_as_length_key_ref()
-                .ok_or(DiagServiceError::InvalidDatabase(
-                    "Expected LengthKeyRef specific data".to_owned(),
-                ))?;
+        let length_key = param_ctx
+            .parameter
+            .specific_data_as_length_key_ref()
+            .ok_or(DiagServiceError::InvalidDatabase(
+                "Expected LengthKeyRef specific data".to_owned(),
+            ))?;
 
         let dop = length_key.dop().map(datatypes::DataOperation).ok_or(
             DiagServiceError::InvalidDatabase("LengthKey DoP is None".to_owned()),
         )?;
 
-        self.map_dop_from_uds(mapped_service, &dop, param, uds_payload, data, base_offset)
+        self.map_dop_from_uds(mapped_service, &dop, uds_payload, data, param_ctx)
     }
 
     fn map_param_matching_request_from_uds(
         &self,
         mapped_service: &datatypes::DiagService,
-        param: &datatypes::Parameter,
         param_name: &str,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
-        base_offset: usize,
+        param_ctx: ParamContext<'_>,
     ) -> Result<(), DiagServiceError> {
-        let matching_req_param = param.specific_data_as_matching_request_param().ok_or(
-            DiagServiceError::InvalidDatabase(
+        let matching_req_param = param_ctx
+            .parameter
+            .specific_data_as_matching_request_param()
+            .ok_or(DiagServiceError::InvalidDatabase(
                 "Expected MatchingRequestParam specific data".to_owned(),
-            ),
-        )?;
+            ))?;
 
         let request = mapped_service
             .request()
@@ -3199,11 +3237,10 @@ impl<S: SecurityPlugin> EcuManager<S> {
             .ok_or_else(|| {
                 DiagServiceError::UdsLookupError(format!(
                     "No matching request parameter found for {}",
-                    param.short_name().unwrap_or_default()
+                    param_ctx.parameter.short_name().unwrap_or_default()
                 ))
             })?;
 
-        let param_byte_pos = param.byte_position();
         let matching_req_param_byte_pos = u32::try_from(matching_req_param.request_byte_pos())
             .map_err(|e| {
                 DiagServiceError::InvalidDatabase(format!(
@@ -3211,18 +3248,17 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 ))
             })?;
 
-        let pop = matching_req_param_byte_pos < param_byte_pos;
+        let pop = matching_req_param_byte_pos < param_ctx.parameter.byte_position();
         if pop {
-            uds_payload.push_slice(param_byte_pos as usize, uds_payload.len())?;
+            uds_payload.push_slice(param_ctx.abs_byte_pos(), uds_payload.len())?;
         }
 
         self.map_param_from_uds(
             mapped_service,
-            &matching_request_param,
             param_name,
             uds_payload,
             data,
-            base_offset,
+            ParamContext::new(&matching_request_param, 0),
         )?;
 
         if pop {
@@ -3232,17 +3268,14 @@ impl<S: SecurityPlugin> EcuManager<S> {
     }
 
     fn map_param_coded_const_from_uds(
-        param: &datatypes::Parameter,
         param_name: &str,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
-        base_offset: usize,
+        param_ctx: ParamContext<'_>,
     ) -> Result<(), DiagServiceError> {
-        let c = param
-            .specific_data_as_coded_const()
-            .ok_or(DiagServiceError::InvalidDatabase(
-                "Expected CodedConst specific data".to_owned(),
-            ))?;
+        let c = param_ctx.parameter.specific_data_as_coded_const().ok_or(
+            DiagServiceError::InvalidDatabase("Expected CodedConst specific data".to_owned()),
+        )?;
 
         let diag_type: datatypes::DiagCodedType = c
             .diag_coded_type()
@@ -3253,9 +3286,9 @@ impl<S: SecurityPlugin> EcuManager<S> {
             ))?;
 
         let value = operations::extract_diag_data_container(
-            param.short_name(),
-            base_offset.saturating_add(param.byte_position() as usize),
-            param.bit_position() as usize,
+            param_ctx.parameter.short_name(),
+            param_ctx.abs_byte_pos(),
+            param_ctx.parameter.bit_position() as usize,
             uds_payload,
             &diag_type,
             None,
@@ -3291,7 +3324,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     tracing::error!(
                         error = ?e,
                         "Failed to convert CodedConst coded value to UDS data for parameter '{}'",
-                        param.short_name().unwrap_or_default()
+                        param_ctx.parameter.short_name().unwrap_or_default()
                     );
                 })?
                 .into_iter()
@@ -3304,7 +3337,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         if value.data != expected {
             return Err(DiagServiceError::BadPayload(format!(
                 "{}: Expected {:?}, got {:?}",
-                param.short_name().unwrap_or_default(),
+                param_ctx.parameter.short_name().unwrap_or_default(),
                 expected,
                 value.data
             )));
@@ -3320,17 +3353,14 @@ impl<S: SecurityPlugin> EcuManager<S> {
     fn map_param_phys_const_from_uds(
         &self,
         mapped_service: &datatypes::DiagService,
-        param: &datatypes::Parameter,
         param_name: &str,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
-        base_offset: usize,
+        param_ctx: ParamContext<'_>,
     ) -> Result<(), DiagServiceError> {
-        let p = param
-            .specific_data_as_phys_const()
-            .ok_or(DiagServiceError::InvalidDatabase(
-                "Expected PhysConst specific data".to_owned(),
-            ))?;
+        let p = param_ctx.parameter.specific_data_as_phys_const().ok_or(
+            DiagServiceError::InvalidDatabase("Expected PhysConst specific data".to_owned()),
+        )?;
 
         let dop =
             p.dop()
@@ -3344,9 +3374,9 @@ impl<S: SecurityPlugin> EcuManager<S> {
             datatypes::DataOperationVariant::Normal(normal_dop) => {
                 let diag_type = normal_dop.diag_coded_type()?;
                 let value = operations::extract_diag_data_container(
-                    param.short_name(),
-                    base_offset.saturating_add(param.byte_position() as usize),
-                    param.bit_position() as usize,
+                    param_ctx.parameter.short_name(),
+                    param_ctx.abs_byte_pos(),
+                    param_ctx.parameter.bit_position() as usize,
                     uds_payload,
                     &diag_type,
                     None,
@@ -3382,7 +3412,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
             | datatypes::DataOperationVariant::StaticField(_)
             | datatypes::DataOperationVariant::Mux(_)
             | datatypes::DataOperationVariant::DynamicLengthField(_) => {
-                self.map_dop_from_uds(mapped_service, &dop, param, uds_payload, data, base_offset)?;
+                self.map_dop_from_uds(mapped_service, &dop, uds_payload, data, param_ctx)?;
             }
             _ => {
                 return Err(DiagServiceError::InvalidDatabase(format!(
@@ -3902,6 +3932,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         structure: &datatypes::StructureDop,
         mapped_service: &datatypes::DiagService,
         uds_payload: &mut Payload,
+        outer_context: &MappedDiagServiceResponsePayload,
     ) -> Result<HashMap<String, DiagDataTypeContainer>, DiagServiceError> {
         let mut data = HashMap::new();
         let Some(params) = structure.params() else {
@@ -3909,16 +3940,16 @@ impl<S: SecurityPlugin> EcuManager<S> {
         };
 
         for param in params {
+            let param = datatypes::Parameter(param);
             let short_name = param.short_name().ok_or_else(|| {
                 DiagServiceError::InvalidDatabase("Unable to find short name for param".to_owned())
             })?;
             self.map_param_from_uds(
                 mapped_service,
-                &param.into(),
                 short_name,
                 uds_payload,
                 &mut data,
-                0,
+                ParamContext::new(&param, 0).with_outer_context(Some(outer_context)),
             )?;
         }
         Ok(data)
@@ -3930,8 +3961,14 @@ impl<S: SecurityPlugin> EcuManager<S> {
         mapped_service: &datatypes::DiagService,
         uds_payload: &mut Payload,
         nested_structs: &mut Vec<HashMap<String, DiagDataTypeContainer>>,
+        outer_context: &MappedDiagServiceResponsePayload,
     ) -> Result<(), DiagServiceError> {
-        nested_structs.push(self.map_struct_from_uds(structure, mapped_service, uds_payload)?);
+        nested_structs.push(self.map_struct_from_uds(
+            structure,
+            mapped_service,
+            uds_payload,
+            outer_context,
+        )?);
         Ok(())
     }
 
@@ -3944,12 +3981,12 @@ impl<S: SecurityPlugin> EcuManager<S> {
         &self,
         mapped_service: &datatypes::DiagService,
         dop: &datatypes::DataOperation,
-        param: &datatypes::Parameter,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
-        base_offset: usize,
+        param_ctx: ParamContext<'_>,
     ) -> Result<(), DiagServiceError> {
-        let short_name = param
+        let short_name = param_ctx
+            .parameter
             .short_name()
             .ok_or_else(|| {
                 DiagServiceError::InvalidDatabase(
@@ -3963,22 +4000,20 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 let diag_coded_type = normal_dop.diag_coded_type()?;
                 if let Some(length_key_name) = diag_coded_type.length_key_name() {
                     Self::map_param_length_info_dop_from_uds(
-                        param,
                         uds_payload,
                         data,
                         short_name,
                         &normal_dop,
                         length_key_name,
-                        base_offset,
+                        param_ctx,
                     )?;
                 } else {
                     Self::map_normal_dop_from_uds(
-                        param,
                         uds_payload,
                         data,
                         short_name,
                         &normal_dop,
-                        base_offset,
+                        param_ctx,
                     )?;
                 }
             }
@@ -3998,65 +4033,85 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     uds_payload,
                     data,
                     &short_name,
-                    param,
                     &structure_dop,
-                    base_offset,
+                    param_ctx,
                 )?;
             }
             datatypes::DataOperationVariant::Dtc(dtc_dop) => {
-                Self::map_dtc_dop_from_uds(param, uds_payload, data, &dtc_dop, base_offset)?;
+                Self::map_dtc_dop_from_uds(&short_name, uds_payload, data, &dtc_dop, param_ctx)?;
+            }
+            datatypes::DataOperationVariant::EnvDataDesc(env_data_desc_dop) => {
+                let item = self.map_env_data_desc_item_from_uds(
+                    mapped_service,
+                    uds_payload,
+                    param_ctx.outer_context.unwrap_or(&*data),
+                    &env_data_desc_dop,
+                    param_ctx.abs_byte_pos(),
+                )?;
+                data.extend(item);
+            }
+            datatypes::DataOperationVariant::EnvData(env_data_dop) => {
+                if let Some(params) = env_data_dop.params() {
+                    for param in params {
+                        let param = datatypes::Parameter(param);
+                        let name = param.short_name().ok_or_else(|| {
+                            DiagServiceError::InvalidDatabase(
+                                "EnvData param missing short_name".to_owned(),
+                            )
+                        })?;
+                        self.map_param_from_uds(
+                            mapped_service,
+                            name,
+                            uds_payload,
+                            data,
+                            ParamContext::new(&param, param_ctx.base_offset)
+                                .with_outer_context(param_ctx.outer_context),
+                        )?;
+                    }
+                }
             }
             datatypes::DataOperationVariant::StaticField(static_field_dop) => {
                 self.map_static_field_dop_from_uds(
                     mapped_service,
-                    param,
                     uds_payload,
                     data,
                     short_name,
                     &static_field_dop,
-                    base_offset,
+                    param_ctx,
                 )?;
             }
             datatypes::DataOperationVariant::Mux(mux_dop) => {
                 self.map_mux_dop_from_uds(
                     mapped_service,
-                    param,
                     uds_payload,
                     data,
                     short_name,
                     &mux_dop,
-                    base_offset,
+                    param_ctx,
                 )?;
             }
             datatypes::DataOperationVariant::DynamicLengthField(dynamic_length_field_dop) => {
                 self.map_dynamic_length_field_from_uds(
                     mapped_service,
-                    param,
                     uds_payload,
                     data,
                     short_name,
                     &dynamic_length_field_dop,
-                    base_offset,
+                    param_ctx,
                 )?;
             }
-
-            _ => tracing::warn!(
-                "DOP variant not supported yet: {:?}",
-                dop.specific_data_type().variant_name().unwrap_or("Unknown")
-            ),
         }
 
         Ok(())
     }
 
     fn map_param_length_info_dop_from_uds(
-        param: &datatypes::Parameter,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
         short_name: String,
         normal_dop: &datatypes::NormalDop,
         length_key_name: &str,
-        base_offset: usize,
+        param_ctx: ParamContext<'_>,
     ) -> Result<(), DiagServiceError> {
         let byte_count = match data.get(length_key_name) {
             Some(DiagDataTypeContainer::RawContainer(raw)) => {
@@ -4114,8 +4169,8 @@ impl<S: SecurityPlugin> EcuManager<S> {
             return Ok(());
         }
 
-        let byte_pos = if param.has_byte_position() {
-            base_offset.saturating_add(param.byte_position() as usize)
+        let byte_pos = if param_ctx.parameter.has_byte_position() {
+            param_ctx.abs_byte_pos()
         } else {
             uds_payload.last_read_byte_pos()
         };
@@ -4137,21 +4192,20 @@ impl<S: SecurityPlugin> EcuManager<S> {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
     #[tracing::instrument(skip_all,
         fields(
             dlt_context = dlt_ctx!("CORE"),
         )
     )]
+    #[allow(clippy::too_many_lines)]
     fn map_dynamic_length_field_from_uds(
         &self,
         mapped_service: &datatypes::DiagService,
-        param: &datatypes::Parameter,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
         short_name: String,
         dynamic_length_field_dop: &datatypes::DynamicLengthDop,
-        base_offset: usize,
+        param_ctx: ParamContext<'_>,
     ) -> Result<(), DiagServiceError> {
         let determine_num_items = dynamic_length_field_dop.determine_number_of_items().ok_or(
             DiagServiceError::InvalidDatabase(
@@ -4175,8 +4229,12 @@ impl<S: SecurityPlugin> EcuManager<S> {
 
         let num_items_diag_type: datatypes::DiagCodedType = num_items_dop.diag_coded_type()?;
 
-        let param_abs_byte_pos = base_offset.saturating_add(param.byte_position() as usize);
-        let (num_items_data, _bit_len) = num_items_diag_type.decode(
+        let param_abs_byte_pos = if param_ctx.parameter.has_byte_position() {
+            param_ctx.abs_byte_pos()
+        } else {
+            param_ctx.base_offset
+        };
+        let (num_items_data, count_field_bit_len) = num_items_diag_type.decode(
             uds_payload
                 .data()?
                 .get(param_abs_byte_pos..)
@@ -4186,6 +4244,18 @@ impl<S: SecurityPlugin> EcuManager<S> {
             determine_num_items.byte_position() as usize,
             determine_num_items.bit_position() as usize,
         )?;
+
+        tracing::debug!(
+            has_byte_position = param_ctx.parameter.has_byte_position(),
+            param_byte_position = param_ctx.parameter.byte_position(),
+            base_offset = param_ctx.base_offset,
+            param_abs_byte_pos,
+            last_read_byte_pos = uds_payload.last_read_byte_pos(),
+            determine_number_of_items_byte_position = determine_num_items.byte_position(),
+            dynamic_length_field_dop_offset = dynamic_length_field_dop.offset(),
+            count_diag_coded_type_bit_len = count_field_bit_len,
+            "DynamicLengthField count decode metadata"
+        );
 
         let num_items_diag_val = operations::uds_data_to_serializable(
             datatypes::DataType::UInt32, // Using hard coded UInt32 as per ISO 22901-1:2008
@@ -4207,26 +4277,79 @@ impl<S: SecurityPlugin> EcuManager<S> {
 
         let mut repeated_data = Vec::new();
 
-        uds_payload.push_slice(
-            dynamic_length_field_dop.offset() as usize,
-            uds_payload.len(),
-        )?;
-        let mut start = uds_payload
-            .last_read_byte_pos()
-            .saturating_add(uds_payload.bytes_to_skip());
+        let items_abs_start =
+            param_abs_byte_pos.saturating_add(dynamic_length_field_dop.offset() as usize);
+
+        tracing::debug!(
+            num_items,
+            items_abs_start,
+            payload_len = uds_payload.len(),
+            count_bytes = ?num_items_data,
+            "DynamicLengthField items loop start"
+        );
+
+        uds_payload.push_slice(items_abs_start, uds_payload.len())?;
+
+        let mut start = 0usize;
 
         for _ in 0..num_items {
+            let bytes_to_skip_before = uds_payload.bytes_to_skip();
             uds_payload.push_slice(start, uds_payload.len())?;
+            let basic_struct_type = repeated_dop
+                .basic_structure()
+                .map(|d| d.specific_data_type());
+            tracing::debug!(
+                has_basic_structure = repeated_dop.basic_structure().is_some(),
+                has_env_data_desc = repeated_dop.env_data_desc().is_some(),
+                basic_struct_specific_data_type = ?basic_struct_type,
+                "DynamicLengthField item decode metadata"
+            );
             if let Some(s) = repeated_dop
                 .basic_structure()
                 .and_then(|d| d.specific_data_as_structure().map(datatypes::StructureDop))
             {
-                let struct_data = self.map_struct_from_uds(&s, mapped_service, uds_payload)?;
+                let struct_data =
+                    self.map_struct_from_uds(&s, mapped_service, uds_payload, data)?;
                 repeated_data.push(struct_data);
-            } else if repeated_dop.env_data_desc().is_some() {
-                tracing::warn!("DynamicLengthField with EnvDataDesc not implemented");
+                let item_size = s.byte_size().map_or_else(
+                    || {
+                        let delta_bytes_to_skip = uds_payload
+                            .bytes_to_skip()
+                            .saturating_sub(bytes_to_skip_before);
+                        uds_payload
+                            .last_read_byte_pos()
+                            .saturating_add(delta_bytes_to_skip)
+                    },
+                    |s| s as usize,
+                );
                 uds_payload.pop_slice()?;
-                continue;
+                start = start.saturating_add(item_size);
+            } else if let Some(env_data_desc_dop) = repeated_dop.env_data_desc() {
+                if let Some(env_data_desc) = env_data_desc_dop.specific_data_as_env_data_desc() {
+                    let env_data_desc = datatypes::EnvDataDescDop(env_data_desc);
+                    let outer_data = data.clone();
+                    let item_data = self.map_env_data_desc_item_from_uds(
+                        mapped_service,
+                        uds_payload,
+                        &outer_data,
+                        &env_data_desc,
+                        0,
+                    )?;
+                    let delta_bytes_to_skip = uds_payload
+                        .bytes_to_skip()
+                        .saturating_sub(bytes_to_skip_before);
+                    let item_size = uds_payload
+                        .last_read_byte_pos()
+                        .saturating_add(delta_bytes_to_skip);
+                    uds_payload.pop_slice()?;
+                    repeated_data.push(item_data);
+                    start = start.saturating_add(item_size);
+                } else {
+                    uds_payload.pop_slice()?;
+                    return Err(DiagServiceError::InvalidDatabase(
+                        "DynamicLengthField env_data_desc DOP is not EnvDataDesc type".to_owned(),
+                    ));
+                }
             } else {
                 uds_payload.pop_slice()?;
                 return Err(DiagServiceError::InvalidDatabase(
@@ -4234,16 +4357,9 @@ impl<S: SecurityPlugin> EcuManager<S> {
                         .to_owned(),
                 ));
             }
-
-            uds_payload.pop_slice()?;
-            start = start.saturating_add(
-                uds_payload
-                    .last_read_byte_pos()
-                    .saturating_add(uds_payload.bytes_to_skip()),
-            );
         }
         uds_payload.pop_slice()?;
-        uds_payload.set_last_read_byte_pos(start.saturating_sub(1));
+        uds_payload.set_last_read_byte_pos(items_abs_start.saturating_add(start));
         data.insert(
             short_name,
             DiagDataTypeContainer::RepeatingStruct(repeated_data),
@@ -4251,34 +4367,29 @@ impl<S: SecurityPlugin> EcuManager<S> {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn map_mux_dop_from_uds(
         &self,
         mapped_service: &datatypes::DiagService,
-        param: &datatypes::Parameter,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
         short_name: String,
         mux_dop: &datatypes::MuxDop,
-        base_offset: usize,
+        param_ctx: ParamContext<'_>,
     ) -> Result<(), DiagServiceError> {
-        let param_byte_pos = base_offset.saturating_add(param.byte_position() as usize);
-        uds_payload.push_slice(param_byte_pos, uds_payload.len())?;
+        uds_payload.push_slice(param_ctx.abs_byte_pos(), uds_payload.len())?;
         self.map_mux_from_uds(mapped_service, uds_payload, data, short_name, mux_dop)?;
         uds_payload.pop_slice()?;
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn map_static_field_dop_from_uds(
         &self,
         mapped_service: &datatypes::DiagService,
-        param: &datatypes::Parameter,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
         short_name: String,
         static_field_dop: &datatypes::StaticFieldDop,
-        base_offset: usize,
+        param_ctx: ParamContext<'_>,
     ) -> Result<(), DiagServiceError> {
         let static_field_size = static_field_dop
             .item_byte_size()
@@ -4296,8 +4407,8 @@ impl<S: SecurityPlugin> EcuManager<S> {
         let mut nested_structs = Vec::new();
 
         for i in 0..static_field_dop.fixed_number_of_items() {
-            let param_byte_pos = base_offset.saturating_add(param.byte_position() as usize);
-            let start = param_byte_pos
+            let start = param_ctx
+                .abs_byte_pos()
                 .saturating_add(i.saturating_mul(static_field_dop.item_byte_size()) as usize);
             let end = start.saturating_add(static_field_dop.item_byte_size() as usize);
             uds_payload.push_slice(start, end)?;
@@ -4307,6 +4418,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 mapped_service,
                 uds_payload,
                 &mut nested_structs,
+                data,
             )?;
 
             uds_payload.pop_slice()?;
@@ -4320,18 +4432,18 @@ impl<S: SecurityPlugin> EcuManager<S> {
     }
 
     fn map_dtc_dop_from_uds(
-        param: &datatypes::Parameter,
+        param_name: &str,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
         dtc_dop: &datatypes::DtcDop,
-        base_offset: usize,
+        param_ctx: ParamContext<'_>,
     ) -> Result<(), DiagServiceError> {
         let coded_type: datatypes::DiagCodedType = dtc_dop.diag_coded_type()?;
 
         let (dtc_value, _size) = coded_type.decode(
             uds_payload.data()?,
-            base_offset.saturating_add(param.byte_position() as usize),
-            param.bit_position() as usize,
+            param_ctx.abs_byte_pos(),
+            param_ctx.parameter.bit_position() as usize,
         )?;
 
         let code: u32 = DiagDataValue::new(coded_type.base_datatype(), &dtc_value)?.try_into()?;
@@ -4344,7 +4456,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
             )))?;
 
         data.insert(
-            "DtcRecord".to_owned(),
+            param_name.to_owned(),
             DiagDataTypeContainer::DtcStruct(DiagDataContainerDtc {
                 code,
                 display_code: record.display_trouble_code().map(ToOwned::to_owned),
@@ -4353,27 +4465,136 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     .and_then(|text| text.value().map(ToOwned::to_owned))
                     .unwrap_or_default(),
                 severity: record.level().unwrap_or_default(),
-                bit_pos: param.byte_position(),
+                bit_pos: param_ctx.parameter.bit_position(),
                 bit_len: DTC_CODE_BIT_LEN,
-                byte_pos: param.byte_position(),
+                byte_pos: u32::try_from(param_ctx.abs_byte_pos()).map_err(|_| {
+                    DiagServiceError::InvalidDatabase("DTC byte position overflows u32".to_owned())
+                })?,
             }),
         );
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    /// Extracts the discriminator value from already-decoded outer data by name.
+    /// Handles both `DtcStruct` (returns `.code`) and `RawContainer` (converts bytes to u32).
+    /// Falls back to scanning for any `DtcStruct` if the named param is absent.
+    fn discriminator_value_from_outer_data(
+        outer_data: &MappedDiagServiceResponsePayload,
+        param_short_name: &str,
+    ) -> Result<u32, DiagServiceError> {
+        match outer_data.get(param_short_name) {
+            Some(DiagDataTypeContainer::DtcStruct(dtc)) => return Ok(dtc.code),
+            Some(DiagDataTypeContainer::RawContainer(raw)) => {
+                let val = operations::uds_data_to_serializable(
+                    raw.data_type,
+                    raw.compu_method.as_ref(),
+                    false,
+                    &raw.data,
+                )?;
+                return match val {
+                    DiagDataValue::UInt32(n) => Ok(n),
+                    DiagDataValue::Int32(n) => u32::try_from(n).map_err(|_| {
+                        DiagServiceError::ParameterConversionError(format!(
+                            "EnvDataDesc discriminator '{param_short_name}' is negative: {n}"
+                        ))
+                    }),
+                    _ => Err(DiagServiceError::ParameterConversionError(format!(
+                        "EnvDataDesc discriminator '{param_short_name}' resolved to unexpected \
+                         type: {val:?}"
+                    ))),
+                };
+            }
+            _ => {}
+        }
+        for container in outer_data.values() {
+            if let DiagDataTypeContainer::DtcStruct(dtc) = container {
+                return Ok(dtc.code);
+            }
+        }
+        Err(DiagServiceError::InvalidDatabase(format!(
+            "EnvDataDesc selector param '{param_short_name}' not found in decoded data"
+        )))
+    }
+
+    /// Looks up the discriminator value from `outer_data`, finds the matching `EnvData` in
+    /// `env_data_desc`, decodes its params and returns them as a new payload map.
+    fn map_env_data_desc_item_from_uds(
+        &self,
+        mapped_service: &datatypes::DiagService,
+        uds_payload: &mut Payload,
+        outer_data: &MappedDiagServiceResponsePayload,
+        env_data_desc: &datatypes::EnvDataDescDop,
+        base_offset: usize,
+    ) -> Result<MappedDiagServiceResponsePayload, DiagServiceError> {
+        let param_short_name = env_data_desc.param_short_name().ok_or_else(|| {
+            DiagServiceError::InvalidDatabase("EnvDataDesc missing param_short_name".to_owned())
+        })?;
+        let discriminator =
+            Self::discriminator_value_from_outer_data(outer_data, param_short_name)?;
+
+        let env_datas = env_data_desc.env_datas().ok_or_else(|| {
+            DiagServiceError::InvalidDatabase("EnvDataDesc has no env_datas".to_owned())
+        })?;
+
+        // First pass: exact match on dtc_values.
+        // Second pass: wildcard (EnvData with empty/absent dtc_values matches any discriminator).
+        let matching_env_data = env_datas
+            .iter()
+            .find_map(|dop| {
+                let env_data = dop.specific_data_as_env_data()?;
+                let dtc_values = env_data.dtc_values()?;
+                if dtc_values.iter().any(|v| v == discriminator) {
+                    Some(env_data)
+                } else {
+                    None
+                }
+            })
+            .or_else(|| {
+                env_datas.iter().find_map(|dop| {
+                    let env_data = dop.specific_data_as_env_data()?;
+                    let is_wildcard = env_data.dtc_values().is_none_or(|v| v.is_empty());
+                    if is_wildcard { Some(env_data) } else { None }
+                })
+            });
+
+        let mut item_data = HashMap::new();
+        let Some(env_data) = matching_env_data else {
+            tracing::warn!(
+                discriminator = format!("{discriminator:#X}"),
+                "No EnvData matched discriminator in EnvDataDesc; returning empty map"
+            );
+            return Ok(item_data);
+        };
+
+        if let Some(params) = env_data.params() {
+            for param in params {
+                let param = datatypes::Parameter(param);
+                let name = param.short_name().ok_or_else(|| {
+                    DiagServiceError::InvalidDatabase("EnvData param missing short_name".to_owned())
+                })?;
+                self.map_param_from_uds(
+                    mapped_service,
+                    name,
+                    uds_payload,
+                    &mut item_data,
+                    ParamContext::new(&param, base_offset).with_outer_context(Some(outer_data)),
+                )?;
+            }
+        }
+
+        Ok(item_data)
+    }
+
     fn map_structure_dop_from_uds(
         &self,
         mapped_service: &datatypes::DiagService,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
         short_name: &str,
-        structure_param: &datatypes::Parameter,
         structure_dop: &datatypes::StructureDop,
-        base_offset: usize,
+        structure_param_ctx: ParamContext<'_>,
     ) -> Result<(), DiagServiceError> {
-        // Slice the payload for the structure
-        let structure_start = base_offset.saturating_add(structure_param.byte_position() as usize);
+        let structure_start = structure_param_ctx.abs_byte_pos();
 
         if let Some(byte_size) = structure_dop.byte_size() {
             let end = structure_start
@@ -4393,11 +4614,10 @@ impl<S: SecurityPlugin> EcuManager<S> {
             for param in params.iter().map(datatypes::Parameter) {
                 self.map_param_from_uds(
                     mapped_service,
-                    &param,
                     short_name,
                     uds_payload,
                     data,
-                    structure_start,
+                    ParamContext::new(&param, structure_start),
                 )?;
             }
         }
@@ -4434,6 +4654,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     mapped_service,
                     uds_payload,
                     &mut nested_structs,
+                    data,
                 ) {
                     Ok(()) => {}
                     Err(e) => {
@@ -4474,12 +4695,11 @@ impl<S: SecurityPlugin> EcuManager<S> {
     }
 
     fn map_normal_dop_from_uds(
-        param: &datatypes::Parameter,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
         short_name: String,
         normal_dop: &datatypes::NormalDop,
-        base_offset: usize,
+        param_ctx: ParamContext<'_>,
     ) -> Result<(), DiagServiceError> {
         let diag_coded_type = normal_dop.diag_coded_type()?;
         let compu_method =
@@ -4490,8 +4710,8 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     "param {short_name} has no compu method"
                 )))?;
 
-        let byte_pos = if param.has_byte_position() {
-            base_offset.saturating_add(param.byte_position() as usize)
+        let byte_pos = if param_ctx.parameter.has_byte_position() {
+            param_ctx.abs_byte_pos()
         } else {
             uds_payload.last_read_byte_pos()
         };
@@ -4499,9 +4719,9 @@ impl<S: SecurityPlugin> EcuManager<S> {
         data.insert(
             short_name,
             operations::extract_diag_data_container(
-                param.short_name(),
+                param_ctx.parameter.short_name(),
                 byte_pos,
-                param.bit_position() as usize,
+                param_ctx.parameter.bit_position() as usize,
                 uds_payload,
                 &diag_coded_type,
                 Some(compu_method),
@@ -4607,8 +4827,12 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     // to last_read_byte_pos; it must be 0 (start of case data)
                     // rather than stale from a previous context.
                     uds_payload.set_last_read_byte_pos(0);
-                    let case_data =
-                        self.map_struct_from_uds(&case_structure, mapped_service, uds_payload)?;
+                    let case_data = self.map_struct_from_uds(
+                        &case_structure,
+                        mapped_service,
+                        uds_payload,
+                        data,
+                    )?;
                     uds_payload.pop_slice()?;
                     mux_data.insert(case_name, DiagDataTypeContainer::Struct(case_data));
                 }
@@ -6260,6 +6484,297 @@ mod tests {
         )
     }
 
+    /// Creates an ECU manager with a service that has a DTC param followed by an ENV-DATA-DESC
+    /// param. The ENV-DATA-DESC selects the right ENV-DATA based on the DTC code and decodes
+    /// a single `temperature` (u8) parameter from it.
+    fn create_ecu_manager_with_env_data_desc() -> (
+        super::EcuManager<DefaultSecurityPluginData>,
+        cda_interfaces::DiagComm,
+        u8,
+        u32,
+    ) {
+        let mut db_builder = EcuDataBuilder::new();
+        let u32_diag_type = db_builder.create_diag_coded_type_standard_length(32, DataType::UInt32);
+        let u8_diag_type = db_builder.create_diag_coded_type_standard_length(8, DataType::UInt32);
+        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let compu_identical =
+            db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
+
+        let dtc_code: u32 = 0x0001_0002;
+        let dtc = db_builder.create_dtc(dtc_code, Some("P0001"), Some("TestEnvFault"), 1);
+        let dtc_dop =
+            db_builder.create_dtc_dop(u32_diag_type, Some(vec![dtc]), Some(compu_identical));
+
+        // ENV-DATA for dtc_code: contains a single u8 param "temperature"
+        let compu_identical2 =
+            db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
+        let temp_dop =
+            db_builder.create_regular_normal_dop("temp_dop", u8_diag_type, compu_identical2);
+        let temp_param = db_builder.create_value_param("temperature", temp_dop, 0, 0);
+        let env_data_dop = db_builder.create_env_data_dop(&[dtc_code], &[temp_param]);
+
+        // ENV-DATA-DESC: selector is "dtc_param"
+        let env_data_desc_dop =
+            db_builder.create_env_data_desc_dop("env_snapshot", "dtc_param", &[env_data_dop]);
+
+        let sid = service_ids::READ_DTC_INFORMATION;
+        let dc_name = "TestEnvDataDescService";
+        let diag_comm = new_diag_comm!(db_builder, dc_name, protocol);
+
+        let request = create_sid_only_request!(db_builder, sid);
+
+        let sid_param = create_sid_param!(db_builder, "test_service_pos_sid", sid);
+        let dtc_value_param = db_builder.create_value_param("dtc_param", dtc_dop, 1, 0);
+        let env_data_value_param =
+            db_builder.create_value_param("env_snapshot", env_data_desc_dop, 5, 0);
+        let pos_response = db_builder.create_response(
+            ResponseType::Positive,
+            Some(vec![sid_param, dtc_value_param, env_data_value_param]),
+            None,
+        );
+
+        let diag_service =
+            new_diag_service!(db_builder, diag_comm, request, vec![pos_response], vec![]);
+
+        let db = finish_db!(db_builder, protocol, vec![diag_service]);
+        (
+            new_ecu_manager(db),
+            cda_interfaces::DiagComm::new(dc_name, DiagCommType::Faults),
+            sid,
+            dtc_code,
+        )
+    }
+
+    // ── StaticField DOP ──────────────────────────────────────────────────────
+
+    fn create_ecu_manager_with_static_field_service() -> (
+        super::EcuManager<DefaultSecurityPluginData>,
+        cda_interfaces::DiagComm,
+        u8,
+    ) {
+        let mut db_builder = EcuDataBuilder::new();
+        let u16_diag_type = db_builder.create_diag_coded_type_standard_length(16, DataType::UInt32);
+        let compu_identical =
+            db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
+        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+
+        let item_dop =
+            db_builder.create_regular_normal_dop("item_dop", u16_diag_type, compu_identical);
+        let item_param = db_builder.create_value_param("item_val", item_dop, 0, 0);
+        let item_structure = db_builder.create_structure(Some(vec![item_param]), Some(2), true);
+
+        // 3 items, each 2 bytes wide
+        let static_field_dop = db_builder.create_static_field_dop(3, 2, item_structure);
+
+        let sid = service_ids::READ_DATA_BY_IDENTIFIER;
+        let dc_name = "TestStaticFieldService";
+        let diag_comm = new_diag_comm!(db_builder, dc_name, protocol);
+        let request = create_sid_only_request!(db_builder, sid);
+        let pos_response =
+            create_pos_response_with_param!(db_builder, sid, "items", static_field_dop, 1);
+        let diag_service =
+            new_diag_service!(db_builder, diag_comm, request, vec![pos_response], vec![]);
+        let db = finish_db!(db_builder, protocol, vec![diag_service]);
+        (
+            new_ecu_manager(db),
+            cda_interfaces::DiagComm::new(dc_name, DiagCommType::Data),
+            sid,
+        )
+    }
+
+    // ── EnvDataDesc wildcard fallback ────────────────────────────────────────
+
+    fn create_ecu_manager_with_env_data_desc_wildcard() -> (
+        super::EcuManager<DefaultSecurityPluginData>,
+        cda_interfaces::DiagComm,
+        u8,
+        u32, // specific_dtc
+        u32, // other_dtc (triggers wildcard)
+    ) {
+        let mut db_builder = EcuDataBuilder::new();
+        let u32_diag_type = db_builder.create_diag_coded_type_standard_length(32, DataType::UInt32);
+        let u8_diag_type = db_builder.create_diag_coded_type_standard_length(8, DataType::UInt32);
+        let compu_identical =
+            db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
+        let compu_identical2 =
+            db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
+        let compu_identical3 =
+            db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
+        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+
+        let specific_dtc: u32 = 0x0001_0002;
+        let other_dtc: u32 = 0x0003_0004;
+
+        let dtc1 = db_builder.create_dtc(specific_dtc, Some("P0001"), Some("SpecificFault"), 1);
+        let dtc2 = db_builder.create_dtc(other_dtc, Some("P0002"), Some("OtherFault"), 2);
+        let dtc_dop =
+            db_builder.create_dtc_dop(u32_diag_type, Some(vec![dtc1, dtc2]), Some(compu_identical));
+
+        let temp_dop =
+            db_builder.create_regular_normal_dop("temp_dop", u8_diag_type, compu_identical2);
+        let humidity_dop =
+            db_builder.create_regular_normal_dop("humidity_dop", u8_diag_type, compu_identical3);
+
+        // Specific env_data matches only specific_dtc → reports "temperature"
+        let temp_param = db_builder.create_value_param("temperature", temp_dop, 0, 0);
+        let specific_env_data_dop = db_builder.create_env_data_dop(&[specific_dtc], &[temp_param]);
+
+        // Wildcard env_data (empty dtc_values) → reports "humidity"
+        let humidity_param = db_builder.create_value_param("humidity", humidity_dop, 0, 0);
+        let wildcard_env_data_dop = db_builder.create_env_data_dop(&[], &[humidity_param]);
+
+        let env_data_desc_dop = db_builder.create_env_data_desc_dop(
+            "env_snapshot",
+            "dtc_param",
+            &[specific_env_data_dop, wildcard_env_data_dop],
+        );
+
+        let sid = service_ids::READ_DTC_INFORMATION;
+        let dc_name = "TestEnvDataDescWildcardService";
+        let diag_comm = new_diag_comm!(db_builder, dc_name, protocol);
+        let request = create_sid_only_request!(db_builder, sid);
+
+        let sid_param = create_sid_param!(db_builder, "test_service_pos_sid", sid);
+        let dtc_value_param = db_builder.create_value_param("dtc_param", dtc_dop, 1, 0);
+        let env_data_value_param =
+            db_builder.create_value_param("env_snapshot", env_data_desc_dop, 5, 0);
+        let pos_response = db_builder.create_response(
+            ResponseType::Positive,
+            Some(vec![sid_param, dtc_value_param, env_data_value_param]),
+            None,
+        );
+
+        let diag_service =
+            new_diag_service!(db_builder, diag_comm, request, vec![pos_response], vec![]);
+        let db = finish_db!(db_builder, protocol, vec![diag_service]);
+        (
+            new_ecu_manager(db),
+            cda_interfaces::DiagComm::new(dc_name, DiagCommType::Faults),
+            sid,
+            specific_dtc,
+            other_dtc,
+        )
+    }
+
+    fn create_ecu_manager_env_data_no_wildcard() -> (
+        super::EcuManager<DefaultSecurityPluginData>,
+        cda_interfaces::DiagComm,
+        u8,
+        u32, // dtc_in_db (used in payload; no matching env_data)
+    ) {
+        let mut db_builder = EcuDataBuilder::new();
+        let u32_diag_type = db_builder.create_diag_coded_type_standard_length(32, DataType::UInt32);
+        let u8_diag_type = db_builder.create_diag_coded_type_standard_length(8, DataType::UInt32);
+        let compu_id =
+            db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
+        let compu_id2 =
+            db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
+        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+
+        let dtc_in_db: u32 = 0x0001_AAAA;
+        let dtc = db_builder.create_dtc(dtc_in_db, Some("P9999"), Some("SomeFault"), 1);
+        let dtc_dop = db_builder.create_dtc_dop(u32_diag_type, Some(vec![dtc]), Some(compu_id));
+
+        // env_data only matches a *different* DTC code; no wildcard
+        let temp_dop = db_builder.create_regular_normal_dop("temp_dop", u8_diag_type, compu_id2);
+        let temp_param = db_builder.create_value_param("temperature", temp_dop, 0, 0);
+        let env_data_dop = db_builder.create_env_data_dop(&[0x0000_1111], &[temp_param]);
+        let env_data_desc_dop =
+            db_builder.create_env_data_desc_dop("env_snapshot", "dtc_param", &[env_data_dop]);
+
+        let sid = service_ids::READ_DTC_INFORMATION;
+        let dc_name = "TestEnvDataNoWildcard";
+        let diag_comm = new_diag_comm!(db_builder, dc_name, protocol);
+        let request = create_sid_only_request!(db_builder, sid);
+        let sid_param = create_sid_param!(db_builder, "test_service_pos_sid", sid);
+        let dtc_value_param = db_builder.create_value_param("dtc_param", dtc_dop, 1, 0);
+        let env_data_value_param =
+            db_builder.create_value_param("env_snapshot", env_data_desc_dop, 5, 0);
+        let pos_response = db_builder.create_response(
+            ResponseType::Positive,
+            Some(vec![sid_param, dtc_value_param, env_data_value_param]),
+            None,
+        );
+        let diag_service =
+            new_diag_service!(db_builder, diag_comm, request, vec![pos_response], vec![]);
+        let db = finish_db!(db_builder, protocol, vec![diag_service]);
+        (
+            new_ecu_manager(db),
+            cda_interfaces::DiagComm::new(dc_name, DiagCommType::Faults),
+            sid,
+            dtc_in_db,
+        )
+    }
+
+    // ── DynamicLengthField: sibling param before DLF with no byte_position ──
+
+    fn create_ecu_manager_dlf_sibling_no_byte_pos() -> (
+        super::EcuManager<DefaultSecurityPluginData>,
+        cda_interfaces::DiagComm,
+        u8,
+    ) {
+        let mut db_builder = EcuDataBuilder::new();
+        let u8_diag_type = db_builder.create_diag_coded_type_standard_length(8, DataType::UInt32);
+        let u16_diag_type = db_builder.create_diag_coded_type_standard_length(16, DataType::UInt32);
+        let compu_identical =
+            db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
+        let compu_identical2 =
+            db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
+        let compu_identical3 =
+            db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
+        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+
+        let sibling_dop =
+            db_builder.create_regular_normal_dop("sibling_dop", u8_diag_type, compu_identical);
+        let num_items_dop =
+            db_builder.create_regular_normal_dop("num_items_dop", u8_diag_type, compu_identical2);
+
+        let item_dop =
+            db_builder.create_regular_normal_dop("item_dop", u16_diag_type, compu_identical3);
+        let item_param = db_builder.create_value_param("item_val", item_dop, 0, 0);
+        let repeated_struct = db_builder.create_structure(Some(vec![item_param]), Some(2), true);
+
+        // offset=3: items start at param_abs_byte_pos + 3 (= byte 0 + 3 = byte 3 absolute)
+        // number_of_items_byte_pos=2:
+        // count at param_abs_byte_pos + 2 (= byte 0 + 2 = byte 2 absolute)
+        let dlf_specific = db_builder
+            .create_dynamic_length_specific_dop_data(3, 2, 0, num_items_dop, Some(repeated_struct))
+            .value_offset();
+        let dlf_dop = db_builder.create_dop(
+            *DopType::REGULAR,
+            Some("dlf_dop"),
+            None,
+            *SpecificDOPData::DynamicLengthField,
+            Some(dlf_specific),
+        );
+
+        let sid = service_ids::WRITE_DATA_BY_IDENTIFIER;
+        let dc_name = "TestDlfSiblingNoBytePosService";
+        let diag_comm = new_diag_comm!(db_builder, dc_name, protocol);
+        let request = create_sid_only_request!(db_builder, sid);
+
+        let pos_response = {
+            let sid_param = create_sid_param!(db_builder, "test_service_pos_sid", sid);
+            // sibling at explicit byte_pos=1, advances last_read_byte_pos to 2 after decoding
+            let sibling_param = db_builder.create_value_param("sibling_val", sibling_dop, 1, 0);
+            // DLF with NO explicit byte_position — must use base_offset=0, not last_read_byte_pos
+            let dlf_param = db_builder.create_value_param_no_byte_pos("dlf_items", dlf_dop);
+            db_builder.create_response(
+                ResponseType::Positive,
+                Some(vec![sid_param, sibling_param, dlf_param]),
+                None,
+            )
+        };
+
+        let diag_service =
+            new_diag_service!(db_builder, diag_comm, request, vec![pos_response], vec![]);
+        let db = finish_db!(db_builder, protocol, vec![diag_service]);
+        (
+            new_ecu_manager(db),
+            cda_interfaces::DiagComm::new(dc_name, DiagCommType::Configurations),
+            sid,
+        )
+    }
     /// Creates an ECU manager configured for variant detection testing.
     ///
     /// # Database contents:
@@ -7919,12 +8434,40 @@ mod tests {
             &service,
             payload,
             json!({
-                "DtcRecord": {
+                "dtc_param": {
                     "code": dtc_code,
                     "display_code": "P1234",
                     "fault_name": "TestFault",
                     "severity": 2,
                 },
+                "test_service_pos_sid": sid
+            }),
+        )
+        .await;
+    }
+    // basic EnvDataDesc decoding: the DTC discriminator is looked up from outer data
+    // and correct EnvData block is decoded
+    #[tokio::test]
+    async fn test_map_env_data_desc_from_uds() {
+        let (ecu_manager, service, sid, dtc_code) = create_ecu_manager_with_env_data_desc();
+
+        // Payload: SID(1) + DTC(4 bytes big-endian) + temperature(1 byte)
+        let mut payload = vec![sid];
+        payload.extend_from_slice(&dtc_code.to_be_bytes());
+        payload.push(0x42); // temperature = 66
+
+        assert_uds_converts_to_json(
+            &ecu_manager,
+            &service,
+            payload,
+            json!({
+                "dtc_param": {
+                    "code": dtc_code,
+                    "display_code": "P0001",
+                    "fault_name": "TestEnvFault",
+                    "severity": 1,
+                },
+                "temperature": 0x42,
                 "test_service_pos_sid": sid
             }),
         )
@@ -10043,5 +10586,169 @@ mod tests {
             result.is_ok(),
             "Expected clean subfunction to still match with default mask, got: {result:?}"
         );
+    }
+
+    //Static DOP with nested structure decodes inner params at the correct absolute byte positions
+    #[tokio::test]
+    async fn test_map_static_field_from_uds() {
+        let (ecu_manager, service, sid) = create_ecu_manager_with_static_field_service();
+
+        // SID(1) + item0(2) + item1(2) + item2(2) = 7 bytes
+        assert_uds_converts_to_json(
+            &ecu_manager,
+            &service,
+            vec![sid, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66],
+            json!({
+                "test_service_pos_sid": sid,
+                "items": [
+                    { "item_val": 0x1122u32 },
+                    { "item_val": 0x3344u32 },
+                    { "item_val": 0x5566u32 },
+                ]
+            }),
+        )
+        .await;
+    }
+    // Static Field returns NotEnoughData when the payload is too short for declared structure size
+    #[tokio::test]
+    async fn test_map_static_field_from_uds_not_enough_data() {
+        let (ecu_manager, service, sid) = create_ecu_manager_with_static_field_service();
+
+        // Only 2 items worth of data (4 bytes) instead of the required 3 items (6 bytes)
+        let error =
+            assert_uds_conversion_fails(&ecu_manager, &service, vec![sid, 0x11, 0x22, 0x33, 0x44])
+                .await;
+        assert!(
+            matches!(error, DiagServiceError::BadPayload(_)),
+            "Expected BadPayload, got: {error:?}"
+        );
+    }
+
+    // EnvDataDesc selects EnvData whose dtc_values exactly matches the discriminator
+    #[tokio::test]
+    async fn test_env_data_desc_specific_match() {
+        let (ecu_manager, service, sid, specific_dtc, _other_dtc) =
+            create_ecu_manager_with_env_data_desc_wildcard();
+
+        let mut payload = vec![sid];
+        payload.extend_from_slice(&specific_dtc.to_be_bytes());
+        payload.push(0x28); // temperature = 40
+
+        assert_uds_converts_to_json(
+            &ecu_manager,
+            &service,
+            payload,
+            json!({
+                "test_service_pos_sid": sid,
+                "dtc_param": {
+                    "code": specific_dtc,
+                    "display_code": "P0001",
+                    "fault_name": "SpecificFault",
+                    "severity": 1,
+                },
+                "temperature": 0x28u32,
+            }),
+        )
+        .await;
+    }
+    // EnvDataDesc falls back to wildcard EnvData when no exact match exists
+    #[tokio::test]
+    async fn test_env_data_desc_wildcard_fallback() {
+        let (ecu_manager, service, sid, _specific_dtc, other_dtc) =
+            create_ecu_manager_with_env_data_desc_wildcard();
+
+        // other_dtc doesn't match the specific env_data → wildcard env_data is used
+        let mut payload = vec![sid];
+        payload.extend_from_slice(&other_dtc.to_be_bytes());
+        payload.push(0x55); // humidity = 85
+
+        assert_uds_converts_to_json(
+            &ecu_manager,
+            &service,
+            payload,
+            json!({
+                "test_service_pos_sid": sid,
+                "dtc_param": {
+                    "code": other_dtc,
+                    "display_code": "P0002",
+                    "fault_name": "OtherFault",
+                    "severity": 2,
+                },
+                "humidity": 0x55u32,
+            }),
+        )
+        .await;
+    }
+
+    // EnvDataDesc returns an empty map when neither an exact match nor a wildcard match exists
+    #[tokio::test]
+    async fn test_env_data_desc_no_match_no_wildcard_returns_empty() {
+        let (ecu_manager, service, sid, dtc_in_db) = create_ecu_manager_env_data_no_wildcard();
+
+        // dtc_in_db has no matching env_data and there is no wildcard →
+        // env params are absent; DTC itself is decoded normally.
+        let mut payload = vec![sid];
+        payload.extend_from_slice(&dtc_in_db.to_be_bytes());
+        payload.push(0x42);
+
+        assert_uds_converts_to_json(
+            &ecu_manager,
+            &service,
+            payload,
+            json!({
+                "test_service_pos_sid": sid,
+                "dtc_param": {
+                    "code": dtc_in_db,
+                    "display_code": "P9999",
+                    "fault_name": "SomeFault",
+                    "severity": 1,
+                },
+            }),
+        )
+        .await;
+    }
+
+    // a dynamic length fiels param with no byte_position anchors to base_offset,
+    // not last_read_byte_pos left over from preceding sibling param
+    #[tokio::test]
+    async fn test_dlf_no_byte_pos_with_sibling_param() {
+        // Regression test: DLF param with has_byte_position=false must anchor to
+        // base_offset, not last_read_byte_pos (which a preceding sibling advances).
+        //
+        // Layout:[SID(0), sibling(1), count(2), item0_hi(3), item0_lo(4), item1_hi(5), item1_lo(6)]
+        let (ecu_manager, service, sid) = create_ecu_manager_dlf_sibling_no_byte_pos();
+
+        assert_uds_converts_to_json(
+            &ecu_manager,
+            &service,
+            vec![sid, 0xAB, 0x02, 0x11, 0x22, 0x33, 0x44],
+            json!({
+                "test_service_pos_sid": sid,
+                "sibling_val": 0xABu32,
+                "dlf_items": [
+                    { "item_val": 0x1122u32 },
+                    { "item_val": 0x3344u32 },
+                ],
+            }),
+        )
+        .await;
+    }
+    // verifies that the empty case doesnt misread the item count
+    #[tokio::test]
+    async fn test_dlf_no_byte_pos_with_sibling_zero_items() {
+        let (ecu_manager, service, sid) = create_ecu_manager_dlf_sibling_no_byte_pos();
+
+        // count=0 → empty array; sibling still decoded correctly
+        assert_uds_converts_to_json(
+            &ecu_manager,
+            &service,
+            vec![sid, 0xAB, 0x00],
+            json!({
+                "test_service_pos_sid": sid,
+                "sibling_val": 0xABu32,
+                "dlf_items": [],
+            }),
+        )
+        .await;
     }
 }

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -571,6 +571,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
                     short_name,
                     &mut uds_payload,
                     &mut data,
+                    0,
                 ) {
                     Ok(()) => {}
                     Err(DiagServiceError::DataError(error)) => {
@@ -1809,6 +1810,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
                 short_name,
                 &mut uds_payload,
                 &mut data,
+                0,
             ) {
                 Ok(()) => {}
                 Err(DiagServiceError::DataError(error)) => {
@@ -2991,10 +2993,17 @@ impl<S: SecurityPlugin> EcuManager<S> {
         param_name: &str,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
+        base_offset: usize,
     ) -> Result<(), DiagServiceError> {
         match param.param_type()? {
             datatypes::ParamType::CodedConst => {
-                Self::map_param_coded_const_from_uds(param, param_name, uds_payload, data)?;
+                Self::map_param_coded_const_from_uds(
+                    param,
+                    param_name,
+                    uds_payload,
+                    data,
+                    base_offset,
+                )?;
             }
             datatypes::ParamType::MatchingRequestParam => {
                 self.map_param_matching_request_from_uds(
@@ -3003,13 +3012,26 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     param_name,
                     uds_payload,
                     data,
+                    base_offset,
                 )?;
             }
             datatypes::ParamType::Value => {
-                self.map_param_value_from_uds(mapped_service, param, uds_payload, data)?;
+                self.map_param_value_from_uds(
+                    mapped_service,
+                    param,
+                    uds_payload,
+                    data,
+                    base_offset,
+                )?;
             }
             datatypes::ParamType::Reserved => {
-                Self::map_param_reserved_from_uds(param, param_name, uds_payload, data)?;
+                Self::map_param_reserved_from_uds(
+                    param,
+                    param_name,
+                    uds_payload,
+                    data,
+                    base_offset,
+                )?;
             }
             datatypes::ParamType::TableEntry => {
                 tracing::error!("TableStructParam not implemented.");
@@ -3018,7 +3040,13 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 tracing::error!("Dynamic ParamType not implemented.");
             }
             datatypes::ParamType::LengthKey => {
-                self.map_param_length_key_from_uds(mapped_service, param, uds_payload, data)?;
+                self.map_param_length_key_from_uds(
+                    mapped_service,
+                    param,
+                    uds_payload,
+                    data,
+                    base_offset,
+                )?;
             }
             datatypes::ParamType::NrcConst => {
                 tracing::error!("NrcConst ParamType not implemented.");
@@ -3030,6 +3058,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     param_name,
                     uds_payload,
                     data,
+                    base_offset,
                 )?;
             }
             datatypes::ParamType::System => {
@@ -3050,6 +3079,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         param_name: &str,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
+        base_offset: usize,
     ) -> Result<(), DiagServiceError> {
         let r = param
             .specific_data_as_reserved()
@@ -3068,7 +3098,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
 
         let (param_data, bit_len) = coded_type.decode(
             uds_payload.data()?,
-            param.byte_position() as usize,
+            base_offset.saturating_add(param.byte_position() as usize),
             param.bit_position() as usize,
         )?;
 
@@ -3090,6 +3120,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         param: &datatypes::Parameter,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
+        base_offset: usize,
     ) -> Result<(), DiagServiceError> {
         let v = param
             .specific_data_as_value()
@@ -3103,7 +3134,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 .ok_or(DiagServiceError::InvalidDatabase(
                     "Value DoP is None".to_owned(),
                 ))?;
-        self.map_dop_from_uds(mapped_service, &dop, param, uds_payload, data)?;
+        self.map_dop_from_uds(mapped_service, &dop, param, uds_payload, data, base_offset)?;
         Ok(())
     }
 
@@ -3113,6 +3144,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         param: &datatypes::Parameter,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
+        base_offset: usize,
     ) -> Result<(), DiagServiceError> {
         let length_key =
             param
@@ -3125,7 +3157,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
             DiagServiceError::InvalidDatabase("LengthKey DoP is None".to_owned()),
         )?;
 
-        self.map_dop_from_uds(mapped_service, &dop, param, uds_payload, data)
+        self.map_dop_from_uds(mapped_service, &dop, param, uds_payload, data, base_offset)
     }
 
     fn map_param_matching_request_from_uds(
@@ -3135,6 +3167,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         param_name: &str,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
+        base_offset: usize,
     ) -> Result<(), DiagServiceError> {
         let matching_req_param = param.specific_data_as_matching_request_param().ok_or(
             DiagServiceError::InvalidDatabase(
@@ -3189,6 +3222,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
             param_name,
             uds_payload,
             data,
+            base_offset,
         )?;
 
         if pop {
@@ -3202,6 +3236,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         param_name: &str,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
+        base_offset: usize,
     ) -> Result<(), DiagServiceError> {
         let c = param
             .specific_data_as_coded_const()
@@ -3219,7 +3254,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
 
         let value = operations::extract_diag_data_container(
             param.short_name(),
-            param.byte_position() as usize,
+            base_offset.saturating_add(param.byte_position() as usize),
             param.bit_position() as usize,
             uds_payload,
             &diag_type,
@@ -3289,6 +3324,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         param_name: &str,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
+        base_offset: usize,
     ) -> Result<(), DiagServiceError> {
         let p = param
             .specific_data_as_phys_const()
@@ -3309,7 +3345,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 let diag_type = normal_dop.diag_coded_type()?;
                 let value = operations::extract_diag_data_container(
                     param.short_name(),
-                    param.byte_position() as usize,
+                    base_offset.saturating_add(param.byte_position() as usize),
                     param.bit_position() as usize,
                     uds_payload,
                     &diag_type,
@@ -3346,7 +3382,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
             | datatypes::DataOperationVariant::StaticField(_)
             | datatypes::DataOperationVariant::Mux(_)
             | datatypes::DataOperationVariant::DynamicLengthField(_) => {
-                self.map_dop_from_uds(mapped_service, &dop, param, uds_payload, data)?;
+                self.map_dop_from_uds(mapped_service, &dop, param, uds_payload, data, base_offset)?;
             }
             _ => {
                 return Err(DiagServiceError::InvalidDatabase(format!(
@@ -3882,6 +3918,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 short_name,
                 uds_payload,
                 &mut data,
+                0,
             )?;
         }
         Ok(data)
@@ -3910,6 +3947,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         param: &datatypes::Parameter,
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
+        base_offset: usize,
     ) -> Result<(), DiagServiceError> {
         let short_name = param
             .short_name()
@@ -3931,6 +3969,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                         short_name,
                         &normal_dop,
                         length_key_name,
+                        base_offset,
                     )?;
                 } else {
                     Self::map_normal_dop_from_uds(
@@ -3939,6 +3978,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                         data,
                         short_name,
                         &normal_dop,
+                        base_offset,
                     )?;
                 }
             }
@@ -3960,10 +4000,11 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     &short_name,
                     param,
                     &structure_dop,
+                    base_offset,
                 )?;
             }
             datatypes::DataOperationVariant::Dtc(dtc_dop) => {
-                Self::map_dtc_dop_from_uds(param, uds_payload, data, &dtc_dop)?;
+                Self::map_dtc_dop_from_uds(param, uds_payload, data, &dtc_dop, base_offset)?;
             }
             datatypes::DataOperationVariant::StaticField(static_field_dop) => {
                 self.map_static_field_dop_from_uds(
@@ -3973,6 +4014,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     data,
                     short_name,
                     &static_field_dop,
+                    base_offset,
                 )?;
             }
             datatypes::DataOperationVariant::Mux(mux_dop) => {
@@ -3983,6 +4025,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     data,
                     short_name,
                     &mux_dop,
+                    base_offset,
                 )?;
             }
             datatypes::DataOperationVariant::DynamicLengthField(dynamic_length_field_dop) => {
@@ -3993,6 +4036,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     data,
                     short_name,
                     &dynamic_length_field_dop,
+                    base_offset,
                 )?;
             }
 
@@ -4012,6 +4056,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         short_name: String,
         normal_dop: &datatypes::NormalDop,
         length_key_name: &str,
+        base_offset: usize,
     ) -> Result<(), DiagServiceError> {
         let byte_count = match data.get(length_key_name) {
             Some(DiagDataTypeContainer::RawContainer(raw)) => {
@@ -4070,7 +4115,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         }
 
         let byte_pos = if param.has_byte_position() {
-            param.byte_position() as usize
+            base_offset.saturating_add(param.byte_position() as usize)
         } else {
             uds_payload.last_read_byte_pos()
         };
@@ -4092,6 +4137,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[tracing::instrument(skip_all,
         fields(
             dlt_context = dlt_ctx!("CORE"),
@@ -4105,6 +4151,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         data: &mut MappedDiagServiceResponsePayload,
         short_name: String,
         dynamic_length_field_dop: &datatypes::DynamicLengthDop,
+        base_offset: usize,
     ) -> Result<(), DiagServiceError> {
         let determine_num_items = dynamic_length_field_dop.determine_number_of_items().ok_or(
             DiagServiceError::InvalidDatabase(
@@ -4128,10 +4175,11 @@ impl<S: SecurityPlugin> EcuManager<S> {
 
         let num_items_diag_type: datatypes::DiagCodedType = num_items_dop.diag_coded_type()?;
 
+        let param_abs_byte_pos = base_offset.saturating_add(param.byte_position() as usize);
         let (num_items_data, _bit_len) = num_items_diag_type.decode(
             uds_payload
                 .data()?
-                .get(param.byte_position() as usize..)
+                .get(param_abs_byte_pos..)
                 .ok_or(DiagServiceError::BadPayload(
                     "Not enough bytes to get DynamicLengthField item count".to_owned(),
                 ))?,
@@ -4203,6 +4251,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn map_mux_dop_from_uds(
         &self,
         mapped_service: &datatypes::DiagService,
@@ -4211,14 +4260,16 @@ impl<S: SecurityPlugin> EcuManager<S> {
         data: &mut MappedDiagServiceResponsePayload,
         short_name: String,
         mux_dop: &datatypes::MuxDop,
+        base_offset: usize,
     ) -> Result<(), DiagServiceError> {
-        let param_byte_pos = param.byte_position();
-        uds_payload.push_slice(param_byte_pos as usize, uds_payload.len())?;
+        let param_byte_pos = base_offset.saturating_add(param.byte_position() as usize);
+        uds_payload.push_slice(param_byte_pos, uds_payload.len())?;
         self.map_mux_from_uds(mapped_service, uds_payload, data, short_name, mux_dop)?;
         uds_payload.pop_slice()?;
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn map_static_field_dop_from_uds(
         &self,
         mapped_service: &datatypes::DiagService,
@@ -4227,6 +4278,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         data: &mut MappedDiagServiceResponsePayload,
         short_name: String,
         static_field_dop: &datatypes::StaticFieldDop,
+        base_offset: usize,
     ) -> Result<(), DiagServiceError> {
         let static_field_size = static_field_dop
             .item_byte_size()
@@ -4244,10 +4296,9 @@ impl<S: SecurityPlugin> EcuManager<S> {
         let mut nested_structs = Vec::new();
 
         for i in 0..static_field_dop.fixed_number_of_items() {
-            let param_byte_pos = param.byte_position();
+            let param_byte_pos = base_offset.saturating_add(param.byte_position() as usize);
             let start = param_byte_pos
-                .saturating_add(i.saturating_mul(static_field_dop.item_byte_size()))
-                as usize;
+                .saturating_add(i.saturating_mul(static_field_dop.item_byte_size()) as usize);
             let end = start.saturating_add(static_field_dop.item_byte_size() as usize);
             uds_payload.push_slice(start, end)?;
 
@@ -4273,12 +4324,13 @@ impl<S: SecurityPlugin> EcuManager<S> {
         uds_payload: &mut Payload,
         data: &mut MappedDiagServiceResponsePayload,
         dtc_dop: &datatypes::DtcDop,
+        base_offset: usize,
     ) -> Result<(), DiagServiceError> {
         let coded_type: datatypes::DiagCodedType = dtc_dop.diag_coded_type()?;
 
         let (dtc_value, _size) = coded_type.decode(
             uds_payload.data()?,
-            param.byte_position() as usize,
+            base_offset.saturating_add(param.byte_position() as usize),
             param.bit_position() as usize,
         )?;
 
@@ -4309,6 +4361,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn map_structure_dop_from_uds(
         &self,
         mapped_service: &datatypes::DiagService,
@@ -4317,31 +4370,36 @@ impl<S: SecurityPlugin> EcuManager<S> {
         short_name: &str,
         structure_param: &datatypes::Parameter,
         structure_dop: &datatypes::StructureDop,
+        base_offset: usize,
     ) -> Result<(), DiagServiceError> {
         // Slice the payload for the structure
+        let structure_start = base_offset.saturating_add(structure_param.byte_position() as usize);
+
         if let Some(byte_size) = structure_dop.byte_size() {
-            let byte_size = byte_size as usize;
-            let start = structure_param.byte_position() as usize;
-            let end = start.checked_add(byte_size).ok_or_else(|| {
-                DiagServiceError::BadPayload("Overflow in end calculation".to_owned())
-            })?;
+            let end = structure_start
+                .checked_add(byte_size as usize)
+                .ok_or_else(|| {
+                    DiagServiceError::BadPayload("Overflow in end calculation".to_owned())
+                })?;
             if uds_payload.len() < end {
                 return Err(DiagServiceError::NotEnoughData {
                     expected: end,
                     actual: uds_payload.len(),
                 });
             }
-            uds_payload.push_slice(start, end)?;
         }
 
         if let Some(params) = structure_dop.params() {
             for param in params.iter().map(datatypes::Parameter) {
-                self.map_param_from_uds(mapped_service, &param, short_name, uds_payload, data)?;
+                self.map_param_from_uds(
+                    mapped_service,
+                    &param,
+                    short_name,
+                    uds_payload,
+                    data,
+                    structure_start,
+                )?;
             }
-        }
-        // Pop the slice after processing
-        if structure_dop.byte_size().is_some() {
-            uds_payload.pop_slice()?;
         }
         Ok(())
     }
@@ -4421,6 +4479,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         data: &mut MappedDiagServiceResponsePayload,
         short_name: String,
         normal_dop: &datatypes::NormalDop,
+        base_offset: usize,
     ) -> Result<(), DiagServiceError> {
         let diag_coded_type = normal_dop.diag_coded_type()?;
         let compu_method =
@@ -4432,7 +4491,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 )))?;
 
         let byte_pos = if param.has_byte_position() {
-            param.byte_position() as usize
+            base_offset.saturating_add(param.byte_position() as usize)
         } else {
             uds_payload.last_read_byte_pos()
         };

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -1445,14 +1445,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
                     .map(|st| (service, st))
             })
             .map(|(service, dtc_service_type)| {
-                let scope = service
-                    .diag_comm()
-                    .and_then(|dc| dc.funct_class())
-                    // using first fc for lack of better option
-                    .and_then(|fc| fc.iter().next())
-                    .and_then(|fc| fc.short_name())
-                    .map(|s| s.replace('_', ""))
-                    .unwrap_or(dtc_service_type.default_scope().to_owned());
+                let scope = *dtc_service_type;
 
                 let service_short_name = service
                     .diag_comm()
@@ -2471,7 +2464,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         let predicate = |service: &datatypes::DiagService<'_>| {
             service.diag_comm().is_some_and(|dc| {
                 dc.short_name()
-                    .is_some_and(|name| name.eq_ignore_ascii_case(&lookup_name))
+                    .is_some_and(|name| starts_with_ignore_ascii_case(name, &lookup_name))
             }) && service
                 .request_id()
                 .is_some_and(|sid| prefixes.contains(&sid))
@@ -4159,8 +4152,6 @@ impl<S: SecurityPlugin> EcuManager<S> {
             dlt_context = dlt_ctx!("CORE"),
         )
     )]
-    // allow keeping the function together as it makes sense structurally
-    #[allow(clippy::too_many_lines)]
     fn map_dynamic_length_field_from_uds(
         &self,
         mapped_service: &datatypes::DiagService,
@@ -4215,13 +4206,9 @@ impl<S: SecurityPlugin> EcuManager<S> {
             &num_items_data,
         )?;
 
-        let repeated_dop =
-            dynamic_length_field_dop
-                .field()
-                .ok_or(DiagServiceError::InvalidDatabase(
-                    "DynamicLengthField field is None".to_owned(),
-                ))?;
-
+        let repeated_dop = datatypes::DopField(dynamic_length_field_dop.field().ok_or(
+            DiagServiceError::InvalidDatabase("DynamicLengthField field is None".to_owned()),
+        )?);
         let num_items: u32 = num_items_diag_val.try_into()?;
         let num_items_byte_pos = determine_num_items.byte_position() as usize;
         uds_payload.set_last_read_byte_pos(num_items_byte_pos.saturating_add(num_items_data.len()));
@@ -4244,74 +4231,29 @@ impl<S: SecurityPlugin> EcuManager<S> {
         let mut start = 0usize;
 
         for _ in 0..num_items {
-            let bytes_to_skip_before = uds_payload.bytes_to_skip();
-            uds_payload.push_slice(start, uds_payload.len())?;
-            // Inner item params may omit BYTE-POSITION, falling back to last_read_byte_pos.
-            // Reset it to 0 so stale state from count decode doesn't corrupt item decoding.
-            uds_payload.set_last_read_byte_pos(0);
-            let basic_struct_type = repeated_dop
-                .basic_structure()
-                .map(|d| d.specific_data_type());
+            let (item_data, item_size) = self.decode_dynamic_length_field_item(
+                mapped_service,
+                uds_payload,
+                data,
+                &repeated_dop,
+                start,
+            )?;
             tracing::debug!(
-                has_basic_structure = repeated_dop.basic_structure().is_some(),
-                has_env_data_desc = repeated_dop.env_data_desc().is_some(),
-                basic_struct_specific_data_type = ?basic_struct_type,
-                "DynamicLengthField item decode metadata"
+                item_index = repeated_data.len(),
+                item_size,
+                next_start = start.saturating_add(item_size),
+                keys = ?item_data.keys().collect::<Vec<_>>(),
+                "DynamicLengthField item decoded"
             );
-            if let Some(s) = repeated_dop
-                .basic_structure()
-                .and_then(|d| d.specific_data_as_structure().map(datatypes::StructureDop))
-            {
-                let struct_data =
-                    self.map_struct_from_uds(&s, mapped_service, uds_payload, data)?;
-                repeated_data.push(struct_data);
-                let item_size = s.byte_size().map_or_else(
-                    || {
-                        let delta_bytes_to_skip = uds_payload
-                            .bytes_to_skip()
-                            .saturating_sub(bytes_to_skip_before);
-                        uds_payload
-                            .last_read_byte_pos()
-                            .saturating_add(delta_bytes_to_skip)
-                    },
-                    |s| s as usize,
-                );
-                uds_payload.pop_slice()?;
-                start = start.saturating_add(item_size);
-            } else if let Some(env_data_desc_dop) = repeated_dop.env_data_desc() {
-                if let Some(env_data_desc) = env_data_desc_dop.specific_data_as_env_data_desc() {
-                    let env_data_desc = datatypes::EnvDataDescDop(env_data_desc);
-                    let outer_data = data.clone();
-                    let item_data = self.map_env_data_desc_item_from_uds(
-                        mapped_service,
-                        uds_payload,
-                        &outer_data,
-                        &env_data_desc,
-                        0,
-                    )?;
-                    let delta_bytes_to_skip = uds_payload
-                        .bytes_to_skip()
-                        .saturating_sub(bytes_to_skip_before);
-                    let item_size = uds_payload
-                        .last_read_byte_pos()
-                        .saturating_add(delta_bytes_to_skip);
-                    uds_payload.pop_slice()?;
-                    repeated_data.push(item_data);
-                    start = start.saturating_add(item_size);
-                } else {
-                    uds_payload.pop_slice()?;
-                    return Err(DiagServiceError::InvalidDatabase(
-                        "DynamicLengthField env_data_desc DOP is not EnvDataDesc type".to_owned(),
-                    ));
-                }
-            } else {
-                uds_payload.pop_slice()?;
-                return Err(DiagServiceError::InvalidDatabase(
-                    "DynamicLengthField repeated_dop is neither Structure nor EnvDataDesc"
-                        .to_owned(),
-                ));
-            }
+            repeated_data.push(item_data);
+            start = start.saturating_add(item_size);
         }
+        tracing::debug!(
+            total_items = repeated_data.len(),
+            final_start = start,
+            last_read_byte_pos = items_abs_start.saturating_add(start),
+            "DynamicLengthField decode complete"
+        );
         uds_payload.pop_slice()?;
         uds_payload.set_last_read_byte_pos(items_abs_start.saturating_add(start));
         data.insert(
@@ -4319,6 +4261,77 @@ impl<S: SecurityPlugin> EcuManager<S> {
             DiagDataTypeContainer::RepeatingStruct(repeated_data),
         );
         Ok(())
+    }
+
+    fn decode_dynamic_length_field_item(
+        &self,
+        mapped_service: &datatypes::DiagService,
+        uds_payload: &mut Payload,
+        data: &mut MappedDiagServiceResponsePayload,
+        repeated_dop: &datatypes::DopField,
+        start: usize,
+    ) -> Result<(HashMap<String, DiagDataTypeContainer>, usize), DiagServiceError> {
+        let bytes_to_skip_before = uds_payload.bytes_to_skip();
+        uds_payload.push_slice(start, uds_payload.len())?;
+        // Inner item params may omit BYTE-POSITION, falling back to last_read_byte_pos.
+        // Reset it to 0 so stale state from count decode doesn't corrupt item decoding.
+        uds_payload.set_last_read_byte_pos(0);
+
+        tracing::debug!(
+            has_basic_structure = repeated_dop.basic_structure().is_some(),
+            has_env_data_desc = repeated_dop.env_data_desc().is_some(),
+            basic_struct_specific_data_type = ?repeated_dop
+                .basic_structure()
+                .map(|d| d.specific_data_type()),
+            "DynamicLengthField item decode metadata"
+        );
+
+        if let Some(s) = repeated_dop
+            .basic_structure()
+            .and_then(|d| d.specific_data_as_structure().map(datatypes::StructureDop))
+        {
+            let struct_data = self.map_struct_from_uds(&s, mapped_service, uds_payload, data)?;
+            let item_size = s.byte_size().map_or_else(
+                || {
+                    let delta_bytes_to_skip = uds_payload
+                        .bytes_to_skip()
+                        .saturating_sub(bytes_to_skip_before);
+                    uds_payload
+                        .last_read_byte_pos()
+                        .saturating_add(delta_bytes_to_skip)
+                },
+                |s| s as usize,
+            );
+            uds_payload.pop_slice()?;
+            Ok((struct_data, item_size))
+        } else if let Some(env_data_desc_dop) = repeated_dop.env_data_desc() {
+            let env_data_desc = env_data_desc_dop.specific_data_as_env_data_desc().ok_or(
+                DiagServiceError::InvalidDatabase(
+                    "DynamicLengthField env_data_desc DOP is not EnvDataDesc type".to_owned(),
+                ),
+            )?;
+            let env_data_desc = datatypes::EnvDataDescDop(env_data_desc);
+            let item_data = self.map_env_data_desc_item_from_uds(
+                mapped_service,
+                uds_payload,
+                data,
+                &env_data_desc,
+                0,
+            )?;
+            let delta_bytes_to_skip = uds_payload
+                .bytes_to_skip()
+                .saturating_sub(bytes_to_skip_before);
+            let item_size = uds_payload
+                .last_read_byte_pos()
+                .saturating_add(delta_bytes_to_skip);
+            uds_payload.pop_slice()?;
+            Ok((item_data, item_size))
+        } else {
+            uds_payload.pop_slice()?;
+            Err(DiagServiceError::InvalidDatabase(
+                "DynamicLengthField repeated_dop is neither Structure nor EnvDataDesc".to_owned(),
+            ))
+        }
     }
 
     fn map_mux_dop_from_uds(
@@ -4431,13 +4444,12 @@ impl<S: SecurityPlugin> EcuManager<S> {
 
     /// Extracts the discriminator value from already-decoded outer data by name.
     /// Handles both `DtcStruct` (returns `.code`) and `RawContainer` (converts bytes to u32).
-    /// Falls back to scanning for any `DtcStruct` if the named param is absent.
     fn discriminator_value_from_outer_data(
         outer_data: &MappedDiagServiceResponsePayload,
         param_short_name: &str,
     ) -> Result<u32, DiagServiceError> {
         match outer_data.get(param_short_name) {
-            Some(DiagDataTypeContainer::DtcStruct(dtc)) => return Ok(dtc.code),
+            Some(DiagDataTypeContainer::DtcStruct(dtc)) => Ok(dtc.code),
             Some(DiagDataTypeContainer::RawContainer(raw)) => {
                 let val = operations::uds_data_to_serializable(
                     raw.data_type,
@@ -4445,7 +4457,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     false,
                     &raw.data,
                 )?;
-                return match val {
+                match val {
                     DiagDataValue::UInt32(n) => Ok(n),
                     DiagDataValue::Int32(n) => u32::try_from(n).map_err(|_| {
                         DiagServiceError::ParameterConversionError(format!(
@@ -4456,18 +4468,12 @@ impl<S: SecurityPlugin> EcuManager<S> {
                         "EnvDataDesc discriminator '{param_short_name}' resolved to unexpected \
                          type: {val:?}"
                     ))),
-                };
+                }
             }
-            _ => {}
+            _ => Err(DiagServiceError::InvalidDatabase(format!(
+                "EnvDataDesc selector param '{param_short_name}' not found in decoded data"
+            ))),
         }
-        for container in outer_data.values() {
-            if let DiagDataTypeContainer::DtcStruct(dtc) = container {
-                return Ok(dtc.code);
-            }
-        }
-        Err(DiagServiceError::InvalidDatabase(format!(
-            "EnvDataDesc selector param '{param_short_name}' not found in decoded data"
-        )))
     }
 
     /// Looks up the discriminator value from `outer_data`, finds the matching `EnvData` in
@@ -5393,16 +5399,16 @@ fn extract_struct_dop_from_field(
 
 fn param_position_order(a: &datatypes::Parameter, b: &datatypes::Parameter) -> std::cmp::Ordering {
     match (a.has_byte_position(), b.has_byte_position()) {
-        // Both have a position → normal comparison
+        // Both have a position -> normal comparison
         (true, true) => a
             .byte_position()
             .cmp(&b.byte_position())
             .then(a.bit_position().cmp(&b.bit_position())),
-        // Only a has no position → a goes after b
+        // Only a has no position -> a goes after b
         (false, true) => std::cmp::Ordering::Greater,
-        // Only b has no position → b goes after a
+        // Only b has no position -> b goes after a
         (true, false) => std::cmp::Ordering::Less,
-        // Neither has a position → preserve order
+        // Neither has a position -> preserve order
         (false, false) => std::cmp::Ordering::Equal,
     }
 }

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -494,6 +494,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
         ),
         err
     )]
+    // allow keeping the function together as it makes sense structurally
     #[allow(clippy::too_many_lines)]
     async fn convert_from_uds(
         &self,
@@ -583,21 +584,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
             }
             let mut mapping_errors = Vec::new();
             let mut sorted_params = params;
-            sorted_params.sort_by(|a, b| {
-                match (a.has_byte_position(), b.has_byte_position()) {
-                    // Both have a position → normal comparison
-                    (true, true) => a
-                        .byte_position()
-                        .cmp(&b.byte_position())
-                        .then(a.bit_position().cmp(&b.bit_position())),
-                    // Only a has no position → a goes after b
-                    (false, true) => std::cmp::Ordering::Greater,
-                    // Only b has no position → b goes after a
-                    (true, false) => std::cmp::Ordering::Less,
-                    // Neither has a position → preserve order
-                    (false, false) => std::cmp::Ordering::Equal,
-                }
-            });
+            sorted_params.sort_by(param_position_order);
             for param in sorted_params {
                 let semantic = param.semantic();
                 if semantic.is_some_and(|semantic| {
@@ -2505,31 +2492,6 @@ impl<S: SecurityPlugin> EcuManager<S> {
 
         let lookup_id = STRINGS.get_or_insert(&lookup_name);
 
-        let prefixes = diag_comm.type_.service_prefixes();
-        let predicate = |service: &datatypes::DiagService<'_>| {
-            service.diag_comm().is_some_and(|dc| {
-                dc.short_name()
-                    .is_some_and(|name| name.eq_ignore_ascii_case(&lookup_name))
-            }) && service
-                .request_id()
-                .is_some_and(|sid| prefixes.contains(&sid))
-        };
-
-        if let Some(fg_name) = functional_group_name {
-            return self
-                .get_services_from_functional_group_and_parent_refs(fg_name, predicate)?
-                .into_iter()
-                .next()
-                .ok_or_else(|| {
-                    DiagServiceError::NotFound(format!(
-                        "Diagnostic service '{lookup_name}' not found in functional group \
-                         '{fg_name}'"
-                    ))
-                });
-        }
-
-        let lookup_id = STRINGS.get_or_insert(&lookup_name);
-
         if let Some(Some(location)) = self.db_cache.diag_services.read().await.get(&lookup_id) {
             return match self.get_service_by_location(location) {
                 Some(service) => Ok(service),
@@ -4197,6 +4159,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
             dlt_context = dlt_ctx!("CORE"),
         )
     )]
+    // allow keeping the function together as it makes sense structurally
     #[allow(clippy::too_many_lines)]
     fn map_dynamic_length_field_from_uds(
         &self,
@@ -4234,7 +4197,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         } else {
             param_ctx.base_offset
         };
-        let (num_items_data, count_field_bit_len) = num_items_diag_type.decode(
+        let (num_items_data, _count_field_bit_len) = num_items_diag_type.decode(
             uds_payload
                 .data()?
                 .get(param_abs_byte_pos..)
@@ -4244,18 +4207,6 @@ impl<S: SecurityPlugin> EcuManager<S> {
             determine_num_items.byte_position() as usize,
             determine_num_items.bit_position() as usize,
         )?;
-
-        tracing::debug!(
-            has_byte_position = param_ctx.parameter.has_byte_position(),
-            param_byte_position = param_ctx.parameter.byte_position(),
-            base_offset = param_ctx.base_offset,
-            param_abs_byte_pos,
-            last_read_byte_pos = uds_payload.last_read_byte_pos(),
-            determine_number_of_items_byte_position = determine_num_items.byte_position(),
-            dynamic_length_field_dop_offset = dynamic_length_field_dop.offset(),
-            count_diag_coded_type_bit_len = count_field_bit_len,
-            "DynamicLengthField count decode metadata"
-        );
 
         let num_items_diag_val = operations::uds_data_to_serializable(
             datatypes::DataType::UInt32, // Using hard coded UInt32 as per ISO 22901-1:2008
@@ -4295,6 +4246,9 @@ impl<S: SecurityPlugin> EcuManager<S> {
         for _ in 0..num_items {
             let bytes_to_skip_before = uds_payload.bytes_to_skip();
             uds_payload.push_slice(start, uds_payload.len())?;
+            // Inner item params may omit BYTE-POSITION, falling back to last_read_byte_pos.
+            // Reset it to 0 so stale state from count decode doesn't corrupt item decoding.
+            uds_payload.set_last_read_byte_pos(0);
             let basic_struct_type = repeated_dop
                 .basic_structure()
                 .map(|d| d.specific_data_type());
@@ -5435,6 +5389,22 @@ fn extract_struct_dop_from_field(
         .ok_or(DiagServiceError::InvalidDatabase(
             "Field none or does not contain a struct".to_owned(),
         ))
+}
+
+fn param_position_order(a: &datatypes::Parameter, b: &datatypes::Parameter) -> std::cmp::Ordering {
+    match (a.has_byte_position(), b.has_byte_position()) {
+        // Both have a position → normal comparison
+        (true, true) => a
+            .byte_position()
+            .cmp(&b.byte_position())
+            .then(a.bit_position().cmp(&b.bit_position())),
+        // Only a has no position → a goes after b
+        (false, true) => std::cmp::Ordering::Greater,
+        // Only b has no position → b goes after a
+        (true, false) => std::cmp::Ordering::Less,
+        // Neither has a position → preserve order
+        (false, false) => std::cmp::Ordering::Equal,
+    }
 }
 
 fn create_diag_service_response(

--- a/cda-core/src/diag_kernel/operations.rs
+++ b/cda-core/src/diag_kernel/operations.rs
@@ -17,7 +17,7 @@ use cda_database::datatypes::{
     PhysicalType,
 };
 use cda_interfaces::{
-    DataParseError, DiagServiceError,
+    DiagServiceError,
     util::{decode_hex, tracing::print_hex},
 };
 
@@ -135,6 +135,13 @@ fn compu_lookup(
     is_negative_response: bool,
     data: &[u8],
 ) -> Result<DiagDataValue, DiagServiceError> {
+    if matches!(category, datatypes::CompuCategory::Linear)
+        && compu_method.internal_to_phys.scales.is_empty()
+    {
+        return Err(DiagServiceError::InvalidDatabase(
+            "LINEAR COMPU-METHOD must have exactly one COMPU-SCALE".to_owned(),
+        ));
+    }
     let lookup = DiagDataValue::new(diag_type, data)?;
     match compu_method.internal_to_phys.scales.iter().find(|scale| {
         let lower = scale.lower_limit.as_ref();
@@ -165,7 +172,6 @@ fn compu_lookup(
             )),
         },
         None => {
-            // lookup NRCs from iso for negative responses
             if is_negative_response {
                 let lookup: u32 = lookup.try_into()?;
                 if lookup <= 0xFF {
@@ -180,10 +186,13 @@ fn compu_lookup(
                     ))
                 }
             } else {
-                Err(DiagServiceError::DataError(DataParseError {
-                    value: print_hex(data, 20),
-                    details: "Value outside of expected range".to_owned(),
-                }))
+                // Value has no matching compu-method scale; fall back to raw numeric representation
+                // so parsing can continue rather than aborting the whole response.
+                tracing::debug!(
+                    value = print_hex(data, 20),
+                    "compu_lookup: value outside defined scales, using raw value"
+                );
+                DiagDataValue::new(diag_type, data)
             }
         }
     }
@@ -2030,7 +2039,7 @@ mod tests {
 
     #[test]
     fn test_compu_lookup_scale_linear_value_outside_intervals() {
-        // Value outside all intervals should return error
+        // Value outside all intervals falls back to raw value so parsing can continue
         let compu_method = CompuMethod {
             category: CompuCategory::ScaleLinear,
             internal_to_phys: CompuFunction {
@@ -2053,17 +2062,19 @@ mod tests {
             },
         };
 
-        // x=5 is outside [10, 20] -> lower limit
+        // x=5 is outside [10, 20] -> falls back to raw value (parsing continues)
         let data = 5u32.to_be_bytes();
         let result =
             super::uds_data_to_serializable(DataType::UInt32, Some(&compu_method), false, &data);
-        assert!(result.is_err());
+        let raw: u32 = result.unwrap().try_into().unwrap();
+        assert_eq!(raw, 5);
 
-        // x=25 is outside [10, 20] -> upper limit
+        // x=25 is outside [10, 20] -> falls back to raw value (parsing continues)
         let data = 25u32.to_be_bytes();
         let result =
             super::uds_data_to_serializable(DataType::UInt32, Some(&compu_method), false, &data);
-        assert!(result.is_err());
+        let raw: u32 = result.unwrap().try_into().unwrap();
+        assert_eq!(raw, 25);
     }
 
     #[test]

--- a/cda-core/src/diag_kernel/payload.rs
+++ b/cda-core/src/diag_kernel/payload.rs
@@ -107,7 +107,7 @@ impl<'a> Payload<'a> {
         &mut self,
         start: usize,
     ) -> Result<(), DiagServiceError> {
-        self.push_slice(start, self.data.len())
+        self.push_slice(start, self.len())
     }
 
     pub(in crate::diag_kernel) fn push_slice(

--- a/cda-core/src/diag_kernel/schema.rs
+++ b/cda-core/src/diag_kernel/schema.rs
@@ -255,7 +255,6 @@ fn params_to_schema(
     })
 }
 
-#[allow(clippy::too_many_lines)]
 fn dop_variant_to_schema(
     ctx: &str,
     ecu_db: &DiagnosticDatabase,
@@ -340,21 +339,7 @@ fn dop_variant_to_schema(
             }
         }
         datatypes::DataOperationVariant::EnvDataDesc(env_data_desc_dop) => {
-            let variants: Vec<serde_json::Value> = env_data_desc_dop
-                .env_datas()
-                .into_iter()
-                .flat_map(|v| v.iter())
-                .filter_map(|dop| {
-                    let env_data = dop.specific_data_as_env_data()?;
-                    let params: Vec<datatypes::Parameter> = env_data
-                        .params()
-                        .into_iter()
-                        .flat_map(|p| p.iter())
-                        .map(datatypes::Parameter)
-                        .collect();
-                    params_to_schema(&params, ctx, ecu_db, request).map(Into::into)
-                })
-                .collect();
+            let variants = env_data_desc_to_variants(&env_data_desc_dop, ctx, ecu_db, request);
             if !variants.is_empty() {
                 schema.insert(name, schemars::json_schema!({ "any-of": variants }).into());
             }
@@ -377,48 +362,10 @@ fn dop_variant_to_schema(
             );
         }
         datatypes::DataOperationVariant::DynamicLengthField(dynamic_length_field) => {
-            if let Some(structure_dop) = dynamic_length_field
-                .field()
-                .and_then(|f| f.basic_structure())
-                .and_then(|s| s.specific_data_as_structure())
+            if let Some(v) =
+                map_dynamic_length_field_to_schema(&dynamic_length_field, ctx, ecu_db, request)?
             {
-                if let Some(struct_schema) =
-                    map_struct_to_schema(&(structure_dop.into()), ctx, ecu_db, request)
-                {
-                    schema.insert(name, serde_json::Value::Array(vec![struct_schema.into()]));
-                }
-            } else if let Some(env_data_desc) = dynamic_length_field
-                .field()
-                .and_then(|f| f.env_data_desc())
-                .and_then(|dop| dop.specific_data_as_env_data_desc())
-            {
-                let variants: Vec<serde_json::Value> = env_data_desc
-                    .env_datas()
-                    .into_iter()
-                    .flat_map(|v| v.iter())
-                    .filter_map(|dop| {
-                        let env_data = dop.specific_data_as_env_data()?;
-                        let params: Vec<datatypes::Parameter> = env_data
-                            .params()
-                            .into_iter()
-                            .flat_map(|p| p.iter())
-                            .map(datatypes::Parameter)
-                            .collect();
-                        params_to_schema(&params, ctx, ecu_db, request).map(Into::into)
-                    })
-                    .collect();
-                if !variants.is_empty() {
-                    schema.insert(
-                        name,
-                        schemars::json_schema!({ "type": "array", "items": { "any-of": variants } })
-                            .into(),
-                    );
-                }
-            } else {
-                return Err(DiagServiceError::ParameterConversionError(format!(
-                    "Mapping {ctx}: DynamicLengthField DopField value is neither BasicStruct nor \
-                     EnvDataDesc."
-                )));
+                schema.insert(name, v);
             }
         }
     }
@@ -436,6 +383,65 @@ fn map_struct_to_schema(
         .map(|params| params.iter().map(datatypes::Parameter).collect::<Vec<_>>())
         .unwrap_or_default();
     params_to_schema(&params, ctx, ecu_db, request)
+}
+
+fn env_data_desc_to_variants(
+    env_data_desc: &datatypes::EnvDataDescDop<'_>,
+    ctx: &str,
+    ecu_db: &DiagnosticDatabase,
+    request: Option<&datatypes::Request<'_>>,
+) -> Vec<serde_json::Value> {
+    env_data_desc
+        .env_datas()
+        .into_iter()
+        .flat_map(|v| v.iter())
+        .filter_map(|dop| {
+            let env_data = dop.specific_data_as_env_data()?;
+            let params: Vec<datatypes::Parameter> = env_data
+                .params()
+                .into_iter()
+                .flat_map(|p| p.iter())
+                .map(datatypes::Parameter)
+                .collect();
+            params_to_schema(&params, ctx, ecu_db, request).map(Into::into)
+        })
+        .collect()
+}
+
+fn map_dynamic_length_field_to_schema(
+    dynamic_length_field: &datatypes::DynamicLengthDop<'_>,
+    ctx: &str,
+    ecu_db: &DiagnosticDatabase,
+    request: Option<&datatypes::Request<'_>>,
+) -> Result<Option<serde_json::Value>, DiagServiceError> {
+    if let Some(structure_dop) = dynamic_length_field
+        .field()
+        .and_then(|f| f.basic_structure())
+        .and_then(|s| s.specific_data_as_structure())
+        .map(datatypes::StructureDop)
+    {
+        Ok(map_struct_to_schema(&structure_dop, ctx, ecu_db, request)
+            .map(|s| serde_json::Value::Array(vec![s.into()])))
+    } else if let Some(env_data_desc) = dynamic_length_field
+        .field()
+        .and_then(|f| f.env_data_desc())
+        .and_then(|dop| dop.specific_data_as_env_data_desc())
+        .map(datatypes::EnvDataDescDop)
+    {
+        let variants = env_data_desc_to_variants(&env_data_desc, ctx, ecu_db, request);
+        if variants.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(
+                schemars::json_schema!({ "type": "array", "items": { "any-of": variants } }).into(),
+            ))
+        }
+    } else {
+        Err(DiagServiceError::ParameterConversionError(format!(
+            "Mapping {ctx}: DynamicLengthField DopField value is neither BasicStruct nor \
+             EnvDataDesc."
+        )))
+    }
 }
 
 #[tracing::instrument(skip_all,
@@ -462,22 +468,9 @@ fn map_dop_field_to_schema(
     } else if let Some(env_data_desc) = dop_field
         .env_data_desc()
         .and_then(|dop| dop.specific_data_as_env_data_desc())
+        .map(datatypes::EnvDataDescDop)
     {
-        let variants: Vec<serde_json::Value> = env_data_desc
-            .env_datas()
-            .into_iter()
-            .flat_map(|v| v.iter())
-            .filter_map(|dop| {
-                let env_data = dop.specific_data_as_env_data()?;
-                let params: Vec<datatypes::Parameter> = env_data
-                    .params()
-                    .into_iter()
-                    .flat_map(|p| p.iter())
-                    .map(datatypes::Parameter)
-                    .collect();
-                params_to_schema(&params, ctx, ecu_db, request).map(Into::into)
-            })
-            .collect();
+        let variants = env_data_desc_to_variants(&env_data_desc, ctx, ecu_db, request);
         if variants.is_empty() {
             None
         } else {

--- a/cda-core/src/diag_kernel/schema.rs
+++ b/cda-core/src/diag_kernel/schema.rs
@@ -255,6 +255,7 @@ fn params_to_schema(
     })
 }
 
+#[allow(clippy::too_many_lines)]
 fn dop_variant_to_schema(
     ctx: &str,
     ecu_db: &DiagnosticDatabase,
@@ -338,11 +339,25 @@ fn dop_variant_to_schema(
                 schema.insert(name, static_field_schema.into());
             }
         }
-        datatypes::DataOperationVariant::EnvDataDesc(_env_data_desc_dop) => {
-            // todo: implement env data desc dop
-            return Err(DiagServiceError::ParameterConversionError(format!(
-                "Mapping {ctx}: EnvDataDesc DOPs are not yet supported in JSON Schema."
-            )));
+        datatypes::DataOperationVariant::EnvDataDesc(env_data_desc_dop) => {
+            let variants: Vec<serde_json::Value> = env_data_desc_dop
+                .env_datas()
+                .into_iter()
+                .flat_map(|v| v.iter())
+                .filter_map(|dop| {
+                    let env_data = dop.specific_data_as_env_data()?;
+                    let params: Vec<datatypes::Parameter> = env_data
+                        .params()
+                        .into_iter()
+                        .flat_map(|p| p.iter())
+                        .map(datatypes::Parameter)
+                        .collect();
+                    params_to_schema(&params, ctx, ecu_db, request).map(Into::into)
+                })
+                .collect();
+            if !variants.is_empty() {
+                schema.insert(name, schemars::json_schema!({ "any-of": variants }).into());
+            }
         }
         datatypes::DataOperationVariant::EnvData(_env_data_dop) => {
             return Err(DiagServiceError::ParameterConversionError(format!(
@@ -372,13 +387,33 @@ fn dop_variant_to_schema(
                 {
                     schema.insert(name, serde_json::Value::Array(vec![struct_schema.into()]));
                 }
-            } else if let Some(_env_data_desc) =
-                dynamic_length_field.field().and_then(|f| f.env_data_desc())
+            } else if let Some(env_data_desc) = dynamic_length_field
+                .field()
+                .and_then(|f| f.env_data_desc())
+                .and_then(|dop| dop.specific_data_as_env_data_desc())
             {
-                return Err(DiagServiceError::ParameterConversionError(format!(
-                    "Mapping {ctx}: DynamicLengthField DopField is an EnvDataDesc which is not \
-                     yet supported in JSON Schema."
-                )));
+                let variants: Vec<serde_json::Value> = env_data_desc
+                    .env_datas()
+                    .into_iter()
+                    .flat_map(|v| v.iter())
+                    .filter_map(|dop| {
+                        let env_data = dop.specific_data_as_env_data()?;
+                        let params: Vec<datatypes::Parameter> = env_data
+                            .params()
+                            .into_iter()
+                            .flat_map(|p| p.iter())
+                            .map(datatypes::Parameter)
+                            .collect();
+                        params_to_schema(&params, ctx, ecu_db, request).map(Into::into)
+                    })
+                    .collect();
+                if !variants.is_empty() {
+                    schema.insert(
+                        name,
+                        schemars::json_schema!({ "type": "array", "items": { "any-of": variants } })
+                            .into(),
+                    );
+                }
             } else {
                 return Err(DiagServiceError::ParameterConversionError(format!(
                     "Mapping {ctx}: DynamicLengthField DopField value is neither BasicStruct nor \
@@ -424,11 +459,30 @@ fn map_dop_field_to_schema(
         .and_then(|s| s.specific_data_as_structure().map(datatypes::StructureDop))
     {
         map_struct_to_schema(&basic_struct, ctx, ecu_db, request)
-    } else if let Some(_env_data_desc) = dop_field.env_data_desc() {
-        tracing::trace!(
-            "Mapping {ctx}: EnvDataDesc DopFields are not yet supported in JSON Schema. skipping"
-        );
-        None
+    } else if let Some(env_data_desc) = dop_field
+        .env_data_desc()
+        .and_then(|dop| dop.specific_data_as_env_data_desc())
+    {
+        let variants: Vec<serde_json::Value> = env_data_desc
+            .env_datas()
+            .into_iter()
+            .flat_map(|v| v.iter())
+            .filter_map(|dop| {
+                let env_data = dop.specific_data_as_env_data()?;
+                let params: Vec<datatypes::Parameter> = env_data
+                    .params()
+                    .into_iter()
+                    .flat_map(|p| p.iter())
+                    .map(datatypes::Parameter)
+                    .collect();
+                params_to_schema(&params, ctx, ecu_db, request).map(Into::into)
+            })
+            .collect();
+        if variants.is_empty() {
+            None
+        } else {
+            Some(schemars::json_schema!({ "any-of": variants }))
+        }
     } else {
         tracing::trace!(
             "Mapping {ctx}: DopField value is neither BasicStruct nor EnvDataDesc. skipping"

--- a/cda-database/src/datatypes/database_builder.rs
+++ b/cda-database/src/datatypes/database_builder.rs
@@ -1403,6 +1403,47 @@ impl<'a> EcuDataBuilder<'a> {
         )
     }
 
+    pub fn create_static_field_dop(
+        &mut self,
+        fixed_number_of_items: u32,
+        item_byte_size: u32,
+        structure: WIPOffset<dataformat::Structure<'a>>,
+    ) -> WIPOffset<dataformat::DOP<'a>> {
+        let structure_dop = self.create_dop(
+            *DopType::STRUCTURE,
+            None,
+            None,
+            *SpecificDOPData::Structure,
+            Some(dataformat::SpecificDOPData::tag_as_structure(structure).value_offset()),
+        );
+
+        let field = dataformat::Field::create(
+            &mut self.fbb,
+            &dataformat::FieldArgs {
+                basic_structure: Some(structure_dop),
+                env_data_desc: None,
+                is_visible: true,
+            },
+        );
+
+        let static_field = dataformat::StaticField::create(
+            &mut self.fbb,
+            &dataformat::StaticFieldArgs {
+                fixed_number_of_items,
+                item_byte_size,
+                field: Some(field),
+            },
+        );
+
+        self.create_dop(
+            *DopType::STATIC_FIELD,
+            None,
+            None,
+            *SpecificDOPData::StaticField,
+            Some(dataformat::SpecificDOPData::tag_as_static_field(static_field).value_offset()),
+        )
+    }
+
     pub fn create_dtc(
         &mut self,
         trouble_code: u32,
@@ -1460,6 +1501,63 @@ impl<'a> EcuDataBuilder<'a> {
             None,
             *SpecificDOPData::DTCDOP,
             Some(dataformat::SpecificDOPData::tag_as_dtcdop(dtc_dop_specific_data).value_offset()),
+        )
+    }
+
+    /// Creates an `ENV-DATA` DOP with the given DTC codes and parameters.
+    /// `dtc_values` specifies which DTC codes this env data applies to.
+    /// `params` are the parameters that carry the snapshot/environment data.
+    pub fn create_env_data_dop(
+        &mut self,
+        dtc_values: &[u32],
+        params: &[WIPOffset<dataformat::Param<'a>>],
+    ) -> WIPOffset<dataformat::DOP<'a>> {
+        let dtc_values_vec = self.fbb.create_vector(dtc_values);
+        let params_vec = self.fbb.create_vector(params);
+
+        let env_data = dataformat::EnvData::create(
+            &mut self.fbb,
+            &dataformat::EnvDataArgs {
+                dtc_values: Some(dtc_values_vec),
+                params: Some(params_vec),
+            },
+        );
+
+        self.create_dop(
+            *DopType::ENV_DATA,
+            None,
+            None,
+            *SpecificDOPData::EnvData,
+            Some(dataformat::SpecificDOPData::tag_as_env_data(env_data).value_offset()),
+        )
+    }
+
+    /// Creates an `ENV-DATA-DESC` DOP that selects one of `env_datas` based on the value
+    /// of the parameter named `selector_param_short_name` in the decoded response.
+    pub fn create_env_data_desc_dop(
+        &mut self,
+        name: &str,
+        selector_param_short_name: &str,
+        env_datas: &[WIPOffset<dataformat::DOP<'a>>],
+    ) -> WIPOffset<dataformat::DOP<'a>> {
+        let param_short_name = self.fbb.create_string(selector_param_short_name);
+        let env_datas_vec = self.fbb.create_vector(env_datas);
+
+        let env_data_desc = dataformat::EnvDataDesc::create(
+            &mut self.fbb,
+            &dataformat::EnvDataDescArgs {
+                param_short_name: Some(param_short_name),
+                param_path_short_name: None,
+                env_datas: Some(env_datas_vec),
+            },
+        );
+
+        self.create_dop(
+            *DopType::ENV_DATA_DESC,
+            Some(name),
+            None,
+            *SpecificDOPData::EnvDataDesc,
+            Some(dataformat::SpecificDOPData::tag_as_env_data_desc(env_data_desc).value_offset()),
         )
     }
 

--- a/cda-interfaces/src/datatypes/faults.rs
+++ b/cda-interfaces/src/datatypes/faults.rs
@@ -25,7 +25,10 @@ pub const CLEAR_FAULT_MEM_POS_RESPONSE_SID: u8 = 0x54;
 /// Essentially the byte values
 /// are sub functions for service 0x19 (Read DTC information)
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, strum_macros::EnumIter)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, strum_macros::EnumIter, strum_macros::EnumString,
+)]
+#[strum(ascii_case_insensitive)]
 pub enum DtcReadInformationFunction {
     FaultMemoryByStatusMask = 0x02,
     FaultMemorySnapshotRecordByDtcNumber = 0x04,
@@ -56,6 +59,16 @@ impl DtcReadInformationFunction {
         Self::iter().collect()
     }
 
+    /// Parses a DTC read information function from its string representation.
+    ///
+    /// # Errors
+    /// Returns `DiagServiceError::InvalidParameter` if `s` does not match any known
+    /// `DtcReadInformationFunction` variant.
+    pub fn try_from_str(s: &str) -> Result<Self, crate::DiagServiceError> {
+        std::str::FromStr::from_str(s).map_err(|_| crate::DiagServiceError::InvalidParameter {
+            possible_values: Self::iter().map(|v| format!("{v:?}")).collect(),
+        })
+    }
     #[must_use]
     pub fn is_user_scope(&self) -> bool {
         matches!(
@@ -90,7 +103,7 @@ impl DtcMask {
 }
 
 pub struct DtcLookup {
-    pub scope: String,
+    pub scope: DtcReadInformationFunction,
     pub service: DiagComm,
     pub dtcs: Vec<DtcRecord>,
 }
@@ -130,7 +143,7 @@ pub struct DtcStatus {
 #[derive(Debug, Clone)]
 pub struct DtcRecordAndStatus {
     pub record: DtcRecord,
-    pub scope: String,
+    pub scope: DtcReadInformationFunction,
     pub status: DtcStatus,
 }
 

--- a/cda-sovd/src/sovd/components/ecu/faults.rs
+++ b/cda-sovd/src/sovd/components/ecu/faults.rs
@@ -48,7 +48,7 @@ impl IntoSovd for DtcRecordAndStatus {
     fn into_sovd(self) -> Self::SovdType {
         Self::SovdType {
             code: format!("{:06X}", self.record.code),
-            scope: Some(self.scope),
+            scope: Some(self.scope.default_scope().to_string()),
             display_code: self.record.display_code,
             fault_name: self.record.fault_name,
             severity: Some(self.record.severity),
@@ -434,7 +434,7 @@ pub(crate) mod id {
 mod tests {
     use cda_interfaces::{
         HashMap,
-        datatypes::{DtcRecord, DtcStatus},
+        datatypes::{DtcReadInformationFunction, DtcRecord, DtcStatus},
         diagservices::mock::MockDiagServiceResponse,
         file_manager::mock::MockFileManager,
         mock::MockUdsEcu,
@@ -459,7 +459,7 @@ mod tests {
                 fault_name: "Test Fault".to_string(),
                 severity: 2,
             },
-            scope: "FaultMem".to_string(),
+            scope: DtcReadInformationFunction::FaultMemoryByStatusMask,
             status: DtcStatus {
                 test_failed: true,
                 test_failed_this_operation_cycle: false,
@@ -536,7 +536,10 @@ mod tests {
         assert_eq!(fault.display_code, test_dtc.record.display_code);
         assert_eq!(fault.fault_name, test_dtc.record.fault_name);
         assert_eq!(fault.severity, Some(test_dtc.record.severity));
-        assert_eq!(fault.scope, Some(test_dtc.scope.clone()));
+        assert_eq!(
+            fault.scope,
+            Some(test_dtc.scope.default_scope().to_string())
+        );
 
         // Verify fault status using values from test_dtc
         let status = fault.status.as_ref().expect("Status should be present");


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
Replaced push_slice/pop_slice coordinate shifting in map_structure_dop_from_uds with a base offset parameter propagated through all decode functions. 
This correctly handles both absolute and relative byte position conventions without corrupting the payload cursor for inner params
## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->
Fixes https://github.com/eclipse-opensovd/classic-diagnostic-adapter/issues/270
## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

