### PR TITLE
test(integration-tests): re-enable functional locks tests

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -81,7 +81,6 @@ cda-build = { workspace = true }
 # We need the health endpoint to check if the CDA is online
 default = ["opensovd_cda_lib/health"]
 integration-tests = []
-functional-locks-tests = []
 
 # Integration tests are only compiled when the feature is enabled.
 [[test]]

--- a/integration-tests/tests/sovd/locks.rs
+++ b/integration-tests/tests/sovd/locks.rs
@@ -148,7 +148,6 @@ async fn lock_unlock() -> Result<(), TestingError> {
     Ok(())
 }
 
-#[cfg(feature = "functional-locks-tests")]
 #[tokio::test]
 async fn cannot_lock_ecu_with_existing_functional_log() -> Result<(), TestingError> {
     let (runtime, _lock) = setup_integration_test(true).await?;
@@ -294,7 +293,6 @@ async fn ownership() -> Result<(), TestingError> {
     Ok(())
 }
 
-#[cfg(feature = "functional-locks-tests")]
 #[tokio::test]
 async fn test_vehicle_locking_blocked_by_other() -> Result<(), TestingError> {
     let (runtime, _lock) = setup_integration_test(true).await?;
@@ -357,21 +355,17 @@ async fn test_vehicle_lock_delete_hierarchy() -> Result<(), TestingError> {
             "id",
         )?;
 
-        let func_lock_id: String = if cfg!(feature = "functional-locks-tests") {
-            response_to_json_to_field(
-                &create_lock(
-                    default_timeout(),
-                    FUNCTIONAL_GROUP_ENDPOINT,
-                    StatusCode::CREATED,
-                    &runtime.config,
-                    user,
-                )
-                .await,
-                "id",
-            )?
-        } else {
-            "empty".to_owned()
-        };
+        let func_lock_id: String = response_to_json_to_field(
+            &create_lock(
+                default_timeout(),
+                FUNCTIONAL_GROUP_ENDPOINT,
+                StatusCode::CREATED,
+                &runtime.config,
+                user,
+            )
+            .await,
+            "id",
+        )?;
 
         Ok((ecu_lock_id, func_lock_id))
     }
@@ -393,7 +387,6 @@ async fn test_vehicle_lock_delete_hierarchy() -> Result<(), TestingError> {
         )
         .await;
 
-        #[cfg(feature = "functional-locks-tests")]
         lock_operation(
             FUNCTIONAL_GROUP_ENDPOINT,
             Some(func_lock_id),
@@ -569,11 +562,7 @@ pub(crate) const ECU_ENDPOINT: &str =
 
 pub(crate) const VEHICLE_ENDPOINT: &str = "locks";
 
-#[cfg(feature = "functional-locks-tests")]
 pub(crate) const ENDPOINTS: [&str; 3] = [FUNCTIONAL_GROUP_ENDPOINT, VEHICLE_ENDPOINT, ECU_ENDPOINT];
-
-#[cfg(not(feature = "functional-locks-tests"))]
-pub(crate) const ENDPOINTS: [&str; 2] = [VEHICLE_ENDPOINT, ECU_ENDPOINT];
 
 pub(crate) async fn lock_operation(
     endpoint: &str,


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

The functional description database (`functional_groups.mdd`) is now present in
the testcontainer, resolving the blocker described in #141. Remove the
`functional-locks-tests` Cargo feature flag and all `#[cfg]` guards that gated
two lock tests behind it. Both tests now run unconditionally as part of the
standard integration test suite.

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related

Closes #141

## Notes for Reviewers

No logic changes — purely removes the feature flag scaffolding that was added
as a temporary workaround while `functional_groups.mdd` was missing. All 37
integration tests pass locally including the two re-enabled tests
(`cannot_lock_ecu_with_existing_functional_log`,
`test_vehicle_locking_blocked_by_other`).

---
Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)