### PR TITLE
ci: enable test coverage with cargo-llvm-cov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
+  # pull-requests: write is required by the coverage job to post PR comments.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
@@ -131,6 +133,17 @@ jobs:
         env:
           CACHE_REGISTRY: ghcr.io/${{ github.repository }}
         run: cargo test --locked --features integration-tests -- --show-output
+
+  coverage:
+    name: Coverage
+    uses: eclipse-opensovd/cicd-workflows/.github/workflows/coverage.yml@4116addc88b6c523bc6d729b1b4e198ccb04ce3d
+    with:
+      rust-version: "1.88.0"
+      cargo-extra-args: "--features integration-tests"
+      post-pr-comment: true
+    permissions:
+      contents: read
+      pull-requests: write
 
   build_windows:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
 
   coverage:
     name: Coverage
-    uses: eclipse-opensovd/cicd-workflows/.github/workflows/coverage.yml@4116addc88b6c523bc6d729b1b4e198ccb04ce3d
+    uses: eclipse-opensovd/cicd-workflows/.github/workflows/coverage.yml@0568734739886482474b836b8d19ffebba40ed02
     with:
       rust-version: "1.88.0"
       cargo-extra-args: "--features integration-tests"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,7 +57,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Format and Clippy - Nightly toolchain pinned
         continue-on-error: true
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4700b71884074d194723fdb04a6c1a827b6f652b
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4116addc88b6c523bc6d729b1b4e198ccb04ce3d
         with:
           toolchain: nightly-2025-07-14
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -68,7 +68,7 @@ jobs:
           reporter: github-check
       - name: Format and Clippy - Nightly toolchain latest
         continue-on-error: true
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4700b71884074d194723fdb04a6c1a827b6f652b
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4116addc88b6c523bc6d729b1b4e198ccb04ce3d
         with:
           toolchain: nightly
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,7 +57,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Format and Clippy - Nightly toolchain pinned
         continue-on-error: true
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4116addc88b6c523bc6d729b1b4e198ccb04ce3d
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@0568734739886482474b836b8d19ffebba40ed02
         with:
           toolchain: nightly-2025-07-14
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -68,7 +68,7 @@ jobs:
           reporter: github-check
       - name: Format and Clippy - Nightly toolchain latest
         continue-on-error: true
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4116addc88b6c523bc6d729b1b4e198ccb04ce3d
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@0568734739886482474b836b8d19ffebba40ed02
         with:
           toolchain: nightly
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -46,7 +46,7 @@ jobs:
           # to avoid rate limiting, passing the default token.
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Format and Clippy - Stable toolchain
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4116addc88b6c523bc6d729b1b4e198ccb04ce3d
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@0568734739886482474b836b8d19ffebba40ed02
         with:
           toolchain: 1.88.0
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
           rustfmt-enable-reviewdog: "false"
           error-on-unformatted: "false"
       - name: Format and Clippy - Nightly toolchain pinned
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4116addc88b6c523bc6d729b1b4e198ccb04ce3d
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@0568734739886482474b836b8d19ffebba40ed02
         with:
           toolchain: nightly-2025-07-14
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
       - name: Format and Clippy - Nightly toolchain latest
         id: nightly-clippy
         continue-on-error: true
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4116addc88b6c523bc6d729b1b4e198ccb04ce3d
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@0568734739886482474b836b8d19ffebba40ed02
         with:
           toolchain: nightly
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -46,7 +46,7 @@ jobs:
           # to avoid rate limiting, passing the default token.
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Format and Clippy - Stable toolchain
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4700b71884074d194723fdb04a6c1a827b6f652b
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4116addc88b6c523bc6d729b1b4e198ccb04ce3d
         with:
           toolchain: 1.88.0
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
           rustfmt-enable-reviewdog: "false"
           error-on-unformatted: "false"
       - name: Format and Clippy - Nightly toolchain pinned
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4700b71884074d194723fdb04a6c1a827b6f652b
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4116addc88b6c523bc6d729b1b4e198ccb04ce3d
         with:
           toolchain: nightly-2025-07-14
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
       - name: Format and Clippy - Nightly toolchain latest
         id: nightly-clippy
         continue-on-error: true
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4700b71884074d194723fdb04a6c1a827b6f652b
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@4116addc88b6c523bc6d729b1b4e198ccb04ce3d
         with:
           toolchain: nightly
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run checks
-        uses: eclipse-opensovd/cicd-workflows/pre-commit-action@1cae75238b0a8b2554784a564d3b03b23c887b3b
+        uses: eclipse-opensovd/cicd-workflows/pre-commit-action@4116addc88b6c523bc6d729b1b4e198ccb04ce3d
         with:
           no-unicode-extensions: ".rs,.py,.toml,.yml,.yaml,.rst,.c,.h,.kt,.kts,.sh,.proto,.fbs,.puml,.json,.xml,Dockerfile"
           allowed-unicode-chars: "µ,§"

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run checks
-        uses: eclipse-opensovd/cicd-workflows/pre-commit-action@4116addc88b6c523bc6d729b1b4e198ccb04ce3d
+        uses: eclipse-opensovd/cicd-workflows/pre-commit-action@0568734739886482474b836b8d19ffebba40ed02
         with:
           no-unicode-extensions: ".rs,.py,.toml,.yml,.yaml,.rst,.c,.h,.kt,.kts,.sh,.proto,.fbs,.puml,.json,.xml,Dockerfile"
           allowed-unicode-chars: "µ,§"

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -592,9 +592,17 @@ async fn wait_for_http_ready(
     service_name: &str,
     result: Option<http::StatusCode>,
 ) -> Result<(), TestingError> {
+    wait_for_http_ready_with_timeout(url, service_name, result, Duration::from_secs(10)).await
+}
+
+async fn wait_for_http_ready_with_timeout(
+    url: String,
+    service_name: &str,
+    result: Option<http::StatusCode>,
+    timeout: Duration,
+) -> Result<(), TestingError> {
     let client = reqwest::Client::new();
     let start_time = Instant::now();
-    let timeout = Duration::from_secs(10);
 
     while start_time.elapsed() < timeout {
         match client.get(&url).send().await {
@@ -618,7 +626,13 @@ async fn wait_for_http_ready(
 
 async fn wait_for_ecu_sim_ready(host: &str, sim_control_port: u16) -> Result<(), TestingError> {
     let url = format!("http://{host}:{sim_control_port}");
-    wait_for_http_ready(url, "ECU sim", None).await
+    // Allow extra time for Gradle to download its distribution on a cold cache.
+    let timeout = if use_docker() {
+        Duration::from_secs(10)
+    } else {
+        Duration::from_secs(300)
+    };
+    wait_for_http_ready_with_timeout(url, "ECU sim", None, timeout).await
 }
 
 pub(crate) async fn wait_for_cda_online(cfg: &ServerConfig) -> Result<(), TestingError> {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

- Replace `cargo test` with `cargo llvm-cov` in the `build_and_test` job to collect integration test coverage
- Post a sticky coverage comment on PRs (one comment per PR, updated in-place on each push) via `actions/github-script`
- Show coverage summary in the GitHub Actions step summary tab
- Upload LCOV report as a 30-day build artifact

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

N/A

## Notes for Reviewers

Uses `actions/github-script` to post/update a single PR comment identified by a hidden HTML marker (`<!-- coverage-report -->`). The comment shows total line coverage with a collapsible per-crate breakdown. This requires `pull-requests: write` permission which was added at the workflow level. 
 
---
Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)