### PR TITLE
feat(config): add allow-no-config build feature

### DIFF
--- a/cda-main/Cargo.toml
+++ b/cda-main/Cargo.toml
@@ -77,7 +77,7 @@ reqwest = { workspace = true }
 chrono = { workspace = true }
 
 [features]
-default = ["health", "openssl"]
+default = ["health", "openssl", "allow-no-config"]
 tokio-tracing = ["cda-interfaces/tokio-tracing", "cda-tracing/tokio-tracing"]
 openssl = ["cda-comm-doip/openssl"]
 openssl-vendored = ["openssl", "cda-comm-doip/openssl-vendored"]
@@ -86,3 +86,4 @@ dlt-tracing = ["cda-tracing/dlt-tracing"]
 integration-tests = []
 
 health = []
+allow-no-config = []

--- a/cda-main/src/config/mod.rs
+++ b/cda-main/src/config/mod.rs
@@ -48,3 +48,60 @@ pub fn load_config() -> Result<configfile::Configuration, String> {
 pub fn default_config() -> configfile::Configuration {
     configfile::Configuration::default()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_file_path_default() {
+        // When CDA_CONFIG_FILE is not set, returns "{CDA_NAME}.toml"
+        // CDA_NAME is a compile-time env var defaulting to "opensovd-cda"
+        unsafe { std::env::remove_var("CDA_CONFIG_FILE") };
+        let path = config_file_path();
+        assert!(
+            path.ends_with(".toml"),
+            "Expected .toml extension, got: {path}"
+        );
+    }
+
+    #[test]
+    fn config_file_path_env_override() {
+        unsafe { std::env::set_var("CDA_CONFIG_FILE", "/tmp/my-test-config.toml") };
+        let path = config_file_path();
+        assert_eq!(path, "/tmp/my-test-config.toml");
+        unsafe { std::env::remove_var("CDA_CONFIG_FILE") };
+    }
+
+    #[test]
+    fn config_file_path_empty_env_is_empty_string() {
+        unsafe { std::env::set_var("CDA_CONFIG_FILE", "") };
+        let path = config_file_path();
+        assert_eq!(path, "");
+        unsafe { std::env::remove_var("CDA_CONFIG_FILE") };
+    }
+
+    #[test]
+    fn default_config_server_address() {
+        let config = default_config();
+        assert_eq!(config.server.address, "0.0.0.0");
+    }
+
+    #[test]
+    fn default_config_server_port() {
+        let config = default_config();
+        assert_eq!(config.server.port, 20002);
+    }
+
+    #[test]
+    fn default_config_database_path() {
+        let config = default_config();
+        assert_eq!(config.database.path, ".");
+    }
+
+    #[test]
+    fn default_config_onboard_tester() {
+        let config = default_config();
+        assert!(config.onboard_tester);
+    }
+}

--- a/cda-main/src/config/mod.rs
+++ b/cda-main/src/config/mod.rs
@@ -17,6 +17,15 @@ use figment::{
 
 pub mod configfile;
 
+/// Returns the path of the configuration file to load.
+/// Uses the `CDA_CONFIG_FILE` environment variable if set,
+/// otherwise defaults to `{CDA_NAME}.toml` (where `CDA_NAME` defaults to `opensovd-cda`).
+#[must_use]
+pub fn config_file_path() -> String {
+    let cda_name = std::option_env!("CDA_NAME").unwrap_or("opensovd-cda");
+    std::env::var("CDA_CONFIG_FILE").unwrap_or_else(|_| format!("{cda_name}.toml"))
+}
+
 /// Loads the configuration from a file specified by the `CDA_CONFIG_FILE` environment variable.
 /// If the variable is not set, it defaults to `opensovd-cda.toml`.
 /// The configuration is merged with default values and environment variables prefixed with `CDA`.
@@ -25,9 +34,7 @@ pub mod configfile;
 /// # Errors
 /// Returns an error message if the configuration file cannot be read or parsed.
 pub fn load_config() -> Result<configfile::Configuration, String> {
-    let cda_name = std::option_env!("CDA_NAME").unwrap_or("opensovd-cda");
-    let config_file =
-        std::env::var("CDA_CONFIG_FILE").unwrap_or_else(|_| format!("{cda_name}.toml"));
+    let config_file = config_file_path();
     println!("Loading configuration from {config_file}");
 
     Figment::from(Serialized::defaults(default_config()))

--- a/cda-main/src/main.rs
+++ b/cda-main/src/main.rs
@@ -86,11 +86,28 @@ struct AppArgs {
 )]
 async fn main() -> Result<(), AppError> {
     let args = AppArgs::parse();
+    #[cfg(feature = "allow-no-config")]
     let mut config = opensovd_cda_lib::config::load_config().unwrap_or_else(|e| {
         println!("Failed to load configuration: {e}");
         println!("Using default values");
         opensovd_cda_lib::config::default_config()
     });
+
+    #[cfg(not(feature = "allow-no-config"))]
+    let mut config = {
+        let config_path = opensovd_cda_lib::config::config_file_path();
+        if !std::path::Path::new(&config_path).exists() {
+            println!("Configuration file '{config_path}' not found.");
+            println!(
+                "Provide a configuration file or build with the 'allow-no-config' feature."
+            );
+            return Err(AppError::ConfigurationError(format!(
+                "Configuration file '{config_path}' not found"
+            )));
+        }
+        opensovd_cda_lib::config::load_config()
+            .map_err(AppError::ConfigurationError)?
+    };
     config.validate_sanity()?;
 
     args.update_config(&mut config);


### PR DESCRIPTION
## Summary

Resolves #251 — Make startup without any configuration an optional build-time feature.

- Adds `allow-no-config` Cargo feature flag (default-enabled for backward compatibility)
- Extracts `config_file_path()` public helper from `load_config()` in `config/mod.rs`
- Gates the startup config fallback in `main.rs` behind `#[cfg(feature = "allow-no-config")]`
- When feature disabled: missing config file → hard error with descriptive message
- When feature enabled: current behavior preserved (fallback to built-in defaults)

## Changes

### `cda-main/Cargo.toml`
- Added `allow-no-config = []` to `[features]`
- Added `"allow-no-config"` to `default` feature list

### `cda-main/src/config/mod.rs`
- Extracted `pub fn config_file_path() -> String` with `#[must_use]`
- Updated `load_config()` to call `config_file_path()` (pure refactor, no behavior change)
- Added 7 unit tests: 3 for `config_file_path()`, 4 for `default_config()` sane defaults

### `cda-main/src/main.rs`
- Replaced unconditional `load_config().unwrap_or_else(...)` with dual `#[cfg]` blocks
- Feature-enabled path: identical to previous behavior
- Feature-disabled path: checks config file existence, returns `AppError::ConfigurationError` if missing

## Testing

- `cargo build --no-default-features -p opensovd-cda` ✅
- `cargo test --lib --no-default-features -p opensovd-cda` — 11 tests pass ✅
- No new clippy warnings in modified files