### PR TITLE
feat(config): add --config CLI flag for config file path [HACKFEST FIX]

### DIFF
--- a/cda-main/Cargo.toml
+++ b/cda-main/Cargo.toml
@@ -39,7 +39,7 @@ cda-tracing = { workspace = true }
 cda-plugin-security = { workspace = true }
 cda-health = { workspace = true }
 # args
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive", "env"] }
 # config
 figment = { workspace = true, features = ["env", "toml"] }
 futures = { workspace = true }

--- a/cda-main/src/config/mod.rs
+++ b/cda-main/src/config/mod.rs
@@ -17,21 +17,21 @@ use figment::{
 
 pub mod configfile;
 
-/// Loads the configuration from a file specified by the `CDA_CONFIG_FILE` environment variable.
-/// If the variable is not set, it defaults to `opensovd-cda.toml`.
-/// The configuration is merged with default values and environment variables prefixed with `CDA`.
-/// # Returns
-/// A `Result` containing the loaded configuration or an error message if the loading fails
+/// Loads the configuration, merged with defaults and `CDA`-prefixed env vars.
+///
+/// Config file resolved in priority order:
+/// * `config_file` arg (includes `CDA_CONFIG_FILE` env via clap)
+/// * `<CDA_NAME>.toml`
 /// # Errors
 /// Returns an error message if the configuration file cannot be read or parsed.
-pub fn load_config() -> Result<configfile::Configuration, String> {
+pub fn load_config(config_file_path: Option<&str>) -> Result<configfile::Configuration, String> {
     let cda_name = std::option_env!("CDA_NAME").unwrap_or("opensovd-cda");
-    let config_file =
-        std::env::var("CDA_CONFIG_FILE").unwrap_or_else(|_| format!("{cda_name}.toml"));
+    let default_path = format!("{cda_name}.toml");
+    let config_file = config_file_path.unwrap_or(&default_path);
     println!("Loading configuration from {config_file}");
 
     Figment::from(Serialized::defaults(default_config()))
-        .merge(Toml::file(&config_file))
+        .merge(Toml::file(config_file))
         .merge(Env::prefixed("CDA").ignore(&["CDA_CONFIG_FILE"]))
         .extract()
         .map_err(|e| format!("Failed to build configuration: {e}"))

--- a/cda-main/src/main.rs
+++ b/cda-main/src/main.rs
@@ -29,6 +29,9 @@ const MAIN_HEALTH_COMPONENT_KEY: &str = "main";
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct AppArgs {
+    #[arg(short, long, env = "CDA_CONFIG_FILE")]
+    config: Option<String>,
+
     #[arg(short, long)]
     databases_path: Option<String>,
 
@@ -86,11 +89,12 @@ struct AppArgs {
 )]
 async fn main() -> Result<(), AppError> {
     let args = AppArgs::parse();
-    let mut config = opensovd_cda_lib::config::load_config().unwrap_or_else(|e| {
-        println!("Failed to load configuration: {e}");
-        println!("Using default values");
-        opensovd_cda_lib::config::default_config()
-    });
+    let mut config =
+        opensovd_cda_lib::config::load_config(args.config.as_deref()).unwrap_or_else(|e| {
+            println!("Failed to load configuration: {e}");
+            println!("Using default values");
+            opensovd_cda_lib::config::default_config()
+        });
     config.validate_sanity()?;
 
     args.update_config(&mut config);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Add a `--config` / `-c` CLI flag to specify the configuration file path at runtime, giving operators a direct way to point CDA at a specific config without relying solely on environment variables.

Config file resolution priority: CLI `--config` arg → `CDA_CONFIG_FILE` env var → `<CDA_NAME>.toml` default.

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

## Notes for Reviewers

- The `clap` dependency gains the `env` feature to support `env = "CDA_CONFIG_FILE"` on the arg definition, keeping env-var fallback behavior co-located with the CLI definition.
- `load_config` now accepts `Option<&str>` — fully backwards-compatible since `None` preserves the previous behavior.

---
Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)