### PR TITLE
Add architecture documentation and integration test for version endpoint

### DIFF
--- a/cda-main/src/main.rs
+++ b/cda-main/src/main.rs
@@ -163,6 +163,7 @@ async fn main() -> Result<(), AppError> {
     )
     .await?;
 
+    // [[ dimpl~sovd-api-version-endpoint, Register Version Endpoint ]]
     if let serde_json::Value::Object(version_info) = serde_json::json!({
         "id": "version",
         "data": {

--- a/docs/02_requirements/02_sovd.rst
+++ b/docs/02_requirements/02_sovd.rst
@@ -319,7 +319,8 @@ Version endpoint
     :status: draft
 
     The CDA must provide a standardized version endpoint ``/apps/sovd2uds/data/version`` which returns the current
-    version of the CDA in use, its SOVD api version, and implementation name.
+    version of the CDA in use, its SOVD api version, and implementation name. The same data shall also be available
+    under ``/data/version``.
 
 
 Health Endpoint

--- a/docs/03_architecture/02_sovd-api/03_extensions/06_other.rst
+++ b/docs/03_architecture/02_sovd-api/03_extensions/06_other.rst
@@ -8,6 +8,51 @@
 .. terms of the Apache License Version 2.0 which is available at
 .. https://www.apache.org/licenses/LICENSE-2.0
 
+Version Endpoint
+----------------
+
+.. arch:: API Version Endpoint
+    :id: arch~sovd-api-version-endpoint
+    :links: req~sovd-api-version-endpoint; dimpl~sovd-api-version-endpoint; itest~sovd-api-version-endpoint
+    :status: draft
+
+    The CDA provides a static data endpoint that returns version information about the running instance.
+
+    **Paths**
+
+    The version data is served on two paths:
+
+    - ``/apps/sovd2uds/data/version`` -- application-scoped version endpoint
+    - ``/data/version`` -- global version endpoint
+
+    Both endpoints return the same data and behave identically.
+
+    **Response Structure**
+
+    The response contains the following fields:
+
+    .. list-table:: Version response fields
+       :header-rows: 1
+
+       * - Field
+         - Description
+       * - id
+         - Always ``version``
+       * - data.name
+         - The implementation name of the CDA
+       * - data.api.version
+         - The SOVD API version supported by this instance
+       * - data.implementation.version
+         - The software version of the CDA
+       * - data.implementation.commit
+         - The Git commit hash of the build
+       * - data.implementation.build_date
+         - The date the binary was built
+
+    The endpoint is registered as a static data endpoint during initialization and does not require
+    any ECU communication. It is available immediately after the HTTP server starts.
+
+
 ECU Variant Detection
 ---------------------
 

--- a/integration-tests/tests/sovd/mod.rs
+++ b/integration-tests/tests/sovd/mod.rs
@@ -33,6 +33,7 @@ mod faults;
 mod flash_download;
 mod locks;
 mod operations;
+mod version_endpoint;
 
 pub(crate) const ECU_FLXC1000_ENDPOINT: &str = "components/flxc1000";
 pub(crate) const ECU_FLXCNG1000_ENDPOINT: &str = "components/flxcng1000";

--- a/integration-tests/tests/sovd/version_endpoint.rs
+++ b/integration-tests/tests/sovd/version_endpoint.rs
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+use axum::http::StatusCode;
+use opensovd_cda_lib::cda_version;
+use reqwest::Method;
+
+use crate::util::{
+    http::{extract_field_from_json, response_to_json},
+    runtime::setup_integration_test,
+};
+
+fn assert_version_response(json: &serde_json::Value) {
+    let id = extract_field_from_json::<String>(json, "id").expect("Missing 'id' field");
+    assert_eq!(id, "version");
+
+    let data =
+        extract_field_from_json::<serde_json::Value>(json, "data").expect("Missing 'data' field");
+    let name = extract_field_from_json::<String>(&data, "name").expect("Missing 'data.name' field");
+    assert_eq!(name, "Eclipse OpenSOVD Classic Diagnostic Adapter");
+
+    let api =
+        extract_field_from_json::<serde_json::Value>(&data, "api").expect("Missing 'data.api'");
+    let api_version =
+        extract_field_from_json::<String>(&api, "version").expect("Missing 'data.api.version'");
+    assert_eq!(api_version, "1.1");
+
+    let implementation = extract_field_from_json::<serde_json::Value>(&data, "implementation")
+        .expect("Missing 'data.implementation'");
+    let impl_version = extract_field_from_json::<String>(&implementation, "version")
+        .expect("Missing 'data.implementation.version'");
+    assert_eq!(impl_version, cda_version());
+}
+
+/// [[ itest~sovd-api-version-endpoint, Version Endpoint Integration Test ]]
+#[tokio::test]
+async fn test_version_endpoint() {
+    let (runtime, _lock) = setup_integration_test(true).await.unwrap();
+    let host = &runtime.config.server.address;
+    let port = runtime.config.server.port;
+
+    // Test app-scoped version endpoint
+    let app_url = reqwest::Url::parse(&format!(
+        "http://{host}:{port}/vehicle/v15/apps/sovd2uds/data/version"
+    ))
+    .expect("Invalid URL");
+
+    let response =
+        crate::util::http::send_request(StatusCode::OK, Method::GET, None, None, app_url)
+            .await
+            .expect("GET app version endpoint failed");
+
+    let json = response_to_json(&response).expect("Failed to parse version response");
+    assert_version_response(&json);
+
+    // Test global version endpoint
+    let global_url = reqwest::Url::parse(&format!("http://{host}:{port}/vehicle/v15/data/version"))
+        .expect("Invalid URL");
+
+    let response =
+        crate::util::http::send_request(StatusCode::OK, Method::GET, None, None, global_url)
+            .await
+            .expect("GET global version endpoint failed");
+
+    let json = response_to_json(&response).expect("Failed to parse version response");
+    assert_version_response(&json);
+}

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -254,6 +254,33 @@ fn start_cda(config: Configuration) {
         })
         .unwrap();
 
+        // Register version endpoints
+        if let serde_json::Value::Object(version_info) = serde_json::json!({
+            "id": "version",
+            "data": {
+                "name": "Eclipse OpenSOVD Classic Diagnostic Adapter",
+                "api": {
+                    "version": "1.1"
+                },
+                "implementation": {
+                    "version": cda_version(),
+                }
+            }
+        }) {
+            cda_sovd::add_static_data_endpoint(
+                &dynamic_router,
+                version_info.clone(),
+                "/vehicle/v15/apps/sovd2uds/data/version",
+            )
+            .await;
+            cda_sovd::add_static_data_endpoint(
+                &dynamic_router,
+                version_info,
+                "/vehicle/v15/data/version",
+            )
+            .await;
+        }
+
         cda_sovd::add_vehicle_routes::<DiagServiceResponseStruct, _, _, DefaultSecurityPlugin>(
             &dynamic_router,
             vehicle_data.uds_manager,


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
Add arch~sovd-api-version-endpoint describing the static version data endpoint served on both /apps/sovd2uds/data/version and /data/version. Link implementation via dimpl codelink and add a dedicated integration test validating both paths return the expected version structure.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)

