### PR TITLE
feature: make protocol lookup optional and protocol names configurable [hackfest fix]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "bytes",
  "cargo_toml",
  "cda-build",
+ "cda-database",
  "cda-interfaces",
  "flatbuffers",
  "memmap2",

--- a/cda-comm-doip/src/config.rs
+++ b/cda-comm-doip/src/config.rs
@@ -10,6 +10,7 @@
  * https://www.apache.org/licenses/LICENSE-2.0
  */
 
+use cda_interfaces::Protocol;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -21,6 +22,7 @@ pub struct DoipConfig {
     pub tls_port: u16,
     pub send_timeout_ms: u64,
     pub send_diagnostic_message_ack: bool,
+    pub protocol_name: String,
 }
 
 impl Default for DoipConfig {
@@ -33,6 +35,7 @@ impl Default for DoipConfig {
             tls_port: 3496,
             send_timeout_ms: 1000,
             send_diagnostic_message_ack: true,
+            protocol_name: Protocol::default().to_string(),
         }
     }
 }

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -172,6 +172,7 @@ impl<T: EcuAddressProvider + DoipComParamProvider> DoipDiagGateway<T> {
             tls_port,
             send_timeout_ms,
             send_diagnostic_message_ack,
+            ..
         } = doip_config;
         let gateway_port = *gateway_port;
         let connection_config = ConnectionConfig {

--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -1278,7 +1278,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
                 qualifier: ecu_name.clone(),
                 variant: ecu.variant(),
                 logical_address: logical_address_string,
-                logical_link: format!("{}_on_{}", ecu_name, ecu.protocol().value()),
+                logical_link: format!("{}_on_{}", ecu_name, ecu.protocol()),
             }
         }
 

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -134,8 +134,6 @@ pub struct EcuManager<S: SecurityPlugin> {
     protocol: Protocol,
     // functional group: protocol prefixed or postfixed
     fg_protocol_position: DiagnosticServiceAffixPosition,
-    // functional group: is protocol case sensitive
-    fg_protocol_case_sensitive: bool,
     ecu_service_states: Arc<RwLock<HashMap<u8, String>>>,
 
     tester_present_retry_policy: bool,
@@ -219,8 +217,8 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
         self.variant.state
     }
 
-    fn protocol(&self) -> Protocol {
-        self.protocol
+    fn protocol(&self) -> &Protocol {
+        &self.protocol
     }
 
     fn is_loaded(&self) -> bool {
@@ -342,7 +340,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
                 cp_ref.protocol().is_some_and(|p| {
                     p.diag_layer().is_some_and(|dl| {
                         dl.short_name()
-                            .is_some_and(|name| name == self.protocol.value())
+                            .is_some_and(|name| name.eq_ignore_ascii_case(self.protocol.str()))
                     })
                 })
             })
@@ -1522,21 +1520,13 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
                     .diag_layer()
                     .and_then(|dl| dl.short_name())
                     .and_then(|name| {
-                        let protocol_value = self.protocol.value();
+                        let protocol_value = self.protocol.str();
                         let matches = match self.fg_protocol_position {
                             DiagnosticServiceAffixPosition::Prefix => {
-                                if self.fg_protocol_case_sensitive {
-                                    name.starts_with(protocol_value)
-                                } else {
-                                    util::starts_with_ignore_ascii_case(name, protocol_value)
-                                }
+                                util::starts_with_ignore_ascii_case(name, protocol_value)
                             }
                             DiagnosticServiceAffixPosition::Suffix => {
-                                if self.fg_protocol_case_sensitive {
-                                    name.ends_with(protocol_value)
-                                } else {
-                                    util::ends_with_ignore_ascii_case(name, protocol_value)
-                                }
+                                util::ends_with_ignore_ascii_case(name, protocol_value)
                             }
                         };
                         if matches {
@@ -2066,7 +2056,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         let variant_detection =
             variant_detection::prepare_variant_detection(&database, &database_naming_convention)?;
 
-        let data_protocol = into_db_protocol(&database, protocol)?;
+        let data_protocol = into_db_protocol(&database, &protocol)?;
 
         let logical_gateway_address = match database.find_logical_address(
             datatypes::LogicalAddressType::Gateway(
@@ -2162,7 +2152,6 @@ impl<S: SecurityPlugin> EcuManager<S> {
             duplicating_ecu_names: None,
             protocol,
             fg_protocol_position: func_description_config.protocol_position.clone(),
-            fg_protocol_case_sensitive: func_description_config.protocol_case_sensitive,
             ecu_service_states: Arc::new(RwLock::default()),
             tester_present_retry_policy: database
                 .find_com_param(&data_protocol, &com_params.uds.tester_present_retry_policy)
@@ -2272,7 +2261,6 @@ impl<S: SecurityPlugin> EcuManager<S> {
             duplicating_ecu_names: None,
             protocol,
             fg_protocol_position: func_description_config.protocol_position.clone(),
-            fg_protocol_case_sensitive: func_description_config.protocol_case_sensitive,
             ecu_service_states: Arc::new(RwLock::default()),
             tester_present_retry_policy: com_params
                 .uds
@@ -5706,7 +5694,7 @@ mod tests {
     ) -> super::EcuManager<DefaultSecurityPluginData> {
         let mut manager = super::EcuManager::new(
             db,
-            Protocol::DoIp,
+            Protocol::default(),
             &ComParams::default(),
             DatabaseNamingConvention::default(),
             EcuManagerType::Ecu,
@@ -5715,7 +5703,6 @@ mod tests {
                 enabled_functional_groups: None,
                 protocol_position:
                     cda_interfaces::datatypes::DiagnosticServiceAffixPosition::Suffix,
-                protocol_case_sensitive: false,
             },
             true,
         )
@@ -5739,7 +5726,7 @@ mod tests {
     ) -> super::EcuManager<DefaultSecurityPluginData> {
         super::EcuManager::new(
             db,
-            Protocol::DoIp,
+            Protocol::default(),
             &ComParams::default(),
             DatabaseNamingConvention::default(),
             EcuManagerType::Ecu,
@@ -5748,7 +5735,6 @@ mod tests {
                 enabled_functional_groups: None,
                 protocol_position:
                     cda_interfaces::datatypes::DiagnosticServiceAffixPosition::Suffix,
-                protocol_case_sensitive: false,
             },
             false,
         )
@@ -5761,7 +5747,8 @@ mod tests {
     fn create_ecu_manager_with_mixed_functional_group()
     -> super::EcuManager<DefaultSecurityPluginData> {
         let mut db_builder = EcuDataBuilder::new();
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
 
         // Create a READ_DATA_BY_IDENTIFIER service
         let read_diag_comm = db_builder.create_diag_comm(DiagCommParams {
@@ -5819,7 +5806,8 @@ mod tests {
         let mut db_builder = EcuDataBuilder::new();
         let u8_diag_type = db_builder.create_diag_coded_type_standard_length(8, DataType::UInt32);
         let u16_diag_type = db_builder.create_diag_coded_type_standard_length(16, DataType::UInt32);
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
         let compu_identical =
             db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
 
@@ -5937,7 +5925,8 @@ mod tests {
     fn create_ecu_manager_with_parameter_metadata() -> super::EcuManager<DefaultSecurityPluginData>
     {
         let mut db_builder = EcuDataBuilder::new();
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
         let compu_identical =
             db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
         let u16_diag_type = db_builder.create_diag_coded_type_standard_length(16, DataType::UInt32);
@@ -6003,7 +5992,8 @@ mod tests {
         u32,
     ) {
         let mut db_builder = EcuDataBuilder::new();
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
         let compu_identical =
             db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
 
@@ -6151,7 +6141,8 @@ mod tests {
             db_builder.create_diag_coded_type_standard_length(32, DataType::Float32);
         let ascii_diag_type =
             db_builder.create_diag_coded_type_standard_length(32, DataType::AsciiString);
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
         let compu_identical =
             db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
 
@@ -6323,7 +6314,8 @@ mod tests {
         let mut db_builder = EcuDataBuilder::new();
         let u8_diag_type = db_builder.create_diag_coded_type_standard_length(8, DataType::UInt32);
         let u16_diag_type = db_builder.create_diag_coded_type_standard_length(16, DataType::UInt32);
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
         let compu_identical =
             db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
 
@@ -6424,7 +6416,8 @@ mod tests {
     ) {
         let mut db_builder = EcuDataBuilder::new();
         let u32_diag_type = db_builder.create_diag_coded_type_standard_length(32, DataType::UInt32);
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
         let compu_identical =
             db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
 
@@ -6469,7 +6462,8 @@ mod tests {
         let mut db_builder = EcuDataBuilder::new();
         let u32_diag_type = db_builder.create_diag_coded_type_standard_length(32, DataType::UInt32);
         let u8_diag_type = db_builder.create_diag_coded_type_standard_length(8, DataType::UInt32);
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let default_protocol = Protocol::default();
+        let protocol = db_builder.create_protocol(default_protocol.str(), None, None, None);
         let compu_identical =
             db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
 
@@ -6529,7 +6523,8 @@ mod tests {
         let u16_diag_type = db_builder.create_diag_coded_type_standard_length(16, DataType::UInt32);
         let compu_identical =
             db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let default_protocol = Protocol::default();
+        let protocol = db_builder.create_protocol(default_protocol.str(), None, None, None);
 
         let item_dop =
             db_builder.create_regular_normal_dop("item_dop", u16_diag_type, compu_identical);
@@ -6573,7 +6568,8 @@ mod tests {
             db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
         let compu_identical3 =
             db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let default_protocol = Protocol::default();
+        let protocol = db_builder.create_protocol(default_protocol.str(), None, None, None);
 
         let specific_dtc: u32 = 0x0001_0002;
         let other_dtc: u32 = 0x0003_0004;
@@ -6642,7 +6638,8 @@ mod tests {
             db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
         let compu_id2 =
             db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let default_protocol = Protocol::default();
+        let protocol = db_builder.create_protocol(default_protocol.str(), None, None, None);
 
         let dtc_in_db: u32 = 0x0001_AAAA;
         let dtc = db_builder.create_dtc(dtc_in_db, Some("P9999"), Some("SomeFault"), 1);
@@ -6695,7 +6692,8 @@ mod tests {
             db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
         let compu_identical3 =
             db_builder.create_compu_method(datatypes::CompuCategory::Identical, None, None);
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let default_protocol = Protocol::default();
+        let protocol = db_builder.create_protocol(default_protocol.str(), None, None, None);
 
         let sibling_dop =
             db_builder.create_regular_normal_dop("sibling_dop", u8_diag_type, compu_identical);
@@ -6770,7 +6768,8 @@ mod tests {
         fallback_to_base: bool,
     ) -> super::EcuManager<DefaultSecurityPluginData> {
         let mut db_builder = EcuDataBuilder::new();
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
         let cp_ref = db_builder.create_com_param_ref(None, None, None, Some(protocol), None);
 
         let u8_diag_type = db_builder.create_diag_coded_type_standard_length(8, DataType::UInt32);
@@ -6988,7 +6987,8 @@ mod tests {
 
         let sid = service_ids::READ_DATA_BY_IDENTIFIER + cda_interfaces::UDS_ID_RESPONSE_BITMASK;
         let dc_name = "TestPhysConstNormalService";
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
         let diag_comm = new_diag_comm!(db_builder, dc_name, protocol);
 
         // Request: SID (coded const) + DID (phys const)
@@ -7126,7 +7126,8 @@ mod tests {
             db_builder.create_structure_dop("structure_dop", structure)
         };
 
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
         let sid_request = service_ids::WRITE_DATA_BY_IDENTIFIER;
         let sid_response =
             service_ids::WRITE_DATA_BY_IDENTIFIER + cda_interfaces::UDS_ID_RESPONSE_BITMASK;
@@ -7196,7 +7197,8 @@ mod tests {
         cda_interfaces::DiagComm,
     ) {
         let mut db_builder = EcuDataBuilder::new();
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
         let cp_ref = db_builder.create_com_param_ref(None, None, None, Some(protocol), None);
 
         // Create security states
@@ -7326,7 +7328,8 @@ mod tests {
         u8,
     ) {
         let mut db_builder = EcuDataBuilder::new();
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
         let cp_ref = db_builder.create_com_param_ref(None, None, None, Some(protocol), None);
 
         let locked_state = db_builder.create_state("LockedSecurity", None);
@@ -7445,7 +7448,8 @@ mod tests {
     fn create_ecu_manager_with_length_key_request_service()
     -> (super::EcuManager<DefaultSecurityPluginData>, DiagComm, u8) {
         let mut db_builder = EcuDataBuilder::new();
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
         let compu_identical = db_builder.create_compu_method(CompuCategory::Identical, None, None);
 
         let u8_diag_type = db_builder.create_diag_coded_type_standard_length(8, DataType::UInt32);
@@ -7493,7 +7497,8 @@ mod tests {
         const VAR_DATA: &str = "var_data";
 
         let mut db_builder = EcuDataBuilder::new();
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
         let compu_identical = db_builder.create_compu_method(CompuCategory::Identical, None, None);
 
         let len_key_diag_type =
@@ -7561,7 +7566,8 @@ mod tests {
         const VAR_DATA: &str = "var_data";
 
         let mut db_builder = EcuDataBuilder::new();
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
         let compu_identical = db_builder.create_compu_method(CompuCategory::Identical, None, None);
 
         // diag coded types
@@ -7631,7 +7637,8 @@ mod tests {
         const SERVICE_NAME: &str = "Test";
 
         let mut db_builder = EcuDataBuilder::new();
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
 
         // Create the SID parameter
         let sid_param = db_builder.create_coded_const_param(
@@ -9777,7 +9784,8 @@ mod tests {
     #[test]
     fn test_get_functional_group_data_info_no_functional_groups() {
         let mut db_builder = EcuDataBuilder::new();
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
 
         // Build a database with no functional groups
         let db = finish_db!(db_builder, protocol, vec![]);
@@ -9985,7 +9993,8 @@ mod tests {
         subfunctions: &[u8],
     ) -> super::EcuManager<DefaultSecurityPluginData> {
         let mut db_builder = EcuDataBuilder::new();
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
 
         let mut services = vec![];
         for &sf in subfunctions {
@@ -10033,7 +10042,8 @@ mod tests {
         subfunctions: &[u8],
     ) -> super::EcuManager<DefaultSecurityPluginData> {
         let mut db_builder = EcuDataBuilder::new();
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
 
         let mut services = vec![];
         for &sf in subfunctions {
@@ -10136,7 +10146,8 @@ mod tests {
     #[test]
     fn test_get_components_operations_info_multiple_routines() {
         let mut db_builder = EcuDataBuilder::new();
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
 
         // Build services for RoutineA (Start + Stop) and RoutineB (Start only).
         let mut services = vec![];
@@ -10207,7 +10218,8 @@ mod tests {
     #[test]
     fn test_get_components_operations_info_empty_when_no_routine_control() {
         let mut db_builder = EcuDataBuilder::new();
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
         let read_request =
             create_sid_only_request!(db_builder, service_ids::READ_DATA_BY_IDENTIFIER);
         let read_diag_comm = new_diag_comm!(db_builder, "SomeData", protocol);
@@ -10328,7 +10340,8 @@ mod tests {
     #[test]
     fn test_get_functional_group_operations_info_with_stop_and_request_results() {
         let mut db_builder = EcuDataBuilder::new();
-        let protocol = db_builder.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
 
         // Build Start, Stop, and RequestResults all in the FG.
         let mut fg_services = vec![];

--- a/cda-core/src/diag_kernel/mod.rs
+++ b/cda-core/src/diag_kernel/mod.rs
@@ -230,29 +230,38 @@ impl TryInto<u32> for DiagDataValue {
     }
 }
 
-pub fn into_db_protocol(
-    database: &datatypes::DiagnosticDatabase,
-    protocol: cda_interfaces::Protocol,
-) -> Result<datatypes::Protocol<'_>, DiagServiceError> {
-    let protocol = database
-        .diag_layers()?
-        .iter()
-        .flat_map(|dl| dl.com_param_refs().into_iter().flatten())
-        .filter_map(|cp_ref| cp_ref.protocol())
-        .find(|p| {
-            p.diag_layer()
-                .and_then(|dl| dl.short_name())
-                .is_some_and(|sn| sn == protocol.value())
-        })
-        .map(datatypes::Protocol)
-        .ok_or_else(|| {
-            DiagServiceError::InvalidDatabase(format!(
-                "Protocol {} not found in database",
-                protocol.value()
-            ))
-        })?;
+pub fn into_db_protocol<'db>(
+    database: &'db datatypes::DiagnosticDatabase,
+    protocol: &cda_interfaces::Protocol,
+) -> Result<datatypes::Protocol<'db>, DiagServiceError> {
+    let protocol_name = protocol.to_string();
+    let all_protocols = database.protocols()?;
 
-    Ok(protocol)
+    // Try exact match first.
+    if let Some(p) = all_protocols.iter().find(|p| {
+        p.diag_layer()
+            .and_then(|dl| dl.short_name())
+            .is_some_and(|sn| sn.eq_ignore_ascii_case(&protocol_name))
+    }) {
+        return Ok(datatypes::Protocol(*p));
+    }
+
+    // Fallback: when ignore_protocol is enabled and only one distinct protocol
+    // exists in the database, use it regardless of name.
+    if database.config().ignore_protocol {
+        // Safe: ignore_protocol validity is checked at database construction time,
+        // guaranteeing at most one distinct protocol in the database.
+        return all_protocols
+            .first()
+            .map(|p| datatypes::Protocol(*p))
+            .ok_or_else(|| {
+                DiagServiceError::InvalidDatabase("No protocols found in database".to_owned())
+            });
+    }
+
+    Err(DiagServiceError::InvalidDatabase(format!(
+        "Protocol {protocol_name} not found in database",
+    )))
 }
 
 impl Serialize for DiagDataValue {

--- a/cda-core/src/diag_kernel/param_metadata.rs
+++ b/cda-core/src/diag_kernel/param_metadata.rs
@@ -484,7 +484,8 @@ mod tests {
         identical: bool,
     ) -> TestDb {
         let mut db = EcuDataBuilder::new();
-        let protocol = db.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db.create_protocol(&protocol_name, None, None, None);
         let diag_type = db.create_diag_coded_type_standard_length(bit_len, DataType::UInt32);
         let compu_method = if identical {
             db.create_compu_method(CompuCategory::Identical, None, None)
@@ -505,7 +506,8 @@ mod tests {
         physical_default_value: Option<&str>,
     ) -> TestDb {
         let mut db = EcuDataBuilder::new();
-        let protocol = db.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db.create_protocol(&protocol_name, None, None, None);
         let diag_type = db.create_diag_coded_type_standard_length(bit_len, DataType::UInt32);
         let compu_method = if identical {
             db.create_compu_method(CompuCategory::Identical, None, None)
@@ -522,7 +524,8 @@ mod tests {
     /// Build a database with a CODED-CONST parameter.
     fn build_coded_const_db(coded_value: &str, bit_len: u32) -> TestDb {
         let mut db = EcuDataBuilder::new();
-        let protocol = db.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db.create_protocol(&protocol_name, None, None, None);
         let param =
             db.create_coded_const_param("test_param", coded_value, 0, 0, bit_len, DataType::UInt32);
         let request = db.create_request(Some(vec![param]), None);
@@ -532,7 +535,8 @@ mod tests {
     /// Build a database with a response containing multiple parameter types.
     fn build_response_db() -> TestDb {
         let mut db = EcuDataBuilder::new();
-        let protocol = db.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db.create_protocol(&protocol_name, None, None, None);
         let diag_type = db.create_diag_coded_type_standard_length(16, DataType::UInt32);
         let compu = db.create_compu_method(CompuCategory::Identical, None, None);
         let dop = db.create_regular_normal_dop("resp_dop", diag_type, compu);
@@ -553,7 +557,8 @@ mod tests {
     /// Build a database with a MUX parameter in the response.
     fn build_mux_response_db() -> TestDb {
         let mut db = EcuDataBuilder::new();
-        let protocol = db.create_protocol(Protocol::DoIp.value(), None, None, None);
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db.create_protocol(&protocol_name, None, None, None);
         let u8_diag = db.create_diag_coded_type_standard_length(8, DataType::UInt32);
         let u16_diag = db.create_diag_coded_type_standard_length(16, DataType::UInt32);
         let compu = db.create_compu_method(CompuCategory::Identical, None, None);

--- a/cda-database/Cargo.toml
+++ b/cda-database/Cargo.toml
@@ -52,6 +52,9 @@ prost-build = { workspace = true }
 cargo_toml = { workspace = true }
 toml = { workspace = true }
 
+[dev-dependencies]
+cda-database = { workspace = true, features = ["database-builder"] }
+
 [features]
 default = []
 gen-protos = []

--- a/cda-database/src/datatypes/comparam.rs
+++ b/cda-database/src/datatypes/comparam.rs
@@ -26,25 +26,36 @@ pub(super) fn lookup(
         DiagServiceError::InvalidDatabase("Protocol has no short name".to_owned()),
     )?;
 
-    let cp_ref = ecu_data
+    let ignore_protocol = ecu_data.config().ignore_protocol;
+
+    let com_param_refs = ecu_data
         .base_variant()?
         .diag_layer()
-        .and_then(|dl| dl.com_param_refs())
+        .and_then(|dl| dl.com_param_refs());
+
+    // When ignore_protocol is true, the protocol filter is bypassed and parameters
+    // are matched by name alone. This is safe because ignore_protocol validity
+    // (single protocol in DB) is enforced at database construction time.
+    let cp_ref = com_param_refs
+        .as_ref()
         .and_then(|refs| {
             refs.iter().find(|cp_ref| {
-                cp_ref
-                    .protocol()
-                    .and_then(|p| p.diag_layer().and_then(|dl| dl.short_name()))
-                    .is_some_and(|sn| sn == protocol_name)
-                    && cp_ref
-                        .com_param()
-                        .and_then(|cp| cp.short_name())
-                        .is_some_and(|n| n == param_name)
+                let name_matches = cp_ref
+                    .com_param()
+                    .and_then(|cp| cp.short_name())
+                    .is_some_and(|n| n == param_name);
+
+                name_matches
+                    && (ignore_protocol
+                        || cp_ref
+                            .protocol()
+                            .and_then(|p| p.diag_layer().and_then(|dl| dl.short_name()))
+                            .is_some_and(|sn| sn.eq_ignore_ascii_case(protocol_name)))
             })
         })
-        .ok_or(DiagServiceError::NotFound(format!(
-            "No ComParamRef found for {param_name} in protocol {protocol_name}"
-        )))?;
+        .ok_or_else(|| {
+            DiagServiceError::NotFound(format!("No ComParamRef found for {param_name}"))
+        })?;
 
     let cp = cp_ref.com_param().ok_or(DiagServiceError::InvalidDatabase(
         "ComParamRef has no ComParam".to_owned(),
@@ -245,4 +256,202 @@ pub fn map_nack_number_of_retries<K: AsRef<str>>(
     });
 
     key_result.map(|key| (key, *value))
+}
+
+#[cfg(test)]
+mod tests {
+    use cda_interfaces::{HashSet, HashSetExtensions};
+
+    use super::*;
+    use crate::datatypes::{
+        DatabaseConfig,
+        database_builder::{DiagLayerParams, EcuDataBuilder, EcuDataParams},
+    };
+
+    struct ComParamRefSpec<'a> {
+        protocol: &'a str,
+        name: &'a str,
+        value: &'a str,
+    }
+
+    fn do_lookup(
+        param_refs: &[ComParamRefSpec<'_>],
+        param_name: &str,
+        ignore_protocol: bool,
+    ) -> Result<ComParamValue, DiagServiceError> {
+        let db = build_db(param_refs, ignore_protocol)?;
+        let mut builder = EcuDataBuilder::new();
+        let protocol = builder.create_protocol("MY_PROTO", None, None, None);
+        let proto_bytes = builder.finish_protocol(protocol);
+        lookup(
+            &db,
+            &flatbuffers::root::<dataformat::Protocol<'_>>(&proto_bytes)
+                .expect("valid Protocol flatbuffer"),
+            param_name,
+        )
+    }
+
+    /// Build a `DiagnosticDatabase` that contains one base variant.
+    ///
+    /// Each element of `param_refs` describes one `ComParamRef` to attach:
+    ///   `(protocol_short_name, param_short_name, simple_value_str)`
+    ///
+    /// When `protocol` is `""` the ref is created without a protocol.
+    fn build_db(
+        param_refs: &[ComParamRefSpec<'_>],
+        ignore_protocol: bool,
+    ) -> Result<crate::datatypes::DiagnosticDatabase, DiagServiceError> {
+        let mut builder = EcuDataBuilder::new();
+
+        // Collect unique protocol names to create parent_refs for the variant.
+        let mut seen_protocols: HashSet<&str> = HashSet::new();
+        let cp_refs: Vec<_> = param_refs
+            .iter()
+            .map(|r| {
+                let com_param = builder.create_com_param(r.name);
+                let simple_value = builder.create_simple_value(r.value);
+
+                let protocol = if r.protocol.is_empty() {
+                    None
+                } else {
+                    seen_protocols.insert(r.protocol);
+                    Some(builder.create_protocol(r.protocol, None, None, None))
+                };
+
+                builder.create_com_param_ref(
+                    Some(simple_value),
+                    None,
+                    Some(com_param),
+                    protocol,
+                    None,
+                )
+            })
+            .collect();
+
+        // Create parent_refs pointing to the distinct protocols.
+        let parent_refs: Vec<_> = seen_protocols
+            .iter()
+            .map(|name| {
+                let proto = builder.create_protocol(name, None, None, None);
+                builder.create_parent_ref(
+                    dataformat::ParentRefType::Protocol,
+                    Some(dataformat::ParentRefType::tag_as_protocol(proto)),
+                )
+            })
+            .collect();
+
+        let diag_layer = builder.create_diag_layer(DiagLayerParams {
+            short_name: "TestLayer",
+            com_param_refs: Some(cp_refs),
+            ..Default::default()
+        });
+        let variant = builder.create_variant(
+            diag_layer,
+            true,
+            None,
+            if parent_refs.is_empty() {
+                None
+            } else {
+                Some(parent_refs)
+            },
+        );
+
+        builder.finish_with_config(
+            EcuDataParams {
+                ecu_name: "TestEcu",
+                revision: "1",
+                version: "1.0",
+                variants: Some(vec![variant]),
+                ..Default::default()
+            },
+            DatabaseConfig {
+                ignore_protocol,
+                ..Default::default()
+            },
+        )
+    }
+
+    #[test]
+    fn test_lookup_protocol_not_found_no_fallback() {
+        // DB has a ComParamRef for protocol "OTHER", but we look up "MY_PROTO".
+        let result = do_lookup(
+            &[ComParamRefSpec {
+                protocol: "OTHER",
+                name: "CP_MyParam",
+                value: "42",
+            }],
+            "CP_MyParam",
+            false,
+        );
+
+        assert!(
+            matches!(result, Err(DiagServiceError::NotFound(_))),
+            "expected NotFound, got an unexpected variant"
+        );
+    }
+
+    #[test]
+    fn test_lookup_fallback_single_protocol_match_found() {
+        // DB has one ComParamRef for protocol "DB_PROTO".
+        // We look up with a different protocol ("MY_PROTO"), but ignore_protocol=true.
+        let result = do_lookup(
+            &[ComParamRefSpec {
+                protocol: "DB_PROTO",
+                name: "CP_MyParam",
+                value: "99",
+            }],
+            "CP_MyParam",
+            true,
+        );
+
+        match result {
+            Ok(ComParamValue::Simple(s)) => assert_eq!(s.value, "99"),
+            Ok(ComParamValue::Complex(_)) => panic!("expected Simple, got Complex"),
+            Err(e) => panic!("expected Ok(Simple(\"99\")), got Err({e:?})"),
+        }
+    }
+
+    #[test]
+    fn test_lookup_fallback_single_protocol_no_match() {
+        let result = do_lookup(
+            &[ComParamRefSpec {
+                protocol: "DB_PROTO",
+                name: "CP_OtherParam",
+                value: "5",
+            }],
+            "CP_Missing",
+            true,
+        );
+
+        assert!(
+            matches!(result, Err(DiagServiceError::NotFound(_))),
+            "expected NotFound, got an unexpected variant"
+        );
+    }
+
+    #[test]
+    fn test_lookup_fallback_multiple_protocols_error() {
+        // DB has ComParamRefs for two distinct protocols.
+        let result = do_lookup(
+            &[
+                ComParamRefSpec {
+                    protocol: "PROTO_A",
+                    name: "CP_MyParam",
+                    value: "1",
+                },
+                ComParamRefSpec {
+                    protocol: "PROTO_B",
+                    name: "CP_MyParam",
+                    value: "2",
+                },
+            ],
+            "CP_MyParam",
+            true,
+        );
+
+        assert!(
+            matches!(result, Err(DiagServiceError::InvalidDatabase(_))),
+            "expected InvalidDatabase, got an unexpected variant"
+        );
+    }
 }

--- a/cda-database/src/datatypes/database_builder.rs
+++ b/cda-database/src/datatypes/database_builder.rs
@@ -26,7 +26,7 @@ use crate::{
     },
     flatbuf::diagnostic_description::{
         dataformat,
-        dataformat::{CompuInternalToPhys, CompuPhysToInternal},
+        dataformat::{CompuInternalToPhys, CompuPhysToInternal, EcuDataArgs},
     },
 };
 
@@ -206,6 +206,28 @@ impl<'a> EcuDataBuilder<'a> {
         })
     }
 
+    fn ecu_data_args(
+        &mut self,
+        params: EcuDataParams<'a>,
+        ecu_name_offset: WIPOffset<&'a str>,
+        revision_offset: WIPOffset<&'a str>,
+        version_offset: WIPOffset<&'a str>,
+    ) -> EcuDataArgs<'a> {
+        dataformat::EcuDataArgs {
+            ecu_name: Some(ecu_name_offset),
+            revision: Some(revision_offset),
+            version: Some(version_offset),
+            variants: params.variants.map(|v| self.fbb.create_vector(&v)),
+            metadata: params.metadata.map(|v| self.fbb.create_vector(&v)),
+            feature_flags: params
+                .feature_flags
+                .as_ref()
+                .map(|flags| self.fbb.create_vector(flags)),
+            functional_groups: params.functional_groups.map(|v| self.fbb.create_vector(&v)),
+            dtcs: params.dtcs.map(|v| self.fbb.create_vector(&v)),
+        }
+    }
+
     /// Serialize the given [`EcuDataParams`] into a flatbuffer, wrap the result
     /// in a [`DiagnosticDatabase`] and return it.  Consumes the builder.
     ///
@@ -222,19 +244,8 @@ impl<'a> EcuDataBuilder<'a> {
         let revision_offset = self.fbb.create_string(params.revision);
         let version_offset = self.fbb.create_string(params.version);
 
-        let ecu_data_args = dataformat::EcuDataArgs {
-            ecu_name: Some(ecu_name_offset),
-            revision: Some(revision_offset),
-            version: Some(version_offset),
-            variants: params.variants.map(|v| self.fbb.create_vector(&v)),
-            metadata: params.metadata.map(|v| self.fbb.create_vector(&v)),
-            feature_flags: params
-                .feature_flags
-                .as_ref()
-                .map(|flags| self.fbb.create_vector(flags)),
-            functional_groups: params.functional_groups.map(|v| self.fbb.create_vector(&v)),
-            dtcs: params.dtcs.map(|v| self.fbb.create_vector(&v)),
-        };
+        let ecu_data_args =
+            self.ecu_data_args(params, ecu_name_offset, revision_offset, version_offset);
 
         let ecu_data = dataformat::EcuData::create(&mut self.fbb, &ecu_data_args);
         self.fbb.finish(ecu_data, None);
@@ -244,8 +255,39 @@ impl<'a> EcuDataBuilder<'a> {
             String::default(),
             blob,
             cda_interfaces::datatypes::FlatbBufConfig::default(),
+            super::DatabaseConfig::default(),
         )
         .expect("Failed to create DiagnosticDatabase from built ECU data")
+    }
+
+    /// Finishes building and returns the
+    /// [`DiagnosticDatabase`](super::DiagnosticDatabase) with the given config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DiagServiceError`](cda_interfaces::DiagServiceError) if the
+    /// database cannot be constructed from the built ECU data.
+    pub fn finish_with_config(
+        mut self,
+        params: EcuDataParams<'a>,
+        config: super::DatabaseConfig,
+    ) -> Result<super::DiagnosticDatabase, cda_interfaces::DiagServiceError> {
+        let ecu_name_offset = self.fbb.create_string(params.ecu_name);
+        let revision_offset = self.fbb.create_string(params.revision);
+        let version_offset = self.fbb.create_string(params.version);
+        let ecu_data_args =
+            self.ecu_data_args(params, ecu_name_offset, revision_offset, version_offset);
+
+        let ecu_data = dataformat::EcuData::create(&mut self.fbb, &ecu_data_args);
+        self.fbb.finish(ecu_data, None);
+        let blob = self.fbb.finished_data().to_vec();
+
+        super::DiagnosticDatabase::new_from_vec(
+            String::default(),
+            blob,
+            cda_interfaces::datatypes::FlatbBufConfig::default(),
+            config,
+        )
     }
 
     /// Finishes the builder into a [`DiagnosticDatabase`]
@@ -337,14 +379,7 @@ impl<'a> EcuDataBuilder<'a> {
     ) -> WIPOffset<dataformat::Protocol<'a>> {
         let diag_layer = self.create_diag_layer(DiagLayerParams {
             short_name,
-            long_name: None,
-            funct_classes: None,
-            com_param_refs: None,
-            diag_services: None,
-            single_ecu_jobs: None,
-            state_charts: None,
-            additional_audiences: None,
-            sdgs: None,
+            ..Default::default()
         });
         let protocol_args = dataformat::ProtocolArgs {
             diag_layer: Some(diag_layer),
@@ -500,6 +535,73 @@ impl<'a> EcuDataBuilder<'a> {
             short_name: Some(short_name_offset),
         };
         dataformat::FunctClass::create(&mut self.fbb, &funct_class_args)
+    }
+
+    /// Create a [`dataformat::SimpleValue`] holding a string value.
+    #[must_use]
+    pub fn create_simple_value(&mut self, value: &str) -> WIPOffset<dataformat::SimpleValue<'a>> {
+        let value_offset = self.fbb.create_string(value);
+        dataformat::SimpleValue::create(
+            &mut self.fbb,
+            &dataformat::SimpleValueArgs {
+                value: Some(value_offset),
+            },
+        )
+    }
+
+    /// Create a `REGULAR`-typed [`dataformat::ComParam`] with a minimal
+    /// [`dataformat::NormalDOP`] as its DOP.
+    ///
+    /// The DOP contains no typed information; it is sufficient for callers (such
+    /// as tests) that only need the `short_name` and `simple_value` of the param
+    /// and do not inspect DOP details.
+    #[must_use]
+    pub fn create_com_param(&mut self, short_name: &str) -> WIPOffset<dataformat::ComParam<'a>> {
+        let normal_dop =
+            dataformat::NormalDOP::create(&mut self.fbb, &dataformat::NormalDOPArgs::default());
+        let specific_dop_data = dataformat::SpecificDOPData::tag_as_normal_dop(normal_dop);
+        let dop = dataformat::DOP::create(
+            &mut self.fbb,
+            &dataformat::DOPArgs {
+                specific_data_type: dataformat::SpecificDOPData::NormalDOP,
+                specific_data: Some(specific_dop_data.value_offset()),
+                ..Default::default()
+            },
+        );
+        let regular_cp = dataformat::RegularComParam::create(
+            &mut self.fbb,
+            &dataformat::RegularComParamArgs {
+                dop: Some(dop),
+                ..Default::default()
+            },
+        );
+        let specific_data = dataformat::ComParamSpecificData::tag_as_regular_com_param(regular_cp);
+        let short_name_offset = self.fbb.create_string(short_name);
+        dataformat::ComParam::create(
+            &mut self.fbb,
+            &dataformat::ComParamArgs {
+                com_param_type: dataformat::ComParamType::REGULAR,
+                short_name: Some(short_name_offset),
+                specific_data_type: dataformat::ComParamSpecificData::RegularComParam,
+                specific_data: Some(specific_data.value_offset()),
+                ..Default::default()
+            },
+        )
+    }
+
+    /// Finish the builder by serialising a standalone [`dataformat::Protocol`] root
+    /// (rather than the usual [`dataformat::EcuData`] root) and return the raw bytes.
+    ///
+    /// This is the counterpart of [`Self::create_protocol`] for cases where a
+    /// `Protocol` must be the flatbuffer root rather than embedded inside an
+    /// `EcuData` object — for example when only a `Protocol` reference is needed
+    /// during a lookup and no full database is required.
+    ///
+    /// Consumes the builder.
+    #[must_use]
+    pub fn finish_protocol(mut self, protocol: WIPOffset<dataformat::Protocol<'a>>) -> Vec<u8> {
+        self.fbb.finish(protocol, None);
+        self.fbb.finished_data().to_vec()
     }
 
     pub fn create_com_param_ref(

--- a/cda-database/src/datatypes/mod.rs
+++ b/cda-database/src/datatypes/mod.rs
@@ -13,7 +13,7 @@
 use std::fmt::Debug;
 
 use cda_interfaces::{
-    DiagServiceError,
+    DiagServiceError, HashSet,
     datatypes::{ComParamConfig, ComParamValue, DeserializableCompParam, FlatbBufConfig},
     dlt_ctx,
 };
@@ -25,7 +25,7 @@ use serde::Serialize;
 pub use service::*;
 
 use crate::{
-    datatypes,
+    DatabaseConfig, datatypes,
     flatbuf::diagnostic_description::dataformat,
     mdd_data::{self, read_ecudata},
 };
@@ -452,6 +452,7 @@ pub struct DiagnosticDatabase {
     ecu_database_path: String,
     ecu_data: Option<EcuData>,
     flatbuf_config: FlatbBufConfig,
+    config: DatabaseConfig,
 }
 
 #[derive(Clone)]
@@ -487,11 +488,13 @@ impl DiagnosticDatabase {
         ecu_database_path: String,
         ecu_data_blob: Vec<u8>,
         flatbuf_config: FlatbBufConfig,
+        settings: DatabaseConfig,
     ) -> Result<Self, DiagServiceError> {
         Self::new_from_bytes(
             ecu_database_path,
             bytes::Bytes::from(ecu_data_blob),
             flatbuf_config,
+            settings,
         )
     }
 
@@ -507,6 +510,7 @@ impl DiagnosticDatabase {
         ecu_database_path: String,
         ecu_data_blob: bytes::Bytes,
         flatbuf_config: FlatbBufConfig,
+        config: DatabaseConfig,
     ) -> Result<Self, DiagServiceError> {
         let ecu_data = EcuDataTryBuilder {
             blob: ecu_data_blob,
@@ -520,16 +524,28 @@ impl DiagnosticDatabase {
         }
         .try_build()?;
 
-        Ok(DiagnosticDatabase {
+        let db = DiagnosticDatabase {
             ecu_database_path,
             ecu_data: Some(ecu_data),
             flatbuf_config,
-        })
+            config,
+        };
+
+        if db.config.ignore_protocol {
+            db.ensure_ignore_protocol_allowed()?;
+        }
+
+        Ok(db)
     }
 
     #[must_use]
     pub fn is_loaded(&self) -> bool {
         self.ecu_data.is_some()
+    }
+
+    #[must_use]
+    pub fn config(&self) -> &DatabaseConfig {
+        &self.config
     }
 
     pub fn unload(&mut self) {
@@ -550,6 +566,7 @@ impl DiagnosticDatabase {
             self.ecu_database_path.clone(),
             blob,
             self.flatbuf_config.clone(),
+            self.config.clone(),
         )?;
         Ok(())
     }
@@ -650,6 +667,87 @@ impl DiagnosticDatabase {
                 "No variants or functional groups found in ECU data.".to_owned(),
             ))
         }
+    }
+
+    /// Collect all protocols referenced in this database.
+    ///
+    /// Sources (in order):
+    /// 1. `parent_refs` from variants and functional groups.
+    /// 2. `com_param_refs` from diag layers (variants and functional groups).
+    ///
+    /// # Errors
+    /// `DiagServiceError::InvalidDatabase` if ECU data is not loaded
+    pub fn protocols(&self) -> Result<Vec<dataformat::Protocol<'_>>, DiagServiceError> {
+        let ecu_data = self.ecu_data()?;
+
+        let from_variants = ecu_data
+            .variants()
+            .into_iter()
+            .flat_map(|v| v.iter())
+            .flat_map(|v| v.parent_refs().into_iter().flatten())
+            .filter_map(|pr| pr.ref__as_protocol());
+
+        let from_fgs = ecu_data
+            .functional_groups()
+            .into_iter()
+            .flat_map(|fgs| fgs.iter())
+            .flat_map(|fg| fg.parent_refs().into_iter().flatten())
+            .filter_map(|pr| pr.ref__as_protocol());
+
+        let variant_diag_layers = ecu_data
+            .variants()
+            .into_iter()
+            .flat_map(|v| v.iter())
+            .filter_map(|v| v.diag_layer());
+
+        let fg_diag_layers = ecu_data
+            .functional_groups()
+            .into_iter()
+            .flat_map(|fgs| fgs.iter())
+            .filter_map(|fg| fg.diag_layer());
+
+        let from_com_param_refs = variant_diag_layers
+            .chain(fg_diag_layers)
+            .flat_map(|dl| dl.com_param_refs().into_iter().flatten())
+            .filter_map(|cp_ref| cp_ref.protocol());
+
+        Ok(from_variants
+            .chain(from_fgs)
+            .chain(from_com_param_refs)
+            .collect())
+    }
+
+    /// Validates that `ignore_protocol` mode is safe to use with this database.
+    ///
+    /// When ignoring protocol lookup, only one distinct protocol
+    /// may exist in the database. This ensures unambiguous parameter resolution.
+    ///
+    /// # Errors
+    /// `DiagServiceError::InvalidDatabase` if more than one distinct protocol exists.
+    pub fn ensure_ignore_protocol_allowed(&self) -> Result<(), DiagServiceError> {
+        let count = self.unique_protocol_count()?;
+        if count > 1 {
+            return Err(DiagServiceError::InvalidDatabase(format!(
+                "ignore_protocol is not valid when multiple protocols exist in the database \
+                 ({count} distinct protocols found)"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Count the number of distinct protocol short names in this database.
+    ///
+    /// Uses a set-based approach to deduplicate by short name. Protocols without a
+    /// diag layer or short name are ignored.
+    /// # Errors
+    /// `DiagServiceError::InvalidDatabase` if ECU data is not loaded
+    pub fn unique_protocol_count(&self) -> Result<usize, DiagServiceError> {
+        let protocols = self.protocols()?;
+        let seen: HashSet<&str> = protocols
+            .iter()
+            .filter_map(|p| p.diag_layer().and_then(|dl| dl.short_name()))
+            .collect();
+        Ok(seen.len())
     }
 
     /// Get the base variant from the ECU data

--- a/cda-database/src/lib.rs
+++ b/cda-database/src/lib.rs
@@ -15,7 +15,32 @@ pub(crate) mod flatbuf;
 pub(crate) mod mdd_data;
 pub(crate) mod proto;
 
+use cda_interfaces::datatypes::DatabaseNamingConvention;
 pub use mdd_data::{
     ProtoLoadConfig, files::FileManager, load_chunk, load_ecudata, load_proto_data,
     update_mdd_uncompressed,
 };
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+pub struct DatabaseConfig {
+    pub path: String,
+    pub naming_convention: DatabaseNamingConvention,
+    /// If true, the application will exit if no database could be loaded.
+    pub exit_no_database_loaded: bool,
+    /// If true, when variant detection fails to find a matching variant,
+    /// the ECU will fall back to the base variant instead of reporting an error.
+    pub fallback_to_base_variant: bool,
+    /// When `true`, com-param and protocol lookups ignore the protocol filter
+    /// and match by parameter name alone.
+    ///
+    /// This is useful for databases that contain only a single protocol but
+    /// where the protocol short-name recorded in the database does not match
+    /// the one used at runtime. Enabling this flag allows the lookup to succeed
+    /// by falling back to a protocol-agnostic match.
+    ///
+    /// Only valid when the database contains exactly one distinct protocol;
+    /// attempting a lookup with this flag set against a multi-protocol database
+    /// returns `DiagServiceError::InvalidDatabase`.
+    pub ignore_protocol: bool,
+}

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -144,11 +144,31 @@ pub struct EcuVariant {
     pub logical_address: u16,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum Protocol {
-    DoIp,
-    DoIpDobt,
-    // todo: other protocols
+#[derive(Debug, Clone)]
+pub struct Protocol(String);
+
+impl Protocol {
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    #[must_use]
+    pub fn str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for Protocol {
+    fn default() -> Self {
+        Self("UDS_Ethernet_DoIP_DOBT".to_owned())
+    }
+}
+
+impl std::fmt::Display for Protocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -305,7 +325,7 @@ pub trait EcuManager:
     fn state(&self) -> EcuState;
 
     #[must_use]
-    fn protocol(&self) -> Protocol;
+    fn protocol(&self) -> &Protocol;
 
     #[must_use]
     fn is_loaded(&self) -> bool;
@@ -669,16 +689,6 @@ pub trait EcuManager:
 pub enum EcuManagerType {
     Ecu,
     FunctionalDescription,
-}
-
-impl Protocol {
-    #[must_use]
-    pub const fn value(&self) -> &'static str {
-        match self {
-            Protocol::DoIp => "UDS_Ethernet_DoIP",
-            Protocol::DoIpDobt => "UDS_Ethernet_DoIP_DOBT",
-        }
-    }
 }
 
 impl std::fmt::Display for EcuState {

--- a/cda-interfaces/src/lib.rs
+++ b/cda-interfaces/src/lib.rs
@@ -282,7 +282,6 @@ pub struct FunctionalDescriptionConfig {
     pub description_database: String,
     pub enabled_functional_groups: Option<HashSet<String>>,
     pub protocol_position: datatypes::DiagnosticServiceAffixPosition,
-    pub protocol_case_sensitive: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]

--- a/cda-main/src/config/configfile.rs
+++ b/cda-main/src/config/configfile.rs
@@ -11,6 +11,7 @@
  */
 
 pub use cda_comm_doip::config::DoipConfig;
+pub use cda_database::DatabaseConfig;
 use cda_interfaces::{
     FunctionalDescriptionConfig, HashMap,
     datatypes::{
@@ -28,7 +29,6 @@ pub struct Configuration {
     pub doip: DoipConfig,
     pub database: DatabaseConfig,
     pub logging: cda_tracing::LoggingConfig,
-    pub onboard_tester: bool,
     pub flash_files_path: String,
     pub com_params: ComParams,
     pub flat_buf: FlatbBufConfig,
@@ -45,17 +45,6 @@ pub struct ServerConfig {
     pub port: u16,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct DatabaseConfig {
-    pub path: String,
-    pub naming_convention: DatabaseNamingConvention,
-    /// If true, the application will exit if no database could be loaded.
-    pub exit_no_database_loaded: bool,
-    /// If true, when variant detection fails to find a matching variant,
-    /// the ECU will fall back to the base variant instead of reporting an error.
-    pub fallback_to_base_variant: bool,
-}
-
 pub trait ConfigSanity {
     /// Checks the configuration for common mistakes and returns an error message if found.
     /// # Errors
@@ -66,12 +55,12 @@ pub trait ConfigSanity {
 impl Default for Configuration {
     fn default() -> Self {
         Configuration {
-            onboard_tester: true,
             database: DatabaseConfig {
                 path: ".".to_owned(),
                 naming_convention: DatabaseNamingConvention::default(),
                 exit_no_database_loaded: false,
                 fallback_to_base_variant: true,
+                ignore_protocol: false,
             },
             flash_files_path: ".".to_owned(),
             server: ServerConfig {
@@ -92,7 +81,6 @@ impl Default for Configuration {
                 enabled_functional_groups: None,
                 protocol_position:
                     cda_interfaces::datatypes::DiagnosticServiceAffixPosition::Suffix,
-                protocol_case_sensitive: false,
             },
             components: ComponentsConfig {
                 additional_fields: HashMap::from_iter([
@@ -196,7 +184,6 @@ mod tests {
     async fn load_config_toml() -> Result<(), Box<dyn std::error::Error>> {
         let config_str = r#"
 flash_files_path = "/app/flash"
-onboard_tester = true
 
 [database]
 path = "/app/database"

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -252,11 +252,8 @@ pub async fn load_databases<S: SecurityPlugin>(
     let database_naming_convention = config.database.naming_convention.clone();
     let func_description_cfg = config.functional_description.clone();
     let fallback_to_base_variant = config.database.fallback_to_base_variant;
-    let protocol = if config.onboard_tester {
-        cda_interfaces::Protocol::DoIpDobt
-    } else {
-        cda_interfaces::Protocol::DoIp
-    };
+    let database_config = config.database.clone();
+    let protocol = cda_interfaces::Protocol::new(config.doip.protocol_name.clone());
     let com_params = config.com_params.clone();
 
     let db_health_provider = setup_db_health_provider(health).await;
@@ -313,6 +310,8 @@ pub async fn load_databases<S: SecurityPlugin>(
             let database_naming_convention = database_naming_convention.clone();
             let flat_buf_settings = flat_buf_settings.clone();
             let func_description_cfg = func_description_cfg.clone();
+            let protocol = protocol.clone();
+            let database_config = database_config.clone();
 
             database_load_futures.push(cda_interfaces::spawn_named!(
                 &format!("load-database-{i}"),
@@ -327,6 +326,7 @@ pub async fn load_databases<S: SecurityPlugin>(
                         flat_buf_settings,
                         func_description_cfg,
                         fallback_to_base_variant,
+                        database_config,
                     )
                     .await;
                 }
@@ -462,6 +462,7 @@ async fn load_database<S: SecurityPlugin>(
     flat_buf_settings: FlatbBufConfig,
     func_description_cfg: FunctionalDescriptionConfig,
     fallback_to_base_variant: bool,
+    database_config: cda_database::DatabaseConfig,
 ) {
     for (mddfile, _) in paths {
         let Some(mdd_path) = mddfile.to_str().map(ToOwned::to_owned) else {
@@ -503,6 +504,7 @@ async fn load_database<S: SecurityPlugin>(
                         mdd_path.clone(),
                         payload,
                         flat_buf_settings.clone(),
+                        database_config.clone(),
                     ) {
                         Ok(db) => db,
                         Err(e) => {
@@ -523,7 +525,7 @@ async fn load_database<S: SecurityPlugin>(
                 };
                 let diag_service_manager = match EcuManager::new(
                     diag_data_base,
-                    protocol,
+                    protocol.clone(),
                     &com_params,
                     database_naming_convention.clone(),
                     ecu_type,

--- a/cda-main/src/main.rs
+++ b/cda-main/src/main.rs
@@ -41,10 +41,11 @@ struct AppArgs {
     #[arg(long)]
     gateway_port: Option<u16>,
 
-    // cannot use Action::SetTrue as it will treat
-    // absent arg same as `= false`
-    #[arg(short, long)]
-    onboard_tester: Option<bool>,
+    /// Protocol name used for com-param lookups
+    /// in the diagnostic database (matched case-insensitively).
+    /// Examples: `UDS_Ethernet_DoIP`, `UDS_Ethernet_DoIP_DOBT`
+    #[arg(long)]
+    protocol_name: Option<String>,
 
     #[arg(long)]
     listen_address: Option<String>,
@@ -232,9 +233,6 @@ impl AppArgs {
         )
     )]
     fn update_config(self, config: &mut Configuration) {
-        if let Some(onboard_tester) = self.onboard_tester {
-            config.onboard_tester = onboard_tester;
-        }
         if let Some(databases_path) = self.databases_path {
             config.database.path = databases_path;
         }
@@ -255,6 +253,9 @@ impl AppArgs {
         }
         if let Some(gateway_port) = self.gateway_port {
             config.doip.gateway_port = gateway_port;
+        }
+        if let Some(protocol_name) = self.protocol_name {
+            config.doip.protocol_name = protocol_name;
         }
         if let Some(listen_address) = self.listen_address {
             config.server.address = listen_address;

--- a/cda-sovd/src/sovd/components/ecu/faults.rs
+++ b/cda-sovd/src/sovd/components/ecu/faults.rs
@@ -314,10 +314,7 @@ pub(crate) mod id {
                             .collect::<serde_json::Map<_, _>>(),
                     );
                     remove_descriptions_recursive(&mut schema);
-                    {
-                        let s = crate::sovd::value_to_schema(schema)?;
-                        Some(s)
-                    }
+                    Some(crate::sovd::value_to_schema(schema)?)
                 } else {
                     None
                 },

--- a/clippy.toml
+++ b/clippy.toml
@@ -16,5 +16,5 @@ allow-unwrap-in-tests = true
 
 disallowed-methods = [
   { path = "std::thread::sleep", reason = "Blocks the async runtime thread; use tokio_ext::sleep_for instead." },
-  { path = "tokio::time::sleep", reason = "Deadline drifts on each call; use tokio_ext::sleep_for with a fixed Instant instead." },
+  { path = "tokio::time::sleep", reason = "Deadline drifts on each call; use tokio_ext::sleep_for with a fixed Instant instead.", allow-invalid = true },
 ]

--- a/integration-tests/tests/sovd/custom_routes.rs
+++ b/integration-tests/tests/sovd/custom_routes.rs
@@ -155,7 +155,6 @@ async fn test_custom_demo_endpoint() {
             description_database: "functional_groups".to_owned(),
             enabled_functional_groups: None,
             protocol_position: cda_interfaces::datatypes::DiagnosticServiceAffixPosition::Suffix,
-            protocol_case_sensitive: false,
         },
         FaultConfig::default(),
     );
@@ -176,7 +175,6 @@ async fn test_custom_demo_endpoint() {
             description_database: "functional_groups".to_owned(),
             enabled_functional_groups: None,
             protocol_position: cda_interfaces::datatypes::DiagnosticServiceAffixPosition::Suffix,
-            protocol_case_sensitive: false,
         },
         ComponentsConfig {
             additional_fields: HashMap::new(),

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -135,9 +135,9 @@ async fn initialize_runtime() -> Result<TestRuntime, TestingError> {
             naming_convention: DatabaseNamingConvention::default(),
             exit_no_database_loaded: true,
             fallback_to_base_variant: true,
+            ignore_protocol: false,
         },
         logging: LoggingConfig::default(),
-        onboard_tester: true,
         flash_files_path: flash_files_path()?,
         com_params: ComParams::default(),
         flat_buf: FlatbBufConfig::default(),
@@ -145,7 +145,6 @@ async fn initialize_runtime() -> Result<TestRuntime, TestingError> {
             description_database: "functional_groups".to_owned(),
             enabled_functional_groups: None,
             protocol_position: cda_interfaces::datatypes::DiagnosticServiceAffixPosition::Suffix,
-            protocol_case_sensitive: false,
         },
         health: HealthConfig::default(),
         components: ComponentsConfig {

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -14,6 +14,9 @@ path = "."
 [doip]
 tester_address = "127.0.0.1"
 tester_subnet = "255.255.0.0"
+# Protocol name used for com-param lookups in the diagnostic database (matched case-insensitively).
+# Examples: "UDS_Ethernet_DoIP", "UDS_Ethernet_DoIP_DOBT"
+protocol_name = "UDS_Ethernet_DoIP_DOBT"
 
 [logging.otel]
 enabled = false


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
- Make protocol lookup optional for MDD files that do not link ComParams back to a protocol. When only one protocol exists in the database, CDA assumes it is the target protocol without requiring explicit ComParam linkage.
- Make protocol names configurable via `doip_protocol_name` and `doip_dobt_protocol_name` in the DoIP config section, replacing the previously hardcoded `Protocol` enum values.
- Remove `protocol_case_sensitive` option in favor of always matching case-insensitively.
- Move `DatabaseConfig` to `cda-database` crate and add `ignore_protocol` option.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->
#122

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
This issue was found during SDV Hackfest 2026.

The `Protocol` enum now carries the protocol name as a `String` instead of being a unit variant, making it configurable per deployment without code changes.


Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)