### PR TITLE
fix: pass configured protocol version to DoIP UDP socket [hackfest fix]

### DIFF
--- a/cda-comm-doip/src/config.rs
+++ b/cda-comm-doip/src/config.rs
@@ -36,3 +36,23 @@ impl Default for DoipConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use doip_definitions::header::ProtocolVersion;
+
+    #[test]
+    fn protocol_version_from_u8() {
+        let v2: u8 = 0x02;
+        let v3: u8 = 0x03;
+
+        assert_eq!(
+            ProtocolVersion::try_from(&v2).unwrap(),
+            ProtocolVersion::Iso13400_2012
+        );
+        assert_eq!(
+            ProtocolVersion::try_from(&v3).unwrap(),
+            ProtocolVersion::Iso13400_2019
+        );
+    }
+}

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -191,7 +191,11 @@ impl<T: EcuAddressProvider + DoipComParamProvider> DoipDiagGateway<T> {
 
         tracing::info!("Initializing DoipDiagGateway");
 
-        let mut socket = create_socket(tester_ip, gateway_port)?;
+        let mut socket = create_socket(
+            tester_ip,
+            gateway_port,
+            doip_connection_config.protocol_version,
+        )?;
         let mask = create_netmask(tester_ip, tester_subnet)?;
 
         let gateways = vir_vam::get_vehicle_identification::<T, F>(
@@ -770,6 +774,7 @@ fn create_netmask(tester_ip: &str, tester_subnet: &str) -> Result<u32, DoipGatew
 fn create_socket(
     tester_ip: &str,
     gateway_port: u16,
+    protocol_version: ProtocolVersion,
 ) -> Result<DoIPUdpSocket, DoipGatewaySetupError> {
     let tester_ip = match tester_ip {
         "127.0.0.1" => "0.0.0.0",
@@ -822,7 +827,7 @@ fn create_socket(
     })?;
 
     let std_sock: std::net::UdpSocket = socket.into();
-    DoIPUdpSocket::new(std_sock).map_err(|e| {
+    DoIPUdpSocket::new(std_sock, protocol_version).map_err(|e| {
         DoipGatewaySetupError::SocketCreationFailed(format!(
             "DoipGateway: Failed to create DoIP socket from std socket: {e:?}"
         ))

--- a/cda-comm-doip/src/socket.rs
+++ b/cda-comm-doip/src/socket.rs
@@ -118,11 +118,14 @@ pub(crate) struct DoIPUdpSocket {
 }
 
 impl DoIPUdpSocket {
-    pub fn new(socket: std::net::UdpSocket) -> Result<Self, std::io::Error> {
+    pub fn new(
+        socket: std::net::UdpSocket,
+        protocol_version: ProtocolVersion,
+    ) -> Result<Self, std::io::Error> {
         let tokio_socket = tokio::net::UdpSocket::from_std(socket)?;
         Ok(Self {
             io: UdpFramed::new(tokio_socket, DoipCodec {}),
-            protocol_version: ProtocolVersion::Iso13400_2012,
+            protocol_version,
         })
     }
 

--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -261,7 +261,11 @@ pub(crate) async fn listen_for_vams<T, F>(
             let broadcast_socket = if connection_config.source_ip == broadcast_ip {
                 Arc::clone(&gateway.socket)
             } else {
-                match crate::create_socket(broadcast_ip, gateway_port) {
+                match crate::create_socket(
+                    broadcast_ip,
+                    gateway_port,
+                    doip_connection_config.protocol_version,
+                ) {
                     Ok(sock) => Arc::new(Mutex::new(sock)),
                     Err(e) => {
                         tracing::warn!(


### PR DESCRIPTION
## Summary

Fix `DoIPUdpSocket` to use the configured `protocol_version` from `DoipConfig` instead of hardcoding `Iso13400_2012`. Threads `protocol_version` through `create_socket` and `DoIPUdpSocket::new`, and adds a unit test verifying `ProtocolVersion::try_from(&u8)` correctly maps `0x02 → Iso13400_2012` and `0x03 → Iso13400_2019`.

### Changes
- `cda-comm-doip/src/socket.rs`: Accept `protocol_version` parameter in `DoIPUdpSocket::new`
- `cda-comm-doip/src/lib.rs`: Pass configured version to `create_socket`
- `cda-comm-doip/src/vir_vam.rs`: Pass configured version to `create_socket` in VAM listener
- `cda-comm-doip/src/config.rs`: Add unit test for `ProtocolVersion` parsing

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related

N/A

## Notes for Reviewers

The protocol version was previously hardcoded to `Iso13400_2012` in the UDP socket creation path, ignoring the user-configured value in `DoipConfig`.

---
Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)