### PR TITLE
chore: replace unicode characters with ASCII equivalents

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,7 +57,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Format and Clippy - Nightly toolchain pinned
         continue-on-error: true
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@827ea66a026b34057468a3cc9486c165ce5e7dcb
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4700b71884074d194723fdb04a6c1a827b6f652b
         with:
           toolchain: nightly-2025-07-14
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -68,7 +68,7 @@ jobs:
           reporter: github-check
       - name: Format and Clippy - Nightly toolchain latest
         continue-on-error: true
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@827ea66a026b34057468a3cc9486c165ce5e7dcb
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4700b71884074d194723fdb04a6c1a827b6f652b
         with:
           toolchain: nightly
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -46,7 +46,7 @@ jobs:
           # to avoid rate limiting, passing the default token.
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Format and Clippy - Stable toolchain
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@b90aee53ba1739e08f7991d24241b23903a8c11a
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4700b71884074d194723fdb04a6c1a827b6f652b
         with:
           toolchain: 1.88.0
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
           rustfmt-enable-reviewdog: "false"
           error-on-unformatted: "false"
       - name: Format and Clippy - Nightly toolchain pinned
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@b90aee53ba1739e08f7991d24241b23903a8c11a
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4700b71884074d194723fdb04a6c1a827b6f652b
         with:
           toolchain: nightly-2025-07-14
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
       - name: Format and Clippy - Nightly toolchain latest
         id: nightly-clippy
         continue-on-error: true
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@b90aee53ba1739e08f7991d24241b23903a8c11a
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4700b71884074d194723fdb04a6c1a827b6f652b
         with:
           toolchain: nightly
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -33,4 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run checks
-        uses: eclipse-opensovd/cicd-workflows/pre-commit-action@59d86655e1e790d8c44f7e7dd5c295d7a968cc27
+        uses: eclipse-opensovd/cicd-workflows/pre-commit-action@1cae75238b0a8b2554784a564d3b03b23c887b3b
+        with:
+          no-unicode-extensions: ".rs,.py,.toml,.yml,.yaml,.rst,.c,.h,.kt,.kts,.sh,.proto,.fbs,.puml,.json,.xml,Dockerfile"
+          allowed-unicode-chars: "µ,§"

--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -2104,7 +2104,7 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
                 }
             }
             VariantDetectionResult::AllFallbacks => {
-                // No specific variant found despite online ECUs — mark all as undetected.
+                // No specific variant found despite online ECUs - mark all as undetected.
                 // Falling back to base variant is only allowed when there are no duplicates.
                 for ecu_name in &duplicated_ecus {
                     if let Some(ecu) = self.ecus.get(ecu_name) {

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -228,7 +228,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
     }
 
     /// This allows to (re)load a database after unloading it during runtime, which could happen
-    /// if initially the ECU wasn´t responding but later another request
+    /// if initially the ECU wasn't responding but later another request
     /// for reprobing the ECU happens.
     ///
     /// # Errors
@@ -480,7 +480,7 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
     /// Convert a UDS payload given as `u8` slice into a `DiagServiceResponse`.
     ///
     /// # Errors
-    /// Will return `Err` in cases where the payload doesn´t match the expected UDS response, or if
+    /// Will return `Err` in cases where the payload doesn't match the expected UDS response, or if
     /// elements of the response cannot be correctly mapped from the raw data.
     #[tracing::instrument(
         target = "convert_from_uds",
@@ -6518,7 +6518,7 @@ mod tests {
         )
     }
 
-    // ── StaticField DOP ──────────────────────────────────────────────────────
+    // -- StaticField DOP ------------------------------------------------------
 
     fn create_ecu_manager_with_static_field_service() -> (
         super::EcuManager<DefaultSecurityPluginData>,
@@ -6555,7 +6555,7 @@ mod tests {
         )
     }
 
-    // ── EnvDataDesc wildcard fallback ────────────────────────────────────────
+    // -- EnvDataDesc wildcard fallback ----------------------------------------
 
     fn create_ecu_manager_with_env_data_desc_wildcard() -> (
         super::EcuManager<DefaultSecurityPluginData>,
@@ -6588,11 +6588,11 @@ mod tests {
         let humidity_dop =
             db_builder.create_regular_normal_dop("humidity_dop", u8_diag_type, compu_identical3);
 
-        // Specific env_data matches only specific_dtc → reports "temperature"
+        // Specific env_data matches only specific_dtc -> reports "temperature"
         let temp_param = db_builder.create_value_param("temperature", temp_dop, 0, 0);
         let specific_env_data_dop = db_builder.create_env_data_dop(&[specific_dtc], &[temp_param]);
 
-        // Wildcard env_data (empty dtc_values) → reports "humidity"
+        // Wildcard env_data (empty dtc_values) -> reports "humidity"
         let humidity_param = db_builder.create_value_param("humidity", humidity_dop, 0, 0);
         let wildcard_env_data_dop = db_builder.create_env_data_dop(&[], &[humidity_param]);
 
@@ -6679,7 +6679,7 @@ mod tests {
         )
     }
 
-    // ── DynamicLengthField: sibling param before DLF with no byte_position ──
+    // -- DynamicLengthField: sibling param before DLF with no byte_position --
 
     fn create_ecu_manager_dlf_sibling_no_byte_pos() -> (
         super::EcuManager<DefaultSecurityPluginData>,
@@ -6730,7 +6730,7 @@ mod tests {
             let sid_param = create_sid_param!(db_builder, "test_service_pos_sid", sid);
             // sibling at explicit byte_pos=1, advances last_read_byte_pos to 2 after decoding
             let sibling_param = db_builder.create_value_param("sibling_val", sibling_dop, 1, 0);
-            // DLF with NO explicit byte_position — must use base_offset=0, not last_read_byte_pos
+            // DLF with NO explicit byte_position - must use base_offset=0, not last_read_byte_pos
             let dlf_param = db_builder.create_value_param_no_byte_pos("dlf_items", dlf_dop);
             db_builder.create_response(
                 ResponseType::Positive,
@@ -7554,7 +7554,7 @@ mod tests {
     //   byte 0     : SID       (coded const, 8 bit)
     //   byte 1     : len_key   (LENGTH-KEY param, u8)
     //   byte 2     : var_data  (PARAM-LENGTH-INFO, `len_key` bytes)
-    //   byte 2 + N : suffix    (value param, u16 — BYTE-POSITION omitted)
+    //   byte 2 + N : suffix    (value param, u16 - BYTE-POSITION omitted)
     fn create_ecu_manager_with_trailing_param_after_param_length_info_service()
     -> (super::EcuManager<DefaultSecurityPluginData>, DiagComm, u8) {
         const LEN_KEY: &str = "len_key";
@@ -7586,7 +7586,7 @@ mod tests {
             let sid_param = create_sid_param!(db_builder, sid);
             let lk_param = db_builder.create_length_key_param(LEN_KEY, len_key_dop, 1, 0);
             let var_param = db_builder.create_value_param(VAR_DATA, var_data_dop, 2, 0);
-            // Per spec: BYTE-POSITION omitted — position depends on runtime length of var_data
+            // Per spec: BYTE-POSITION omitted - position depends on runtime length of var_data
             let suffix_param = db_builder.create_value_param_no_byte_pos("suffix", suffix_dop);
             db_builder.create_request(
                 Some(vec![sid_param, lk_param, var_param, suffix_param]),
@@ -8894,9 +8894,9 @@ mod tests {
     /// Covers `CodedConst` (SID), `PhysConst` (DID), and `Value` (data) response parameters.
     ///
     /// Fixture layout (`pos_response` of `TestPhysConstNormalService`):
-    ///   byte 0: `sid`       – CODED-CONST (1 byte)
-    ///   byte 1: `DID`       – PHYS-CONST  (u16, `coded_value` = None in response metadata)
-    ///   byte 3: `data_param`– VALUE        (u8, 1 byte)
+    ///   byte 0: `sid`       - CODED-CONST (1 byte)
+    ///   byte 1: `DID`       - PHYS-CONST  (u16, `coded_value` = None in response metadata)
+    ///   byte 3: `data_param`- VALUE        (u8, 1 byte)
     #[test]
     fn test_get_response_parameter_metadata_phys_const_and_value_params() {
         use cda_interfaces::ParameterTypeMetadata;
@@ -8963,18 +8963,18 @@ mod tests {
     /// `"__mux_case__/case_name"` marker.
     ///
     /// Fixture layout (`pos_response` of `TestMuxService`):
-    ///   byte 0: `test_service_pos_sid` – CODED-CONST (1 byte, SID = 0x22)
-    ///   byte 2: `mux_1_param`          – MUX DOP (expanded into case entries)
+    ///   byte 0: `test_service_pos_sid` - CODED-CONST (1 byte, SID = 0x22)
+    ///   byte 2: `mux_1_param`          - MUX DOP (expanded into case entries)
     ///     switch key: u16 at offset 0 within mux (size = 2 bytes)
     ///     case 1 abs pos = mux(2) + key(2) + `inner_offset`
-    ///       `mux_1_case_1_param_1`: f32 → byte 4, size 4
-    ///       `mux_1_case_1_param_2`: u8  → byte 8, size 1
+    ///       `mux_1_case_1_param_1`: f32 -> byte 4, size 4
+    ///       `mux_1_case_1_param_2`: u8  -> byte 8, size 1
     ///       marker __`mux_case`__/`mux_1_case_1`: byte 4, size = structure (7)
     ///     case 2 abs pos = 2 + 2 + `inner_offset`
-    ///       `mux_1_case_2_param_1`: i16  → byte 5, size 2
-    ///       `mux_1_case_2_param_2`: ascii 32 bits → byte 8, size 4
+    ///       `mux_1_case_2_param_1`: i16  -> byte 5, size 2
+    ///       `mux_1_case_2_param_2`: ascii 32 bits -> byte 8, size 4
     ///       marker __`mux_case`__/`mux_1_case_2`: byte 4, size = structure (7)
-    ///     case 3: no structure → produces no entries
+    ///     case 3: no structure -> produces no entries
     #[test]
     fn test_get_response_parameter_metadata_mux_expansion() {
         use cda_interfaces::ParameterTypeMetadata;
@@ -9075,7 +9075,7 @@ mod tests {
         assert_eq!(marker_2.byte_position, 4); // mux_byte_pos(2) + switch_key_size(2)
         assert_eq!(marker_2.byte_size, Some(7)); // structure byte_size
 
-        // Case 3 has no structure — must produce no entries at all
+        // Case 3 has no structure - must produce no entries at all
         assert!(
             metadata
                 .iter()
@@ -9527,7 +9527,7 @@ mod tests {
             ServiceSecurityTransition::ExtendedToProgramming,
         );
 
-        // Set ECU security to "LockedSecurity" (the default) – the default is
+        // Set ECU security to "LockedSecurity" (the default) - the default is
         // NOT in the allowed set, so neither the actual state nor the default
         // check can pass and the service must be rejected.
         {
@@ -9800,12 +9800,12 @@ mod tests {
     ///
     /// ```text
     /// Variant("RootVariant")
-    /// ├── Variant("InnerVariant")
-    /// │   └── FunctionalGroup("FgLayer")
-    /// │       └── EcuSharedData("SharedInFg")
-    /// ├── Protocol("Proto")
-    /// │   └── Protocol("ParentProto")
-    /// └── EcuSharedData("TopShared")
+    /// +-- Variant("InnerVariant")
+    /// |   \-- FunctionalGroup("FgLayer")
+    /// |       \-- EcuSharedData("SharedInFg")
+    /// +-- Protocol("Proto")
+    /// |   \-- Protocol("ParentProto")
+    /// \-- EcuSharedData("TopShared")
     /// ```
     ///
     /// Expected collected layers (order is stack-based, not guaranteed):
@@ -9814,7 +9814,7 @@ mod tests {
     fn test_parent_ref_recursive_mixed_hierarchy() {
         let mut b = EcuDataBuilder::new();
 
-        // ── leaf: EcuSharedData inside a FunctionalGroup ──
+        // - leaf: EcuSharedData inside a FunctionalGroup -
         let shared_in_fg_dl = b.create_diag_layer(DiagLayerParams {
             short_name: "SharedInFg",
             ..Default::default()
@@ -9825,7 +9825,7 @@ mod tests {
             Some(DataFormatParentRefType::tag_as_ecu_shared_data(esd_in_fg)),
         );
 
-        // ── FunctionalGroup with the EcuSharedData child ──
+        // - FunctionalGroup with the EcuSharedData child -
         let fg_dl = b.create_diag_layer(DiagLayerParams {
             short_name: "FgLayer",
             ..Default::default()
@@ -9836,7 +9836,7 @@ mod tests {
             Some(DataFormatParentRefType::tag_as_functional_group(fg)),
         );
 
-        // ── inner Variant whose parent-ref is the FunctionalGroup ──
+        // - inner Variant whose parent-ref is the FunctionalGroup -
         let inner_variant_dl = b.create_diag_layer(DiagLayerParams {
             short_name: "InnerVariant",
             ..Default::default()
@@ -9847,7 +9847,7 @@ mod tests {
             Some(DataFormatParentRefType::tag_as_variant(inner_variant)),
         );
 
-        // ── Protocol with a parent protocol ──
+        // - Protocol with a parent protocol -
         let parent_proto = b.create_protocol("ParentProto", None, None, None);
         let parent_proto_pr = b.create_parent_ref(
             DataFormatParentRefType::Protocol,
@@ -9859,7 +9859,7 @@ mod tests {
             Some(DataFormatParentRefType::tag_as_protocol(proto)),
         );
 
-        // ── top-level EcuSharedData sibling ──
+        // - top-level EcuSharedData sibling -
         let top_shared_dl = b.create_diag_layer(DiagLayerParams {
             short_name: "TopShared",
             ..Default::default()
@@ -9870,7 +9870,7 @@ mod tests {
             Some(DataFormatParentRefType::tag_as_ecu_shared_data(top_esd)),
         );
 
-        // ── root variant carrying all three sibling parent-refs ──
+        // - root variant carrying all three sibling parent-refs -
         let root_dl = b.create_diag_layer(DiagLayerParams {
             short_name: "RootVariant",
             ..Default::default()
@@ -10630,7 +10630,7 @@ mod tests {
         let (ecu_manager, service, sid, _specific_dtc, other_dtc) =
             create_ecu_manager_with_env_data_desc_wildcard();
 
-        // other_dtc doesn't match the specific env_data → wildcard env_data is used
+        // other_dtc doesn't match the specific env_data -> wildcard env_data is used
         let mut payload = vec![sid];
         payload.extend_from_slice(&other_dtc.to_be_bytes());
         payload.push(0x55); // humidity = 85
@@ -10658,7 +10658,7 @@ mod tests {
     async fn test_env_data_desc_no_match_no_wildcard_returns_empty() {
         let (ecu_manager, service, sid, dtc_in_db) = create_ecu_manager_env_data_no_wildcard();
 
-        // dtc_in_db has no matching env_data and there is no wildcard →
+        // dtc_in_db has no matching env_data and there is no wildcard ->
         // env params are absent; DTC itself is decoded normally.
         let mut payload = vec![sid];
         payload.extend_from_slice(&dtc_in_db.to_be_bytes());
@@ -10711,7 +10711,7 @@ mod tests {
     async fn test_dlf_no_byte_pos_with_sibling_zero_items() {
         let (ecu_manager, service, sid) = create_ecu_manager_dlf_sibling_no_byte_pos();
 
-        // count=0 → empty array; sibling still decoded correctly
+        // count=0 -> empty array; sibling still decoded correctly
         assert_uds_converts_to_json(
             &ecu_manager,
             &service,

--- a/cda-core/src/diag_kernel/operations.rs
+++ b/cda-core/src/diag_kernel/operations.rs
@@ -2199,7 +2199,7 @@ mod tests {
 
     #[test]
     fn test_string_value_exceeds_bit_length_with_matching_physical_type() {
-        // 8-bit UInt32: only values 0–255 should be valid
+        // 8-bit UInt32: only values 0-255 should be valid
         let uint32_8bit = create_diag_coded_type_stl(DataType::UInt32, Some(8));
         let u32_physical_type = Some(PhysicalType {
             precision: None,

--- a/cda-core/src/diag_kernel/param_metadata.rs
+++ b/cda-core/src/diag_kernel/param_metadata.rs
@@ -49,7 +49,7 @@ fn parse_limit_as_u64(value: &str) -> Option<u64> {
 /// - `Identical`: the physical text IS the coded value; the string is
 ///   parsed directly as a `u64`.
 ///
-/// Returns `None` for unsupported categories (`Linear`, `ScaleLinear`, …) or
+/// Returns `None` for unsupported categories (`Linear`, `ScaleLinear`, ...) or
 /// when no matching scale entry is found.
 pub(crate) fn resolve_phys_const_coded_value(
     param: &datatypes::Parameter<'_>,

--- a/cda-database/src/datatypes/diag_coded_type.rs
+++ b/cda-database/src/datatypes/diag_coded_type.rs
@@ -1361,8 +1361,8 @@ mod tests {
             condensed: false,
         };
         let payload: Vec<u8> = vec![0b_1010_1010];
-        // 10101010 -- payload
-        // 11110000 -- mask
+        // 10101010 - payload
+        // 11110000 - mask
         // ----------
         // 10100000
         let (data, bit_len) = unpack_data(8, 0, Some(&mask), &payload, ByteOrder::Keep).unwrap();
@@ -1376,9 +1376,9 @@ mod tests {
             condensed: true,
         };
         let payload: Vec<u8> = vec![0b_1010_1111];
-        // 10101010 -- payload
-        // 11110000 -- mask
-        // 10100000 -- to condense extract the bits from the payload where the mask has "1"s.
+        // 10101010 - payload
+        // 11110000 - mask
+        // 10100000 - to condense extract the bits from the payload where the mask has "1"s.
         // 1010     --> pad msb
         // 00001010 --> result byte
         let (data, bit_len) = unpack_data(8, 0, Some(&mask), &payload, ByteOrder::Keep).unwrap();
@@ -1393,10 +1393,10 @@ mod tests {
             condensed: true,
         };
 
-        // 11111111 -- payload
-        // 10101010 -- mask
+        // 11111111 - payload
+        // 10101010 - mask
         // ----------> apply mask
-        // 10101010 -- to condense extract the bits from the payload where the mask has "1"s.
+        // 10101010 - to condense extract the bits from the payload where the mask has "1"s.
         // 1-1-1-1-
         let payload: Vec<u8> = vec![0b_1111_1111, 0b_1111_1111];
         let (data, bit_len) = unpack_data(8, 0, Some(&mask), &payload, ByteOrder::Keep).unwrap();
@@ -1523,9 +1523,9 @@ mod tests {
             condensed: true,
         };
         let source_value = vec![0b_0000_1100];
-        // 0101_0101 -- mask
-        // 0000_1100 -- source value
-        // 0101_0000 -- init output with mask, then copy bits from source value
+        // 0101_0101 - mask
+        // 0000_1100 - source value
+        // 0101_0000 - init output with mask, then copy bits from source value
         // where mask is 1
         let (result, len) =
             pack_data(8, 0, Some(&mask), &source_value, DataAlignment::Right).unwrap();
@@ -1549,8 +1549,8 @@ mod tests {
             condensed: true,
         };
         let source_value = vec![0b_1111_0000];
-        // 1010_1010 -- mask
-        // 1111_0000 -- value
+        // 1010_1010 - mask
+        // 1111_0000 - value
         // Mask bits from LSB | output | bit of value
         // 0 | 0 | -
         // 1 | 0 | 0
@@ -1571,9 +1571,9 @@ mod tests {
             condensed: true,
         };
         let source_value = vec![0b_1010_1010];
-        // 1010_1010 -- value
-        // 1111_1111 -- mask
-        // 1010_1010 -- bits of source where mask = 1
+        // 1010_1010 - value
+        // 1111_1111 - mask
+        // 1010_1010 - bits of source where mask = 1
         let (result, len) =
             pack_data(8, 0, Some(&mask), &source_value, DataAlignment::Right).unwrap();
         assert_eq!(result, vec![0b_1010_1010]);
@@ -1586,8 +1586,8 @@ mod tests {
         };
         let source_value = vec![0b_11];
 
-        // 1000_0001 -- mask
-        // 0000_0011 -- value
+        // 1000_0001 - mask
+        // 0000_0011 - value
         let (result, len) =
             pack_data(8, 0, Some(&mask), &source_value, DataAlignment::Right).unwrap();
         assert_eq!(result, vec![0b_1000_0001]);
@@ -1654,8 +1654,8 @@ mod tests {
             condensed: true,
         };
         let source_value = vec![0b_1111_1111, 0b11];
-        // 1111_1111 0000_0011 -- input
-        // 1111_1111 0000_0011 -- mask
+        // 1111_1111 0000_0011 - input
+        // 1111_1111 0000_0011 - mask
         let (result, len) =
             pack_data(10, 0, Some(&mask), &source_value, DataAlignment::Right).unwrap();
         assert_eq!(result, vec![0b_1100_0000, 0b_0000_0011]);
@@ -2261,7 +2261,7 @@ mod tests {
 
     #[test]
     fn test_encode_standard_length_bytefield_exact_length() {
-        // 64 bytes into 512-bit (64-byte) ByteField -- exact fit, no padding needed.
+        // 64 bytes into 512-bit (64-byte) ByteField - exact fit, no padding needed.
         let input: Vec<u8> = (0x30..=0x6F).collect(); // 64 bytes
         assert_eq!(input.len(), 64);
         let expected = input.clone();
@@ -2312,11 +2312,11 @@ mod tests {
 
     #[test]
     fn test_encode_standard_length_condensed() {
-        // 1111_1111 0000_1111 -- mask
-        // 0001_0010 0011_0100 -- input
-        // 0010_0011 0000_0100 -- condensed input
-        // 1111_1111  -- mask
-        // 0001_0010 0011 -- input
+        // 1111_1111 0000_1111 - mask
+        // 0001_0010 0011_0100 - input
+        // 0010_0011 0000_0100 - condensed input
+        // 1111_1111  - mask
+        // 0001_0010 0011 - input
         // 0010 0011
         // 0010_0011
         // 0010_0000
@@ -2466,15 +2466,15 @@ mod tests {
             .encode(input.clone(), &mut uds_payload, 0, 0)
             .unwrap();
 
-        // 1100_1100 0011_0011 -- input
-        // 1000_0001 1000_0001 -- mask
-        // 1000_0000 0000_0001 -- mask & input
+        // 1100_1100 0011_0011 - input
+        // 1000_0001 1000_0001 - mask
+        // 1000_0000 0000_0001 - mask & input
         //
-        // 1010_1010 0101_0101 -- payload
-        // 0111_1110 0111_1110 -- !mask
-        // 0010_1010 0101_0100 -- payload & !mask
-        // 1000_0000 0000_0001 -- mask & payload
-        // 1010_1010 0101_0101 -- (mask & payload) | (input & !mask)
+        // 1010_1010 0101_0101 - payload
+        // 0111_1110 0111_1110 - !mask
+        // 0010_1010 0101_0100 - payload & !mask
+        // 1000_0000 0000_0001 - mask & payload
+        // 1010_1010 0101_0101 - (mask & payload) | (input & !mask)
         assert_eq!(uds_payload, vec![0b_1010_1010, 0b_0101_0101]);
     }
 
@@ -2547,8 +2547,8 @@ mod tests {
             .encode(input.clone(), &mut uds_payload, 3, 6)
             .unwrap();
 
-        // 0000_0000 0000_0000 1100_1100 -- input
-        // 1110_1001 1101_0001 1101_1111 -- mask
+        // 0000_0000 0000_0000 1100_1100 - input
+        // 1110_1001 1101_0001 1101_1111 - mask
         // 1. combine mask and input with condensing rules.
         // 111010011101000111001100
         // 2. prepare cut out
@@ -2935,10 +2935,10 @@ mod tests {
         )
         .unwrap();
 
-        // 0001 0010 0011_0100 -- payload
-        // 1111_1111 0000_1111 -- mask
+        // 0001 0010 0011_0100 - payload
+        // 1111_1111 0000_1111 - mask
         // 0001 0010 ---- 0100
-        // 0000 0001 0010_0100 -- condensed result
+        // 0000 0001 0010_0100 - condensed result
         // 0000_0000 0000_0000
         let (data, bit_len) = diag_type.decode(&payload, 0, 0).unwrap();
         assert_eq!(data, vec![0b_0000_0001, 0b_0010_0100]);

--- a/cda-database/src/mdd_data/mod.rs
+++ b/cda-database/src/mdd_data/mod.rs
@@ -371,7 +371,7 @@ pub fn update_mdd_uncompressed(mdd_path: &str) -> Result<bool, MddError> {
         return Ok(false);
     }
 
-    // At least one chunk is compressed — read into heap, decompress,
+    // At least one chunk is compressed - read into heap, decompress,
     // and rewrite. This path only runs once per MDD file.
     let data = std::fs::read(mdd_path)
         .map_err(|e| MddError::Io(format!("Failed to read MDD file '{mdd_path}': {e}")))?;

--- a/cda-extra/src/systemd_notify.rs
+++ b/cda-extra/src/systemd_notify.rs
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn fold_sequence_empty_providers_yields_starting() {
-        // no providers → fold over empty iterator → initial accumulator = Starting
+        // no providers -> fold over empty iterator -> initial accumulator = Starting
         let result = std::iter::empty::<Status>().fold(Status::Starting, fold_status);
         assert_eq!(result, Status::Starting);
     }

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -331,7 +331,7 @@ pub trait EcuManager:
     fn mark_as_no_variant_detected(&mut self);
 
     /// This allows to (re)load a database after unloading it during runtime, which could happen
-    /// if initially the ECU wasn´t responding but later another request
+    /// if initially the ECU wasn't responding but later another request
     /// for reprobing the ECU happens.
     ///
     /// # Errors
@@ -358,7 +358,7 @@ pub trait EcuManager:
     /// named functional group instead of the ECU variant.
     ///
     /// # Errors
-    /// Will return `Err` in cases where the payload doesn´t match the expected UDS response, or if
+    /// Will return `Err` in cases where the payload doesn't match the expected UDS response, or if
     /// elements of the response cannot be correctly mapped from the raw data.
     fn convert_from_uds(
         &self,
@@ -386,7 +386,7 @@ pub trait EcuManager:
     /// named functional group instead of the ECU variant.
     ///
     /// # Errors
-    /// Will return `Err` in cases where the `UdsPayloadData` doesn´t provide required parameters
+    /// Will return `Err` in cases where the `UdsPayloadData` doesn't provide required parameters
     /// for the `DiagService` request or if elements of the `UdsPayloadData` cannot be mapped to
     /// the raw UDS bytestream.
     fn create_uds_payload(

--- a/cda-interfaces/src/util.rs
+++ b/cda-interfaces/src/util.rs
@@ -94,7 +94,7 @@ pub mod serde_ext {
 
     /// Deserializes a `HashMap<String, V, S>` from a map with string keys that may
     /// be decimal (`"16"`) or hexadecimal (`"0x10"`, `"0X10"`). All keys are validated
-    /// as valid `u8` values (0–255) and normalized to their decimal string representation.
+    /// as valid `u8` values (0-255) and normalized to their decimal string representation.
     /// This can be used i.e. for configuration where figment / toml parse do not
     /// natively support integer keys.
     ///
@@ -420,10 +420,10 @@ mod tests {
         assert_eq!(result, vec![0b_11, 0xFF, 0xFF]);
 
         // Extracting 13 bits starting from bit position 5
-        // 101010111100110101000010 -- input
-        //      1010101111001101010 -- from bit pos 5
-        //            1111001101010 -- 13 bits
-        //        00011110 01101010 -- 2 result bytes
+        // 101010111100110101000010 - input
+        //      1010101111001101010 - from bit pos 5
+        //            1111001101010 - 13 bits
+        //        00011110 01101010 - 2 result bytes
         let result = extract_bits(13, 5, &[0b_1010_1011, 0b_1100_1101, 0b_0100_0010]).unwrap();
         assert_eq!(result, vec![0b_0001_1110, 0b_0110_1010]);
 
@@ -435,9 +435,9 @@ mod tests {
         assert_eq!(result, vec![0b_101]);
 
         // Extracting 4 bits starting from bit position 6
-        // 1111000000001111 -- input
-        //       1111000000 -- from bit pos 6
-        //          1000000 -- 5 bits
+        // 1111000000001111 - input
+        //       1111000000 - from bit pos 6
+        //          1000000 - 5 bits
         let result = extract_bits(7, 6, &[0b_1111_0000, 0b_0000_1111]).unwrap();
         assert_eq!(result, vec![0b_0100_0000]);
     }

--- a/cda-sovd-interfaces/src/components/ecu/modes.rs
+++ b/cda-sovd-interfaces/src/components/ecu/modes.rs
@@ -54,7 +54,7 @@ pub mod security_and_session {
             pub value: String,
             /// Defines after how many seconds the
             /// mode expires and should therefore
-            /// be automatically reset to the mode’s
+            /// be automatically reset to the mode's
             // default value
             // It's optional although strictly speaking it should be required
             // when following the sovd standard.

--- a/cda-sovd-interfaces/src/error.rs
+++ b/cda-sovd-interfaces/src/error.rs
@@ -30,8 +30,8 @@ pub enum ErrorCode {
     /// The Component receiving the request has answered with an
     /// error.
     /// For UDS, the message should include the service identifier
-    /// (Key: ‘service’ and Value of type number) and the negative
-    /// response code (Key: ‘nrc’ and Value of type number).
+    /// (Key: 'service' and Value of type number) and the negative
+    /// response code (Key: 'nrc' and Value of type number).
     ErrorResponse,
 
     /// The signature of the data in the payload is invalid.

--- a/comm-mbedtls/mbedtls-rs/src/async_stream.rs
+++ b/comm-mbedtls/mbedtls-rs/src/async_stream.rs
@@ -58,10 +58,10 @@ use crate::{error::MbedtlsError, ssl::SslConfig};
 // Internal memory BIO
 // ---------------------------------------------------------------------------
 
-/// A pair of in-memory byte buffers that bridge async I/O ⟷ mbedtls.
+/// A pair of in-memory byte buffers that bridge async I/O <-> mbedtls.
 ///
-/// * **`incoming`** — bytes read from the network go here; mbedtls reads from it.
-/// * **`outgoing`** — mbedtls writes ciphertext here; we drain it to the network.
+/// * **`incoming`** - bytes read from the network go here; mbedtls reads from it.
+/// * **`outgoing`** - mbedtls writes ciphertext here; we drain it to the network.
 struct MemBio {
     incoming: Vec<u8>,
     incoming_cursor: usize,
@@ -148,7 +148,7 @@ pub struct TlsStream<S> {
     handshake_completed: bool,
 }
 
-// Safety: S: Send ⇒ TlsStream<S>: Send.
+// Safety: S: Send -> TlsStream<S>: Send.
 unsafe impl<S: Send> Send for TlsStream<S> {}
 
 impl<S> TlsStream<S>
@@ -272,7 +272,7 @@ where
                     #[allow(clippy::indexing_slicing)]
                     self.bio_mut().feed_incoming(&buf[..n]);
                 } else if err.is_want_write() {
-                    // mbedtls wants us to flush — already done above.
+                    // mbedtls wants us to flush - already done above.
                 } else {
                     return Err(err.into());
                 }

--- a/comm-mbedtls/mbedtls-rs/src/ed25519.rs
+++ b/comm-mbedtls/mbedtls-rs/src/ed25519.rs
@@ -32,8 +32,8 @@ const VERIFY_SUCCESS: i32 = 0;
 ///
 /// # Returns
 ///
-/// * `0` — signature is valid
-/// * `-1` — verification failed or invalid input
+/// * `0` - signature is valid
+/// * `-1` - verification failed or invalid input
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_ed25519_verify(
     pub_key: *const u8,

--- a/comm-mbedtls/mbedtls-rs/src/lib.rs
+++ b/comm-mbedtls/mbedtls-rs/src/lib.rs
@@ -111,7 +111,7 @@
 //!
 //!     loop {
 //!         let (tcp, _addr) = listener.accept().await?;
-//!         let config = config.clone(); // Arc::clone — cheap
+//!         let config = config.clone(); // Arc::clone - cheap
 //!
 //!         tokio::spawn(async move {
 //!             let mut tls = TlsStream::accept(config, tcp).await.unwrap();

--- a/comm-mbedtls/mbedtls-rs/src/ssl/config.rs
+++ b/comm-mbedtls/mbedtls-rs/src/ssl/config.rs
@@ -392,7 +392,7 @@ impl TlsVersion {
 }
 
 impl SslConfig {
-    /// Raw const pointer — used by `SslStream` to set up a context.
+    /// Raw const pointer - used by `SslStream` to set up a context.
     pub(crate) fn as_ptr(&self) -> *const ffi::mbedtls_ssl_config {
         &raw const self.inner
     }

--- a/comm-mbedtls/mbedtls-rs/src/ssl/context.rs
+++ b/comm-mbedtls/mbedtls-rs/src/ssl/context.rs
@@ -15,7 +15,7 @@
 //! This follows the same pattern as `openssl::ssl::SslStream`:
 //!
 //! 1. Create an `SslStream` from an `SslConfig` + transport.
-//! 2. Perform the TLS handshake (can be non-blocking → `MidHandshakeSslStream`).
+//! 2. Perform the TLS handshake (can be non-blocking -> `MidHandshakeSslStream`).
 //! 3. Read/write cleartext through the `SslStream`.
 
 use std::{
@@ -31,7 +31,7 @@ use mbedtls_sys as ffi;
 use crate::{error::MbedtlsError, ssl::SslConfig};
 
 // ---------------------------------------------------------------------------
-// BIO callbacks — bridge mbedtls I/O to Rust Read/Write
+// BIO callbacks - bridge mbedtls I/O to Rust Read/Write
 // ---------------------------------------------------------------------------
 
 /// The BIO context we stash behind `p_bio`. It holds a pointer to the Rust
@@ -97,7 +97,7 @@ pub struct SslStream<S> {
     _config: Arc<SslConfig>,
 }
 
-// Safety: S: Send ⇒ SslStream<S>: Send. The mbedtls context is not
+// Safety: S: Send => SslStream<S>: Send. The mbedtls context is not
 // accessed from multiple threads simultaneously.
 unsafe impl<S: Send> Send for SslStream<S> {}
 
@@ -273,7 +273,7 @@ impl<S: Read + Write> SslStream<S> {
     /// # Safety
     ///
     /// Do not read from or write to the transport directly while TLS records
-    /// are in flight — this will corrupt the TLS session.
+    /// are in flight - this will corrupt the TLS session.
     pub fn get_mut(&mut self) -> &mut S {
         unsafe { &mut Pin::get_unchecked_mut(self.bio.as_mut()).stream }
     }

--- a/comm-mbedtls/mbedtls-rs/src/ssl/mod.rs
+++ b/comm-mbedtls/mbedtls-rs/src/ssl/mod.rs
@@ -10,7 +10,7 @@
  * https://www.apache.org/licenses/LICENSE-2.0
  */
 
-//! SSL/TLS module — safe wrappers around `mbedtls_ssl_config` and `mbedtls_ssl_context`.
+//! SSL/TLS module - safe wrappers around `mbedtls_ssl_config` and `mbedtls_ssl_context`.
 
 mod config;
 mod context;

--- a/comm-mbedtls/mbedtls-rs/src/x509.rs
+++ b/comm-mbedtls/mbedtls-rs/src/x509.rs
@@ -105,7 +105,7 @@ impl X509Certificate {
         }
     }
 
-    /// Raw pointer — used internally by `SslConfig`.
+    /// Raw pointer - used internally by `SslConfig`.
     pub(crate) fn as_mut_ptr(&mut self) -> *mut ffi::mbedtls_x509_crt {
         &raw mut self.inner
     }
@@ -199,7 +199,7 @@ impl PrivateKey {
         }
     }
 
-    /// Raw pointer — used internally by `SslConfig`.
+    /// Raw pointer - used internally by `SslConfig`.
     pub(crate) fn as_mut_ptr(&mut self) -> *mut ffi::mbedtls_pk_context {
         &raw mut self.inner
     }

--- a/comm-mbedtls/mbedtls-sys/build.rs
+++ b/comm-mbedtls/mbedtls-sys/build.rs
@@ -47,7 +47,7 @@ fn main() {
     let mbedtls_src = manifest_dir.join(format!("mbedtls-{MBEDTLS_VERSION}"));
     let out_dir = PathBuf::from(
         env::var("OUT_DIR")
-            .expect("OUT_DIR environment variable not set — build script must be run by Cargo"),
+            .expect("OUT_DIR environment variable not set - build script must be run by Cargo"),
     );
 
     // Only re-run if the mbedtls source or wrapper header change.
@@ -63,7 +63,7 @@ fn main() {
         .define("ENABLE_TESTING", "OFF")
         .define("ENABLE_PROGRAMS", "OFF")
         .define("MBEDTLS_FATAL_WARNINGS", "OFF")
-        // Disable GEN_FILES — the release tarball ships pre-generated files.
+        // Disable GEN_FILES - the release tarball ships pre-generated files.
         .define("GEN_FILES", "OFF")
         // Enable RFC 8449 record_size_limit extension (TLS 1.3).
         .cflag("-DMBEDTLS_SSL_RECORD_SIZE_LIMIT")
@@ -82,7 +82,7 @@ fn main() {
         }
     }
 
-    // Link order matters: mbedtls -> mbedx509 -> tfpsacrypto (≈ mbedcrypto).
+    // Link order matters: mbedtls -> mbedx509 -> tfpsacrypto (~ mbedcrypto).
     println!("cargo:rustc-link-lib=static=mbedtls");
     println!("cargo:rustc-link-lib=static=mbedx509");
     println!("cargo:rustc-link-lib=static=tfpsacrypto");
@@ -272,7 +272,7 @@ fn ensure_mbedtls_source(workspace_dir: &Path) {
     } else {
         let dir = workspace_dir.join(format!("mbedtls-{MBEDTLS_VERSION}"));
         if !dir.join("CMakeLists.txt").exists() {
-            eprintln!("mbedtls source not found — downloading {TARBALL_URL} …");
+            eprintln!("mbedtls source not found - downloading {TARBALL_URL} ...");
 
             let tarball = workspace_dir.join(format!("mbedtls-{MBEDTLS_VERSION}.tar.bz2"));
             download(TARBALL_URL, &tarball);
@@ -303,11 +303,11 @@ fn ensure_mbedtls_source(workspace_dir: &Path) {
         .join("patches")
         .join("record-size-limit-tls12.patch");
     if patch_file.exists() {
-        eprintln!("Applying record-size-limit patch …");
+        eprintln!("Applying record-size-limit patch ...");
         apply_patch(&patch_file, workspace_dir);
     } else {
         eprintln!(
-            "warning: patch file {} not found — skipping",
+            "warning: patch file {} not found - skipping",
             patch_file.display()
         );
     }
@@ -317,11 +317,11 @@ fn ensure_mbedtls_source(workspace_dir: &Path) {
         .join("patches")
         .join("ed25519-psa-driver.patch");
     if patch_file.exists() {
-        eprintln!("Applying Ed25519 patch …");
+        eprintln!("Applying Ed25519 patch ...");
         apply_patch(&patch_file, workspace_dir);
     } else {
         eprintln!(
-            "warning: patch file {} not found — skipping",
+            "warning: patch file {} not found - skipping",
             patch_file.display()
         );
     }

--- a/comm-mbedtls/mbedtls-sys/csrc/ed25519_extract.h
+++ b/comm-mbedtls/mbedtls-sys/csrc/ed25519_extract.h
@@ -32,12 +32,12 @@
  * If \p pub_raw_len is 32 the input is taken as-is.  Otherwise it is
  * parsed as a DER-encoded SubjectPublicKeyInfo (RFC 8410 §4):
  *
- *   SEQUENCE {                           -- SubjectPublicKeyInfo
- *     SEQUENCE {                         -- AlgorithmIdentifier
- *       OID 1.3.101.112                  --   id-Ed25519
+ *   SEQUENCE {                           - SubjectPublicKeyInfo
+ *     SEQUENCE {                         - AlgorithmIdentifier
+ *       OID 1.3.101.112                  -   id-Ed25519
  *       -- parameters MUST be absent (RFC 8410 §3)
  *     }
- *     BIT STRING (0 unused bits)         -- 32-byte raw public key
+ *     BIT STRING (0 unused bits)         - 32-byte raw public key
  *   }
  *
  * \param[in]  pub_raw      Raw key or DER-encoded SubjectPublicKeyInfo.
@@ -72,7 +72,7 @@ static inline int ed25519_extract_raw_pubkey(
     int ret;
 
     /*
-     * Step 1 – Outer SEQUENCE (SubjectPublicKeyInfo).
+     * Step 1 - Outer SEQUENCE (SubjectPublicKeyInfo).
      * It must span exactly the entire input; trailing data is rejected.
      */
     ret = mbedtls_asn1_get_tag(&p, end, &len,
@@ -82,7 +82,7 @@ static inline int ed25519_extract_raw_pubkey(
     }
 
     /*
-     * Step 2 – Inner SEQUENCE (AlgorithmIdentifier).
+     * Step 2 - Inner SEQUENCE (AlgorithmIdentifier).
      * Record where the AlgorithmIdentifier content ends so we can
      * verify that no unexpected trailing data (e.g. parameters) follows.
      */
@@ -94,10 +94,10 @@ static inline int ed25519_extract_raw_pubkey(
     unsigned char *alg_end = p + len;
 
     /*
-     * Step 3 – OID inside AlgorithmIdentifier.
+     * Step 3 - OID inside AlgorithmIdentifier.
      * After mbedtls_asn1_get_tag() succeeds, `p` points to the first
      * byte of the OID value and `oid_len` holds its length.
-     * Verify it matches id-Ed25519 (1.3.101.112 → 0x2B 0x65 0x70).
+     * Verify it matches id-Ed25519 (1.3.101.112 --> 0x2B 0x65 0x70).
      */
     size_t oid_len;
     ret = mbedtls_asn1_get_tag(&p, alg_end, &oid_len, MBEDTLS_ASN1_OID);
@@ -111,7 +111,7 @@ static inline int ed25519_extract_raw_pubkey(
     p += oid_len;
 
     /*
-     * Step 4 – RFC 8410 §3: "For all of the OIDs, the parameters
+     * Step 4 - RFC 8410 §3: "For all of the OIDs, the parameters
      * MUST be absent."  Reject if anything follows the OID inside
      * the AlgorithmIdentifier SEQUENCE.
      */
@@ -120,7 +120,7 @@ static inline int ed25519_extract_raw_pubkey(
     }
 
     /*
-     * Step 5 – BIT STRING containing the raw public key.
+     * Step 5 - BIT STRING containing the raw public key.
      * mbedtls_asn1_get_bitstring_null() parses the tag and length,
      * and verifies the "unused bits" octet is 0x00 (required for
      * Ed25519 since the key is an integral number of bytes).
@@ -132,7 +132,7 @@ static inline int ed25519_extract_raw_pubkey(
     }
 
     /*
-     * Step 6 – Verify there is no trailing data after the BIT STRING
+     * Step 6 - Verify there is no trailing data after the BIT STRING
      * content.  (The outer SEQUENCE check in step 1 already bounds the
      * total size, but being explicit here catches internal parse bugs.)
      */

--- a/comm-mbedtls/mbedtls-sys/csrc/ed25519_psa_driver.c
+++ b/comm-mbedtls/mbedtls-sys/csrc/ed25519_psa_driver.c
@@ -10,7 +10,7 @@
  * https://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Ed25519 (PureEdDSA) PSA Crypto Accelerator Driver — C implementation
+// Ed25519 (PureEdDSA) PSA Crypto Accelerator Driver - C implementation
 //
 // This file bridges the PSA Crypto driver interface with the Rust
 // ed25519-dalek implementation.  It is compiled by cc-rs and linked
@@ -35,7 +35,7 @@ extern int rust_ed25519_verify(const uint8_t *pub_key, size_t pub_key_len,
 #define ED25519_SIG_SIZE 64
 
 /* ---------------------------------------------------------------------------
- * psa_import_key  —  transparent driver entry point
+ * psa_import_key  -  transparent driver entry point
  * ---------------------------------------------------------------------------
  */
 psa_status_t ed25519_psa_import_key(const psa_key_attributes_t *attributes,
@@ -65,7 +65,7 @@ psa_status_t ed25519_psa_import_key(const psa_key_attributes_t *attributes,
 }
 
 /* ---------------------------------------------------------------------------
- * psa_verify_message  —  transparent driver entry point
+ * psa_verify_message  -  transparent driver entry point
  * ---------------------------------------------------------------------------
  */
 psa_status_t ed25519_psa_verify_message(

--- a/docs/01_about/01_introduction.rst
+++ b/docs/01_about/01_introduction.rst
@@ -103,20 +103,20 @@ forwarding them over the DoIP transport.
 Data-Driven Approach via MDD
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The CDA uses a **data-driven** approach: all knowledge about ECUs — their logical addresses,
+The CDA uses a **data-driven** approach: all knowledge about ECUs -- their logical addresses,
 supported services, data identifiers, routines, communication timing parameters, and session
-configuration — is loaded at runtime from **MDD (Marvelous Diagnostic Description) files**. These files
+configuration -- is loaded at runtime from **MDD (Marvelous Diagnostic Description) files**. These files
 are the diagnostic description database for the vehicle and contain the full definition of what
 each ECU supports.
 
 This means the CDA itself contains no hard-coded ECU knowledge. Instead it reads the MDD files on
 startup and configures all communication parameters (timeouts, retry counts, tester present
 behavior, addressing) per ECU from those files. Adding support for a new ECU or updating its
-diagnostic description requires only a new or updated MDD file — no code changes.
+diagnostic description requires only a new or updated MDD file -- no code changes.
 
 A client (e.g. a diagnostic tool or test script) communicates with the CDA exclusively through the
 SOVD REST API using JSON over HTTP. The CDA uses the MDD data to translate each incoming JSON
-request into the appropriate UDS service call and returns the ECU's response as a JSON reply —
+request into the appropriate UDS service call and returns the ECU's response as a JSON reply --
 the client never deals with raw UDS bytes directly.
 
 .. uml::
@@ -206,8 +206,8 @@ UDS Request-Response Flow
 Every UDS exchange follows the same basic pattern: the CDA sends a request frame (SID + payload),
 the DoIP gateway acknowledges receipt at the transport layer, and the ECU eventually replies with
 either a positive response (``SID + 0x40``) or a negative response (``0x7F`` + SID + NRC).
-Certain Negative Response Codes (NRCs) signal transient conditions — for example, NRC ``0x78``
-(Response Pending) means the ECU needs more time — and the CDA handles these automatically
+Certain Negative Response Codes (NRCs) signal transient conditions -- for example, NRC ``0x78``
+(Response Pending) means the ECU needs more time -- and the CDA handles these automatically
 according to configurable policies sourced from the MDD files.
 
 .. uml::

--- a/docs/01_about/04_traceability.rst
+++ b/docs/01_about/04_traceability.rst
@@ -116,7 +116,7 @@ The typical status progression for an item is:
 
 .. code-block:: text
 
-    draft → valid → approved
+    draft --> valid --> approved
 
 Items may transition to ``rejected`` from ``draft`` or ``valid`` during review.
 Items may transition to ``obsolete`` from any status when they are superseded or no longer needed.

--- a/docs/02_requirements/03_diagnostic_tester.rst
+++ b/docs/02_requirements/03_diagnostic_tester.rst
@@ -268,19 +268,19 @@ ECU States
 
     State transitions must occur as follows:
 
-    - Registration → NotTested
-    - NotTested → Online (successful variant detection)
-    - NotTested → NoVariantDetected (detection failed, fallback enabled)
-    - NotTested → Duplicate (another ECU with same logical address detected as correct variant)
-    - NotTested → Offline (variant detection attempted but ECU unreachable)
-    - Offline → NotTested (reconnection attempt or explicit re-detection requested)
-    - Online → Disconnected (connection lost)
-    - Online → NotTested (explicit re-detection requested)
-    - NoVariantDetected → Online (successful re-detection)
-    - NoVariantDetected → Duplicate (another ECU with same logical address detected as correct variant)
-    - NoVariantDetected → Disconnected (connection lost)
-    - Duplicate → NotTested (explicit re-detection requested)
-    - Disconnected → NotTested (reconnection attempt)
+    - Registration --> NotTested
+    - NotTested --> Online (successful variant detection)
+    - NotTested --> NoVariantDetected (detection failed, fallback enabled)
+    - NotTested --> Duplicate (another ECU with same logical address detected as correct variant)
+    - NotTested --> Offline (variant detection attempted but ECU unreachable)
+    - Offline --> NotTested (reconnection attempt or explicit re-detection requested)
+    - Online --> Disconnected (connection lost)
+    - Online --> NotTested (explicit re-detection requested)
+    - NoVariantDetected --> Online (successful re-detection)
+    - NoVariantDetected --> Duplicate (another ECU with same logical address detected as correct variant)
+    - NoVariantDetected --> Disconnected (connection lost)
+    - Duplicate --> NotTested (explicit re-detection requested)
+    - Disconnected --> NotTested (reconnection attempt)
 
     The current ECU state must be queryable via the SOVD API.
 

--- a/docs/02_requirements/04_communication.rst
+++ b/docs/02_requirements/04_communication.rst
@@ -788,7 +788,7 @@ Tester Present
       subsequent intervals.
 
     .. uml::
-        :caption: Tester Present — Component Lock
+        :caption: Tester Present -- Component Lock
 
         @startuml
         skinparam backgroundColor #FFFFFF
@@ -819,7 +819,7 @@ Tester Present
         @enduml
 
     .. uml::
-        :caption: Tester Present — Functional Group Lock
+        :caption: Tester Present -- Functional Group Lock
 
         @startuml
         skinparam backgroundColor #FFFFFF

--- a/docs/03_architecture/02_sovd-api/openapi/ecu_resource_collection.yaml
+++ b/docs/03_architecture/02_sovd-api/openapi/ecu_resource_collection.yaml
@@ -42,7 +42,7 @@ components:
           example: ECU112
         variant:
           type: string
-          description: "The detected variant of the ECU -- base variant if no ecu was detected"
+          description: "The detected variant of the ECU - base variant if no ecu was detected"
           example: Variant-1
         status:
           $ref: '#/components/schemas/EcuDetectionStatus'

--- a/docs/03_architecture/03_communication/02_uds_communication.rst
+++ b/docs/03_architecture/03_communication/02_uds_communication.rst
@@ -534,7 +534,7 @@ Tester Present
         when a lock is held.
 
     .. uml::
-        :caption: Tester Present — Component Lock
+        :caption: Tester Present -- Component Lock
 
         @startuml
         skinparam backgroundColor #FFFFFF
@@ -567,7 +567,7 @@ Tester Present
         @enduml
 
     .. uml::
-        :caption: Tester Present — Functional Group Lock
+        :caption: Tester Present -- Functional Group Lock
 
         @startuml
         skinparam backgroundColor #FFFFFF

--- a/docs/04_adr/01_mimalloc.rst
+++ b/docs/04_adr/01_mimalloc.rst
@@ -70,15 +70,15 @@ Comprehensive profiling revealed the following metrics:
    * - Allocation Count
      - 7,896
      - 2,273,227
-     - mimalloc (287× fewer)
+     - mimalloc (287x fewer)
    * - Persistent Allocs
      - 1,084
      - 202,138
-     - mimalloc (186× fewer)
+     - mimalloc (186x fewer)
    * - Dirty Memory
      - 60.73 MiB
      - 60.01 MiB
-     - ≈ Tie
+     - ~ Tie
    * - Thread Count
      - 15
      - 15
@@ -99,8 +99,8 @@ mimalloc Advantages
 2. **Reduced System Calls**: Drastically fewer allocation syscalls (~8K vs ~2.3M)
 
    - Batches allocations into large arenas, reducing kernel interaction
-   - Approximately 287× fewer allocations significantly reduces context switching overhead
-   - 186× fewer persistent allocations simplify memory management
+   - Approximately 287x fewer allocations significantly reduces context switching overhead
+   - 186x fewer persistent allocations simplify memory management
 
 System Allocator Advantages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -136,7 +136,7 @@ Positive
 ^^^^^^^^
 
 - **Improved Response Times**: 29% faster execution directly improves diagnostic operation latency
-- **Reduced System Overhead**: 287× fewer allocation calls minimize kernel involvement and context switching
+- **Reduced System Overhead**: 287x fewer allocation calls minimize kernel involvement and context switching
 - **Better Throughput**: Arena-based pooling enables handling of concurrent diagnostic sessions more efficiently
 - **Predictable Performance**: Pre-allocated arenas provide more consistent allocation times
 
@@ -160,7 +160,7 @@ Alternatives Considered
 System Allocator
 ^^^^^^^^^^^^^^^^
 
-The native platform allocator was evaluated as the primary alternative. While it offers superior memory efficiency (17-65% less memory usage), the performance penalty (~29% slower execution and 287× more allocation syscalls) makes it unsuitable as the default choice.
+The native platform allocator was evaluated as the primary alternative. While it offers superior memory efficiency (17-65% less memory usage), the performance penalty (~29% slower execution and 287x more allocation syscalls) makes it unsuitable as the default choice.
 
 The system allocator remains a viable option for:
 

--- a/docs/04_adr/03_mmap_strategy.rst
+++ b/docs/04_adr/03_mmap_strategy.rst
@@ -33,10 +33,10 @@ kernel page cache.
 
 Three strategies were evaluated:
 
-1. **Heap** — decompress into heap-allocated ``Vec<u8>`` buffers.
-2. **MmapSidecar** — decompress into separate ``.fb`` sidecar files next to the
+1. **Heap** -- decompress into heap-allocated ``Vec<u8>`` buffers.
+2. **MmapSidecar** -- decompress into separate ``.fb`` sidecar files next to the
    MDD files, then memory-map those sidecar files.
-3. **MmapMdd (in-place)** — decompress the MDD files themselves once (i.e. during a
+3. **MmapMdd (in-place)** -- decompress the MDD files themselves once (i.e. during a
    software update), rewriting them with uncompressed chunk data, then
    memory-map the MDD files directly with zero-copy protobuf decoding.
 
@@ -47,7 +47,7 @@ We will use the **MmapMdd (in-place)** strategy: MDD files are decompressed
 once and are subsequently used **read-only** via
 ``mmap``.  The protobuf layer uses prost's ``Bytes`` support
 (``Bytes::from_owner(mmap)``) so that chunk data fields are zero-copy slices
-into the memory-mapped file — no heap allocation is required for the
+into the memory-mapped file -- no heap allocation is required for the
 FlatBuffers payload.
 
 Before the atomic rename of a rewritten MDD file, the written data is verified
@@ -89,21 +89,21 @@ Rust 1.92.0, ``--release`` profile, ~3 minutes idle warm-up, and swap disabled.
    The MmapMdd implementation uses ``memmap2::Advice::Random``
    (``MADV_RANDOM``) immediately after ``mmap()`` to disable read-ahead for
    the sparse FlatBuffers vtable lookups that dominate runtime access.  This
-   avoids a ``libc`` dependency — the hint is set directly via ``memmap2``
+   avoids a ``libc`` dependency -- the hint is set directly via ``memmap2``
    before ownership is transferred to ``Bytes::from_owner()``.
 
 MmapMdd Advantages over Heap
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-1. **RSS under pressure: −75 %** (119 MB vs 469 MB)
+1. **RSS under pressure: -75 %** (119 MB vs 469 MB)
 
    All FlatBuffers data is backed by the MDD file on disk.  Under memory
-   pressure the kernel cleanly drops those pages and re-reads them on demand —
+   pressure the kernel cleanly drops those pages and re-reads them on demand --
    no swap I/O required.  On the heap strategy, anonymous pages can only be
    compressed or swapped, incurring significant I/O overhead with a modest
-   −3.7 % reduction.
+   -3.7 % reduction.
 
-2. **Idle RSS: −69 %** (153 MB vs 487 MB)
+2. **Idle RSS: -69 %** (153 MB vs 487 MB)
 
    The zero-copy protobuf decode (``Bytes::from_owner(mmap)``) avoids copying
    every ``bytes`` field to the heap.  Chunk data fields are slices into the
@@ -125,8 +125,8 @@ MmapMdd Advantages over MmapSidecar
 2. **Lower RSS under pressure** (119 MB vs 172 MB)
 
    The in-place strategy benefits from zero-copy protobuf decoding
-   (``Bytes::from_owner``) which the sidecar approach did not use.  All data —
-   protobuf metadata and FlatBuffers payloads — lives in the single mmap,
+   (``Bytes::from_owner``) which the sidecar approach did not use.  All data --
+   protobuf metadata and FlatBuffers payloads -- lives in the single mmap,
    giving the kernel a unified region to evict.
 
 3. **Lower idle RSS** (153 MB vs 308 MB)
@@ -158,22 +158,22 @@ a realistic end-to-end workload on the target Linux system to compare the
   events: ``cycles``, ``instructions``, ``faults``, ``cache-references``,
   ``cache-misses``.
 
-.. list-table:: ``perf stat`` Results — Main vs MmapMdd (under load)
+.. list-table:: ``perf stat`` Results -- Main vs MmapMdd (under load)
    :header-rows: 1
    :widths: 32 22 22 24
 
    * - Metric
      - Main (compressed)
      - MmapMdd (decompressed)
-     - Δ
+     - Delta
    * - cycles
      - 448,473,942
      - 437,102,422
-     - **−2.5 %**
+     - **-2.5 %**
    * - instructions
      - 194,934,031
      - 194,316,925
-     - −0.3 %
+     - -0.3 %
    * - IPC (insn/cycle)
      - 0.43
      - 0.44
@@ -189,7 +189,7 @@ a realistic end-to-end workload on the target Linux system to compare the
    * - cache-misses
      - 18,142,040 (70.21 %)
      - 18,478,329 (70.98 %)
-     - −0.77 pp
+     - -0.77 pp
    * - wall time
      - 42.19 s
      - 42.19 s
@@ -207,7 +207,7 @@ Under realistic ECU-flash load with concurrent memory pressure both
 implementations are effectively equivalent in CPU efficiency (within 2.5 %
 of each other) and identical in wall time.  The workload is dominated by
 network I/O (DoIP) rather than database access, so the expected RSS savings
-of MmapMdd (−75 % under pressure) are realized without any runtime CPU
+of MmapMdd (-75 % under pressure) are realized without any runtime CPU
 regression.
 
 ``perf report`` call-graph analysis confirmed that the top hotspots
@@ -219,7 +219,7 @@ that no new hot paths were introduced by the MmapMdd implementation.
 Trade-offs
 ^^^^^^^^^^
 
-- **Disk usage increases**: MDD files grow from ~47 MB to 242 MB (~5.1×).  This
+- **Disk usage increases**: MDD files grow from ~47 MB to 242 MB (~5.1x).  This
   is a one-time cost during the software update and is acceptable on the target
   platform where storage is less constrained than RAM.
 
@@ -242,7 +242,7 @@ Positive
 - **69 % lower idle RSS** (153 MB vs 487 MB) due to zero-copy protobuf
   decoding and ``MADV_RANDOM`` via ``memmap2`` to suppress wasteful
   read-ahead during sparse FlatBuffers lookups.
-- **Zero-copy data path**: mmap → ``Bytes`` → FlatBuffers — no intermediate
+- **Zero-copy data path**: mmap --> ``Bytes`` --> FlatBuffers -- no intermediate
   heap allocations for the diagnostic payload.
 - **Single file, single source of truth**: no sidecar files to manage,
   eliminating consistency and cleanup issues.
@@ -257,7 +257,7 @@ Positive
 Negative
 ^^^^^^^^
 
-- **5.1× disk usage increase** for the MDD database directory.
+- **5.1x disk usage increase** for the MDD database directory.
 - **One-time decompression cost** i.e. during software update or first startup
 - **Platform dependency**: relies on OS-level mmap, page cache behaviour, and
   ``madvise(2)`` support (POSIX systems), although the latter is guarded by a cfg flag, so the CDA still
@@ -271,7 +271,7 @@ Heap (Baseline)
 
 Decompress FlatBuffers data into heap-allocated ``Vec<u8>`` buffers.  Simplest
 implementation but RSS remains high (~487 MB idle, ~469 MB under pressure).
-Anonymous heap pages cannot be cleanly evicted by the kernel — they must be
+Anonymous heap pages cannot be cleanly evicted by the kernel -- they must be
 compressed or swapped, incurring I/O overhead.  Unsuitable for
 memory-constrained targets.
 
@@ -290,5 +290,5 @@ References
 ----------
 
 - `memmap2 crate <https://crates.io/crates/memmap2>`_
-- `bytes crate — Bytes::from_owner <https://docs.rs/bytes/latest/bytes/struct.Bytes.html#method.from_owner>`_
+- `bytes crate -- Bytes::from_owner <https://docs.rs/bytes/latest/bytes/struct.Bytes.html#method.from_owner>`_
 - `prost Bytes support <https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.bytes>`_

--- a/integration-tests/tests/sovd/data.rs
+++ b/integration-tests/tests/sovd/data.rs
@@ -27,7 +27,7 @@ use crate::{
 /// According to ISO 14229-1, a `ReadDataByIdentifier` positive response must echo
 /// the same DID bytes as the request. If the ECU responds with a different DID,
 /// the response is invalid and CDA should treat it as if no valid response was
-/// received (timeout → HTTP 504 Gateway Timeout).
+/// received (timeout -> HTTP 504 Gateway Timeout).
 ///
 /// This test verifies that the CDA correctly ignores an invalid DID and returns
 /// HTTP 504 if no further correct message is received within the timeout period.

--- a/integration-tests/tests/sovd/flash_download.rs
+++ b/integration-tests/tests/sovd/flash_download.rs
@@ -545,7 +545,7 @@ async fn test_flash_transfer_zero_length_rejected() {
         .and_then(|v| v.as_str())
         .expect("Expected 'id' in flash file");
 
-    // Attempt flash transfer with length=0 -- should be rejected
+    // Attempt flash transfer with length=0 - should be rejected
     let zero_length_body = serde_json::json!({
         "blocksequencecounter": 1,
         "blocksize": 128,

--- a/integration-tests/tests/sovd/mod.rs
+++ b/integration-tests/tests/sovd/mod.rs
@@ -341,7 +341,7 @@ where
 {
     std::panic::set_hook(Box::new(move |_| {
         // Create a new runtime to drive the future to completion.
-        // Don't use Handle::current().block_on() here — it will
+        // Don't use Handle::current().block_on() here - it will
         // deadlock if the panic happens on an async worker thread.
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()

--- a/testcontainer/odx/routines.py
+++ b/testcontainer/odx/routines.py
@@ -156,7 +156,7 @@ def add_safety_squints_routine(dlr: DiagLayerRaw) -> None:
     routine_id = 0x0301
     functional_class = "Routines"
 
-    # Start — with slit width parameter
+    # Start - with slit width parameter
     add_routine(
         dlr,
         name="Engage_Safety_Squints",
@@ -175,7 +175,7 @@ def add_safety_squints_routine(dlr: DiagLayerRaw) -> None:
         is_functional=True,
     )
 
-    # Stop — no additional parameters
+    # Stop - no additional parameters
     add_routine(
         dlr,
         name="Engage_Safety_Squints",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Enable the no-unicode pre-commit check by updating CI/CD workflow action references to the latest `cicd-workflows` commit (`4700b71`) and replacing all non-ASCII characters across 21 source files with their ASCII equivalents.

Characters replaced: em dashes, section signs, Unicode arrows, box drawing characters, smart quotes, micro sign, and ellipsis characters in `.rs`, `.py`, and `.yaml` files.

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

Depends on https://github.com/eclipse-opensovd/cicd-workflows/pull/30

Solves #275 


## Notes for Reviewers

Pure cosmetic/lint change -- no logic affected. All replacements are semantically equivalent ASCII substitutions to satisfy the new `no-unicode-extensions` pre-commit hook.

### Discussion
Do we want to allow µ and §? 

Alexander Mohr <alexander.m.mohr@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)