### PR TITLE
operations: add /operations/{operation}/docs

### DIFF
--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -2927,6 +2927,18 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> SchemaP
             .schema_for_responses(service)
             .await
     }
+
+    async fn schema_for_fg_request(
+        &self,
+        service: &DiagComm,
+        functional_group_name: &str,
+    ) -> Result<cda_interfaces::SchemaDescription, DiagServiceError> {
+        self.ecu_manager(&self.functional_description_database)?
+            .read()
+            .await
+            .schema_for_fg_request(service, functional_group_name)
+            .await
+    }
 }
 
 #[tracing::instrument(skip_all,

--- a/cda-core/src/diag_kernel/schema.rs
+++ b/cda-core/src/diag_kernel/schema.rs
@@ -80,6 +80,27 @@ impl<S: SecurityPlugin> EcuSchemaProvider for EcuManager<S> {
             main_schema,
         ))
     }
+
+    async fn schema_for_fg_request(
+        &self,
+        service: &cda_interfaces::DiagComm,
+        functional_group_name: &str,
+    ) -> Result<SchemaDescription, DiagServiceError> {
+        let mapped_service = self
+            .lookup_diag_service(service, Some(functional_group_name), None)
+            .await?;
+        let ctx = service_context(service, &mapped_service);
+
+        let request = mapped_service.request().map(datatypes::Request).ok_or(
+            DiagServiceError::InvalidDatabase(format!(
+                "Missing request for service {} in functional group {}.",
+                service.name, functional_group_name
+            )),
+        )?;
+        let schema = request.json_schema(&ctx, &self.diag_database);
+
+        Ok(schema)
+    }
 }
 
 fn service_context(service: &cda_interfaces::DiagComm, mapped_service: &DiagService) -> String {
@@ -255,6 +276,135 @@ fn params_to_schema(
     })
 }
 
+/// Collect accepted text values from a `TextTable` compu method's scales.
+///
+/// Each scale entry maps a coded/internal value to a human-readable text value.
+/// Returns the text values (`vt`, with `vt_ti` as fallback) that the user can
+/// supply when executing this service.
+fn text_table_enum_values<'a>(normal_dop: &'a datatypes::NormalDop<'a>) -> Vec<&'a str> {
+    normal_dop
+        .compu_method()
+        .and_then(|cm| cm.internal_to_phys())
+        .and_then(|itp| itp.compu_scales())
+        .map(|scales| {
+            scales
+                .iter()
+                .filter_map(|scale| scale.consts().and_then(|c| c.vt().or(c.vt_ti())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// If the `NormalDop` carries a physical constraint (`phys_constr`) with
+/// parseable numeric limits, add the corresponding JSON Schema range keywords
+/// (`minimum` / `maximum` / `exclusiveMinimum` / `exclusiveMaximum`) to `schema`.
+///
+/// Limits with `IntervalType::Infinite` or non-numeric values are silently
+/// skipped so that this helper never fails.
+fn add_phys_constr_range(normal_dop: &datatypes::NormalDop, schema: &mut schemars::Schema) {
+    let Some(constr) = normal_dop.phys_constr() else {
+        return;
+    };
+    let Some(props) = schema.as_object_mut() else {
+        return;
+    };
+
+    if let Some(lower) = constr.lower_limit() {
+        let interval: datatypes::IntervalType = lower.interval_type().into();
+        if interval != datatypes::IntervalType::Infinite
+            && let Some(value) = lower.value().and_then(|v| v.parse::<f64>().ok())
+        {
+            let key = if interval == datatypes::IntervalType::Open {
+                "exclusiveMinimum"
+            } else {
+                "minimum"
+            };
+            props.insert(key.to_owned(), serde_json::json!(value));
+        }
+    }
+
+    if let Some(upper) = constr.upper_limit() {
+        let interval: datatypes::IntervalType = upper.interval_type().into();
+        if interval != datatypes::IntervalType::Infinite
+            && let Some(value) = upper.value().and_then(|v| v.parse::<f64>().ok())
+        {
+            let key = if interval == datatypes::IntervalType::Open {
+                "exclusiveMaximum"
+            } else {
+                "maximum"
+            };
+            props.insert(key.to_owned(), serde_json::json!(value));
+        }
+    }
+}
+
+fn normal_dop_to_schema(
+    ctx: &str,
+    normal_dop: &datatypes::NormalDop,
+    name: String,
+    default_value: &str,
+    schema: &mut schemars::Schema,
+) -> Result<(), DiagServiceError> {
+    let Some(category) = normal_dop
+        .compu_method()
+        .map(|cm| cm.category())
+        .map(Into::into)
+    else {
+        return Err(DiagServiceError::ParameterConversionError(format!(
+            "Mapping {ctx}: Compu Method or Category not found in ECU database"
+        )));
+    };
+
+    match category {
+        datatypes::CompuCategory::TextTable => {
+            let enum_values = text_table_enum_values(normal_dop);
+
+            if enum_values.is_empty() {
+                schema.insert(
+                    name,
+                    schemars::json_schema!({
+                        "default": default_value,
+                        "type": "string"
+                    })
+                    .into(),
+                );
+            } else {
+                schema.insert(
+                    name,
+                    schemars::json_schema!({
+                        "default": default_value,
+                        "type": "string",
+                        "enum": enum_values
+                    })
+                    .into(),
+                );
+            }
+        }
+        datatypes::CompuCategory::Identical
+        | datatypes::CompuCategory::Linear
+        | datatypes::CompuCategory::ScaleLinear
+        | datatypes::CompuCategory::TabIntp
+        | datatypes::CompuCategory::RatFunc
+        | datatypes::CompuCategory::ScaleRatFunc
+        | datatypes::CompuCategory::CompuCode => {
+            let Some(datatype) = normal_dop.diag_coded_type().ok() else {
+                return Err(DiagServiceError::ParameterConversionError(format!(
+                    "Mapping {ctx}: Diag Coded Type not found in ECU database"
+                )));
+            };
+            let type_ = ecu_datatype_to_jsontype(datatype.base_datatype());
+
+            let mut param_schema = schemars::json_schema!({
+                "default": default_value,
+                "type": type_
+            });
+            add_phys_constr_range(normal_dop, &mut param_schema);
+            schema.insert(name, param_schema.into());
+        }
+    }
+    Ok(())
+}
+
 fn dop_variant_to_schema(
     ctx: &str,
     ecu_db: &DiagnosticDatabase,
@@ -266,44 +416,7 @@ fn dop_variant_to_schema(
 ) -> Result<(), DiagServiceError> {
     match variant {
         datatypes::DataOperationVariant::Normal(normal_dop) => {
-            // todo: schould we add a description or something
-            // regarding how the DOPs work? (scales, ...)
-            let Some(category) = normal_dop
-                .compu_method()
-                .map(|cm| cm.category())
-                .map(Into::into)
-            else {
-                return Err(DiagServiceError::ParameterConversionError(format!(
-                    "Mapping {ctx}: Compu Method or Category not found in ECU database"
-                )));
-            };
-
-            let type_ = match category {
-                datatypes::CompuCategory::TextTable => "string".to_owned(),
-                datatypes::CompuCategory::Identical
-                | datatypes::CompuCategory::Linear
-                | datatypes::CompuCategory::ScaleLinear
-                | datatypes::CompuCategory::TabIntp
-                | datatypes::CompuCategory::RatFunc
-                | datatypes::CompuCategory::ScaleRatFunc
-                | datatypes::CompuCategory::CompuCode => {
-                    let Some(datatype) = normal_dop.diag_coded_type().ok() else {
-                        return Err(DiagServiceError::ParameterConversionError(format!(
-                            "Mapping {ctx}: Diag Coded Type not found in ECU database"
-                        )));
-                    };
-                    ecu_datatype_to_jsontype(datatype.base_datatype())
-                }
-            };
-
-            schema.insert(
-                name,
-                schemars::json_schema!({
-                    "default": default_value,
-                    "type": type_
-                })
-                .into(),
-            );
+            normal_dop_to_schema(ctx, &normal_dop, name, default_value, schema)?;
         }
         datatypes::DataOperationVariant::EndOfPdu(end_of_pdu_dop) => {
             if let Some(end_of_pdu_schema) = map_dop_field_to_schema(

--- a/cda-interfaces/src/ecuuds.rs
+++ b/cda-interfaces/src/ecuuds.rs
@@ -847,6 +847,14 @@ pub mod mock {
         ) -> Result<SchemaDescription, DiagServiceError> {
             Err(DiagServiceError::NotFound(String::new()))
         }
+
+        async fn schema_for_fg_request(
+            &self,
+            _service: &crate::DiagComm,
+            _functional_group_name: &str,
+        ) -> Result<SchemaDescription, DiagServiceError> {
+            Err(DiagServiceError::NotFound(String::new()))
+        }
     }
 }
 

--- a/cda-interfaces/src/schema.rs
+++ b/cda-interfaces/src/schema.rs
@@ -90,6 +90,16 @@ pub trait EcuSchemaProvider {
         &self,
         service: &DiagComm,
     ) -> impl Future<Output = Result<SchemaDescription, DiagServiceError>> + Send;
+
+    /// Get the request schema for a service defined in a functional group's diag layer.
+    ///
+    /// This is equivalent to [`schema_for_request`](EcuSchemaProvider::schema_for_request)
+    /// but looks up the service in the given functional group instead of the variant.
+    fn schema_for_fg_request(
+        &self,
+        service: &DiagComm,
+        functional_group_name: &str,
+    ) -> impl Future<Output = Result<SchemaDescription, DiagServiceError>> + Send;
 }
 
 pub trait SchemaProvider {
@@ -103,5 +113,15 @@ pub trait SchemaProvider {
         &self,
         ecu: &str,
         service: &DiagComm,
+    ) -> impl Future<Output = Result<SchemaDescription, DiagServiceError>> + Send;
+
+    /// Get the request schema for an operation defined in a functional group.
+    ///
+    /// The implementation resolves the functional description database internally;
+    /// the caller only needs to provide the functional group name and service.
+    fn schema_for_fg_request(
+        &self,
+        service: &DiagComm,
+        functional_group_name: &str,
     ) -> impl Future<Output = Result<SchemaDescription, DiagServiceError>> + Send;
 }

--- a/cda-sovd-interfaces/src/docs.rs
+++ b/cda-sovd-interfaces/src/docs.rs
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+//! Constants for SOVD online/offline capability description extensions
+//! (ISO 17978-3 Table 169).
+
+/// Extension on the [`Operation`](https://spec.openapis.org/oas/v3.1.0#operation-object)
+/// object indicating that the operation executes asynchronously.
+pub const X_SOVD_ASYNCHRONOUS_EXECUTION: &str = "x-sovd-asynchronous-execution";
+
+/// Extension on the [`PathItem`](https://spec.openapis.org/oas/v3.1.0#path-item-object)
+/// object indicating that execution of the operation requires proof of
+/// co-location.
+pub const X_SOVD_PROXIMITY_PROOF_REQUIRED: &str = "x-sovd-proximity-proof-required";

--- a/cda-sovd-interfaces/src/lib.rs
+++ b/cda-sovd-interfaces/src/lib.rs
@@ -17,6 +17,7 @@ use crate::error::DataError;
 
 pub mod apps;
 pub mod components;
+pub mod docs;
 pub mod error;
 pub mod functions;
 pub mod locking;

--- a/cda-sovd/src/sovd/components/ecu/operations.rs
+++ b/cda-sovd/src/sovd/components/ecu/operations.rs
@@ -480,6 +480,106 @@ pub(crate) mod comparams {
 }
 
 pub(crate) mod service {
+    /// `GET /operations/{service}/docs` - online capability description
+    pub(crate) mod docs_endpoint {
+        use aide::{UseApi, openapi::OpenApi, transform::TransformOperation};
+        use axum::{
+            Json,
+            extract::{Path, State},
+            http::StatusCode,
+            response::{IntoResponse as _, Response},
+        };
+        use cda_interfaces::{
+            DiagComm, DiagCommType, DynamicPlugin, SchemaProvider, UdsEcu,
+            diagservices::DiagServiceResponse, file_manager::FileManager, subfunction_ids,
+        };
+        use cda_plugin_security::Secured;
+
+        use crate::{
+            openapi,
+            sovd::{
+                WebserverEcuState,
+                docs::{self, operations::OperationDocsMeta},
+                error::ApiError,
+            },
+        };
+
+        openapi::aide_helper::gen_path_param!(OperationNamePathParam service String);
+
+        pub(crate) async fn get<
+            R: DiagServiceResponse,
+            T: UdsEcu + SchemaProvider + Clone,
+            U: FileManager,
+        >(
+            UseApi(Secured(security_plugin), _): UseApi<Secured, ()>,
+            Path(OperationNamePathParam { service }): Path<OperationNamePathParam>,
+            State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<R, T, U>>,
+        ) -> Response {
+            let security_plugin: DynamicPlugin = security_plugin;
+
+            let ops_info = match uds
+                .get_components_operations_info(&ecu_name, &security_plugin)
+                .await
+            {
+                Ok(info) => info,
+                Err(e) => return ApiError::from(e).into_response(),
+            };
+
+            let Some(op_info) = ops_info
+                .iter()
+                .find(|o| o.id.eq_ignore_ascii_case(&service))
+            else {
+                return ApiError::NotFound(Some(format!("Operation '{service}' not found")))
+                    .into_response();
+            };
+
+            let is_async = op_info.has_stop || op_info.has_request_results;
+
+            let diag_service = DiagComm {
+                name: service.clone(),
+                type_: DiagCommType::Operations,
+                lookup_name: None,
+                subfunction_id: Some(subfunction_ids::routine::START),
+            };
+
+            let request_params_schema = uds
+                .schema_for_request(&ecu_name, &diag_service)
+                .await
+                .ok()
+                .and_then(cda_interfaces::SchemaDescription::into_schema);
+
+            let response_params_schema = uds
+                .schema_for_responses(&ecu_name, &diag_service)
+                .await
+                .ok()
+                .and_then(cda_interfaces::SchemaDescription::into_schema);
+
+            let meta = OperationDocsMeta {
+                name: service.clone(),
+                is_async,
+                request_params_schema,
+                response_params_schema,
+            };
+
+            let base_path = format!("/components/{ecu_name}/operations/{service}");
+            let path_items = docs::operations::build_path_items(&base_path, &meta);
+            let doc = docs::build_openapi_doc(&format!("Operation: {service}"), path_items);
+
+            (StatusCode::OK, Json(doc)).into_response()
+        }
+
+        pub(crate) fn docs_transform(op: TransformOperation) -> TransformOperation {
+            op.description(
+                "Online capability description for a specific operation on this ECU component \
+                 (ISO 17978-3 Section 7.5). Returns a self-contained OpenAPI specification.",
+            )
+            .response_with::<200, Json<OpenApi>, _>(|res| {
+                res.description("Self-contained OpenAPI 3.1 specification for this operation.")
+            })
+            .with(openapi::error_not_found)
+        }
+    }
+
     pub(crate) mod executions {
         use aide::{UseApi, transform::TransformOperation};
         use axum::{

--- a/cda-sovd/src/sovd/docs/mod.rs
+++ b/cda-sovd/src/sovd/docs/mod.rs
@@ -1,0 +1,125 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+//! Reusable utilities for building self-contained `OpenAPI` 3.1 documents
+//! that serve as SOVD online capability descriptions (ISO 17978-3 Section 7.5).
+//!
+//! Each SOVD resource type (operations, data, faults, ...) constructs its own
+//! [`PathItem`]s and passes them to [`build_openapi_doc`] to produce a valid,
+//! self-contained `OpenAPI` specification returned by `GET .../docs`.
+
+pub mod operations;
+
+use aide::openapi::{
+    Info, MediaType, OpenApi, Operation, PathItem, Paths, ReferenceOr, RequestBody, Response,
+    Responses, SchemaObject, StatusCode,
+};
+use indexmap::IndexMap;
+use schemars::Schema;
+
+/// Build a minimal, self-contained `OpenAPI` 3.1 document.
+///
+/// `title` - used as `info.title` (e.g. `"Operation: CalibrateSensors"`).
+/// `paths` - the set of path items that describe the resource's API surface.
+pub fn build_openapi_doc(title: &str, paths: IndexMap<String, PathItem>) -> OpenApi {
+    OpenApi {
+        info: Info {
+            title: title.to_owned(),
+            version: "1.0.0".to_owned(),
+            ..Default::default()
+        },
+        paths: Some(Paths {
+            paths: paths
+                .into_iter()
+                .map(|(k, v)| (k, ReferenceOr::Item(v)))
+                .collect(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+/// Wrap a [`schemars::Schema`] into an aide [`SchemaObject`].
+pub fn schema_object(schema: Schema) -> SchemaObject {
+    SchemaObject {
+        json_schema: schema,
+        external_docs: None,
+        example: None,
+    }
+}
+
+/// Build a JSON media type entry from a [`schemars::Schema`].
+pub fn json_media_type(schema: Schema) -> MediaType {
+    MediaType {
+        schema: Some(schema_object(schema)),
+        ..Default::default()
+    }
+}
+
+/// Create a JSON request body from a [`schemars::Schema`].
+pub fn json_request_body(schema: Schema) -> ReferenceOr<RequestBody> {
+    ReferenceOr::Item(RequestBody {
+        content: IndexMap::from([("application/json".to_owned(), json_media_type(schema))]),
+        ..Default::default()
+    })
+}
+
+/// Create a response entry with a JSON body.
+pub fn json_response(description: &str, schema: Schema) -> ReferenceOr<Response> {
+    ReferenceOr::Item(Response {
+        description: description.to_owned(),
+        content: IndexMap::from([("application/json".to_owned(), json_media_type(schema))]),
+        ..Default::default()
+    })
+}
+
+/// Create a response entry without a body.
+pub fn empty_response(description: &str) -> ReferenceOr<Response> {
+    ReferenceOr::Item(Response {
+        description: description.to_owned(),
+        ..Default::default()
+    })
+}
+
+/// Build a [`Responses`] map from `(status_code, response)` pairs.
+pub fn responses(entries: Vec<(u16, ReferenceOr<Response>)>) -> Responses {
+    Responses {
+        responses: entries
+            .into_iter()
+            .map(|(code, resp)| (StatusCode::Code(code), resp))
+            .collect(),
+        ..Default::default()
+    }
+}
+
+/// Build an [`Operation`] with optional SOVD extension properties.
+pub fn operation_with_extensions(
+    summary: &str,
+    extensions: IndexMap<String, serde_json::Value>,
+) -> Operation {
+    Operation {
+        summary: Some(summary.to_owned()),
+        extensions,
+        ..Default::default()
+    }
+}
+
+/// Minimal SOVD error response schema (spec 5.8).
+pub fn error_schema() -> Schema {
+    schemars::json_schema!({
+        "type": "object",
+        "properties": {
+            "error_code": { "type": "string" },
+            "message": { "type": "string" }
+        }
+    })
+}

--- a/cda-sovd/src/sovd/docs/operations.rs
+++ b/cda-sovd/src/sovd/docs/operations.rs
@@ -1,0 +1,348 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+//! Builders for the online capability description of SOVD operation resources.
+//!
+//! Produces the [`PathItem`]s that describe an operation's execution surface
+//! (`/executions`, `/executions/{execution-id}`) and embeds request/response
+//! parameter schemas obtained from the diagnostic layer.
+
+use aide::openapi::{Operation, PathItem};
+use indexmap::IndexMap;
+use schemars::Schema;
+
+use super::{
+    empty_response, error_schema, json_request_body, json_response, operation_with_extensions,
+    responses,
+};
+
+/// Metadata needed to construct the online capability description for a single
+/// SOVD operation resource.
+pub struct OperationDocsMeta {
+    /// Human-readable name of the operation.
+    pub name: String,
+    /// Whether the operation executes asynchronously (has Stop / `RequestResults`).
+    pub is_async: bool,
+    /// JSON Schema describing the operation's request parameters (the value of
+    /// the `parameters` attribute in the POST request body). `None` if the
+    /// operation takes no parameters.
+    pub request_params_schema: Option<Schema>,
+    /// JSON Schema describing the operation's response parameters. `None` if
+    /// the operation produces no response data.
+    pub response_params_schema: Option<Schema>,
+}
+
+/// Build the `PathItem` entries for a single operation's execution endpoints.
+///
+/// Returns an ordered map with two entries:
+/// - `{base_path}/executions` - POST (start), GET (list)
+/// - `{base_path}/executions/{execution-id}` - GET (status), PUT (capabilities), DELETE (terminate)
+///
+/// The second entry is only present for asynchronous operations.
+pub fn build_path_items(base_path: &str, meta: &OperationDocsMeta) -> IndexMap<String, PathItem> {
+    let mut paths = IndexMap::new();
+
+    let executions_path_item = PathItem {
+        post: Some(build_post_operation(meta)),
+        get: Some(build_list_executions_operation(meta)),
+        ..Default::default()
+    };
+    paths.insert(format!("{base_path}/executions"), executions_path_item);
+
+    if meta.is_async {
+        paths.insert(
+            format!("{base_path}/executions/{{execution-id}}"),
+            build_execution_id_path_item(meta),
+        );
+    }
+
+    paths
+}
+
+/// POST operation for starting an execution (7.14.6).
+fn build_post_operation(meta: &OperationDocsMeta) -> Operation {
+    let post_request_schema = build_post_request_schema(meta);
+    let mut post_op = operation_with_extensions(
+        &format!("Start execution of {}", meta.name),
+        sovd_extensions(meta),
+    );
+    post_op.request_body = Some(json_request_body(post_request_schema));
+
+    if meta.is_async {
+        post_op.responses = Some(responses(vec![
+            (
+                202,
+                json_response(
+                    "Execution started asynchronously. Poll the returned execution resource for \
+                     status.",
+                    schemars::json_schema!({
+                        "type": "object",
+                        "properties": {
+                            "id": { "type": "string", "description": "Execution identifier" },
+                            "status": {
+                                "type": "string",
+                                "enum": ["running", "completed", "failed", "stopped"]
+                            }
+                        },
+                        "required": ["id"]
+                    }),
+                ),
+            ),
+            (
+                409,
+                json_response(
+                    "Operation already executing or resource conflict.",
+                    error_schema(),
+                ),
+            ),
+        ]));
+    } else {
+        let sync_response_schema = build_sync_response_schema(meta);
+        post_op.responses = Some(responses(vec![
+            (
+                200,
+                json_response("Operation completed synchronously.", sync_response_schema),
+            ),
+            (
+                409,
+                json_response("Operation not available.", error_schema()),
+            ),
+        ]));
+    }
+
+    post_op
+}
+
+/// GET operation for listing executions of an operation (7.14.4).
+fn build_list_executions_operation(meta: &OperationDocsMeta) -> Operation {
+    let mut list_op = Operation {
+        summary: Some(format!("List executions of {}", meta.name)),
+        ..Default::default()
+    };
+    list_op.responses = Some(responses(vec![(
+        200,
+        json_response(
+            "List of current execution identifiers.",
+            schemars::json_schema!({
+                "type": "object",
+                "properties": {
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": { "type": "string" }
+                            },
+                            "required": ["id"]
+                        }
+                    }
+                }
+            }),
+        ),
+    )]));
+    list_op
+}
+
+/// Build the `PathItem` for `/executions/{execution-id}` (async operations only).
+///
+/// Contains GET (status, 7.14.7), PUT (capabilities, 7.14.9) and DELETE (terminate, 7.14.8).
+fn build_execution_id_path_item(meta: &OperationDocsMeta) -> PathItem {
+    PathItem {
+        get: Some(build_get_status_operation(meta)),
+        put: Some(build_put_capability_operation(meta)),
+        delete: Some(build_delete_terminate_operation(meta)),
+        ..Default::default()
+    }
+}
+
+/// GET - poll execution status (7.14.7).
+fn build_get_status_operation(meta: &OperationDocsMeta) -> Operation {
+    let mut status_schema = schemars::json_schema!({
+        "type": "object",
+        "properties": {
+            "status": {
+                "type": "string",
+                "enum": ["running", "completed", "failed", "stopped"],
+                "description": "Current execution status."
+            },
+            "capability": {
+                "type": "string",
+                "description": "Capability currently being executed."
+            },
+            "progress": {
+                "type": "integer",
+                "description": "Execution progress in percent (0-100)."
+            },
+            "error": {
+                "type": "array",
+                "items": { "type": "object" },
+                "description": "Errors that occurred during execution."
+            }
+        },
+        "required": ["status", "capability"]
+    });
+    embed_response_params(&mut status_schema, meta);
+
+    let mut get_status = Operation {
+        summary: Some(format!("Read the status of an execution of {}", meta.name)),
+        ..Default::default()
+    };
+    get_status.responses = Some(responses(vec![
+        (
+            200,
+            json_response("Current execution status.", status_schema),
+        ),
+        (404, json_response("Execution not found.", error_schema())),
+    ]));
+    get_status
+}
+
+/// PUT - stop / freeze / reset / execute capabilities (7.14.9).
+fn build_put_capability_operation(meta: &OperationDocsMeta) -> Operation {
+    let mut put_capability = Operation {
+        summary: Some(format!(
+            "Execute a capability (stop, freeze, reset, execute) on {}",
+            meta.name
+        )),
+        ..Default::default()
+    };
+    put_capability.request_body = Some(json_request_body(schemars::json_schema!({
+        "type": "object",
+        "properties": {
+            "capability": {
+                "type": "string",
+                "enum": ["execute", "stop", "freeze", "reset"],
+                "description": "Capability to be executed."
+            },
+            "timeout": {
+                "type": "integer",
+                "description": "Timeout in seconds."
+            },
+            "parameters": { "type": "object" },
+            "proximity_response": { "type": "string" }
+        },
+        "required": ["capability"]
+    })));
+    put_capability.responses = Some(responses(vec![
+        (
+            202,
+            json_response(
+                "Capability execution triggered.",
+                schemars::json_schema!({
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" },
+                        "status": { "type": "string" }
+                    }
+                }),
+            ),
+        ),
+        (404, json_response("Execution not found.", error_schema())),
+    ]));
+    put_capability
+}
+
+/// DELETE - terminate execution (7.14.8).
+fn build_delete_terminate_operation(meta: &OperationDocsMeta) -> Operation {
+    let mut delete_terminate = Operation {
+        summary: Some(format!("Terminate execution of {}", meta.name)),
+        ..Default::default()
+    };
+    delete_terminate.responses = Some(responses(vec![
+        (204, empty_response("Execution terminated and removed.")),
+        (404, json_response("Execution not found.", error_schema())),
+    ]));
+    delete_terminate
+}
+
+/// Build the JSON Schema for the POST request body of an operation execution.
+fn build_post_request_schema(meta: &OperationDocsMeta) -> Schema {
+    let mut properties = serde_json::Map::new();
+
+    properties.insert(
+        "timeout".to_owned(),
+        serde_json::json!({
+            "type": "integer",
+            "description": "Seconds after which the server should terminate the operation."
+        }),
+    );
+
+    if let Some(params_schema) = &meta.request_params_schema {
+        properties.insert(
+            "parameters".to_owned(),
+            serde_json::Value::from(params_schema.clone()),
+        );
+    } else {
+        properties.insert(
+            "parameters".to_owned(),
+            serde_json::json!({ "type": "object" }),
+        );
+    }
+
+    properties.insert(
+        "proximity_response".to_owned(),
+        serde_json::json!({
+            "type": "string",
+            "description": "Response to a co-location proximity challenge."
+        }),
+    );
+
+    schemars::json_schema!({
+        "type": "object",
+        "properties": properties
+    })
+}
+
+/// Collect the SOVD-specific extension properties for the Operation object
+/// (ISO 17978-3 Table 24).
+fn sovd_extensions(meta: &OperationDocsMeta) -> IndexMap<String, serde_json::Value> {
+    let mut ext = IndexMap::new();
+    if meta.is_async {
+        ext.insert(
+            "x-sovd-asynchronous-execution".to_owned(),
+            serde_json::Value::Bool(true),
+        );
+    }
+    // proximity_proof_required is always false for classic UDS routines.
+    ext.insert(
+        "x-sovd-proximity-proof-required".to_owned(),
+        serde_json::Value::Bool(false),
+    );
+    ext
+}
+
+/// Embed the operation's response parameter schema as a `"parameters"` property
+/// inside an existing JSON Schema object (mutates in place).
+fn embed_response_params(schema: &mut Schema, meta: &OperationDocsMeta) {
+    if let Some(resp_schema) = &meta.response_params_schema
+        && let Some(obj) = schema.as_object_mut()
+        && let Some(props) = obj.get_mut("properties")
+        && let Some(props_obj) = props.as_object_mut()
+    {
+        props_obj.insert(
+            "parameters".to_owned(),
+            serde_json::Value::from(resp_schema.clone()),
+        );
+    }
+}
+
+/// Build the response schema for a synchronous operation (200 from POST).
+fn build_sync_response_schema(meta: &OperationDocsMeta) -> Schema {
+    let mut schema = schemars::json_schema!({
+        "type": "object",
+        "properties": {
+            "parameters": { "type": "object" }
+        }
+    });
+    embed_response_params(&mut schema, meta);
+    schema
+}

--- a/cda-sovd/src/sovd/docs/operations.rs
+++ b/cda-sovd/src/sovd/docs/operations.rs
@@ -19,6 +19,7 @@
 use aide::openapi::{Operation, PathItem};
 use indexmap::IndexMap;
 use schemars::Schema;
+use sovd_interfaces::docs;
 
 use super::{
     empty_response, error_schema, json_request_body, json_response, operation_with_extensions,
@@ -54,6 +55,7 @@ pub fn build_path_items(base_path: &str, meta: &OperationDocsMeta) -> IndexMap<S
     let executions_path_item = PathItem {
         post: Some(build_post_operation(meta)),
         get: Some(build_list_executions_operation(meta)),
+        extensions: path_item_extensions(meta),
         ..Default::default()
     };
     paths.insert(format!("{base_path}/executions"), executions_path_item);
@@ -73,7 +75,7 @@ fn build_post_operation(meta: &OperationDocsMeta) -> Operation {
     let post_request_schema = build_post_request_schema(meta);
     let mut post_op = operation_with_extensions(
         &format!("Start execution of {}", meta.name),
-        sovd_extensions(meta),
+        operation_extensions(meta),
     );
     post_op.request_body = Some(json_request_body(post_request_schema));
 
@@ -160,6 +162,7 @@ fn build_execution_id_path_item(meta: &OperationDocsMeta) -> PathItem {
         get: Some(build_get_status_operation(meta)),
         put: Some(build_put_capability_operation(meta)),
         delete: Some(build_delete_terminate_operation(meta)),
+        extensions: path_item_extensions(meta),
         ..Default::default()
     }
 }
@@ -302,21 +305,36 @@ fn build_post_request_schema(meta: &OperationDocsMeta) -> Schema {
     })
 }
 
-/// Collect the SOVD-specific extension properties for the Operation object
-/// (ISO 17978-3 Table 24).
-fn sovd_extensions(meta: &OperationDocsMeta) -> IndexMap<String, serde_json::Value> {
+/// Collect the SOVD extension properties for the `PathItem` object
+/// (ISO 17978-3 Table 169).
+///
+/// Currently emits `x-sovd-proximity-proof-required` which applies to all HTTP
+/// methods on the path. For classic UDS routines this is always `false`.
+/// meta is passed but not used, to keep the signature consistent with `operation_extensions`.
+/// As proximity proof is always false for UDS, no access to meta is needed.
+fn path_item_extensions(_meta: &OperationDocsMeta) -> IndexMap<String, serde_json::Value> {
+    let mut ext = IndexMap::new();
+    // proximity_proof_required is always false for classic UDS routines.
+    ext.insert(
+        docs::X_SOVD_PROXIMITY_PROOF_REQUIRED.to_owned(),
+        serde_json::Value::Bool(false),
+    );
+    ext
+}
+
+/// Collect the SOVD extension properties for the Operation object
+/// (ISO 17978-3 Table 169).
+///
+/// Currently emits `x-sovd-asynchronous-execution` on the POST operation when
+/// the operation is asynchronous.
+fn operation_extensions(meta: &OperationDocsMeta) -> IndexMap<String, serde_json::Value> {
     let mut ext = IndexMap::new();
     if meta.is_async {
         ext.insert(
-            "x-sovd-asynchronous-execution".to_owned(),
+            docs::X_SOVD_ASYNCHRONOUS_EXECUTION.to_owned(),
             serde_json::Value::Bool(true),
         );
     }
-    // proximity_proof_required is always false for classic UDS routines.
-    ext.insert(
-        "x-sovd-proximity-proof-required".to_owned(),
-        serde_json::Value::Bool(false),
-    );
     ext
 }
 

--- a/cda-sovd/src/sovd/functions/functional_groups/mod.rs
+++ b/cda-sovd/src/sovd/functions/functional_groups/mod.rs
@@ -23,7 +23,7 @@ use axum::{
 };
 use axum_extra::extract::WithRejection;
 use cda_interfaces::{
-    FunctionalDescriptionConfig, HashMap, UdsEcu,
+    FunctionalDescriptionConfig, HashMap, SchemaProvider, UdsEcu,
     diagservices::{DiagServiceResponse, DiagServiceResponseType},
 };
 use http::StatusCode;
@@ -54,7 +54,7 @@ pub(crate) struct WebserverFgState<T: UdsEcu + Clone> {
     fg_executions: Arc<RwLock<HashMap<String, IndexMap<Uuid, FgServiceExecution>>>>,
 }
 
-pub(crate) async fn create_functional_group_routes<T: UdsEcu + Clone>(
+pub(crate) async fn create_functional_group_routes<T: UdsEcu + SchemaProvider + Clone>(
     state: WebserverState<T>,
     functional_group_config: FunctionalDescriptionConfig,
 ) -> Router {
@@ -150,7 +150,9 @@ pub(crate) async fn create_functional_group_routes<T: UdsEcu + Clone>(
     functional_groups_router
 }
 
-fn create_functional_group_route<T: UdsEcu + Clone>(fg_state: WebserverFgState<T>) -> Router {
+fn create_functional_group_route<T: UdsEcu + SchemaProvider + Clone>(
+    fg_state: WebserverFgState<T>,
+) -> Router {
     Router::new()
         .api_route(
             "/",
@@ -175,6 +177,13 @@ fn create_functional_group_route<T: UdsEcu + Clone>(fg_state: WebserverFgState<T
         .api_route(
             "/operations",
             routing::get_with(operations::get, operations::docs_get),
+        )
+        .api_route(
+            "/operations/{service}/docs",
+            routing::get_with(
+                operations::docs_endpoint::get,
+                operations::docs_endpoint::docs_transform,
+            ),
         )
         .api_route(
             "/operations/{service}/executions",

--- a/cda-sovd/src/sovd/functions/functional_groups/operations.rs
+++ b/cda-sovd/src/sovd/functions/functional_groups/operations.rs
@@ -85,6 +85,104 @@ pub(crate) fn docs_get(op: TransformOperation) -> TransformOperation {
         })
 }
 
+/// `GET /operations/{service}/docs` - online capability description for a
+/// functional-group operation.
+pub(crate) mod docs_endpoint {
+    use aide::{UseApi, openapi::OpenApi, transform::TransformOperation};
+    use axum::{
+        Json,
+        extract::{Path, State},
+        response::{IntoResponse, Response},
+    };
+    use cda_interfaces::{
+        DiagComm, DiagCommType, DynamicPlugin, SchemaProvider, UdsEcu, subfunction_ids,
+    };
+    use cda_plugin_security::Secured;
+    use http::StatusCode;
+
+    use super::super::WebserverFgState;
+    use crate::{
+        openapi,
+        sovd::{
+            docs::{self, operations::OperationDocsMeta},
+            error::ApiError,
+        },
+    };
+
+    openapi::aide_helper::gen_path_param!(FgOperationDocsPathParam service String);
+
+    pub(crate) async fn get<T: UdsEcu + SchemaProvider + Clone>(
+        UseApi(Secured(security_plugin), _): UseApi<Secured, ()>,
+        Path(FgOperationDocsPathParam { service }): Path<FgOperationDocsPathParam>,
+        State(WebserverFgState {
+            uds,
+            functional_group_name,
+            ..
+        }): State<WebserverFgState<T>>,
+    ) -> Response {
+        let security_plugin: DynamicPlugin = security_plugin;
+        let ops_info = match uds
+            .get_functional_group_operations_info(&security_plugin, &functional_group_name)
+            .await
+        {
+            Ok(info) => info,
+            Err(e) => return ApiError::from(e).into_response(),
+        };
+
+        let Some(op_info) = ops_info
+            .iter()
+            .find(|o| o.id.eq_ignore_ascii_case(&service))
+        else {
+            return ApiError::NotFound(Some(format!("Operation '{service}' not found")))
+                .into_response();
+        };
+
+        let is_async = op_info.has_stop || op_info.has_request_results;
+
+        let diag_service = DiagComm {
+            name: service.clone(),
+            type_: DiagCommType::Operations,
+            lookup_name: None,
+            subfunction_id: Some(subfunction_ids::routine::START),
+        };
+
+        let request_params_schema = uds
+            .schema_for_fg_request(&diag_service, &functional_group_name)
+            .await
+            .ok()
+            .and_then(cda_interfaces::SchemaDescription::into_schema);
+
+        // Note: schema_for_fg_responses is not yet available; response schema
+        // is omitted for now and can be added once the trait method exists.
+        let response_params_schema = None;
+
+        let meta = OperationDocsMeta {
+            name: service.clone(),
+            is_async,
+            request_params_schema,
+            response_params_schema,
+        };
+
+        let base_path =
+            format!("/functions/functionalgroups/{functional_group_name}/operations/{service}");
+        let path_items = docs::operations::build_path_items(&base_path, &meta);
+        let doc = docs::build_openapi_doc(&format!("Operation: {service}"), path_items);
+
+        (StatusCode::OK, Json(doc)).into_response()
+    }
+
+    pub(crate) fn docs_transform(op: TransformOperation) -> TransformOperation {
+        op.description(
+            "Online capability description for a specific functional-group operation (ISO 17978-3 \
+             Section 7.5). Returns a self-contained OpenAPI specification.",
+        )
+        .response_with::<200, Json<OpenApi>, _>(|res| {
+            res.description("Self-contained OpenAPI 3.1 specification for this operation.")
+        })
+        .with(openapi::error_not_found)
+    }
+}
+
 pub(crate) mod diag_service {
     use aide::{UseApi, transform::TransformOperation};
     use axum::{

--- a/cda-sovd/src/sovd/mod.rs
+++ b/cda-sovd/src/sovd/mod.rs
@@ -58,6 +58,7 @@ use crate::{
 
 pub(crate) mod apps;
 pub(crate) mod components;
+pub(crate) mod docs;
 pub(crate) mod error;
 pub(crate) mod functions;
 pub(crate) mod locks;
@@ -616,6 +617,13 @@ fn ecu_route<
         .api_route(
             "/operations",
             routing::get_with(operations::get, operations::docs_get),
+        )
+        .api_route(
+            "/operations/{service}/docs",
+            routing::get_with(
+                operations::service::docs_endpoint::get,
+                operations::service::docs_endpoint::docs_transform,
+            ),
         )
         .api_route(
             "/operations/comparam/executions",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
This PR adds the basic helpers and structures to provide an online capability description (ISO 17978-3 Section 7.5). As a first step the /docs endpoint is added for ../operations/{operation}/docs in both component and functional groups. 

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)