### PR TITLE
ci: use actions-rust-lang/setup-rust-toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,11 +36,9 @@ jobs:
         with:
           submodules: false
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2025-07-14
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -75,12 +73,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.88.0
           components: clippy, rustfmt
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
       - name: Install cargo-deny
         run: cargo install --locked --version 0.18.9 cargo-deny
       - name: Build
@@ -135,12 +131,10 @@ jobs:
         with:
           submodules: false
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.88.0
           components: clippy, rustfmt
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
       - name: Setup OpenSSL (Windows) Environment
         run: |
           echo "OPENSSL_DIR=$env:OPENSSL_DIR" >> $env:GITHUB_ENV

--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -75,11 +75,9 @@ jobs:
         with:
           submodules: false
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.88.0
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
       - name: Clean docs folder
         run: cargo clean --doc
       - name: Build docs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,11 +33,9 @@ jobs:
         with:
           submodules: false
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.88.0
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
       - name: Install cargo-deny
         run: cargo install --locked --version 0.18.9 cargo-deny
       - name: Check advisories


### PR DESCRIPTION
<!--
SPDX-License-Identifier: Apache-2.0
SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
-->

## Summary

- Replace `dtolnay/rust-toolchain@master` with `actions-rust-lang/setup-rust-toolchain@v1` across all CI workflows
- Remove separate `Swatinem/rust-cache@v2` steps since `setup-rust-toolchain` includes integrated caching
- Aligns with [eclipse-opensovd/cicd-workflows#18](https://github.com/eclipse-opensovd/cicd-workflows/pull/18)

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [ ] I have added or updated tests
- [x] I have linked related issues or discussions

## Related

Closes #237

## Notes for Reviewers

Affects `build.yml` (3 occurrences), `nightly.yml` (1 occurrence), and `generate_documentation.yml` (1 occurrence). The `components` and `toolchain` inputs are unchanged — `setup-rust-toolchain` accepts the same parameters as `dtolnay/rust-toolchain`.

---

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)