### PR TITLE
mbedtls: fix ed25519 OID

### DIFF
--- a/comm-mbedtls/mbedtls-sys/patches/ed25519-psa-driver.patch
+++ b/comm-mbedtls/mbedtls-sys/patches/ed25519-psa-driver.patch
@@ -207,7 +207,7 @@ diff --color -ruN a/mbedtls-4.0.0/include/mbedtls/oid.h b/mbedtls-4.0.0/include/
 +/* ed25519 OBJECT IDENTIFIER ::= {
 + *   iso(1) identified-organization(3) thawte(101) 112
 + * } */
-+#define MBEDTLS_OID_ED25519                 MBEDTLS_OID_THAWTE "\0x70"
++#define MBEDTLS_OID_ED25519                 MBEDTLS_OID_THAWTE "\x70"
 +
  #if defined(MBEDTLS_X509_USE_C)
  /**


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
remove 0 from hex string as this caused an error during handshake when compiled with latest clang. This is now in line with how the other OIDs are defined aswell (without 0 on the hex string)

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)