### PR TITLE
fix: update cicd-workflows ref to taplo schema catalog fix branch

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -33,4 +33,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run checks
-        uses: eclipse-opensovd/cicd-workflows/pre-commit-action@b90aee53ba1739e08f7991d24241b23903a8c11a
+        uses: eclipse-opensovd/cicd-workflows/pre-commit-action@59d86655e1e790d8c44f7e7dd5c295d7a968cc27


### PR DESCRIPTION
## Problem

The `ComPWA/taplo-pre-commit` hook in the shared `cicd-workflows` pre-commit config runs `taplo lint --default-schema-catalogs`, which causes a runtime failure when fetching the remote schema catalog:

```
WARN taplo: failed to fetch catalog error=error decoding response body: data did not match any variant of untagged enum SchemaCatalog

Caused by:
    data did not match any variant of untagged enum SchemaCatalog
ERROR operation failed error=failed to load schema catalog: error decoding response body: data did not match any variant of untagged enum SchemaCatalog: data did not match any variant of untagged enum SchemaCatalog
```

The hook provides no way to disable schema catalog fetching through configuration.

## Solution

Pins to the merged fix commit [`59d8665`](https://github.com/eclipse-opensovd/cicd-workflows/commit/59d86655e1e790d8c44f7e7dd5c295d7a968cc27) from [eclipse-opensovd/cicd-workflows#28](https://github.com/eclipse-opensovd/cicd-workflows/pull/28), which replaces the `ComPWA/taplo-pre-commit` hook with direct `language: system` taplo invocations that omit `--default-schema-catalogs`.



Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)