### PR TITLE
use Option::zip instead of manual implementation in ecumanager

### DIFF
--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -3501,14 +3501,11 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 let (case_name, struct_) = selected_case
                     .or_else(|| {
                         mux_dop.default_case().and_then(|default_case| {
-                            default_case.short_name().and_then(|name| {
-                                default_case
+                            default_case.short_name().zip(default_case
                                     .structure()
                                     .and_then(|s| {
                                         s.specific_data_as_structure().map(|s| Some(s.into()))
-                                    })
-                                    .map(|struct_| (name, struct_))
-                            })
+                                    }))
                         })
                     })
                     .ok_or_else(|| {

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -3501,11 +3501,11 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 let (case_name, struct_) = selected_case
                     .or_else(|| {
                         mux_dop.default_case().and_then(|default_case| {
-                            default_case.short_name().zip(default_case
-                                    .structure()
-                                    .and_then(|s| {
-                                        s.specific_data_as_structure().map(|s| Some(s.into()))
-                                    }))
+                            default_case
+                                .short_name()
+                                .zip(default_case.structure().and_then(|s| {
+                                    s.specific_data_as_structure().map(|s| Some(s.into()))
+                                }))
                         })
                     })
                     .ok_or_else(|| {


### PR DESCRIPTION
Summary
Replace manual Option::zip implementation with the built-in Option::zip method in ecumanager.rs to fix a Clippy warning (clippy::manual_option_zip).

Checklist
 I have tested my changes locally
Related
Fixes #283

Notes for Reviewers
Minimal, mechanical change suggested directly by Clippy. No behavior change.