### PR TITLE
cda-extra: add systemd_notify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -112,7 +112,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -417,6 +417,17 @@ dependencies = [
  "tracing",
  "uuid",
  "xz2",
+]
+
+[[package]]
+name = "cda-extra"
+version = "0.1.0"
+dependencies = [
+ "cda-health",
+ "cda-interfaces",
+ "sd-notify",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1045,7 +1056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2103,7 +2114,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2188,6 +2199,7 @@ dependencies = [
  "cda-comm-uds",
  "cda-core",
  "cda-database",
+ "cda-extra",
  "cda-health",
  "cda-interfaces",
  "cda-plugin-security",
@@ -2932,7 +2944,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3022,6 +3034,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sd-notify"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4ef7359e694bfaf1dd27a30f9d760b54c00dfae9f19bd0c05a39bc9128fe76"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "sec1"
@@ -3441,7 +3462,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
   "cda-tracing",
   "cda-plugin-security",
   "cda-health",
+  "cda-extra",
   "integration-tests",
   "cda-build",
   "comm-mbedtls/mbedtls-sys",
@@ -44,6 +45,7 @@ cda-plugin-security = { path = "cda-plugin-security" }
 cda-sovd = { path = "cda-sovd" }
 cda-tracing = { path = "cda-tracing" }
 cda-health = { path = "cda-health" }
+cda-extra = { path = "cda-extra" }
 sovd-interfaces = { path = "cda-sovd-interfaces" }
 cda-build = { path = "cda-build" }
 mbedtls-sys = { path = "comm-mbedtls/mbedtls-sys" }
@@ -59,6 +61,7 @@ serde_json = "1.0"
 tokio = { version = "1.48.0", default-features = false }
 tokio-util = { version = "0.7.3", default-features = false }
 futures = "0.3"
+sd-notify = "0.5.0"
 regex = "1.12.2"
 uuid = "1.18.1"
 bytes = "1"

--- a/cda-extra/Cargo.toml
+++ b/cda-extra/Cargo.toml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2025 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+# SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/cda-extra/Cargo.toml
+++ b/cda-extra/Cargo.toml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+
+[package]
+name = "cda-extra"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+description = "Optional extras for the Eclipse OpenSOVD CDA"
+homepage.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# internal dependencies
+cda-health = { workspace = true, optional = true }
+cda-interfaces = { workspace = true, optional = true }
+
+# external
+sd-notify = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["time"], optional = true }
+tracing = { workspace = true, optional = true }
+
+[features]
+default = []
+systemd-notify = [
+  "dep:sd-notify",
+  "dep:cda-health",
+  "dep:cda-interfaces",
+  "dep:tokio",
+  "dep:tracing",
+]

--- a/cda-extra/src/lib.rs
+++ b/cda-extra/src/lib.rs
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2025 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#[cfg(feature = "systemd-notify")]
+mod systemd_notify;
+
+#[cfg(feature = "systemd-notify")]
+pub use systemd_notify::create_sd_notify_task;

--- a/cda-extra/src/lib.rs
+++ b/cda-extra/src/lib.rs
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
- * SPDX-FileCopyrightText: 2025 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+ * SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/cda-extra/src/systemd_notify.rs
+++ b/cda-extra/src/systemd_notify.rs
@@ -1,0 +1,286 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2025 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+use std::time::Duration;
+
+use cda_health::HealthState;
+use cda_interfaces::spawn_named;
+use tokio::task::JoinHandle;
+
+/// Creates a background task that integrates with the systemd watchdog.
+///
+/// If the process was booted via systemd and the watchdog is enabled,
+/// this function spawns a task that periodically checks the health state
+/// and sends the appropriate `sd_notify` notification:
+///
+/// - `Ready` when transitioning from `Starting` to `Up`
+/// - `Watchdog` while healthy (`Up` -> `Up`)
+/// - `WatchdogTrigger` when health degrades (`Up` -> `Failed`)
+///
+/// The notification interval is the systemd-configured watchdog timeout
+/// minus 5 seconds (to avoid timing issues).
+///
+/// If systemd is not detected or the watchdog is not enabled, returns `None`
+/// and the CDA runs without `sd_notify` behavior.
+pub fn create_sd_notify_task<F>(
+    health_state: Option<HealthState>,
+    shutdown_signal: F,
+) -> Option<JoinHandle<()>>
+where
+    F: Future<Output = ()> + Clone + Send + 'static,
+{
+    if let Ok(true) = sd_notify::booted()
+        && let Some(interval) = determine_interval()
+    {
+        // init sd notify task
+        let watchdog_future = async move {
+            let mut interval_timer = tokio::time::interval(interval);
+            let mut state = cda_health::Status::Starting;
+            loop {
+                interval_timer.tick().await;
+                state = trigger_watchdog(health_state.as_ref(), state).await;
+            }
+        };
+        let sd_notify_future = spawn_named!("sd_notify", async move {
+            tokio::select! {
+                _ = watchdog_future => {},
+                () = shutdown_signal => {},
+            }
+        });
+        tracing::info!(
+            "Systemd detected and watchdog enabled, initialized sd_notify task with interval of \
+             {:?} seconds",
+            interval.as_secs()
+        );
+        Some(sd_notify_future)
+    } else {
+        tracing::info!(
+            "Systemd not detected or watchdog not enabled, skipping sd_notify initialization"
+        );
+        None
+    }
+}
+
+fn determine_interval() -> Option<Duration> {
+    if let Some(duration) = sd_notify::watchdog_enabled() {
+        // ensure we are sending a bit more often than the watchdog expects,
+        // to avoid any timing issues
+        let interval = if let Some(interval) = duration.checked_sub(Duration::from_secs(5)) {
+            interval
+        } else {
+            duration
+        };
+        Some(interval)
+    } else {
+        None
+    }
+}
+
+async fn trigger_watchdog(
+    health_state: Option<&HealthState>,
+    prev_state: cda_health::Status,
+) -> cda_health::Status {
+    let new_status = fold_health_state(health_state).await;
+    let notify = match (prev_state, new_status) {
+        (cda_health::Status::Starting, cda_health::Status::Up) => sd_notify::NotifyState::Ready,
+        (cda_health::Status::Up, cda_health::Status::Failed) => {
+            sd_notify::NotifyState::WatchdogTrigger
+        }
+        (cda_health::Status::Up, cda_health::Status::Up) => sd_notify::NotifyState::Watchdog,
+        // this would be Failure -> Starting or Up -> Starting. so makes no sense
+        _ => {
+            tracing::warn!(
+                "Unexpected health status transition from {prev_state:?} to {new_status:?} when \
+                 triggering sd_notify watchdog"
+            );
+            sd_notify::NotifyState::Watchdog
+        }
+    };
+    tracing::debug!("Triggering sd_notify watchdog with status {notify:?}");
+    if let Err(e) = sd_notify::notify(&[notify]) {
+        tracing::warn!(error = %e, "Failed to send sd_notify watchdog notification");
+    }
+    new_status
+}
+
+fn fold_status(acc: cda_health::Status, status: cda_health::Status) -> cda_health::Status {
+    match (acc, status) {
+        (
+            cda_health::Status::Up | cda_health::Status::Starting | cda_health::Status::Pending,
+            cda_health::Status::Failed,
+        )
+        | (cda_health::Status::Failed, _) => cda_health::Status::Failed,
+        (
+            cda_health::Status::Starting | cda_health::Status::Pending,
+            cda_health::Status::Pending,
+        ) => cda_health::Status::Starting,
+        (cda_health::Status::Starting | cda_health::Status::Pending, cda_health::Status::Up) => {
+            cda_health::Status::Up
+        }
+        (_, status) => status,
+    }
+}
+
+async fn fold_health_state(health_state: Option<&HealthState>) -> cda_health::Status {
+    if let Some(health_state) = health_state {
+        health_state
+            .query_all_providers()
+            .await
+            .into_values()
+            .fold(cda_health::Status::Starting, fold_status)
+    } else {
+        cda_health::Status::Up
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cda_health::Status;
+
+    use super::fold_status;
+
+    #[test]
+    fn fold_up_then_failed_yields_failed() {
+        assert_eq!(fold_status(Status::Up, Status::Failed), Status::Failed);
+    }
+
+    #[test]
+    fn fold_starting_then_failed_yields_failed() {
+        assert_eq!(
+            fold_status(Status::Starting, Status::Failed),
+            Status::Failed
+        );
+    }
+
+    #[test]
+    fn fold_pending_then_failed_yields_failed() {
+        assert_eq!(fold_status(Status::Pending, Status::Failed), Status::Failed);
+    }
+
+    #[test]
+    fn fold_failed_then_up_yields_failed() {
+        assert_eq!(fold_status(Status::Failed, Status::Up), Status::Failed);
+    }
+
+    #[test]
+    fn fold_failed_then_starting_yields_failed() {
+        assert_eq!(
+            fold_status(Status::Failed, Status::Starting),
+            Status::Failed
+        );
+    }
+
+    #[test]
+    fn fold_failed_then_pending_yields_failed() {
+        assert_eq!(fold_status(Status::Failed, Status::Pending), Status::Failed);
+    }
+
+    #[test]
+    fn fold_failed_then_failed_yields_failed() {
+        assert_eq!(fold_status(Status::Failed, Status::Failed), Status::Failed);
+    }
+
+    #[test]
+    fn fold_starting_then_pending_yields_starting() {
+        assert_eq!(
+            fold_status(Status::Starting, Status::Pending),
+            Status::Starting
+        );
+    }
+
+    #[test]
+    fn fold_pending_then_pending_yields_starting() {
+        assert_eq!(
+            fold_status(Status::Pending, Status::Pending),
+            Status::Starting
+        );
+    }
+
+    #[test]
+    fn fold_starting_then_up_yields_up() {
+        assert_eq!(fold_status(Status::Starting, Status::Up), Status::Up);
+    }
+
+    #[test]
+    fn fold_pending_then_up_yields_up() {
+        assert_eq!(fold_status(Status::Pending, Status::Up), Status::Up);
+    }
+
+    #[test]
+    fn fold_up_then_up_yields_up() {
+        assert_eq!(fold_status(Status::Up, Status::Up), Status::Up);
+    }
+
+    #[test]
+    fn fold_up_then_starting_yields_starting() {
+        assert_eq!(fold_status(Status::Up, Status::Starting), Status::Starting);
+    }
+
+    #[test]
+    fn fold_up_then_pending_yields_pending() {
+        assert_eq!(fold_status(Status::Up, Status::Pending), Status::Pending);
+    }
+
+    #[test]
+    fn fold_sequence_all_up_from_starting() {
+        // initial acc = Starting (as fold_health_state does), all providers Up
+        let result = [Status::Up, Status::Up, Status::Up]
+            .into_iter()
+            .fold(Status::Starting, fold_status);
+        assert_eq!(result, Status::Up);
+    }
+
+    #[test]
+    fn fold_sequence_any_failed_dominates() {
+        let result = [Status::Up, Status::Failed, Status::Up]
+            .into_iter()
+            .fold(Status::Starting, fold_status);
+        assert_eq!(result, Status::Failed);
+    }
+
+    #[test]
+    fn fold_sequence_failed_at_start_stays_failed() {
+        let result = [Status::Failed, Status::Up, Status::Up]
+            .into_iter()
+            .fold(Status::Starting, fold_status);
+        assert_eq!(result, Status::Failed);
+    }
+
+    #[test]
+    fn fold_sequence_all_starting_stays_starting() {
+        let result = [Status::Starting, Status::Starting]
+            .into_iter()
+            .fold(Status::Starting, fold_status);
+        assert_eq!(result, Status::Starting);
+    }
+
+    #[test]
+    fn fold_sequence_mix_starting_pending_yields_starting() {
+        let result = [Status::Pending, Status::Starting, Status::Pending]
+            .into_iter()
+            .fold(Status::Starting, fold_status);
+        assert_eq!(result, Status::Starting);
+    }
+
+    #[test]
+    fn fold_sequence_empty_providers_yields_starting() {
+        // no providers → fold over empty iterator → initial accumulator = Starting
+        let result = std::iter::empty::<Status>().fold(Status::Starting, fold_status);
+        assert_eq!(result, Status::Starting);
+    }
+
+    #[tokio::test]
+    async fn fold_health_state_none_yields_up() {
+        let result = super::fold_health_state(None).await;
+        assert_eq!(result, Status::Up);
+    }
+}

--- a/cda-extra/src/systemd_notify.rs
+++ b/cda-extra/src/systemd_notify.rs
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
- * SPDX-FileCopyrightText: 2025 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+ * SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,7 +12,7 @@
 
 use std::time::Duration;
 
-use cda_health::HealthState;
+use cda_health::{HealthState, Status as HealthStatus};
 use cda_interfaces::spawn_named;
 use tokio::task::JoinHandle;
 
@@ -38,51 +38,48 @@ pub fn create_sd_notify_task<F>(
 where
     F: Future<Output = ()> + Clone + Send + 'static,
 {
-    if let Ok(true) = sd_notify::booted()
-        && let Some(interval) = determine_interval()
-    {
-        // init sd notify task
-        let watchdog_future = async move {
-            let mut interval_timer = tokio::time::interval(interval);
-            let mut state = cda_health::Status::Starting;
-            loop {
-                interval_timer.tick().await;
-                state = trigger_watchdog(health_state.as_ref(), state).await;
-            }
-        };
-        let sd_notify_future = spawn_named!("sd_notify", async move {
-            tokio::select! {
-                _ = watchdog_future => {},
-                () = shutdown_signal => {},
-            }
-        });
-        tracing::info!(
-            "Systemd detected and watchdog enabled, initialized sd_notify task with interval of \
-             {:?} seconds",
-            interval.as_secs()
-        );
-        Some(sd_notify_future)
-    } else {
-        tracing::info!(
-            "Systemd not detected or watchdog not enabled, skipping sd_notify initialization"
-        );
-        None
+    // map std_notify::booted Err(_) to false and treat as not systemd booted
+    if !sd_notify::booted().unwrap_or(false) {
+        tracing::info!("Systemd not detected, skipping sd_notify initialization");
+        return None;
     }
+    let Some(interval) = determine_interval() else {
+        tracing::info!("Systemd watchdog not enabled, skipping sd_notify initialization");
+        return None;
+    };
+    // init sd notify task
+    let watchdog_future = async move {
+        let mut interval_timer = tokio::time::interval(interval);
+        let mut state = cda_health::Status::Starting;
+        loop {
+            interval_timer.tick().await;
+            state = trigger_watchdog(health_state.as_ref(), state).await;
+        }
+    };
+    let sd_notify_future = spawn_named!("sd_notify", async move {
+        tokio::select! {
+            _ = watchdog_future => {},
+            () = shutdown_signal => {},
+        }
+    });
+    tracing::info!(
+        "Systemd detected and watchdog enabled, initialized sd_notify task with interval of {:?} \
+         seconds",
+        interval.as_secs()
+    );
+    Some(sd_notify_future)
 }
 
 fn determine_interval() -> Option<Duration> {
-    if let Some(duration) = sd_notify::watchdog_enabled() {
+    sd_notify::watchdog_enabled().map(|duration| {
         // ensure we are sending a bit more often than the watchdog expects,
         // to avoid any timing issues
-        let interval = if let Some(interval) = duration.checked_sub(Duration::from_secs(5)) {
-            interval
+        if let Some(interval) = duration.checked_sub(Duration::from_secs(5)) {
+            interval.min(Duration::from_secs(1))
         } else {
             duration
-        };
-        Some(interval)
-    } else {
-        None
-    }
+        }
+    })
 }
 
 async fn trigger_watchdog(
@@ -112,34 +109,30 @@ async fn trigger_watchdog(
     new_status
 }
 
-fn fold_status(acc: cda_health::Status, status: cda_health::Status) -> cda_health::Status {
+fn fold_status(acc: HealthStatus, status: HealthStatus) -> HealthStatus {
     match (acc, status) {
         (
-            cda_health::Status::Up | cda_health::Status::Starting | cda_health::Status::Pending,
-            cda_health::Status::Failed,
+            HealthStatus::Up | HealthStatus::Starting | HealthStatus::Pending,
+            HealthStatus::Failed,
         )
-        | (cda_health::Status::Failed, _) => cda_health::Status::Failed,
-        (
-            cda_health::Status::Starting | cda_health::Status::Pending,
-            cda_health::Status::Pending,
-        ) => cda_health::Status::Starting,
-        (cda_health::Status::Starting | cda_health::Status::Pending, cda_health::Status::Up) => {
-            cda_health::Status::Up
+        | (HealthStatus::Failed, _) => HealthStatus::Failed,
+        (HealthStatus::Starting | HealthStatus::Pending, HealthStatus::Pending) => {
+            HealthStatus::Starting
         }
+        (HealthStatus::Starting | HealthStatus::Pending, HealthStatus::Up) => HealthStatus::Up,
         (_, status) => status,
     }
 }
 
-async fn fold_health_state(health_state: Option<&HealthState>) -> cda_health::Status {
-    if let Some(health_state) = health_state {
-        health_state
-            .query_all_providers()
-            .await
-            .into_values()
-            .fold(cda_health::Status::Starting, fold_status)
-    } else {
-        cda_health::Status::Up
-    }
+async fn fold_health_state(health_state: Option<&HealthState>) -> HealthStatus {
+    let Some(health_state) = health_state else {
+        return cda_health::Status::Up;
+    };
+    health_state
+        .query_all_providers()
+        .await
+        .into_values()
+        .fold(cda_health::Status::Starting, fold_status)
 }
 
 #[cfg(test)]

--- a/cda-main/Cargo.toml
+++ b/cda-main/Cargo.toml
@@ -38,6 +38,7 @@ cda-sovd = { workspace = true }
 cda-tracing = { workspace = true }
 cda-plugin-security = { workspace = true }
 cda-health = { workspace = true }
+cda-extra = { workspace = true, optional = true }
 # args
 clap = { workspace = true, features = ["derive"] }
 # config
@@ -86,3 +87,4 @@ dlt-tracing = ["cda-tracing/dlt-tracing"]
 integration-tests = []
 
 health = []
+systemd-notify = ["dep:cda-extra", "cda-extra/systemd-notify"]

--- a/cda-main/src/main.rs
+++ b/cda-main/src/main.rs
@@ -137,6 +137,10 @@ async fn main() -> Result<(), AppError> {
         Option<Arc<cda_health::StatusHealthProvider>>,
     ) = (None, None);
 
+    #[cfg(feature = "systemd-notify")]
+    let _sd_notify_task =
+        cda_extra::create_sd_notify_task(health_state.clone(), clonable_shutdown_signal.clone());
+
     tracing::debug!("Webserver is running. Loading sovd routes...");
 
     let vehicle_data = opensovd_cda_lib::load_vehicle_data::<_, DefaultSecurityPluginData>(

--- a/testcontainer/cda/Dockerfile
+++ b/testcontainer/cda/Dockerfile
@@ -42,6 +42,7 @@ COPY cda-sovd/Cargo.toml ./cda-sovd/Cargo.toml
 COPY cda-tracing/Cargo.toml ./cda-tracing/Cargo.toml
 COPY cda-sovd-interfaces/Cargo.toml ./cda-sovd-interfaces/Cargo.toml
 COPY cda-health/Cargo.toml ./cda-health/Cargo.toml
+COPY cda-extra/Cargo.toml ./cda-extra/Cargo.toml
 COPY integration-tests/Cargo.toml ./integration-tests/Cargo.toml
 COPY cda-build/Cargo.toml ./cda-build/Cargo.toml
 COPY comm-mbedtls/mbedtls-rs/Cargo.toml ./comm-mbedtls/mbedtls-rs/Cargo.toml
@@ -86,6 +87,7 @@ COPY cda-sovd ./cda-sovd
 COPY cda-tracing ./cda-tracing
 COPY cda-sovd-interfaces ./cda-sovd-interfaces
 COPY cda-health ./cda-health/
+COPY cda-extra ./cda-extra
 COPY integration-tests ./integration-tests
 COPY cda-build ./cda-build
 COPY comm-mbedtls ./comm-mbedtls


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

This PR adds a cda-extra crate for additional features (inspired by axum-extra)

As a first feature, systemd-notify is implemented in cda-extra. If cda is running in an systemd environment systemd-notify is used to update the status according to the health state.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)