### PR TITLE
fix: correct leading length extraction slice bounds when byte_pos > 0

### DIFF
--- a/cda-database/src/datatypes/diag_coded_type.rs
+++ b/cda-database/src/datatypes/diag_coded_type.rs
@@ -449,7 +449,7 @@ impl DiagCodedType {
             bit_pos,
             None,
             uds_payload
-                .get(byte_pos..bits.div_ceil(8) as usize)
+                .get(byte_pos..byte_pos.saturating_add(bits.div_ceil(8) as usize))
                 .ok_or_else(|| {
                     DiagServiceError::BadPayload(
                         "Payload slice for leading length out of bounds".to_owned(),
@@ -2749,6 +2749,42 @@ mod tests {
         let (data, bit_len) = diag_type.decode(&payload, 0, 0).unwrap();
         assert_eq!(data, vec![0x01, 0x02, 0x03]);
         assert_eq!(bit_len, 24);
+    }
+
+    #[test]
+    fn test_decode_leading_length_with_non_zero_byte_pos() {
+        // Validates that leading length extraction correctly uses byte_pos
+        // Payload structure: [0xFF, 0xFF, 0x03, 0xAA, 0xBB, 0xCC]
+        //                     ^padding^    ^len^ ^---data---^
+        // The leading length (0x03 = 3 bytes) is at byte_pos=2
+        let payload = vec![0xFF, 0xFF, 0x03, 0xAA, 0xBB, 0xCC];
+        let diag_type = DiagCodedType::new_high_low_byte_order(
+            DataType::ByteField,
+            DiagCodedTypeVariant::LeadingLengthInfo(8),
+        )
+        .unwrap();
+
+        // Decode starting at byte position 2
+        let (data, bit_len) = diag_type.decode(&payload, 2, 0).unwrap();
+        assert_eq!(data, vec![0xAA, 0xBB, 0xCC]);
+        assert_eq!(bit_len, 24);
+    }
+
+    #[test]
+    fn test_decode_leading_length_16bit_with_non_zero_byte_pos() {
+        // Test with 16-bit leading length at non-zero byte position
+        // Payload: [0x99, 0x00, 0x02, 0xDE, 0xAD]
+        //           ^pad^ ^--len--^ ^-data-^
+        let payload = vec![0x99, 0x00, 0x02, 0xDE, 0xAD];
+        let diag_type = DiagCodedType::new_high_low_byte_order(
+            DataType::ByteField,
+            DiagCodedTypeVariant::LeadingLengthInfo(16),
+        )
+        .unwrap();
+
+        let (data, bit_len) = diag_type.decode(&payload, 1, 0).unwrap();
+        assert_eq!(data, vec![0xDE, 0xAD]);
+        assert_eq!(bit_len, 16);
     }
 
     #[test]


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

The leading length extraction was using an incorrect slice range that ignored byte_pos when calculating the end position. This caused the slice to start at byte_pos but end at an absolute position, leading to incorrect behavior when byte_pos > 0.

If byte_pos = 5 and bits = 16, it would try uds_payload.get(5..2)

Added regression tests to verify leading length decoding works correctly with non-zero byte positions for both 8-bit and 16-bit leading lengths.


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->


Signed-off-by: Alexander Mohr <alexander.m.mohr@mercedes-benz.com>