### PR TITLE
feat: add CAN bus transport and multi-transport gateway

### DIFF
--- a/.github/actions/process-docker-coverage/action.yml
+++ b/.github/actions/process-docker-coverage/action.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Process Docker coverage
+description: >-
+  Export an lcov tracefile from a coverage-instrumented docker test run (target/coverage/*.profraw) and rewrite the in-container /app/ source paths to the runner workspace so lcov --add unions hit counts across suites. Produces an empty tracefile when the run left no coverage data.
+inputs:
+  output-file:
+    description: Path of the resulting lcov tracefile
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Export Docker coverage
+      shell: bash
+      run: |
+        set -x
+        LLVM_PROFDATA=$(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata
+        LLVM_COV=$(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov
+        if [ -f "target/coverage/opensovd-cda" ] && ls target/coverage/*.profraw 1>/dev/null 2>&1; then
+          $LLVM_PROFDATA merge -sparse target/coverage/*.profraw -o target/coverage/docker.profdata
+          $LLVM_COV export -format=lcov \
+            target/coverage/opensovd-cda \
+            -instr-profile=target/coverage/docker.profdata \
+            --ignore-filename-regex='/usr/local/cargo|/usr/local/rustup' \
+            > "${{ inputs.output-file }}.raw"
+          WORKSPACE=$(cargo metadata --no-deps --format-version 1 | jq -r '.workspace_root')
+          sed "s|SF:/app/|SF:${WORKSPACE}/|g" "${{ inputs.output-file }}.raw" > "${{ inputs.output-file }}"
+        else
+          echo "No Docker coverage data found"
+          touch "${{ inputs.output-file }}"
+        fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,6 +248,137 @@ jobs:
         with:
           name: pr-comment-coverage
           path: pr-comment-coverage/
+  can_integration_tests:
+    name: CAN integration tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.88.0
+          components: clippy, rustfmt
+      # The vcan kernel module backs the socketcand container's shared bus.
+      - name: Load vcan kernel module
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y "linux-modules-extra-$(uname -r)" || true
+          sudo modprobe vcan
+      # The CAN suite runs the same containers as the DoIP suite plus a
+      # socketcand daemon (compose profile `can`) that fronts a shared vcan
+      # bus. The CDA image is built with the `can-socketcand` transport and the
+      # ecu-sim connects to the daemon (wired via docker-compose
+      # `SIM_CAN_SOCKETCAND_*`/`CDA_FEATURES`, written into the generated .env by
+      # the test harness). CDA and the ecu-sim reach the bus over TCP.
+      - name: Build CDA docker image (can-socketcand)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: testcontainer/cda/Dockerfile
+          push: false
+          tags: ghcr.io/${{ github.repository }}/opensovd-cda:can
+          load: true
+          build-args: |
+            CDA_FEATURES=can-socketcand
+          cache-from: |
+            type=gha,scope=cda-can-cargo-${{ github.ref_name }}
+            type=gha,scope=cda-can-cargo-main
+            type=gha,scope=cda-can-sccache-${{ github.ref_name }}
+            type=gha,scope=cda-can-sccache-main
+          cache-to: |
+            type=gha,mode=max,scope=cda-can-cargo-${{ github.ref_name }}
+            type=gha,mode=max,scope=cda-can-sccache-${{ github.ref_name }}
+      - name: Build ECU Sim docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: testcontainer/ecu-sim/
+          file: testcontainer/ecu-sim/docker/Dockerfile
+          push: false
+          tags: ghcr.io/${{ github.repository }}/ecu-sim:latest
+          load: true
+          cache-from: |
+            type=gha,scope=ecu-sim-gradle-${{ github.ref_name }}
+            type=gha,scope=ecu-sim-gradle-main
+          cache-to: |
+            type=gha,mode=max,scope=ecu-sim-gradle-${{ github.ref_name }}
+      - name: Run CAN integration tests
+        env:
+          CACHE_REGISTRY: ghcr.io/${{ github.repository }}
+          CDA_INTEGRATION_TEST_USE_CAN: "true"
+        # Run serially: the CAN transport is timing-sensitive (per-transaction
+        # TCP sockets + TesterPresent keepalive), so parallel tests can flake.
+        run: cargo test --locked -p integration-tests --features can-integration-tests --test integration_tests -- --show-output --test-threads=1
+
+  mixed_integration_tests:
+    name: Mixed DoIP+CAN integration tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.88.0
+          components: clippy, rustfmt
+      - name: Load vcan kernel module
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y "linux-modules-extra-$(uname -r)" || true
+          sudo modprobe vcan
+      # Mixed mode runs DoIP and CAN simultaneously against the same sim:
+      # TMCC3000/HOVR4000/JGWT5000 are pinned to CAN, FLXC1000 to DoIP, the
+      # remaining ECUs bind to the transport that detects them first. This is
+      # the only job that exercises MultiTransportGateway routing (pins,
+      # DoIP-preferred first detection, sticky bindings) with both gateways
+      # alive, and it also runs the session/security tests that the pure-CAN
+      # job skips.
+      - name: Build CDA docker image (can-socketcand)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: testcontainer/cda/Dockerfile
+          push: false
+          tags: ghcr.io/${{ github.repository }}/opensovd-cda:can
+          load: true
+          build-args: |
+            CDA_FEATURES=can-socketcand
+          cache-from: |
+            type=gha,scope=cda-can-cargo-${{ github.ref_name }}
+            type=gha,scope=cda-can-cargo-main
+            type=gha,scope=cda-can-sccache-${{ github.ref_name }}
+            type=gha,scope=cda-can-sccache-main
+          cache-to: |
+            type=gha,mode=max,scope=cda-can-cargo-${{ github.ref_name }}
+            type=gha,mode=max,scope=cda-can-sccache-${{ github.ref_name }}
+      - name: Build ECU Sim docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: testcontainer/ecu-sim/
+          file: testcontainer/ecu-sim/docker/Dockerfile
+          push: false
+          tags: ghcr.io/${{ github.repository }}/ecu-sim:latest
+          load: true
+          cache-from: |
+            type=gha,scope=ecu-sim-gradle-${{ github.ref_name }}
+            type=gha,scope=ecu-sim-gradle-main
+          cache-to: |
+            type=gha,mode=max,scope=ecu-sim-gradle-${{ github.ref_name }}
+      - name: Run mixed integration tests
+        env:
+          CACHE_REGISTRY: ghcr.io/${{ github.repository }}
+          CDA_INTEGRATION_TEST_USE_MIXED: "true"
+        run: cargo test --locked -p integration-tests --features can-integration-tests --test integration_tests -- --show-output --test-threads=1
 
   cargo-crap:
     name: CRAP (Change Risk Anti-Patterns)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,31 +183,16 @@ jobs:
           CACHE_REGISTRY: ghcr.io/${{ github.repository }}
           CDA_INTEGRATION_TEST_COVERAGE: "true"
         run: cargo test --locked -p integration-tests --features integration-tests -- --show-output
-      - name: Collect and merge coverage data
+      - name: Install lcov
+        run: sudo apt-get update && sudo apt-get install -y lcov
+      - name: Process Docker coverage
+        uses: ./.github/actions/process-docker-coverage
+        with:
+          output-file: lcov-docker.info
+      - name: Merge coverage data
         run: |
           set -x
-
-          LLVM_PROFDATA=$(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata
-          LLVM_COV=$(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov
-
-          sudo apt-get update && sudo apt-get install -y lcov
-
-          if [ -f "target/coverage/opensovd-cda" ] && ls target/coverage/*.profraw 1>/dev/null 2>&1; then
-            echo "Processing Docker coverage data..."
-            $LLVM_PROFDATA merge -sparse target/coverage/*.profraw -o target/coverage/docker.profdata
-
-            # Export Docker coverage, filtering to workspace sources (/app/) only
-            $LLVM_COV export -format=lcov \
-              target/coverage/opensovd-cda \
-              -instr-profile=target/coverage/docker.profdata \
-              --ignore-filename-regex='/usr/local/cargo|/usr/local/rustup' \
-              > lcov-docker-raw.info
-
-            # Rewrite /app/ paths to match the runner workspace paths so lcov --add
-            # recognises them as the same files and unions hit counts instead of stacking
-            WORKSPACE=$(cargo metadata --no-deps --format-version 1 | jq -r '.workspace_root')
-            sed "s|SF:/app/|SF:${WORKSPACE}/|g" lcov-docker-raw.info > lcov-docker.info
-
+          if [ -s lcov-docker.info ]; then
             echo "Merging unit test and Docker integration coverage..."
             lcov --add-tracefile lcov.info --add-tracefile lcov-docker.info \
               --output-file lcov-merged.info --ignore-errors inconsistent
@@ -219,35 +204,16 @@ jobs:
           SUMMARY=$(lcov --summary lcov-merged.info 2>&1 || true)
           echo "$SUMMARY"
           TOTAL_COV=$(echo "$SUMMARY" | grep -oP 'lines\.*:\s*\K[0-9.]+' || echo "0")
-          echo "**Total line coverage: ${TOTAL_COV}%**" >> "$GITHUB_STEP_SUMMARY"
-      - name: Upload coverage artifact
+          echo "**Line coverage (unit + DoIP integration): ${TOTAL_COV}%**" >> "$GITHUB_STEP_SUMMARY"
+          cp lcov-merged.info lcov-doip.info
+      # The final merged artifact (unit + DoIP + CAN + mixed) is assembled in
+      # the merge_coverage job; this uploads the per-suite share.
+      - name: Upload coverage artifact (unit + DoIP)
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-lcov
-          path: lcov-merged.info
+          name: coverage-lcov-doip
+          path: lcov-doip.info
           retention-days: 30
-      - name: Generate coverage PR comment artifact
-        if: github.event_name == 'pull_request'
-        run: |
-          TOTAL_COV=$(lcov --summary lcov-merged.info 2>&1 | grep -oP 'lines\.*:\s*\K[0-9.]+' || echo "0")
-          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          SYMBOL="$(printf '\xf0\x9f\x93\x8a')"
-          mkdir -p pr-comment-coverage
-          echo "${{ github.event.number }}" > pr-comment-coverage/pr_number
-          printf '%s\n' \
-            '<!-- coverage-report -->' \
-            "### ${SYMBOL} Coverage Report (unit + integration)" \
-            '' \
-            "**Total line coverage: ${TOTAL_COV}%**" \
-            '' \
-            "[Full build artifacts](${RUN_URL})" \
-            > pr-comment-coverage/body.md
-      - name: Upload coverage PR comment artifact
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v7
-        with:
-          name: pr-comment-coverage
-          path: pr-comment-coverage/
   can_integration_tests:
     name: CAN integration tests
     runs-on: ubuntu-latest
@@ -263,7 +229,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.88.0
-          components: clippy, rustfmt
+          components: clippy, rustfmt, llvm-tools
       # The vcan kernel module backs the socketcand container's shared bus.
       - name: Load vcan kernel module
         run: |
@@ -276,15 +242,19 @@ jobs:
       # ecu-sim connects to the daemon (wired via docker-compose
       # `SIM_CAN_SOCKETCAND_*`/`CDA_FEATURES`, written into the generated .env by
       # the test harness). CDA and the ecu-sim reach the bus over TCP.
-      - name: Build CDA docker image (can-socketcand)
+      # The suite always runs coverage-instrumented so it counts toward the
+      # merged coverage report (see merge_coverage).
+      - name: Build CDA docker image (can-socketcand, coverage-enabled)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: testcontainer/cda/Dockerfile
           push: false
-          tags: ghcr.io/${{ github.repository }}/opensovd-cda:can
+          tags: ghcr.io/${{ github.repository }}/opensovd-cda:coverage
           load: true
           build-args: |
+            BUILD_PROFILE=dev
+            RUSTFLAGS=-C instrument-coverage
             CDA_FEATURES=can-socketcand
           cache-from: |
             type=gha,scope=cda-can-cargo-${{ github.ref_name }}
@@ -307,13 +277,47 @@ jobs:
             type=gha,scope=ecu-sim-gradle-main
           cache-to: |
             type=gha,mode=max,scope=ecu-sim-gradle-${{ github.ref_name }}
+      # Unit tests gated on the can features (e.g. the CAN example config
+      # validity test) run nowhere else: the main test job uses default
+      # features and the clippy workflow does not execute tests. Collected
+      # under coverage so they count toward the merged report like the
+      # default-features unit tests in build_and_test.
+      - name: Install cargo-llvm-cov
+        run: cargo install --locked cargo-llvm-cov
+      - name: Run unit tests with coverage (CAN features)
+        run: cargo llvm-cov --locked -p opensovd-cda -p cda-comm-can --features opensovd-cda/can-socketcand,cda-comm-can/can-socketcand --lcov --output-path lcov-can-unit.info -- --show-output
       - name: Run CAN integration tests
         env:
           CACHE_REGISTRY: ghcr.io/${{ github.repository }}
           CDA_INTEGRATION_TEST_USE_CAN: "true"
+          CDA_INTEGRATION_TEST_COVERAGE: "true"
         # Run serially: the CAN transport is timing-sensitive (per-transaction
         # TCP sockets + TesterPresent keepalive), so parallel tests can flake.
         run: cargo test --locked -p integration-tests --features can-integration-tests --test integration_tests -- --show-output --test-threads=1
+      - name: Install lcov
+        run: sudo apt-get update && sudo apt-get install -y lcov
+      - name: Process Docker coverage
+        uses: ./.github/actions/process-docker-coverage
+        with:
+          output-file: lcov-can-docker.info
+      - name: Merge CAN coverage data
+        run: |
+          set -x
+          # Union with the host unit-test coverage (CAN features).
+          if [ -s lcov-can-docker.info ] && [ -s lcov-can-unit.info ]; then
+            lcov --add-tracefile lcov-can-docker.info --add-tracefile lcov-can-unit.info \
+              --output-file lcov-can.info --ignore-errors inconsistent
+          elif [ -s lcov-can-unit.info ]; then
+            cp lcov-can-unit.info lcov-can.info
+          else
+            cp lcov-can-docker.info lcov-can.info
+          fi
+      - name: Upload CAN coverage artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-lcov-can
+          path: lcov-can.info
+          retention-days: 30
 
   mixed_integration_tests:
     name: Mixed DoIP+CAN integration tests
@@ -330,7 +334,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.88.0
-          components: clippy, rustfmt
+          components: clippy, rustfmt, llvm-tools
       - name: Load vcan kernel module
         run: |
           sudo apt-get update
@@ -343,15 +347,19 @@ jobs:
       # DoIP-preferred first detection, sticky bindings) with both gateways
       # alive, and it also runs the session/security tests that the pure-CAN
       # job skips.
-      - name: Build CDA docker image (can-socketcand)
+      # The suite always runs coverage-instrumented so it counts toward the
+      # merged coverage report (see merge_coverage).
+      - name: Build CDA docker image (can-socketcand, coverage-enabled)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: testcontainer/cda/Dockerfile
           push: false
-          tags: ghcr.io/${{ github.repository }}/opensovd-cda:can
+          tags: ghcr.io/${{ github.repository }}/opensovd-cda:coverage
           load: true
           build-args: |
+            BUILD_PROFILE=dev
+            RUSTFLAGS=-C instrument-coverage
             CDA_FEATURES=can-socketcand
           cache-from: |
             type=gha,scope=cda-can-cargo-${{ github.ref_name }}
@@ -378,12 +386,77 @@ jobs:
         env:
           CACHE_REGISTRY: ghcr.io/${{ github.repository }}
           CDA_INTEGRATION_TEST_USE_MIXED: "true"
+          CDA_INTEGRATION_TEST_COVERAGE: "true"
         run: cargo test --locked -p integration-tests --features can-integration-tests --test integration_tests -- --show-output --test-threads=1
+      - name: Process Docker coverage
+        uses: ./.github/actions/process-docker-coverage
+        with:
+          output-file: lcov-mixed.info
+      - name: Upload mixed coverage artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-lcov-mixed
+          path: lcov-mixed.info
+          retention-days: 30
+
+  merge_coverage:
+    name: Merge coverage
+    runs-on: ubuntu-latest
+    needs: [build_and_test, can_integration_tests, mixed_integration_tests]
+    steps:
+      - name: Download per-suite coverage artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: coverage-lcov-*
+          merge-multiple: true
+      - name: Merge coverage data
+        run: |
+          set -x
+          sudo apt-get update && sudo apt-get install -y lcov
+          ADD_ARGS=""
+          for f in lcov-doip.info lcov-can.info lcov-mixed.info; do
+            if [ -s "$f" ]; then
+              ADD_ARGS="$ADD_ARGS --add-tracefile $f"
+            fi
+          done
+          lcov $ADD_ARGS --output-file lcov-merged.info --ignore-errors inconsistent
+          SUMMARY=$(lcov --summary lcov-merged.info 2>&1 || true)
+          echo "$SUMMARY"
+          TOTAL_COV=$(echo "$SUMMARY" | grep -oP 'lines\.*:\s*\K[0-9.]+' || echo "0")
+          echo "**Total line coverage: ${TOTAL_COV}%**" >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload merged coverage artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-lcov
+          path: lcov-merged.info
+          retention-days: 30
+      - name: Generate coverage PR comment artifact
+        if: github.event_name == 'pull_request'
+        run: |
+          TOTAL_COV=$(lcov --summary lcov-merged.info 2>&1 | grep -oP 'lines\.*:\s*\K[0-9.]+' || echo "0")
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          SYMBOL="$(printf '\xf0\x9f\x93\x8a')"
+          mkdir -p pr-comment-coverage
+          echo "${{ github.event.number }}" > pr-comment-coverage/pr_number
+          printf '%s\n' \
+            '<!-- coverage-report -->' \
+            "### ${SYMBOL} Coverage Report (unit + DoIP/CAN/mixed integration)" \
+            '' \
+            "**Total line coverage: ${TOTAL_COV}%**" \
+            '' \
+            "[Full build artifacts](${RUN_URL})" \
+            > pr-comment-coverage/body.md
+      - name: Upload coverage PR comment artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-comment-coverage
+          path: pr-comment-coverage/
 
   cargo-crap:
     name: CRAP (Change Risk Anti-Patterns)
     if: github.event_name == 'pull_request'
-    needs: [build_and_test]
+    needs: [merge_coverage]
     uses: eclipse-opensovd/cicd-workflows/.github/workflows/crap.yml@07140bdd84f20b66fd4aff58a83c5148deec388c
     with:
       rust-version: "1.88.0"
@@ -408,7 +481,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.88.0
-          components: clippy, rustfmt
+          components: clippy, rustfmt, llvm-tools
       - name: Setup OpenSSL (Windows) Environment
         run: |
           echo "OPENSSL_DIR=$env:OPENSSL_DIR" >> $env:GITHUB_ENV

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ docs/images/*.svg
 
 **/*.html
 
+# MDD database files (proprietary, not for version control)
+mdds/*.mdd
+
 # Docker environment settings
 .env
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -271,6 +271,12 @@ dependencies = [
  "shlex",
  "syn",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -368,6 +374,22 @@ name = "cda-build"
 version = "0.1.0"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cda-comm-can"
+version = "0.1.0"
+dependencies = [
+ "cda-interfaces",
+ "hex",
+ "schemars",
+ "serde",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-socketcan-isotp",
+ "tokio-util",
+ "toml 0.9.8",
+ "tracing",
 ]
 
 [[package]]
@@ -1115,6 +1137,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-can"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d2e857f87ac832df68fa498d18ddc679175cf3d2e4aa893988e5601baf9438"
+dependencies = [
+ "nb",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,7 +1234,7 @@ name = "flatbuffers"
 version = "25.9.23"
 source = "git+https://github.com/alexmohr/flatbuffers.git?rev=0ba3307d#0ba3307d110a6def7419ad1158245cdf47c6d0c5"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "rustc_version",
 ]
 
@@ -2011,7 +2042,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
  "plain",
  "redox_syscall 0.7.3",
@@ -2109,6 +2140,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -2250,6 +2290,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "nb"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,6 +2416,7 @@ name = "opensovd-cda"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "cda-comm-can",
  "cda-comm-doip",
  "cda-comm-uds",
  "cda-core",
@@ -2391,7 +2451,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2971,7 +3031,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2980,7 +3040,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -3209,7 +3269,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3333,7 +3393,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3701,7 +3761,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3911,6 +3971,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-socketcan-isotp"
+version = "0.6.0"
+source = "git+https://github.com/MarkSchmitt/tokio-socketcan-isotp.git?tag=v0.6.0#8e252642a5a3043284741319d74986c51f5fe67b"
+dependencies = [
+ "bitflags 2.10.0",
+ "embedded-can",
+ "libc",
+ "nix",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4090,7 +4163,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "futures-core",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
   "cda-interfaces",
   "cda-core",
   "cda-comm-doip",
+  "cda-comm-can",
   "cda-comm-uds",
   "cda-sovd",
   "cda-sovd-interfaces",
@@ -44,6 +45,10 @@ opensovd_cda_lib = { path = "cda-main", package = "opensovd-cda" }
 cda-interfaces = { path = "cda-interfaces" }
 cda-core = { path = "cda-core" }
 cda-comm-doip = { path = "cda-comm-doip" }
+cda-comm-can = { path = "cda-comm-can" }
+# CAN / ISO-TP library shared by the can feature set (fork: upstream 0.2.0
+# lacks the socketcand and userspace ISO-TP backends the CI suites use)
+tokio-socketcan-isotp = { git = "https://github.com/MarkSchmitt/tokio-socketcan-isotp.git", tag = "v0.6.0" }
 cda-comm-uds = { path = "cda-comm-uds" }
 cda-database = { path = "cda-database" }
 cda-plugin-security = { path = "cda-plugin-security" }

--- a/cda-comm-can/Cargo.toml
+++ b/cda-comm-can/Cargo.toml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "cda-comm-can"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+description = "CAN bus communication layer used in CDA"
+homepage.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# internal dependencies
+cda-interfaces = { workspace = true }
+# external
+thiserror = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+# tokio
+tokio = { workspace = true, features = ["rt", "time", "sync", "io-util"] }
+tokio-util = { workspace = true }
+# logging & tracing
+tracing = { workspace = true }
+# utilities
+hex = { workspace = true }
+schemars = { workspace = true }
+
+# CAN / ISO-TP, enabled by the `can` feature. The crate gates its
+# SocketCAN/kernel code to Linux internally; with its `socketcand` feature it
+# also builds on other platforms. A `compile_error!` in `src/lib.rs` enforces
+# that off-Linux builds with `can` also enable `can-socketcand`.
+tokio-socketcan-isotp = { workspace = true, optional = true }
+
+[dev-dependencies]
+toml = { workspace = true }
+
+[features]
+default = []
+can = ["dep:tokio-socketcan-isotp"]
+# Userspace ISO-TP over raw CAN: enables the `rawcan:<ifname>` interface
+# scheme (vcan without the can_isotp kernel module).
+can-isotp-userspace = ["can", "tokio-socketcan-isotp/isotp-userspace"]
+# CAN frames over a socketcand daemon: enables the
+# `socketcand:<host>:<port>:<bus>` interface scheme (no kernel CAN needed on
+# the client; also works on non-Linux platforms).
+can-socketcand = ["can-isotp-userspace", "tokio-socketcan-isotp/socketcand"]
+dlt-tracing = ["cda-interfaces/dlt-tracing"]

--- a/cda-comm-can/src/config.rs
+++ b/cda-comm-can/src/config.rs
@@ -1,0 +1,278 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use serde::{Deserialize, Serialize};
+
+use crate::multi_transport::TransportType;
+
+/// Configuration for CAN bus communication.
+#[derive(Deserialize, Serialize, Clone, Debug, schemars::JsonSchema)]
+pub struct CanConfig {
+    /// CAN interface name (e.g., "vxcan0", "can0")
+    pub interface: String,
+
+    /// Optional explicit ECU CAN ID mappings.
+    /// If not provided, CAN IDs will be read from the MDD COM parameters.
+    #[serde(default)]
+    pub ecu_mappings: Vec<CanEcuMapping>,
+
+    /// Per-ECU transport override.
+    ///
+    /// Keys are ECU names (case-insensitive), values are the transport to use.
+    /// ECUs not listed here default to `DoIP` when a `DoIP` gateway is available,
+    /// falling back to CAN otherwise.
+    ///
+    /// Example (TOML):
+    /// ```toml
+    /// [[can.transport_overrides]]
+    /// ecu_name = "MyCanOnlyEcu"
+    /// transport = "can"
+    /// ```
+    #[serde(default)]
+    pub transport_overrides: Vec<TransportOverride>,
+
+    /// Timeout for waiting for a response in milliseconds.
+    ///
+    /// The serde default is needed (unlike for other config types) because
+    /// `[can]` is an optional section: the figment defaults tree carries no
+    /// values below it, so omitted fields must default at deserialization
+    /// time. The canonical values live in the `Default` impl.
+    #[serde(default = "default_response_timeout_ms")]
+    pub response_timeout_ms: u64,
+
+    /// Timeout for probing ECUs during discovery in milliseconds.
+    /// See `response_timeout_ms` for why the serde default is needed.
+    #[serde(default = "default_probe_timeout_ms")]
+    pub probe_timeout_ms: u64,
+
+    /// Extra rounds through the probe sequence when an ECU did not answer,
+    /// self-healing transiently lost exchanges (e.g. bus arbitration during
+    /// startup) inside the transport instead of surfacing a spurious offline
+    /// to the UDS layer. `0` probes each ECU exactly once per discovery.
+    /// See `response_timeout_ms` for why the serde default is needed.
+    #[serde(default = "default_probe_retries")]
+    pub probe_retries: u32,
+
+    /// Delay between probe retry rounds in milliseconds.
+    /// See `response_timeout_ms` for why the serde default is needed.
+    #[serde(default = "default_probe_retry_delay_ms")]
+    pub probe_retry_delay_ms: u64,
+
+    /// Interval of the functional-broadcast `TesterPresent` keep-alive in
+    /// milliseconds; `0` (the default) disables it, keeping a resident
+    /// on-board CDA from interfering with network management - sleeping
+    /// ECUs are recovered by rediscovery on wake. External testers should
+    /// set an interval (e.g. 2000) to hold ECUs awake for the session.
+    /// See `response_timeout_ms` for why the serde default is needed.
+    #[serde(default = "default_keepalive_interval_ms")]
+    pub keepalive_interval_ms: u64,
+
+    /// Whether the built-in `TesterPresent` probe heads the discovery
+    /// probe sequence; with `false`, `probe_fallbacks` must be non-empty
+    /// and is used verbatim.
+    /// See `response_timeout_ms` for why the serde default is needed.
+    #[serde(default = "default_default_probes")]
+    pub default_probes: bool,
+
+    /// Optional fallback probe payloads used after the default `TesterPresent` probe
+    /// (or, with `default_probes = false`, the complete probe sequence).
+    ///
+    /// This is useful for ECUs that do not answer `TesterPresent` during discovery,
+    /// but do respond to another lightweight diagnostic request.
+    #[serde(default)]
+    pub probe_fallbacks: Vec<CanProbeConfig>,
+}
+
+/// Per-ECU transport selection override.
+#[derive(Deserialize, Serialize, Clone, Debug, schemars::JsonSchema)]
+pub struct TransportOverride {
+    /// ECU name as defined in the MDD file (case-insensitive).
+    pub ecu_name: String,
+
+    /// Transport to use for this ECU.
+    pub transport: TransportType,
+}
+
+/// Additional probe payload to try during CAN discovery.
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, schemars::JsonSchema)]
+pub struct CanProbeConfig {
+    /// Optional friendly label for logs.
+    pub name: Option<String>,
+
+    /// UDS request payload encoded as hex, e.g. `22F190` or `22 F1 90`.
+    pub payload_hex: String,
+}
+
+impl CanProbeConfig {
+    /// Parse the configured hex payload into raw bytes.
+    ///
+    /// # Errors
+    /// Returns an error if the payload contains invalid hex or has odd length.
+    pub fn payload_bytes(&self) -> Result<Vec<u8>, String> {
+        let normalized = self
+            .payload_hex
+            .replace("0x", "")
+            .replace("0X", "")
+            .chars()
+            .filter(|c| !c.is_whitespace() && *c != '_')
+            .collect::<String>();
+
+        if normalized.is_empty() {
+            return Err("Probe payload must not be empty".to_owned());
+        }
+
+        if !normalized.len().is_multiple_of(2) {
+            // Reject instead of deferring to decode_hex's zero-padding: for a
+            // UDS probe payload a missing nibble is a config mistake, and
+            // silently padding it would put a different request on the bus.
+            return Err(format!(
+                "Probe payload `{}` must contain an even number of hex digits",
+                self.payload_hex
+            ));
+        }
+
+        cda_interfaces::util::decode_hex(&normalized)
+            .map_err(|e| format!("Invalid probe payload `{}`: {e}", self.payload_hex))
+    }
+}
+
+/// Explicit CAN ID mapping for an ECU.
+/// Used when MDD COM parameters don't contain CAN addressing info.
+#[derive(Deserialize, Serialize, Clone, Debug, schemars::JsonSchema)]
+pub struct CanEcuMapping {
+    /// ECU name as defined in the MDD file.
+    pub ecu_name: String,
+
+    /// Physical request CAN identifier.
+    ///
+    /// Supports both:
+    /// - 11-bit standard CAN IDs (e.g. `0x7E0`)
+    /// - 29-bit extended CAN IDs (e.g. `0x18DA10F1`, ISO 15765-4 normal
+    ///   fixed addressing)
+    pub request_id: u32,
+
+    /// Physical response CAN identifier.
+    ///
+    /// Supports both:
+    /// - 11-bit standard CAN IDs (e.g. `0x7E8`)
+    /// - 29-bit extended CAN IDs (e.g. `0x18DAF110`)
+    pub response_id: u32,
+}
+
+impl Default for CanConfig {
+    fn default() -> Self {
+        Self {
+            interface: "can0".to_owned(),
+            ecu_mappings: Vec::new(),
+            transport_overrides: Vec::new(),
+            response_timeout_ms: 5000,
+            probe_timeout_ms: 100,
+            probe_retries: 0,
+            probe_retry_delay_ms: 100,
+            keepalive_interval_ms: 0,
+            default_probes: true,
+            probe_fallbacks: Vec::new(),
+        }
+    }
+}
+
+fn default_response_timeout_ms() -> u64 {
+    CanConfig::default().response_timeout_ms
+}
+
+fn default_probe_timeout_ms() -> u64 {
+    CanConfig::default().probe_timeout_ms
+}
+
+fn default_probe_retries() -> u32 {
+    CanConfig::default().probe_retries
+}
+
+fn default_probe_retry_delay_ms() -> u64 {
+    CanConfig::default().probe_retry_delay_ms
+}
+
+fn default_default_probes() -> bool {
+    CanConfig::default().default_probes
+}
+
+fn default_keepalive_interval_ms() -> u64 {
+    CanConfig::default().keepalive_interval_ms
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CanConfig, CanProbeConfig};
+
+    /// `[can]` is an optional config section, so it is deserialized directly
+    /// from the user's TOML without the figment defaults tree behind it. A
+    /// minimal section must still work; this pins the serde-default fields.
+    #[test]
+    fn minimal_can_section_deserializes_with_defaults() {
+        let config: CanConfig = toml::from_str(r#"interface = "vcan0""#).expect("minimal config");
+
+        assert_eq!(config.interface, "vcan0");
+        assert_eq!(
+            config.response_timeout_ms,
+            CanConfig::default().response_timeout_ms
+        );
+        assert_eq!(
+            config.probe_timeout_ms,
+            CanConfig::default().probe_timeout_ms
+        );
+        assert!(config.default_probes);
+        assert_eq!(
+            config.keepalive_interval_ms,
+            CanConfig::default().keepalive_interval_ms
+        );
+        assert!(config.ecu_mappings.is_empty());
+        assert!(config.transport_overrides.is_empty());
+        assert!(config.probe_fallbacks.is_empty());
+    }
+
+    #[test]
+    fn parse_probe_payload_hex_without_spacing() {
+        let probe = CanProbeConfig {
+            name: Some("read-did".to_owned()),
+            payload_hex: "22F190".to_owned(),
+        };
+
+        assert_eq!(
+            probe.payload_bytes().expect("valid payload"),
+            vec![0x22, 0xF1, 0x90]
+        );
+    }
+
+    #[test]
+    fn parse_probe_payload_hex_with_spacing() {
+        let probe = CanProbeConfig {
+            name: None,
+            payload_hex: "22 F1 90".to_owned(),
+        };
+
+        assert_eq!(
+            probe.payload_bytes().expect("valid payload"),
+            vec![0x22, 0xF1, 0x90]
+        );
+    }
+
+    #[test]
+    fn reject_odd_probe_payload_hex() {
+        let probe = CanProbeConfig {
+            name: None,
+            payload_hex: "22F19".to_owned(),
+        };
+
+        assert!(probe.payload_bytes().is_err());
+    }
+}

--- a/cda-comm-can/src/gateway/background.rs
+++ b/cda-comm-can/src/gateway/background.rs
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Handle for the gateway's cancellable background tasks (keep-alive
+//! broadcast, rediscovery).
+
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+/// A running background task of the gateway.
+///
+/// Call [`Self::shutdown`] to stop the task and wait for its termination.
+/// Dropping the handle without a shutdown aborts the task as a last resort,
+/// without waiting for it to finish.
+pub(crate) struct BackgroundTask {
+    cancel: CancellationToken,
+    task: std::sync::Mutex<Option<JoinHandle<()>>>,
+}
+
+impl BackgroundTask {
+    /// Wraps a spawned task with the token that cancels it.
+    pub(crate) fn new(cancel: CancellationToken, task: JoinHandle<()>) -> Self {
+        Self {
+            cancel,
+            task: std::sync::Mutex::new(Some(task)),
+        }
+    }
+
+    /// Stops the task and waits until it has terminated. Idempotent.
+    pub(crate) async fn shutdown(&self) {
+        self.cancel.cancel();
+        let task = self.task.lock().map_or(None, |mut guard| guard.take());
+        if let Some(task) = task {
+            let _ = task.await;
+        }
+    }
+}
+
+impl Drop for BackgroundTask {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        if let Ok(mut guard) = self.task.lock()
+            && let Some(task) = guard.take()
+        {
+            task.abort();
+        }
+    }
+}

--- a/cda-comm-can/src/gateway/can_id.rs
+++ b/cda-comm-can/src/gateway/can_id.rs
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Socket-side conversion for [`CanId`]: only the mapping onto the
+//! ISO-TP library's typed identifiers is transport-specific, so it lives
+//! behind the feature gate while the type itself is in `cda_interfaces`.
+
+use cda_interfaces::CanId;
+use tokio_socketcan_isotp::{ExtendedId, Id, StandardId};
+
+use super::error::CanError;
+
+/// Conversion of a validated [`CanId`] into the ISO-TP socket identifier.
+pub(crate) trait CanIdExt {
+    /// Converts into the typed socket identifier of the ISO-TP library.
+    ///
+    /// # Errors
+    /// Unreachable after `TryFrom` validation; mapped instead of unwrapped
+    /// to keep the conversion total.
+    fn to_socket_id(self) -> Result<Id, CanError>;
+}
+
+impl CanIdExt for CanId {
+    fn to_socket_id(self) -> Result<Id, CanError> {
+        match self {
+            Self::Standard(id) => StandardId::new(id).map(Id::Standard),
+            Self::Extended(id) => ExtendedId::new(id).map(Id::Extended),
+        }
+        .ok_or_else(|| CanError::InvalidId(format!("invalid CAN ID {self}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn socket_ids_match_the_id_kind() {
+        let standard = CanId::try_from(0x7E0).expect("valid standard ID");
+        assert!(matches!(standard.to_socket_id(), Ok(Id::Standard(_))));
+
+        let extended = CanId::try_from(0x18DA_10F1).expect("valid extended ID");
+        assert!(matches!(extended.to_socket_id(), Ok(Id::Extended(_))));
+    }
+}

--- a/cda-comm-can/src/gateway/connection.rs
+++ b/cda-comm-can/src/gateway/connection.rs
@@ -1,0 +1,267 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::time::Duration;
+
+use cda_interfaces::CanId;
+use tokio_socketcan_isotp::{IsoTpBehaviour, IsoTpOptions, IsoTpSocket};
+
+use super::{can_id::CanIdExt, error::CanError};
+
+/// Represents a CAN connection to a single ECU using ISO-TP.
+pub struct CanEcuConnection {
+    /// ECU name for logging/identification
+    pub ecu_name: String,
+    /// Physical request CAN ID
+    pub request_id: CanId,
+    /// Physical response CAN ID
+    pub response_id: CanId,
+    /// CAN interface name
+    interface: String,
+}
+
+impl CanEcuConnection {
+    /// Creates a new CAN ECU connection configuration.
+    #[must_use]
+    pub fn new(ecu_name: String, interface: String, request_id: CanId, response_id: CanId) -> Self {
+        Self {
+            ecu_name,
+            request_id,
+            response_id,
+            interface,
+        }
+    }
+
+    /// Opens an ISO-TP socket for this ECU connection.
+    ///
+    /// Supports both 11-bit standard and 29-bit extended CAN IDs; see
+    /// [`CanId`].
+    fn open_socket(&self) -> Result<IsoTpSocket, CanError> {
+        // Following tokio IsoTpSocket naming scheme:
+        // src (ISO-TP rx_id) = what we receive on (ECU's response ID, e.g. 0x7E8)
+        // dst (ISO-TP tx_id) = what we transmit on (ECU's request ID, e.g. 0x7E0)
+        let src = self.response_id.to_socket_id()?;
+        let dst = self.request_id.to_socket_id()?;
+
+        // Enable TX padding to send 8-byte CAN frames (required by many ECUs)
+        let isotp_opts = IsoTpOptions::new(
+            IsoTpBehaviour::CAN_ISOTP_TX_PADDING,
+            Duration::ZERO, // frame_txtime
+            0,              // ext_address
+            0x00,           // txpad_content (padding byte value)
+            0x00,           // rxpad_content
+            0,              // rx_ext_address
+        )
+        .ok();
+
+        IsoTpSocket::open_with_opts(&self.interface, src, dst, isotp_opts, None, None).map_err(
+            |e| {
+                CanError::SocketError(format!(
+                    "Failed to open ISO-TP socket on {}: {}",
+                    self.interface, e
+                ))
+            },
+        )
+    }
+
+    /// Verifies that an ISO-TP socket can be opened for this connection.
+    ///
+    /// Used at gateway setup to fail fast when the CAN interface does not
+    /// exist (or the socketcand daemon is unreachable) instead of timing out
+    /// on every probe and request later.
+    pub(crate) fn verify_socket_openable(&self) -> Result<(), CanError> {
+        self.open_socket().map(|_| ())
+    }
+
+    /// Sends a UDS request and waits for a single response.
+    ///
+    /// Opens a fresh ISO-TP socket, sends the request, reads one response, and
+    /// drops the socket. For interactions that require multiple reads on the same
+    /// socket (e.g., NRC 0x78 Response Pending), use [`begin_exchange`] instead.
+    pub async fn send_receive(
+        &self,
+        request: &[u8],
+        timeout: Duration,
+    ) -> Result<Vec<u8>, CanError> {
+        let exchange = self.begin_exchange(request).await?;
+        exchange.read_response(timeout).await
+    }
+
+    /// Opens an ISO-TP socket, sends the request, and returns a [`CanExchange`]
+    /// that keeps the socket alive for reading follow-up responses.
+    ///
+    /// This is essential for handling NRC 0x78 (Response Pending): the ECU sends
+    /// a pending notification and then later the real response on the same
+    /// transport connection. Dropping the socket between reads would create a
+    /// race where the real response arrives while no socket is listening.
+    pub async fn begin_exchange(&self, request: &[u8]) -> Result<CanExchange, CanError> {
+        let socket = self.open_socket()?;
+
+        tracing::debug!(
+            ecu = %self.ecu_name,
+            request_id = %self.request_id,
+            response_id = %self.response_id,
+            data = %hex::encode(request),
+            "Sending CAN request"
+        );
+
+        socket.write_packet(request).await.map_err(|e| {
+            CanError::SendFailed(format!("Failed to send to {}: {}", self.ecu_name, e))
+        })?;
+
+        Ok(CanExchange {
+            socket,
+            ecu_name: self.ecu_name.clone(),
+        })
+    }
+
+    /// Probes the ECU using the provided request payload.
+    ///
+    /// Any non-empty response counts as proof that the ECU is alive. This allows
+    /// discovery fallbacks such as lightweight `ReadDataByIdentifier` requests.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails, times out, or the ECU sends an empty response.
+    pub async fn probe_with_payload(
+        &self,
+        request: &[u8],
+        timeout: Duration,
+    ) -> Result<Vec<u8>, CanError> {
+        let response = self.send_receive(request, timeout).await?;
+
+        if response.is_empty() {
+            Err(CanError::ReceiveFailed(format!(
+                "Received empty probe response from {}",
+                self.ecu_name
+            )))
+        } else {
+            Ok(response)
+        }
+    }
+
+    /// Returns a network address string for this connection.
+    /// Format: "interface:request_id->response_id"
+    #[must_use]
+    pub fn network_address(&self) -> String {
+        format!(
+            "{}:{}->{}",
+            self.interface, self.request_id, self.response_id
+        )
+    }
+}
+
+/// An in-progress ISO-TP exchange with an ECU.
+///
+/// Keeps the underlying socket open so that multiple responses can be read
+/// from the same transport session (required for NRC 0x78 handling).
+pub(crate) struct CanExchange {
+    socket: IsoTpSocket,
+    ecu_name: String,
+}
+
+impl CanExchange {
+    /// Reads the next response from the ECU on this exchange's socket.
+    pub async fn read_response(&self, timeout: Duration) -> Result<Vec<u8>, CanError> {
+        let read_result = tokio::time::timeout(timeout, self.socket.read_packet()).await;
+
+        match read_result {
+            Ok(Ok(response_buf)) => {
+                tracing::debug!(
+                    ecu = %self.ecu_name,
+                    data = %hex::encode(&response_buf),
+                    len = response_buf.len(),
+                    "Received CAN response"
+                );
+                Ok(response_buf)
+            }
+            Ok(Err(e)) => Err(CanError::ReceiveFailed(format!(
+                "Failed to receive from {}: {}",
+                self.ecu_name, e
+            ))),
+            Err(_) => Err(CanError::Timeout),
+        }
+    }
+}
+
+impl std::fmt::Debug for CanEcuConnection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CanEcuConnection")
+            .field("ecu_name", &self.ecu_name)
+            .field("interface", &self.interface)
+            .field("request_id", &self.request_id.to_string())
+            .field("response_id", &self.response_id.to_string())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "can-socketcand")]
+    use super::*;
+
+    /// End-to-end smoke test: a full request/response round trip using
+    /// 29-bit extended IDs (ISO 15765-4 normal fixed addressing) through the
+    /// socketcand backend - the same transport the CI suite uses.
+    ///
+    /// Requires a local socketcand on 127.0.0.1:29536 fronting vcan0, e.g.:
+    /// `sudo modprobe vcan && sudo ip link add dev vcan0 type vcan && sudo ip
+    /// link set up vcan0 && socketcand -n -i vcan0 -l <iface>`
+    #[cfg(feature = "can-socketcand")]
+    #[tokio::test]
+    #[ignore = "needs a local socketcand on 127.0.0.1:29536 fronting vcan0"]
+    async fn extended_id_round_trip_over_socketcand() {
+        const IFACE: &str = "socketcand:127.0.0.1:29536:vcan0";
+        // The socketcand backend shares one TCP connection per endpoint
+        // string, and socketcand does not echo frames back to the connection
+        // that sent them. Spell the ECU side's endpoint differently so the
+        // two ends get separate connections, as they would in production
+        // (CDA and the simulator are separate processes).
+        const ECU_IFACE: &str = "socketcand:localhost:29536:vcan0";
+        const REQ_ID: u32 = 0x18DA_10F1;
+        const RESP_ID: u32 = 0x18DA_F110;
+
+        // "ECU" side: receives requests on REQ_ID, answers on RESP_ID.
+        let ecu_rx = CanId::try_from(REQ_ID).unwrap().to_socket_id().unwrap();
+        let ecu_tx = CanId::try_from(RESP_ID).unwrap().to_socket_id().unwrap();
+        let ecu_socket =
+            IsoTpSocket::open(ECU_IFACE, ecu_rx, ecu_tx).expect("open ecu-side socket");
+        // The socketcand handshake (`< open >` / `< rawmode >`) completes in
+        // the background; give the ECU side a moment to be subscribed before
+        // the tester transmits, otherwise the request frame is lost.
+        cda_interfaces::util::tokio_ext::sleep_for(Duration::from_millis(300)).await;
+
+        let echo = tokio::spawn(async move {
+            let request = ecu_socket.read_packet().await.expect("ecu-side read");
+            assert_eq!(request, vec![0x3E, 0x00], "ecu should see the request");
+            ecu_socket
+                .write_packet(&[0x7E, 0x00])
+                .await
+                .expect("ecu-side write");
+        });
+
+        // Tester side: the production connection type with extended IDs.
+        let conn = CanEcuConnection::new(
+            "smoke".to_owned(),
+            IFACE.to_owned(),
+            CanId::try_from(REQ_ID).unwrap(),
+            CanId::try_from(RESP_ID).unwrap(),
+        );
+        let response = conn
+            .send_receive(&[0x3E, 0x00], Duration::from_secs(2))
+            .await
+            .expect("round trip over extended IDs");
+        assert_eq!(response, vec![0x7E, 0x00]);
+
+        echo.await.expect("ecu-side task");
+    }
+}

--- a/cda-comm-can/src/gateway/error.rs
+++ b/cda-comm-can/src/gateway/error.rs
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use thiserror::Error;
+
+/// Errors that can occur during CAN gateway setup.
+#[derive(Error, Debug, Clone)]
+pub enum CanGatewaySetupError {
+    #[error("Failed to open CAN interface `{0}`: {1}")]
+    InterfaceOpenFailed(String, String),
+
+    #[error("Invalid CAN configuration: {0}")]
+    InvalidConfiguration(String),
+
+    #[error(
+        "[can] is configured but no usable ECU addressing was found: add [[can.ecu_mappings]] \
+         entries for ECUs present in the database (or provide CAN COM parameters in the MDD)"
+    )]
+    NoEcuMappings,
+}
+
+impl From<cda_interfaces::InvalidCanId> for CanError {
+    fn from(value: cda_interfaces::InvalidCanId) -> Self {
+        Self::InvalidId(value.to_string())
+    }
+}
+
+/// Errors that can occur during CAN communication.
+#[derive(Error, Debug, Clone)]
+pub enum CanError {
+    #[error("ECU not responding on CAN ID 0x{0:03X}")]
+    EcuNotResponding(u32),
+
+    #[error("Invalid CAN ID: {0}")]
+    InvalidId(String),
+
+    #[error("ISO-TP socket error: {0}")]
+    SocketError(String),
+
+    #[error("Timeout waiting for response")]
+    Timeout,
+
+    #[error("Send failed: {0}")]
+    SendFailed(String),
+
+    #[error("Receive failed: {0}")]
+    ReceiveFailed(String),
+}

--- a/cda-comm-can/src/gateway/keepalive.rs
+++ b/cda-comm-can/src/gateway/keepalive.rs
@@ -1,0 +1,186 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Functional broadcast `TesterPresent` keep-alive for CAN bus.
+//!
+//! Periodically sends a UDS `TesterPresent` (`0x3E 0x80`) on the functional
+//! broadcast CAN ID to prevent all ECUs from going to sleep. The ID is
+//! derived from the MDD com-params (`CP_CanFuncReqId`) when available and
+//! defaults to `0x7DF` (ISO 15765-4). The sub-function `0x80` sets the
+//! `suppressPositiveResponse` bit so no ECU will reply, keeping the bus
+//! quiet.
+//!
+//! The interval comes from `can.keepalive_interval_ms`; `0` disables the
+//! broadcast for resident (on-board) deployments.
+
+use std::time::Duration;
+
+use cda_interfaces::{CanId, util::tokio_ext::sleep_for};
+use tokio_socketcan_isotp::{IsoTpBehaviour, IsoTpOptions, IsoTpSocket};
+use tokio_util::sync::CancellationToken;
+
+use super::{background::BackgroundTask, can_id::CanIdExt, error::CanError};
+
+/// Default functional broadcast CAN ID (ISO 15765-4), used when the MDD
+/// com-params do not define `CP_CanFuncReqId`.
+pub(crate) const DEFAULT_FUNCTIONAL_BROADCAST_ID: u32 = 0x7DF;
+
+/// RX side of the TX-only broadcast socket; no response ever arrives
+/// (suppressPositiveResponse) but the socket API requires an `rx_id`.
+/// Gateway setup rejects ECUs configured on these IDs.
+pub(crate) const UNUSED_RX_ID_STANDARD: u32 = 0x7FF;
+pub(crate) const UNUSED_RX_ID_EXTENDED: u32 = 0x1FFF_FFFF;
+
+/// UDS `TesterPresent` with `suppressPositiveResponse`.
+const TESTER_PRESENT_PAYLOAD: [u8; 2] = [0x3E, 0x80];
+
+/// Starts a background task that periodically sends a functional-broadcast
+/// `TesterPresent` (`0x3E 0x80`) on the given CAN interface.
+///
+/// This keeps all ECUs on the bus awake without requiring individual
+/// physical addressing. The socket is opened once and reused across
+/// iterations; it is only reopened after a send failure.
+///
+/// # Arguments
+/// * `interface` - CAN interface name (e.g. `"can0"`, `"vxcan0"`)
+/// * `functional_id` - Functional broadcast CAN ID (from com-params), 11-bit
+///   standard (e.g. `0x7DF`) or 29-bit extended (e.g. `0x18DB33F1`)
+/// * `interval` - How often to send the keep-alive
+///
+/// # Returns
+/// A [`BackgroundTask`] that stops the broadcast via
+/// [`BackgroundTask::shutdown`].
+#[must_use]
+pub(crate) fn start_keepalive_broadcast(
+    interface: String,
+    functional_id: CanId,
+    interval: Duration,
+) -> BackgroundTask {
+    let cancel = CancellationToken::new();
+    let task_cancel = cancel.clone();
+    let task = cda_interfaces::spawn_named!("can-keepalive-broadcast", async move {
+        tracing::info!(
+            interface = %interface,
+            interval_ms = u32::try_from(interval.as_millis()).unwrap_or(u32::MAX),
+            broadcast_id = %functional_id,
+            "Starting functional broadcast TesterPresent keep-alive"
+        );
+
+        let mut socket: Option<IsoTpSocket> = None;
+        let mut consecutive_open_failures: u64 = 0;
+        loop {
+            if socket.is_none() {
+                match open_broadcast_socket(&interface, functional_id) {
+                    Ok(s) => {
+                        if consecutive_open_failures > 0 {
+                            tracing::info!(
+                                interface = %interface,
+                                failed_attempts = consecutive_open_failures,
+                                "Keep-alive broadcast socket opened after failures"
+                            );
+                        }
+                        consecutive_open_failures = 0;
+                        socket = Some(s);
+                    }
+                    Err(e) => {
+                        // Warn once per outage instead of on every tick: with
+                        // the interface down this loop retries forever, and a
+                        // 2 s warn cadence floods the log.
+                        consecutive_open_failures = consecutive_open_failures.saturating_add(1);
+                        if consecutive_open_failures == 1 {
+                            tracing::warn!(
+                                error = %e,
+                                interface = %interface,
+                                "Failed to open keep-alive broadcast socket, retrying each tick"
+                            );
+                        } else {
+                            tracing::debug!(
+                                error = %e,
+                                interface = %interface,
+                                failed_attempts = consecutive_open_failures,
+                                "Keep-alive broadcast socket still unavailable"
+                            );
+                        }
+                    }
+                }
+            }
+
+            if let Some(ref s) = socket {
+                tokio::select! {
+                    // Prefer shutdown when both arms are ready.
+                    biased;
+                    () = task_cancel.cancelled() => break,
+                    result = s.write_packet(&TESTER_PRESENT_PAYLOAD) => match result {
+                        Ok(()) => {
+                            tracing::trace!(
+                                interface = %interface,
+                                broadcast_id = %functional_id,
+                                "Sent TesterPresent keep-alive broadcast"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                interface = %interface,
+                                "Keep-alive broadcast failed; reopening socket on next tick"
+                            );
+                            socket = None;
+                        }
+                    }
+                }
+            }
+
+            tokio::select! {
+                // Prefer shutdown over starting another tick.
+                biased;
+                () = task_cancel.cancelled() => break,
+                () = sleep_for(interval) => {}
+            }
+        }
+        tracing::debug!(
+            interface = %interface,
+            "Keep-alive broadcast stopped"
+        );
+    });
+
+    BackgroundTask::new(cancel, task)
+}
+
+/// Opens the ISO-TP socket used for the functional broadcast.
+fn open_broadcast_socket(interface: &str, functional_id: CanId) -> Result<IsoTpSocket, CanError> {
+    let tx_id = functional_id.to_socket_id()?;
+    // Match the dummy RX kind to the broadcast kind so standard and extended
+    // buses both work.
+    let rx_id = CanId::try_from(if functional_id.is_standard() {
+        UNUSED_RX_ID_STANDARD
+    } else {
+        UNUSED_RX_ID_EXTENDED
+    })?
+    .to_socket_id()?;
+
+    let isotp_opts = IsoTpOptions::new(
+        IsoTpBehaviour::CAN_ISOTP_TX_PADDING,
+        Duration::ZERO,
+        0,
+        0x00,
+        0x00,
+        0,
+    )
+    .ok();
+
+    IsoTpSocket::open_with_opts(interface, rx_id, tx_id, isotp_opts, None, None).map_err(|e| {
+        CanError::SocketError(format!(
+            "Failed to open keep-alive socket on {interface}: {e}"
+        ))
+    })
+}

--- a/cda-comm-can/src/gateway/mod.rs
+++ b/cda-comm-can/src/gateway/mod.rs
@@ -1,0 +1,822 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! The CAN transport implementation, compiled only with the `can` feature.
+//!
+//! Everything below this module can assume the feature is enabled; the
+//! feature gate lives on the single `mod gateway` declaration in `lib.rs`.
+
+mod background;
+pub(crate) mod can_id;
+pub(crate) mod connection;
+pub mod error;
+pub mod keepalive;
+mod probe;
+mod rediscovery;
+
+use std::{sync::Arc, time::Duration};
+
+use cda_interfaces::{
+    CanComParamProvider, CanId, DiagServiceError, EcuAddresses, EcuGateway, HashMap,
+    ServicePayload, TransmissionParameters, UdsResponse, dlt_ctx,
+};
+use tokio::sync::{RwLock, mpsc};
+
+use self::{
+    background::BackgroundTask,
+    connection::CanEcuConnection,
+    error::{CanError, CanGatewaySetupError},
+    probe::ProbeRequest,
+};
+use crate::config::CanConfig;
+
+const NRC_RESPONSE_PENDING: u8 = 0x78;
+
+/// The instant `timeout` from now, saturating instead of panicking on the
+/// (theoretical) overflow of the underlying monotonic clock.
+fn deadline_in(timeout: Duration) -> tokio::time::Instant {
+    let now = tokio::time::Instant::now();
+    now.checked_add(timeout).unwrap_or(now)
+}
+
+/// CAN bus diagnostic gateway implementing the `EcuGateway` trait.
+///
+/// This gateway handles communication with ECUs over CAN bus using ISO-TP
+/// (ISO 15765-2) for transport layer segmentation.
+pub struct CanDiagGateway {
+    /// CAN interface name
+    interface: String,
+    /// Map of ECU name (lowercase) to CAN connection info. Never written
+    /// after construction, so no lock is needed.
+    connections: Arc<HashMap<String, Arc<CanEcuConnection>>>,
+    /// Set of ECU names that responded to discovery
+    discovered_ecus: Arc<RwLock<cda_interfaces::HashSet<String>>>,
+    /// Owned mapping from logical address to ECU name (lowercase).
+    /// Populated once during construction so that runtime lookups never
+    /// need to touch the shared ECU `RwLock`s.
+    logical_address_to_ecu: Arc<HashMap<u16, String>>,
+    /// Response timeout duration
+    response_timeout: Duration,
+    /// Probe timeout duration
+    probe_timeout: Duration,
+    /// Extra rounds through the probe sequence for unanswered ECUs; see
+    /// `CanConfig::probe_retries`.
+    probe_retries: u32,
+    /// Delay between probe retry rounds.
+    probe_retry_delay: Duration,
+    /// Ordered list of discovery probes to try per ECU.
+    probe_sequence: Arc<Vec<ProbeRequest>>,
+    /// Keep-alive broadcast handle; `None` when disabled via
+    /// `keepalive_interval_ms = 0`. Stopped in [`EcuGateway::shutdown`];
+    /// dropping the last clone aborts the task as a fallback.
+    keepalive_handle: Option<Arc<BackgroundTask>>,
+    /// Rediscovery task handle; empty only in unit-test instances. Set once
+    /// right after construction (the task needs a gateway clone, so it
+    /// cannot be spawned before the struct exists).
+    rediscovery_handle: Arc<std::sync::OnceLock<BackgroundTask>>,
+}
+
+impl CanDiagGateway {
+    /// Creates a new CAN diagnostic gateway.
+    ///
+    /// This constructor sets up the gateway and performs initial ECU discovery.
+    /// Discovered ECUs are sent through the `variant_detection` channel to trigger
+    /// variant detection.
+    ///
+    /// The shared `ecus` map is only borrowed during construction to extract
+    /// CAN IDs and build an owned address-to-name lookup table. It is **not**
+    /// stored, so no runtime `RwLock` contention with the UDS layer can occur.
+    ///
+    /// # Arguments
+    /// * `config` - CAN configuration
+    /// * `ecus` - Map of ECU names to ECU managers (borrowed, not stored)
+    /// * `variant_detection` - Channel to notify about discovered ECUs
+    ///
+    /// # Errors
+    /// Returns error if the CAN interface cannot be opened or configured.
+    #[tracing::instrument(
+        skip(config, ecus, variant_detection),
+        fields(
+            interface = %config.interface,
+            ecu_count = ecus.len(),
+            dlt_context = dlt_ctx!("CAN"),
+        )
+    )]
+    pub async fn new<T: EcuAddresses + CanComParamProvider>(
+        config: &CanConfig,
+        ecus: &HashMap<String, RwLock<T>>,
+        variant_detection: mpsc::Sender<Vec<String>>,
+    ) -> Result<Self, CanGatewaySetupError> {
+        tracing::info!("Initializing CanDiagGateway");
+
+        let probe_sequence = Self::build_probe_sequence(config)?;
+
+        // Functional broadcast ID for the TesterPresent keep-alive: prefer the
+        // MDD com-params (CP_CanFuncReqId), fall back to the ISO 15765-4
+        // default 0x7DF. May be an 11-bit standard or a 29-bit extended ID
+        // (e.g. 0x18DB33F1 for normal fixed addressing). Resolved before the
+        // connections so their IDs can be checked against it.
+        let mut functional_id = Self::validate_can_id(
+            "<functional>",
+            "default",
+            keepalive::DEFAULT_FUNCTIONAL_BROADCAST_ID,
+        )?;
+        for ecu_lock in ecus.values() {
+            // Already range-validated at MDD extraction.
+            if let Some(id) = ecu_lock.read().await.can_functional_id() {
+                functional_id = id;
+                break;
+            }
+        }
+
+        let mut connections: HashMap<String, Arc<CanEcuConnection>> = HashMap::default();
+        let mut logical_address_to_ecu: HashMap<u16, String> = HashMap::default();
+
+        // Initialize connections from explicit mappings first
+        for mapping in &config.ecu_mappings {
+            let request_id =
+                Self::validate_can_id(&mapping.ecu_name, "request_id", mapping.request_id)?;
+            let response_id =
+                Self::validate_can_id(&mapping.ecu_name, "response_id", mapping.response_id)?;
+            // Reserved IDs (broadcast, keep-alive RX) cannot address an
+            // ECU; config values are user-controlled, so fail setup.
+            for (field, id) in [("request_id", request_id), ("response_id", response_id)] {
+                if Self::is_reserved_can_id(id, functional_id) {
+                    return Err(CanGatewaySetupError::InvalidConfiguration(format!(
+                        "ECU {}: {field} {id} collides with the functional broadcast ID \
+                         ({functional_id}) or a reserved keep-alive ID",
+                        mapping.ecu_name
+                    )));
+                }
+            }
+            let ecu_name = mapping.ecu_name.to_lowercase();
+            if let Some(ecu_lock) = ecus.get(&ecu_name) {
+                let ecu = ecu_lock.read().await;
+                let logical_addr = ecu.logical_address();
+
+                let conn = CanEcuConnection::new(
+                    mapping.ecu_name.clone(),
+                    config.interface.clone(),
+                    request_id,
+                    response_id,
+                );
+
+                tracing::debug!(
+                    ecu = %mapping.ecu_name,
+                    logical_addr = logical_addr,
+                    request_id = %request_id,
+                    response_id = %response_id,
+                    "Added CAN connection from config mapping"
+                );
+
+                Self::register_logical_address(
+                    &mut logical_address_to_ecu,
+                    logical_addr,
+                    &ecu_name,
+                );
+                connections.insert(ecu_name, Arc::new(conn));
+            } else {
+                tracing::warn!(
+                    ecu = %mapping.ecu_name,
+                    "ECU mapping specified but ECU not found in database"
+                );
+            }
+        }
+
+        Self::add_connections_from_com_params(
+            config,
+            ecus,
+            functional_id,
+            &mut connections,
+            &mut logical_address_to_ecu,
+        )
+        .await;
+
+        Self::validate_can_pins(config, ecus, &connections)?;
+
+        // Fail fast on configurations that cannot work: a [can] section with
+        // no usable ECU addressing means every request would fail at runtime
+        // with nothing pointing at the actual mistake.
+        if connections.is_empty() {
+            return Err(CanGatewaySetupError::NoEcuMappings);
+        }
+
+        // Fail fast when the CAN interface itself is unusable (interface
+        // missing, vcan module not loaded, socketcand unreachable). Opening a
+        // socket for a real connection exercises the exact same path every
+        // later request uses.
+        if let Some(conn) = connections.values().next() {
+            conn.verify_socket_openable().map_err(|e| {
+                CanGatewaySetupError::InterfaceOpenFailed(config.interface.clone(), e.to_string())
+            })?;
+        }
+
+        // Keeps ECUs awake while CDA runs; disabled (= 0) for resident
+        // deployments, see CanConfig::keepalive_interval_ms.
+        let keepalive_handle = if config.keepalive_interval_ms == 0 {
+            tracing::info!("Functional broadcast keep-alive disabled by config");
+            None
+        } else {
+            Some(Arc::new(keepalive::start_keepalive_broadcast(
+                config.interface.clone(),
+                functional_id,
+                Duration::from_millis(config.keepalive_interval_ms),
+            )))
+        };
+
+        let gateway = Self {
+            interface: config.interface.clone(),
+            connections: Arc::new(connections),
+            discovered_ecus: Arc::new(RwLock::new(cda_interfaces::HashSet::default())),
+            logical_address_to_ecu: Arc::new(logical_address_to_ecu),
+            response_timeout: Duration::from_millis(config.response_timeout_ms),
+            probe_timeout: Duration::from_millis(config.probe_timeout_ms),
+            probe_retries: config.probe_retries,
+            probe_retry_delay: Duration::from_millis(config.probe_retry_delay_ms),
+            probe_sequence: Arc::new(probe_sequence),
+            keepalive_handle,
+            rediscovery_handle: Arc::new(std::sync::OnceLock::new()),
+        };
+
+        // Perform initial discovery
+        let discovered = gateway.discover_ecus().await;
+        if discovered.is_empty() {
+            tracing::info!("No ECUs discovered on CAN bus during initial probe");
+        } else {
+            tracing::info!(
+                discovered_count = discovered.len(),
+                ecus = ?discovered,
+                "Initial CAN ECU discovery complete"
+            );
+            // Send discovered ECUs to trigger variant detection
+            if let Err(e) = variant_detection.send(discovered).await {
+                tracing::warn!(
+                    error = %e,
+                    "Failed to send variant detection notification"
+                );
+            }
+        }
+
+        // Start after the initial sweep so the two never probe concurrently.
+        let _ = gateway
+            .rediscovery_handle
+            .set(gateway.start_rediscovery(variant_detection));
+
+        Ok(gateway)
+    }
+
+    /// Adds connections for ECUs whose CAN addressing comes from the MDD
+    /// com-params (ECUs with an explicit `[[can.ecu_mappings]]` entry are
+    /// skipped - config overrides the database).
+    ///
+    /// Unlike config mappings, database values are not under the user's
+    /// control, so a bad value skips the ECU (with a warning) instead of
+    /// failing setup: one malformed MDD must not take down diagnostics for
+    /// the whole vehicle. Several ECU descriptions may legitimately share
+    /// one ID pair - candidate models of the same physical node (e.g. the
+    /// radio variants of a duplicate group); each gets its own connection
+    /// and variant detection decides which one is actually installed,
+    /// exactly like `DoIP` address duplicates.
+    async fn add_connections_from_com_params<T: EcuAddresses + CanComParamProvider>(
+        config: &CanConfig,
+        ecus: &HashMap<String, RwLock<T>>,
+        functional_id: CanId,
+        connections: &mut HashMap<String, Arc<CanEcuConnection>>,
+        logical_address_to_ecu: &mut HashMap<u16, String>,
+    ) {
+        for (name, ecu_lock) in ecus {
+            let ecu = ecu_lock.read().await;
+            let logical_addr = ecu.logical_address();
+            let ecu_name = name.to_lowercase();
+
+            if connections.contains_key(&ecu_name) {
+                continue;
+            }
+            // Normal for DoIP-only ECUs in a mixed fleet, so debug level;
+            // an all-miss CAN-only setup still fails via NoEcuMappings.
+            let Some(ids) = ecu.can_ids() else {
+                tracing::debug!(
+                    ecu = %name,
+                    "No CAN addressing in MDD com-params and no [[can.ecu_mappings]] entry, \
+                     ECU gets no CAN connection"
+                );
+                continue;
+            };
+
+            if ids.request == ids.response {
+                tracing::warn!(
+                    ecu = %name,
+                    can_id = %ids.request,
+                    "MDD CAN addressing uses the same ID for request and response, skipping \
+                     this ECU (a [[can.ecu_mappings]] entry can override)"
+                );
+                continue;
+            }
+            // Same reserved-ID rule, but MDD values are not
+            // user-controlled: warn and skip instead of failing setup.
+            if Self::is_reserved_can_id(ids.request, functional_id)
+                || Self::is_reserved_can_id(ids.response, functional_id)
+            {
+                tracing::warn!(
+                    ecu = %name,
+                    request_id = %ids.request,
+                    response_id = %ids.response,
+                    functional_id = %functional_id,
+                    "MDD CAN addressing collides with the functional broadcast ID or a \
+                     reserved keep-alive ID, skipping this ECU (a [[can.ecu_mappings]] entry \
+                     can override)"
+                );
+                continue;
+            }
+            let conn = CanEcuConnection::new(
+                name.clone(),
+                config.interface.clone(),
+                ids.request,
+                ids.response,
+            );
+            tracing::debug!(
+                ecu = %name,
+                logical_addr = logical_addr,
+                request_id = %ids.request,
+                response_id = %ids.response,
+                "Added CAN connection from MDD COM params"
+            );
+            Self::register_logical_address(logical_address_to_ecu, logical_addr, &ecu_name);
+            connections.insert(ecu_name, Arc::new(conn));
+        }
+    }
+
+    /// Transport pins to CAN are validated here rather than in the config
+    /// sanity check: whether an ECU has CAN addressing may only be known
+    /// once the database is loaded (MDD com-params), which the config layer
+    /// cannot see.
+    ///
+    /// A pin for an ECU that is not in the loaded database at all is moot,
+    /// not an error: the configuration legitimately outlives the currently
+    /// loaded fleet (runtime file updates add and remove ECU databases while
+    /// the config stays put), and an absent ECU has no routes the pin could
+    /// misdirect.
+    fn validate_can_pins<T>(
+        config: &CanConfig,
+        ecus: &HashMap<String, RwLock<T>>,
+        connections: &HashMap<String, Arc<CanEcuConnection>>,
+    ) -> Result<(), CanGatewaySetupError> {
+        for pinned in config
+            .transport_overrides
+            .iter()
+            .filter(|o| o.transport == crate::multi_transport::TransportType::Can)
+        {
+            let ecu_name = pinned.ecu_name.to_lowercase();
+            if connections.contains_key(&ecu_name) {
+                continue;
+            }
+            if !ecus.contains_key(&ecu_name) {
+                tracing::debug!(
+                    ecu = %pinned.ecu_name,
+                    "Transport pin to CAN for an ECU without a loaded database, ignoring"
+                );
+                continue;
+            }
+            return Err(CanGatewaySetupError::InvalidConfiguration(format!(
+                "transport_overrides pins ECU '{}' to CAN, but it has neither a \
+                 [[can.ecu_mappings]] entry nor CAN addressing in its MDD com-params",
+                pinned.ecu_name
+            )));
+        }
+        Ok(())
+    }
+
+    /// Records the logical-address -> ECU lookup used by the
+    /// address-oriented `EcuGateway` methods (network structure, discovery
+    /// checks). ECUs of CAN-only databases have no `DoIP` addressing and all
+    /// carry the unresolved fallback address `0x0000` - registering that
+    /// would map the shared "address" onto whichever ECU came last, so those
+    /// ECUs stay unregistered here and are served by the name-based paths
+    /// only.
+    fn register_logical_address(
+        logical_address_to_ecu: &mut HashMap<u16, String>,
+        logical_addr: u16,
+        ecu_name: &str,
+    ) {
+        if logical_addr == 0 {
+            tracing::debug!(
+                ecu = %ecu_name,
+                "No resolved logical address; ECU reachable via name-based lookups only"
+            );
+            return;
+        }
+        logical_address_to_ecu.insert(logical_addr, ecu_name.to_owned());
+    }
+
+    /// IDs no ECU pair may use: the functional broadcast ID and the
+    /// reserved RX IDs backing the keep-alive socket.
+    fn is_reserved_can_id(id: CanId, functional_id: CanId) -> bool {
+        id == functional_id
+            || id.raw() == keepalive::UNUSED_RX_ID_STANDARD
+            || id.raw() == keepalive::UNUSED_RX_ID_EXTENDED
+    }
+
+    /// Converts a raw configured/com-param CAN ID into a validated [`CanId`]
+    /// at setup time, attaching the ECU/field context to range errors. Both
+    /// 11-bit standard and 29-bit extended (e.g. ISO 15765-4 normal fixed
+    /// addressing `0x18DA10F1`) identifiers are accepted.
+    fn validate_can_id(
+        ecu_name: &str,
+        field: &str,
+        id: u32,
+    ) -> Result<CanId, CanGatewaySetupError> {
+        CanId::try_from(id).map_err(|e| {
+            CanGatewaySetupError::InvalidConfiguration(format!("ECU {ecu_name}: {field}: {e}"))
+        })
+    }
+
+    /// Checks if an ECU was discovered by logical address.
+    ///
+    /// Uses the owned `logical_address_to_ecu` map instead of iterating the
+    /// shared ECU `RwLock`s, avoiding potential deadlocks.
+    pub async fn is_ecu_discovered(&self, logical_addr: u16) -> bool {
+        if let Some(ecu_name) = self.logical_address_to_ecu.get(&logical_addr) {
+            return self.discovered_ecus.read().await.contains(ecu_name);
+        }
+        false
+    }
+
+    /// Resolves a logical address to an ECU name from the owned lookup table.
+    fn logical_address_for_ecu(&self, ecu_name: &str) -> u16 {
+        self.logical_address_to_ecu
+            .iter()
+            .find_map(|(addr, name)| if name == ecu_name { Some(*addr) } else { None })
+            .unwrap_or(0)
+    }
+
+    /// Checks if a specific ECU was discovered (responded to probe).
+    pub(crate) async fn is_ecu_discovered_by_name(&self, ecu_name: &str) -> bool {
+        self.discovered_ecus.read().await.contains(ecu_name)
+    }
+
+    /// Returns whether this gateway has CAN addressing for the ECU
+    /// (regardless of whether the ECU answered a probe yet).
+    pub(crate) fn knows_ecu(&self, ecu_name: &str) -> bool {
+        self.connections.contains_key(ecu_name)
+    }
+
+    /// Gets a connection for the given ECU name.
+    fn get_connection(&self, ecu_name: &str) -> Option<Arc<CanEcuConnection>> {
+        self.connections.get(ecu_name).cloned()
+    }
+}
+
+impl EcuGateway for CanDiagGateway {
+    async fn shutdown(&mut self) {
+        // CAN uses per-transaction ISO-TP sockets (no long-lived connection
+        // tasks); only the broadcast keep-alive and the rediscovery loop run
+        // in the background. Rediscovery first: it holds a gateway clone, so
+        // awaiting it here also breaks that reference cycle.
+        if let Some(rediscovery) = self.rediscovery_handle.get() {
+            rediscovery.shutdown().await;
+        }
+        if let Some(ref keepalive) = self.keepalive_handle {
+            keepalive.shutdown().await;
+        }
+    }
+
+    async fn get_gateway_network_address(&self, logical_address: u16) -> Option<String> {
+        let ecu_name = self.logical_address_to_ecu.get(&logical_address)?;
+        if !self.is_ecu_discovered_by_name(ecu_name).await {
+            return None;
+        }
+        self.connections
+            .get(ecu_name)
+            .map(|conn| conn.network_address())
+    }
+
+    #[tracing::instrument(skip_all, fields(
+        ecu = %transmission_params.ecu_name,
+        gateway_addr = transmission_params.gateway_address,
+        dlt_context = dlt_ctx!("CAN"),
+    ))]
+    async fn send(
+        &self,
+        transmission_params: TransmissionParameters,
+        message: ServicePayload,
+        response_sender: mpsc::Sender<Result<Option<UdsResponse>, DiagServiceError>>,
+        expect_uds_reply: bool,
+    ) -> Result<(), DiagServiceError> {
+        let ecu_name = transmission_params.ecu_name.to_lowercase();
+        let conn = self
+            .get_connection(&ecu_name)
+            .ok_or_else(|| DiagServiceError::EcuOffline(transmission_params.ecu_name.clone()))?;
+
+        // Check if ECU was discovered
+        if !self.is_ecu_discovered_by_name(&ecu_name).await {
+            return Err(DiagServiceError::EcuOffline(
+                transmission_params.ecu_name.clone(),
+            ));
+        }
+
+        tracing::debug!(
+            request_data = %hex::encode(&message.data),
+            "Sending CAN message"
+        );
+
+        // Spawn a task to handle the send/receive cycle
+        let response_timeout = self.response_timeout;
+        let probe_timeout = self.probe_timeout;
+        let discovered_ecus = Arc::clone(&self.discovered_ecus);
+        let ecu_map_key = ecu_name;
+        let ecu_name = transmission_params.ecu_name.clone();
+        let source_address = message.source_address;
+        let target_address = message.target_address;
+        let request_data = message.data;
+
+        cda_interfaces::spawn_named!(&format!("can-send-{ecu_name}"), {
+            async move {
+                // Open socket and send request, keeping the socket alive for the
+                // entire exchange so response-pending follow-ups arrive on the
+                // same transport session.
+                // begin_exchange opens the socket and writes the request; it
+                // has no timeout of its own, so every failure maps to
+                // NoResponse.
+                let exchange = match conn.begin_exchange(&request_data).await {
+                    Ok(ex) => ex,
+                    Err(e) => {
+                        let _ = response_sender
+                            .send(Err(DiagServiceError::NoResponse(e.to_string())))
+                            .await;
+                        return;
+                    }
+                };
+
+                // No UDS reply expected (e.g. suppressPositiveResponse): the
+                // request is on the bus, acknowledge immediately like the DoIP
+                // gateway does instead of blocking on a response that will
+                // never come (and holding the per-ECU semaphore meanwhile).
+                if !expect_uds_reply {
+                    let _ = response_sender.send(Ok(None)).await;
+                    return;
+                }
+
+                // Read until a response that belongs to this request arrives
+                // or the overall deadline expires. CAN is a shared medium:
+                // frames can show up on the response ID that were never an
+                // answer to our request - e.g. an ECU that rejects the
+                // broadcast keep-alive replies `7F 3E 12` on its physical
+                // response ID, and that lands on this socket if it arrives
+                // inside the request/response window. Treating the first
+                // frame read as "the" response would close the socket while
+                // the real answer is still in flight, turning a healthy
+                // exchange into a timeout. So frames whose SID does not echo
+                // the request are dropped here and the read continues; the
+                // socket closes as soon as a genuine final response has been
+                // forwarded, keeping its lifetime short (two sockets open on
+                // the same ID pair would both answer a segmented transfer
+                // with flow control and abort it).
+                //
+                // The deadline is extended only when the ECU signals NRC
+                // 0x78 (Response Pending), matching the caller's rc_78
+                // policy. Dropped unsolicited frames do NOT extend it, so a
+                // peer chattering on our response ID cannot keep a request
+                // whose real response never arrives (e.g. its reassembly was
+                // aborted by an interleaved frame) alive forever and wedge
+                // the per-ECU request semaphore.
+                let sent_sid = request_data.first().copied().unwrap_or_default();
+                let mut deadline = deadline_in(response_timeout);
+                // Whether any frame arrived on this exchange at all - see the
+                // silence check after the loop.
+                let mut received_any_frame = false;
+                let exchange_start = tokio::time::Instant::now();
+                loop {
+                    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                    let response = tokio::select! {
+                        () = response_sender.closed() => break,
+                        response = exchange.read_response(remaining) => response,
+                    };
+                    match response {
+                        Ok(data) => {
+                            received_any_frame = true;
+                            let is_negative = data.first()
+                                == Some(&cda_interfaces::service_ids::NEGATIVE_RESPONSE);
+                            if is_negative
+                                && data.len() >= 3
+                                && data.get(2) == Some(&NRC_RESPONSE_PENDING)
+                            {
+                                // NRC 0x78 (Response Pending): typed so the
+                                // UDS layer applies its completion policy;
+                                // the next response arrives on this socket.
+                                deadline = deadline_in(response_timeout);
+                                if response_sender
+                                    .send(Ok(Some(UdsResponse::ResponsePending(source_address))))
+                                    .await
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                                continue;
+                            }
+                            if !cda_interfaces::util::uds_response_matches_request_sid(
+                                sent_sid, &data,
+                            ) {
+                                tracing::debug!(
+                                    data = %hex::encode(&data),
+                                    request_sid = format_args!("{sent_sid:#04x}"),
+                                    "Dropping response not belonging to the pending \
+                                     request, continue reading"
+                                );
+                                continue;
+                            }
+
+                            // Final response (positive or negative)
+                            let uds_response = UdsResponse::Message(ServicePayload {
+                                data,
+                                source_address,
+                                target_address,
+                                new_session: None,
+                                new_security: None,
+                            });
+                            let _ = response_sender.send(Ok(Some(uds_response))).await;
+                            break;
+                        }
+                        Err(CanError::Timeout) => {
+                            let _ = response_sender.send(Err(DiagServiceError::Timeout)).await;
+                            break;
+                        }
+                        Err(e) => {
+                            let _ = response_sender
+                                .send(Err(DiagServiceError::NoResponse(e.to_string())))
+                                .await;
+                            break;
+                        }
+                    }
+                }
+
+                // Zero frames for the whole exchange is the sleep
+                // signature: drop the ECU from the discovered set so
+                // background rediscovery (undiscovered ECUs only) recovers
+                // it on wake. Checked after the loop because the caller's
+                // receive window (CP_P6Max) usually closes the channel
+                // before the gateway deadline; an awake ECU emits something
+                // within P6Max. The probe-timeout floor keeps instant
+                // client aborts from striking healthy ECUs.
+                if !received_any_frame && exchange_start.elapsed() >= probe_timeout {
+                    tracing::info!(
+                        ecu = %ecu_name,
+                        elapsed_ms =
+                            u32::try_from(exchange_start.elapsed().as_millis()).unwrap_or(u32::MAX),
+                        "No frame received for the whole exchange; marking the ECU undiscovered \
+                         so background rediscovery re-probes it"
+                    );
+                    discovered_ecus.write().await.remove(&ecu_map_key);
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self, _ecu_db), fields(dlt_context = dlt_ctx!("CAN")))]
+    async fn ecu_online<E: EcuAddresses>(
+        &self,
+        ecu_name: &str,
+        _ecu_db: &RwLock<E>,
+    ) -> Result<(), DiagServiceError> {
+        let ecu_name = ecu_name.to_lowercase();
+
+        // All lookups use owned data - no shared ECU RwLock is touched.
+        if !self.connections.contains_key(&ecu_name) {
+            return Err(DiagServiceError::EcuOffline(ecu_name.clone()));
+        }
+        if self.is_ecu_discovered_by_name(&ecu_name).await {
+            return Ok(());
+        }
+        // On-demand re-detection: the ECU may have come online after the
+        // startup discovery (or dropped off and rebooted). One bounded probe
+        // per call; on success the ECU is marked discovered again.
+        if self.probe_ecu(&ecu_name).await {
+            Ok(())
+        } else {
+            Err(DiagServiceError::EcuOffline(ecu_name.clone()))
+        }
+    }
+
+    async fn get_ecu_network_address(&self, ecu_name: &str) -> Option<String> {
+        self.get_connection(&ecu_name.to_lowercase())
+            .map(|conn| conn.network_address())
+    }
+
+    async fn send_functional(
+        &self,
+        _transmission_params: cda_interfaces::TransmissionParameters,
+        _message: cda_interfaces::ServicePayload,
+        _expected_ecu_logical_addrs: cda_interfaces::HashMap<u16, String>,
+        _timeout: std::time::Duration,
+        _expect_positive_response: bool,
+    ) -> Result<
+        cda_interfaces::HashMap<String, Result<cda_interfaces::UdsResponse, DiagServiceError>>,
+        DiagServiceError,
+    > {
+        // CAN functional addressing is not implemented yet, see #417.
+        // Fail the whole request honestly; the UDS layer maps a gateway-level
+        // error to a per-ECU error result, so clients see WHY it failed
+        // instead of every ECU appearing to be offline.
+        Err(DiagServiceError::RequestNotSupported(
+            "functional addressing is not implemented for the CAN transport".to_owned(),
+        ))
+    }
+}
+
+impl Clone for CanDiagGateway {
+    fn clone(&self) -> Self {
+        Self {
+            interface: self.interface.clone(),
+            connections: Arc::clone(&self.connections),
+            discovered_ecus: Arc::clone(&self.discovered_ecus),
+            logical_address_to_ecu: Arc::clone(&self.logical_address_to_ecu),
+            response_timeout: self.response_timeout,
+            probe_timeout: self.probe_timeout,
+            probe_retries: self.probe_retries,
+            probe_retry_delay: self.probe_retry_delay,
+            probe_sequence: Arc::clone(&self.probe_sequence),
+            keepalive_handle: self.keepalive_handle.clone(),
+            rediscovery_handle: Arc::clone(&self.rediscovery_handle),
+        }
+    }
+}
+
+#[cfg(test)]
+impl CanDiagGateway {
+    /// Drops all discovery state, simulating every ECU vanishing from the
+    /// bus. Test-only counterpart to `probe_ecu` marking ECUs undiscovered.
+    pub(crate) async fn clear_discovered(&self) {
+        self.discovered_ecus.write().await.clear();
+    }
+
+    /// Builds a gateway instance for unit tests without touching any CAN
+    /// interface: no init check, no discovery, keep-alive disabled.
+    pub(crate) fn test_instance(
+        connections: Vec<(&str, CanEcuConnection)>,
+        discovered: Vec<&str>,
+    ) -> Self {
+        let connections: HashMap<String, Arc<CanEcuConnection>> = connections
+            .into_iter()
+            .map(|(name, conn)| (name.to_lowercase(), Arc::new(conn)))
+            .collect();
+        let discovered: cda_interfaces::HashSet<String> =
+            discovered.into_iter().map(str::to_lowercase).collect();
+        Self {
+            interface: "test0".to_owned(),
+            connections: Arc::new(connections),
+            discovered_ecus: Arc::new(RwLock::new(discovered)),
+            logical_address_to_ecu: Arc::new(HashMap::default()),
+            response_timeout: Duration::from_millis(100),
+            probe_timeout: Duration::from_millis(10),
+            probe_retries: 0,
+            probe_retry_delay: Duration::from_millis(10),
+            probe_sequence: Arc::new(vec![ProbeRequest::tester_present()]),
+            rediscovery_handle: Arc::new(std::sync::OnceLock::new()),
+            keepalive_handle: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reserved_ids_cover_broadcast_and_keepalive_rx() {
+        let functional = CanId::try_from(0x7DF).expect("valid ID");
+        for reserved in [0x7DF, 0x7FF, 0x1FFF_FFFF] {
+            assert!(CanDiagGateway::is_reserved_can_id(
+                CanId::try_from(reserved).expect("valid ID"),
+                functional
+            ));
+        }
+        assert!(!CanDiagGateway::is_reserved_can_id(
+            CanId::try_from(0x7E0).expect("valid ID"),
+            functional
+        ));
+    }
+
+    #[test]
+    fn validate_can_id_accepts_standard_and_extended() {
+        // 11-bit standard and 29-bit extended (ISO 15765-4) IDs are both
+        // valid; anything wider must fail setup instead of being truncated
+        // when the ISO-TP socket is opened.
+        assert!(CanDiagGateway::validate_can_id("ecu1", "request_id", 0x7E0).is_ok());
+        assert!(CanDiagGateway::validate_can_id("ecu1", "request_id", 0x7FF).is_ok());
+        assert!(CanDiagGateway::validate_can_id("ecu1", "request_id", 0x18DA_10F1).is_ok());
+        assert!(CanDiagGateway::validate_can_id("ecu1", "request_id", 0x1FFF_FFFF).is_ok());
+        assert!(CanDiagGateway::validate_can_id("ecu1", "request_id", 0x2000_0000).is_err());
+        assert!(CanDiagGateway::validate_can_id("ecu1", "request_id", u32::MAX).is_err());
+    }
+}

--- a/cda-comm-can/src/gateway/probe.rs
+++ b/cda-comm-can/src/gateway/probe.rs
@@ -1,0 +1,298 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! ECU discovery probing: the probe sequence and the bounded per-ECU
+//! discovery/re-probe logic of [`CanDiagGateway`].
+
+use std::time::Instant;
+
+use cda_interfaces::dlt_ctx;
+
+use super::{
+    CanDiagGateway,
+    connection::CanEcuConnection,
+    error::{CanError, CanGatewaySetupError},
+};
+use crate::config::CanConfig;
+
+#[derive(Clone, Debug)]
+pub(super) struct ProbeRequest {
+    name: String,
+    payload: Vec<u8>,
+}
+
+impl ProbeRequest {
+    pub(super) fn tester_present() -> Self {
+        Self {
+            name: "tester_present".to_owned(),
+            payload: vec![cda_interfaces::service_ids::TESTER_PRESENT, 0x00],
+        }
+    }
+}
+
+impl CanDiagGateway {
+    pub(super) fn build_probe_sequence(
+        config: &CanConfig,
+    ) -> Result<Vec<ProbeRequest>, CanGatewaySetupError> {
+        let mut probes = if config.default_probes {
+            vec![ProbeRequest::tester_present()]
+        } else {
+            // With the built-in probe disabled the fallbacks are the whole
+            // sequence; empty would make discovery a silent no-op.
+            if config.probe_fallbacks.is_empty() {
+                return Err(CanGatewaySetupError::InvalidConfiguration(
+                    "can.default_probes = false requires at least one [[can.probe_fallbacks]] \
+                     entry"
+                        .to_owned(),
+                ));
+            }
+            Vec::new()
+        };
+
+        for fallback in &config.probe_fallbacks {
+            let payload = fallback
+                .payload_bytes()
+                .map_err(CanGatewaySetupError::InvalidConfiguration)?;
+
+            if probes.iter().any(|existing| existing.payload == payload) {
+                continue;
+            }
+
+            let name = fallback
+                .name
+                .clone()
+                .unwrap_or_else(|| format!("probe_{}", hex::encode_upper(&payload)));
+
+            probes.push(ProbeRequest { name, payload });
+        }
+
+        Ok(probes)
+    }
+
+    async fn probe_connection(
+        &self,
+        conn: &CanEcuConnection,
+        logical_addr: u16,
+    ) -> Result<(), CanError> {
+        let mut last_error = None;
+
+        for retry_round in 0..=self.probe_retries {
+            if retry_round > 0 {
+                // A missed exchange during discovery is often transient (e.g.
+                // the ECU still waking up); retry inside the transport so the
+                // UDS layer only ever sees settled online/offline states.
+                tracing::debug!(
+                    ecu = %conn.ecu_name,
+                    retry_round,
+                    probe_retries = self.probe_retries,
+                    "Re-running CAN discovery probe sequence"
+                );
+                cda_interfaces::util::tokio_ext::sleep_for(self.probe_retry_delay).await;
+            }
+            if let Ok(()) = self
+                .probe_sequence_once(conn, logical_addr)
+                .await
+                .map_err(|e| last_error = Some(e))
+            {
+                return Ok(());
+            }
+        }
+
+        Err(last_error.unwrap_or(CanError::EcuNotResponding(conn.request_id.raw())))
+    }
+
+    /// One round through the configured probe sequence; `Ok` on the first
+    /// probe the ECU answers.
+    async fn probe_sequence_once(
+        &self,
+        conn: &CanEcuConnection,
+        logical_addr: u16,
+    ) -> Result<(), CanError> {
+        let mut last_error = None;
+
+        for probe in self.probe_sequence.iter() {
+            let start = Instant::now();
+            tracing::debug!(
+                ecu = %conn.ecu_name,
+                logical_addr,
+                network_addr = %conn.network_address(),
+                probe_name = %probe.name,
+                probe_payload = %hex::encode_upper(&probe.payload),
+                timeout_ms = u32::try_from(self.probe_timeout.as_millis()).unwrap_or(u32::MAX),
+                "Starting CAN discovery probe"
+            );
+
+            match conn
+                .probe_with_payload(&probe.payload, self.probe_timeout)
+                .await
+            {
+                Ok(response) => {
+                    let elapsed = start.elapsed();
+                    let response_kind = if response.first() == Some(&0x7F) {
+                        format!(
+                            "negative-response nrc={:#04X}",
+                            response.get(2).copied().unwrap_or(0)
+                        )
+                    } else {
+                        format!(
+                            "positive-response sid={:#04X}",
+                            response.first().copied().unwrap_or(0)
+                        )
+                    };
+
+                    tracing::info!(
+                        ecu = %conn.ecu_name,
+                        logical_addr,
+                        network_addr = %conn.network_address(),
+                        probe_name = %probe.name,
+                        probe_payload = %hex::encode_upper(&probe.payload),
+                        response_kind,
+                        response_data = %hex::encode_upper(&response),
+                        elapsed_ms = u32::try_from(elapsed.as_millis()).unwrap_or(u32::MAX),
+                        "CAN discovery probe succeeded"
+                    );
+                    return Ok(());
+                }
+                Err(error) => {
+                    let elapsed = start.elapsed();
+                    tracing::debug!(
+                        ecu = %conn.ecu_name,
+                        logical_addr,
+                        network_addr = %conn.network_address(),
+                        probe_name = %probe.name,
+                        probe_payload = %hex::encode_upper(&probe.payload),
+                        elapsed_ms = u32::try_from(elapsed.as_millis()).unwrap_or(u32::MAX),
+                        error = %error,
+                        "CAN discovery probe failed"
+                    );
+                    last_error = Some(error);
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or(CanError::EcuNotResponding(conn.request_id.raw())))
+    }
+
+    /// Discovers ECUs on the CAN bus by running the configured probe
+    /// sequence (`TesterPresent` by default, plus/or the configured
+    /// fallbacks) against each configured ECU. ECUs that answer any probe
+    /// are considered online.
+    ///
+    /// # Returns
+    /// A list of ECU names that responded to a probe.
+    #[tracing::instrument(skip_all, fields(dlt_context = dlt_ctx!("CAN")))]
+    pub async fn discover_ecus(&self) -> Vec<String> {
+        let mut discovered = Vec::new();
+
+        for (ecu_name, conn) in self.connections.iter() {
+            let logical_addr = self.logical_address_for_ecu(ecu_name);
+
+            match self.probe_connection(conn, logical_addr).await {
+                Ok(()) => {
+                    tracing::info!(
+                        ecu = %conn.ecu_name,
+                        logical_addr = logical_addr,
+                        network_addr = %conn.network_address(),
+                        "ECU discovered on CAN"
+                    );
+                    self.discovered_ecus.write().await.insert(ecu_name.clone());
+                    // Push the lowercase map key, not `conn.ecu_name`: for
+                    // ECUs from [[can.ecu_mappings]] the latter carries the
+                    // config-file casing, which the variant-detection
+                    // consumer would not find in its lowercase-keyed ECU map.
+                    discovered.push(ecu_name.clone());
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        ecu = %conn.ecu_name,
+                        logical_addr = logical_addr,
+                        error = %e,
+                        "ECU not responding on CAN"
+                    );
+                    self.discovered_ecus.write().await.remove(ecu_name);
+                }
+            }
+        }
+
+        discovered
+    }
+
+    /// Re-probes a specific ECU to check if it's online.
+    ///
+    /// # Arguments
+    /// * `ecu_name` - Name of the ECU to probe
+    ///
+    /// # Returns
+    /// `true` if the ECU responded, `false` otherwise.
+    #[tracing::instrument(skip(self), fields(dlt_context = dlt_ctx!("CAN")))]
+    pub(crate) async fn probe_ecu(&self, ecu_name: &str) -> bool {
+        let ecu_name = ecu_name.to_lowercase();
+        let Some(conn) = self.connections.get(&ecu_name).cloned() else {
+            return false;
+        };
+        let logical_addr = self.logical_address_for_ecu(&ecu_name);
+
+        if self.probe_connection(&conn, logical_addr).await.is_ok() {
+            self.discovered_ecus.write().await.insert(ecu_name);
+            true
+        } else {
+            self.discovered_ecus.write().await.remove(&ecu_name);
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CanProbeConfig;
+
+    #[test]
+    fn default_probe_sequence_starts_with_tester_present() {
+        let config = CanConfig::default();
+        let probes = CanDiagGateway::build_probe_sequence(&config).expect("valid config");
+        assert_eq!(probes.len(), 1);
+        assert_eq!(
+            probes.first().map(|p| p.payload.clone()),
+            Some(vec![cda_interfaces::service_ids::TESTER_PRESENT, 0x00])
+        );
+    }
+
+    #[test]
+    fn disabled_default_probes_use_the_fallbacks_verbatim() {
+        let config = CanConfig {
+            default_probes: false,
+            probe_fallbacks: vec![CanProbeConfig {
+                name: Some("read-did".to_owned()),
+                payload_hex: "22F190".to_owned(),
+            }],
+            ..CanConfig::default()
+        };
+        let probes = CanDiagGateway::build_probe_sequence(&config).expect("valid config");
+        assert_eq!(probes.len(), 1);
+        assert_eq!(
+            probes.first().map(|p| p.payload.clone()),
+            Some(vec![0x22, 0xF1, 0x90])
+        );
+    }
+
+    #[test]
+    fn disabled_default_probes_without_fallbacks_fail_setup() {
+        let config = CanConfig {
+            default_probes: false,
+            ..CanConfig::default()
+        };
+        // An empty probe sequence would make discovery a silent no-op.
+        assert!(CanDiagGateway::build_probe_sequence(&config).is_err());
+    }
+}

--- a/cda-comm-can/src/gateway/rediscovery.rs
+++ b/cda-comm-can/src/gateway/rediscovery.rs
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Background rediscovery of configured-but-undiscovered ECUs.
+//!
+//! CAN has no connection events: the only way to learn that an ECU (re)joined
+//! the bus is to ask it. Requests to undiscovered ECUs are rejected before
+//! reaching the bus, and state reads never touch the transport, so without
+//! this task an ECU that was offline during startup discovery - or dropped
+//! off and rebooted, or was marked undiscovered after an all-silent
+//! exchange (an ECU asleep while the keep-alive broadcast is disabled) -
+//! would stay `Offline` until some caller happens to trigger the on-demand
+//! probe in `ecu_online`. The transport is responsible for presenting
+//! settled online/offline states on its own.
+//!
+//! Bus load is bounded: only currently-undiscovered ECUs are probed, one
+//! round per interval, sequentially.
+
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+
+use super::{CanDiagGateway, background::BackgroundTask};
+
+/// Delay between rediscovery rounds. Chosen so a returning ECU is picked up
+/// within a few seconds without turning absent ECUs into permanent probe
+/// chatter on the bus.
+const REDISCOVERY_INTERVAL: Duration = Duration::from_secs(5);
+
+impl CanDiagGateway {
+    /// Starts the background task that periodically re-probes ECUs the
+    /// gateway knows addresses for but has not (currently) discovered.
+    /// Newly answering ECUs are pushed into `variant_detection`, which brings
+    /// them `Online` through the regular detection flow.
+    pub(super) fn start_rediscovery(
+        &self,
+        variant_detection: tokio::sync::mpsc::Sender<Vec<String>>,
+    ) -> BackgroundTask {
+        let gateway = self.clone();
+        let cancel = CancellationToken::new();
+        let task_cancel = cancel.clone();
+        let task = cda_interfaces::spawn_named!("can-rediscovery", async move {
+            loop {
+                tokio::select! {
+                    // Prefer shutdown over starting another round.
+                    biased;
+                    () = task_cancel.cancelled() => break,
+                    () = cda_interfaces::util::tokio_ext::sleep_for(REDISCOVERY_INTERVAL) => {}
+                }
+
+                let undiscovered: Vec<String> = {
+                    let discovered = gateway.discovered_ecus.read().await;
+                    gateway
+                        .connections
+                        .keys()
+                        .filter(|name| !discovered.contains(*name))
+                        .cloned()
+                        .collect()
+                };
+                if undiscovered.is_empty() {
+                    continue;
+                }
+
+                let mut recovered = Vec::new();
+                for ecu_name in undiscovered {
+                    if task_cancel.is_cancelled() {
+                        return;
+                    }
+                    if gateway.probe_ecu(&ecu_name).await {
+                        recovered.push(ecu_name);
+                    }
+                }
+
+                if !recovered.is_empty() {
+                    tracing::info!(
+                        ecus = ?recovered,
+                        "ECUs rediscovered on CAN"
+                    );
+                    if variant_detection.send(recovered).await.is_err() {
+                        tracing::warn!(
+                            "Variant detection channel closed, stopping CAN rediscovery"
+                        );
+                        break;
+                    }
+                }
+            }
+            tracing::debug!("CAN rediscovery stopped");
+        });
+        BackgroundTask::new(cancel, task)
+    }
+}

--- a/cda-comm-can/src/lib.rs
+++ b/cda-comm-can/src/lib.rs
@@ -1,0 +1,113 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The `can` feature alone relies on Linux SocketCAN ISO-TP sockets
+// (tokio-socketcan-isotp). Off Linux it is only usable together with a
+// platform-independent transport: `can-socketcand`
+// (`socketcand:<host>:<port>:<bus>`). Fail early with an actionable message
+// instead of letting socket creation fail at runtime with a cryptic error.
+#[cfg(all(
+    feature = "can",
+    not(target_os = "linux"),
+    not(feature = "can-socketcand")
+))]
+compile_error!(
+    "The `can` feature requires Linux (SocketCAN/ISO-TP). On other platforms enable \
+     `can-socketcand` to reach a CAN bus over a socketcand daemon."
+);
+
+pub mod config;
+pub mod multi_transport;
+
+// Re-export types that are always available
+pub use multi_transport::{MultiTransportGateway, TransportType};
+
+// The CAN transport itself is compiled only with the `can` feature; the
+// single gate here lets everything inside `gateway` assume the feature is
+// enabled.
+#[cfg(feature = "can")]
+mod gateway;
+#[cfg(feature = "can")]
+pub use gateway::{CanDiagGateway, error};
+
+/// Stub `CanDiagGateway` when the `can` feature is disabled.
+///
+/// This type exists only to satisfy the `Option<CanDiagGateway>` field in
+/// [`MultiTransportGateway`]. It has no constructor, so a value of this type
+/// can never exist in a non-`can` build: the `EcuGateway` impl below is only
+/// needed for type-checking and is statically unreachable.
+#[cfg(not(feature = "can"))]
+#[derive(Clone)]
+pub struct CanDiagGateway {
+    _unconstructable: std::convert::Infallible,
+}
+
+#[cfg(not(feature = "can"))]
+impl cda_interfaces::EcuGateway for CanDiagGateway {
+    async fn shutdown(&mut self) {}
+
+    async fn get_gateway_network_address(&self, _logical_address: u16) -> Option<String> {
+        None
+    }
+
+    async fn send(
+        &self,
+        _transmission_params: cda_interfaces::TransmissionParameters,
+        _message: cda_interfaces::ServicePayload,
+        _response_sender: tokio::sync::mpsc::Sender<
+            Result<Option<cda_interfaces::UdsResponse>, cda_interfaces::DiagServiceError>,
+        >,
+        _expect_uds_reply: bool,
+    ) -> Result<(), cda_interfaces::DiagServiceError> {
+        Err(cda_interfaces::DiagServiceError::EcuOffline(
+            "CAN support is not enabled. Compile with the `can` feature.".to_owned(),
+        ))
+    }
+
+    async fn ecu_online<E: cda_interfaces::EcuAddresses>(
+        &self,
+        _ecu_name: &str,
+        _ecu_db: &tokio::sync::RwLock<E>,
+    ) -> Result<(), cda_interfaces::DiagServiceError> {
+        Err(cda_interfaces::DiagServiceError::EcuOffline(
+            "CAN support is not enabled. Compile with the `can` feature.".to_owned(),
+        ))
+    }
+
+    async fn send_functional(
+        &self,
+        _transmission_params: cda_interfaces::TransmissionParameters,
+        _message: cda_interfaces::ServicePayload,
+        expected_ecu_logical_addrs: cda_interfaces::HashMap<u16, String>,
+        _timeout: std::time::Duration,
+        _expect_positive_response: bool,
+    ) -> Result<
+        cda_interfaces::HashMap<
+            String,
+            Result<cda_interfaces::UdsResponse, cda_interfaces::DiagServiceError>,
+        >,
+        cda_interfaces::DiagServiceError,
+    > {
+        Ok(expected_ecu_logical_addrs
+            .into_values()
+            .map(|name| {
+                (
+                    name,
+                    Err(cda_interfaces::DiagServiceError::EcuOffline(
+                        "CAN support is not enabled. Compile with the `can` feature.".to_owned(),
+                    )),
+                )
+            })
+            .collect())
+    }
+}

--- a/cda-comm-can/src/multi_transport.rs
+++ b/cda-comm-can/src/multi_transport.rs
@@ -1,0 +1,673 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Multi-transport gateway that can route UDS messages over `DoIP` or CAN.
+//!
+//! This module provides `MultiTransportGateway` which implements the `EcuGateway`
+//! trait and can route messages to ECUs over multiple transports (`DoIP` and/or CAN).
+//!
+//! # Routing Strategy
+//!
+//! 1. An explicit per-ECU **transport override** from the config is a hard
+//!    pin: the ECU always uses that transport.
+//! 2. Without a pin, the ECU is bound to the transport it is **first
+//!    detected** on. `DoIP` is preferred when both transports know the ECU at
+//!    that moment; a CAN-mapped ECU that never appeared over `DoIP` is probed
+//!    on demand.
+//! 3. The binding is **sticky**: `ecu_online` and all subsequent sends use
+//!    the bound transport. There is no automatic failover - if the bound
+//!    transport loses the ECU it is reported offline until that same
+//!    transport detects it again.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use cda_interfaces::HashMap;
+//! let overrides = HashMap::default(); // or populate from config
+//! let gateway = MultiTransportGateway::new(overrides)
+//!     .with_doip(doip_gateway)
+//!     .with_can(can_gateway);
+//! ```
+
+use std::sync::Arc;
+
+use cda_interfaces::{
+    DiagServiceError, EcuAddresses, EcuGateway, HashMap, ServicePayload, TransmissionParameters,
+    UdsResponse,
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::{RwLock, mpsc};
+
+use crate::CanDiagGateway;
+
+/// Identifies which transport is being used for an ECU.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum TransportType {
+    /// Diagnostics over IP (Ethernet)
+    #[serde(alias = "DoIP", alias = "DOIP")]
+    DoIP,
+    /// CAN bus with ISO-TP
+    #[serde(alias = "CAN", alias = "Can")]
+    Can,
+}
+
+/// A gateway that can route diagnostic messages over multiple transports.
+///
+/// This gateway wraps both `DoIP` and CAN gateways. Each ECU is either pinned
+/// to a transport via config override or bound to the transport it was first
+/// detected on (`DoIP` preferred); see the module docs for the full strategy.
+///
+/// The `DoIP` side is generic over [`EcuGateway`] while the CAN side is
+/// concrete: routing needs CAN-specific capabilities (on-demand probing,
+/// the `can://` scheme). Lifting this into a transport orchestrator
+/// generic over all transports is tracked in #442.
+pub struct MultiTransportGateway<D: EcuGateway> {
+    /// Optional `DoIP` gateway
+    doip_gateway: Option<D>,
+    /// Optional CAN gateway
+    can_gateway: Option<CanDiagGateway>,
+    /// Per-ECU transport overrides (ECU name lowercase -> transport).
+    /// ECUs not in this map are bound at first detection.
+    transport_overrides: Arc<HashMap<String, TransportType>>,
+    /// Transport each un-pinned ECU was first detected on (lowercase name ->
+    /// transport). Entries are written once and never change at runtime, so
+    /// a diagnostic session can never silently switch transports.
+    ecu_bindings: Arc<RwLock<HashMap<String, TransportType>>>,
+}
+
+impl<D: EcuGateway> MultiTransportGateway<D> {
+    /// Creates a new multi-transport gateway with the given per-ECU transport overrides.
+    #[must_use]
+    pub fn new(transport_overrides: HashMap<String, TransportType>) -> Self {
+        Self {
+            doip_gateway: None,
+            can_gateway: None,
+            transport_overrides: Arc::new(transport_overrides),
+            ecu_bindings: Arc::new(RwLock::new(HashMap::default())),
+        }
+    }
+
+    /// Adds a `DoIP` gateway to this multi-transport gateway.
+    #[must_use]
+    pub fn with_doip(mut self, gateway: D) -> Self {
+        self.doip_gateway = Some(gateway);
+        self
+    }
+
+    /// Adds a CAN gateway to this multi-transport gateway.
+    #[must_use]
+    pub fn with_can(mut self, gateway: CanDiagGateway) -> Self {
+        self.can_gateway = Some(gateway);
+        self
+    }
+
+    /// Returns the wrapped `DoIP` gateway, if one is configured.
+    ///
+    /// Used by the runtime-update reload path to hand the existing `DoIP` UDP
+    /// socket over to the replacement gateway (avoiding a second socket bound
+    /// to the same `DoIP` port). `None` in CAN-only operation.
+    #[must_use]
+    pub fn doip(&self) -> Option<&D> {
+        self.doip_gateway.as_ref()
+    }
+
+    /// Returns the transport this ECU is pinned or already bound to, if any.
+    async fn pinned_or_bound(&self, ecu_name: &str) -> Option<TransportType> {
+        if let Some(&pinned) = self.transport_overrides.get(ecu_name) {
+            return Some(pinned);
+        }
+        self.ecu_bindings.read().await.get(ecu_name).copied()
+    }
+
+    /// Binds the ECU to a transport, sticky: if another task bound it first,
+    /// the earlier binding wins and is returned.
+    async fn bind(&self, ecu_name: &str, transport: TransportType) -> TransportType {
+        let bound = *self
+            .ecu_bindings
+            .write()
+            .await
+            .entry(ecu_name.to_owned())
+            .or_insert(transport);
+        tracing::debug!(
+            ecu = %ecu_name,
+            transport = ?bound,
+            "ECU bound to transport (first detection)"
+        );
+        bound
+    }
+
+    /// The CAN gateway's network address for the ECU, behind the `can://`
+    /// scheme (see `get_ecu_network_address`).
+    async fn can_ecu_network_address(&self, ecu_name: &str) -> Option<String> {
+        match self.can_gateway {
+            Some(ref can) => can
+                .get_ecu_network_address(ecu_name)
+                .await
+                .map(|addr| format!("can://{addr}")),
+            None => None,
+        }
+    }
+
+    /// Attempts to detect the ECU on the CAN bus: already discovered, or
+    /// mapped and answering an on-demand probe. A CAN-mapped ECU that was
+    /// offline during startup discovery is detected here on first use.
+    #[cfg_attr(
+        not(feature = "can"),
+        allow(
+            clippy::unused_async,
+            unused_variables,
+            reason = "in a non-can build the body is a constant `false` (the stub gateway cannot \
+                      exist), but the signature must stay async for the can build"
+        )
+    )]
+    async fn detect_on_can(&self, ecu_name: &str) -> bool {
+        #[cfg(feature = "can")]
+        {
+            let Some(ref can) = self.can_gateway else {
+                return false;
+            };
+            if can.is_ecu_discovered_by_name(ecu_name).await {
+                return true;
+            }
+            if can.knows_ecu(ecu_name) {
+                return can.probe_ecu(ecu_name).await;
+            }
+            false
+        }
+        #[cfg(not(feature = "can"))]
+        {
+            // The stub CanDiagGateway cannot be constructed, so a CAN
+            // detection can never succeed in a non-can build.
+            false
+        }
+    }
+}
+
+impl<D: EcuGateway> EcuGateway for MultiTransportGateway<D> {
+    async fn shutdown(&mut self) {
+        if let Some(ref mut doip) = self.doip_gateway {
+            doip.shutdown().await;
+        }
+        if let Some(ref mut can) = self.can_gateway {
+            can.shutdown().await;
+        }
+    }
+
+    async fn get_gateway_network_address(&self, logical_address: u16) -> Option<String> {
+        // DoIP addresses are returned verbatim (bare IP) to keep the SOVD
+        // network-structure API compatible with pre-multi-transport releases.
+        if let Some(ref doip) = self.doip_gateway
+            && let Some(addr) = doip.get_gateway_network_address(logical_address).await
+        {
+            return Some(addr);
+        }
+
+        if let Some(ref can) = self.can_gateway
+            && let Some(addr) = can.get_gateway_network_address(logical_address).await
+        {
+            return Some(format!("can://{addr}"));
+        }
+
+        None
+    }
+
+    async fn get_ecu_network_address(&self, ecu_name: &str) -> Option<String> {
+        // Answer for the transport the ECU is pinned or bound to, so the
+        // reported address always agrees with where send() routes (an ECU
+        // can be known to both transports, e.g. a CAN mapping alongside its
+        // DoIP identity). Same scheme convention as the address-based
+        // lookup: DoIP addresses verbatim (the default impl yields None
+        // today), CAN addresses behind a can:// scheme.
+        let ecu_name = ecu_name.to_lowercase();
+        match self.pinned_or_bound(&ecu_name).await {
+            Some(TransportType::DoIP) => match self.doip_gateway {
+                Some(ref doip) => doip.get_ecu_network_address(&ecu_name).await,
+                None => None,
+            },
+            Some(TransportType::Can) => self.can_ecu_network_address(&ecu_name).await,
+            None => {
+                if let Some(ref doip) = self.doip_gateway
+                    && let Some(addr) = doip.get_ecu_network_address(&ecu_name).await
+                {
+                    return Some(addr);
+                }
+                self.can_ecu_network_address(&ecu_name).await
+            }
+        }
+    }
+
+    #[tracing::instrument(skip_all, fields(
+        ecu = %transmission_params.ecu_name,
+        gateway_addr = transmission_params.gateway_address
+    ))]
+    async fn send(
+        &self,
+        transmission_params: TransmissionParameters,
+        message: ServicePayload,
+        response_sender: mpsc::Sender<Result<Option<UdsResponse>, DiagServiceError>>,
+        expect_uds_reply: bool,
+    ) -> Result<(), DiagServiceError> {
+        let ecu_name = transmission_params.ecu_name.to_lowercase();
+
+        let transport = if let Some(t) = self.pinned_or_bound(&ecu_name).await {
+            t
+        } else {
+            // First detection binds the ECU; DoIP is preferred when it
+            // already knows the ECU (an established gateway connection
+            // serves its logical address).
+            let doip_knows = if let Some(ref doip) = self.doip_gateway {
+                doip.get_gateway_network_address(transmission_params.gateway_address)
+                    .await
+                    .is_some()
+            } else {
+                false
+            };
+            if doip_knows {
+                self.bind(&ecu_name, TransportType::DoIP).await
+            } else if self.detect_on_can(&ecu_name).await {
+                self.bind(&ecu_name, TransportType::Can).await
+            } else {
+                return Err(DiagServiceError::EcuOffline(
+                    transmission_params.ecu_name.clone(),
+                ));
+            }
+        };
+
+        match transport {
+            TransportType::DoIP => {
+                let doip = self.doip_gateway.as_ref().ok_or_else(|| {
+                    DiagServiceError::EcuOffline(transmission_params.ecu_name.clone())
+                })?;
+                tracing::debug!(transport = "DoIP", "Routing message via DoIP");
+                doip.send(
+                    transmission_params,
+                    message,
+                    response_sender,
+                    expect_uds_reply,
+                )
+                .await
+            }
+            TransportType::Can => {
+                let can = self.can_gateway.as_ref().ok_or_else(|| {
+                    DiagServiceError::EcuOffline(transmission_params.ecu_name.clone())
+                })?;
+                tracing::debug!(transport = "CAN", "Routing message via CAN");
+                can.send(
+                    transmission_params,
+                    message,
+                    response_sender,
+                    expect_uds_reply,
+                )
+                .await
+            }
+        }
+    }
+
+    async fn ecu_online<E: EcuAddresses>(
+        &self,
+        ecu_name: &str,
+        ecu_db: &RwLock<E>,
+    ) -> Result<(), DiagServiceError> {
+        let ecu_name = ecu_name.to_lowercase();
+
+        match self.pinned_or_bound(&ecu_name).await {
+            // Pinned or bound: online means online on THAT transport, so the
+            // answer always agrees with where send() routes. No failover.
+            Some(TransportType::DoIP) => match self.doip_gateway {
+                Some(ref doip) => doip.ecu_online(&ecu_name, ecu_db).await,
+                None => Err(DiagServiceError::EcuOffline(ecu_name.clone())),
+            },
+            Some(TransportType::Can) => match self.can_gateway {
+                Some(ref can) => can.ecu_online(&ecu_name, ecu_db).await,
+                None => Err(DiagServiceError::EcuOffline(ecu_name.clone())),
+            },
+            None => {
+                // Not seen yet: first successful detection binds the ECU,
+                // DoIP preferred.
+                if let Some(ref doip) = self.doip_gateway
+                    && doip.ecu_online(&ecu_name, ecu_db).await.is_ok()
+                {
+                    self.bind(&ecu_name, TransportType::DoIP).await;
+                    return Ok(());
+                }
+                if self.detect_on_can(&ecu_name).await {
+                    self.bind(&ecu_name, TransportType::Can).await;
+                    return Ok(());
+                }
+                Err(DiagServiceError::EcuOffline(ecu_name.clone()))
+            }
+        }
+    }
+
+    async fn send_functional(
+        &self,
+        transmission_params: cda_interfaces::TransmissionParameters,
+        message: cda_interfaces::ServicePayload,
+        expected_ecu_logical_addrs: cda_interfaces::HashMap<u16, String>,
+        timeout: std::time::Duration,
+        expect_positive_response: bool,
+    ) -> Result<
+        cda_interfaces::HashMap<String, Result<cda_interfaces::UdsResponse, DiagServiceError>>,
+        DiagServiceError,
+    > {
+        if let Some(ref doip) = self.doip_gateway {
+            return doip
+                .send_functional(
+                    transmission_params,
+                    message,
+                    expected_ecu_logical_addrs,
+                    timeout,
+                    expect_positive_response,
+                )
+                .await;
+        }
+        if let Some(ref can) = self.can_gateway {
+            return can
+                .send_functional(
+                    transmission_params,
+                    message,
+                    expected_ecu_logical_addrs,
+                    timeout,
+                    expect_positive_response,
+                )
+                .await;
+        }
+        Err(DiagServiceError::EcuOffline(
+            "no transport configured for functional request".to_owned(),
+        ))
+    }
+}
+
+impl<D: EcuGateway> Clone for MultiTransportGateway<D> {
+    fn clone(&self) -> Self {
+        Self {
+            doip_gateway: self.doip_gateway.clone(),
+            can_gateway: self.can_gateway.clone(),
+            transport_overrides: Arc::clone(&self.transport_overrides),
+            ecu_bindings: Arc::clone(&self.ecu_bindings),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_transport_type_debug() {
+        assert_eq!(format!("{:?}", TransportType::DoIP), "DoIP");
+        assert_eq!(format!("{:?}", TransportType::Can), "Can");
+    }
+
+    #[cfg(feature = "can")]
+    mod routing {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        };
+
+        use cda_interfaces::{CanId, DiagServiceError, EcuAddresses};
+        use tokio::sync::RwLock;
+
+        use super::super::*;
+        use crate::gateway::connection::CanEcuConnection;
+
+        /// `DoIP` gateway stub whose ECU knowledge can be toggled at runtime.
+        #[derive(Clone, Default)]
+        struct DoipStub {
+            online: Arc<AtomicBool>,
+            ecu_online_calls: Arc<AtomicUsize>,
+        }
+
+        impl EcuGateway for DoipStub {
+            async fn get_gateway_network_address(&self, _logical_address: u16) -> Option<String> {
+                self.online
+                    .load(Ordering::SeqCst)
+                    .then(|| "1.2.3.4".to_owned())
+            }
+
+            async fn send(
+                &self,
+                _transmission_params: TransmissionParameters,
+                _message: ServicePayload,
+                _response_sender: mpsc::Sender<Result<Option<UdsResponse>, DiagServiceError>>,
+                _expect_uds_reply: bool,
+            ) -> Result<(), DiagServiceError> {
+                Ok(())
+            }
+
+            async fn ecu_online<T: EcuAddresses>(
+                &self,
+                ecu_name: &str,
+                _ecu_db: &RwLock<T>,
+            ) -> Result<(), DiagServiceError> {
+                self.ecu_online_calls.fetch_add(1, Ordering::SeqCst);
+                if self.online.load(Ordering::SeqCst) {
+                    Ok(())
+                } else {
+                    Err(DiagServiceError::EcuOffline(ecu_name.to_owned()))
+                }
+            }
+
+            async fn send_functional(
+                &self,
+                _transmission_params: TransmissionParameters,
+                _message: ServicePayload,
+                _expected_ecu_logical_addrs: HashMap<u16, String>,
+                _timeout: std::time::Duration,
+                _expect_positive_response: bool,
+            ) -> Result<HashMap<String, Result<UdsResponse, DiagServiceError>>, DiagServiceError>
+            {
+                Ok(HashMap::default())
+            }
+
+            async fn shutdown(&mut self) {}
+        }
+
+        struct EcuStub;
+
+        impl EcuAddresses for EcuStub {
+            fn tester_address(&self) -> u16 {
+                0x0E80
+            }
+            fn logical_address(&self) -> u16 {
+                0x1000
+            }
+            fn logical_gateway_address(&self) -> u16 {
+                0x1000
+            }
+            fn logical_functional_address(&self) -> u16 {
+                0xE400
+            }
+            fn ecu_name(&self) -> String {
+                "ecu1".to_owned()
+            }
+            fn logical_address_eq<T: EcuAddresses>(&self, other: &T) -> bool {
+                self.logical_address() == other.logical_address()
+            }
+        }
+
+        fn can_gateway_with_discovered_ecu1() -> CanDiagGateway {
+            CanDiagGateway::test_instance(
+                vec![(
+                    "ecu1",
+                    CanEcuConnection::new(
+                        "ecu1".to_owned(),
+                        "test0".to_owned(),
+                        CanId::try_from(0x700).expect("valid CAN ID"),
+                        CanId::try_from(0x708).expect("valid CAN ID"),
+                    ),
+                )],
+                vec!["ecu1"],
+            )
+        }
+
+        #[tokio::test]
+        async fn pin_beats_detection() {
+            // ecu1 pinned to CAN; DoIP knows it, but the pin must win and
+            // the DoIP gateway must not even be consulted.
+            let doip = DoipStub::default();
+            doip.online.store(true, Ordering::SeqCst);
+            let overrides = [("ecu1".to_owned(), TransportType::Can)]
+                .into_iter()
+                .collect::<HashMap<_, _>>();
+            let gw = MultiTransportGateway::new(overrides)
+                .with_doip(doip.clone())
+                .with_can(can_gateway_with_discovered_ecu1());
+
+            let db = RwLock::new(EcuStub);
+            assert!(gw.ecu_online("ECU1", &db).await.is_ok());
+            assert_eq!(doip.ecu_online_calls.load(Ordering::SeqCst), 0);
+        }
+
+        #[tokio::test]
+        async fn doip_preferred_at_first_detection() {
+            // Both transports know ecu1: first detection must bind DoIP.
+            let doip = DoipStub::default();
+            doip.online.store(true, Ordering::SeqCst);
+            let gw = MultiTransportGateway::new(HashMap::default())
+                .with_doip(doip)
+                .with_can(can_gateway_with_discovered_ecu1());
+
+            let db = RwLock::new(EcuStub);
+            assert!(gw.ecu_online("ecu1", &db).await.is_ok());
+            assert_eq!(
+                gw.ecu_bindings.read().await.get("ecu1").copied(),
+                Some(TransportType::DoIP)
+            );
+        }
+
+        #[tokio::test]
+        async fn can_binding_is_sticky_and_has_no_failover() {
+            // DoIP is down at first detection -> ecu1 binds CAN. When DoIP
+            // comes up later the binding must not change; when CAN loses the
+            // ECU it is offline (no failover to DoIP).
+            let doip = DoipStub::default();
+            let can = can_gateway_with_discovered_ecu1();
+            let gw = MultiTransportGateway::new(HashMap::default())
+                .with_doip(doip.clone())
+                .with_can(can.clone());
+
+            let db = RwLock::new(EcuStub);
+            assert!(gw.ecu_online("ecu1", &db).await.is_ok());
+            assert_eq!(
+                gw.ecu_bindings.read().await.get("ecu1").copied(),
+                Some(TransportType::Can)
+            );
+
+            // DoIP comes up: bound ECU must stay on CAN (DoIP not consulted).
+            doip.online.store(true, Ordering::SeqCst);
+            let calls_before = doip.ecu_online_calls.load(Ordering::SeqCst);
+            assert!(gw.ecu_online("ecu1", &db).await.is_ok());
+            assert_eq!(doip.ecu_online_calls.load(Ordering::SeqCst), calls_before);
+
+            // CAN loses the ECU: offline, even though DoIP would know it.
+            can.clear_discovered().await;
+            assert!(matches!(
+                gw.ecu_online("ecu1", &db).await,
+                Err(DiagServiceError::EcuOffline(_))
+            ));
+        }
+
+        fn test_send_params() -> (TransmissionParameters, ServicePayload) {
+            (
+                TransmissionParameters {
+                    gateway_address: 0x1000,
+                    timeout_ack: std::time::Duration::from_millis(100),
+                    ecu_name: "ecu1".to_owned(),
+                    repeat_request_count_transmission: 0,
+                },
+                ServicePayload {
+                    data: vec![0x3E, 0x00],
+                    source_address: 0x0E80,
+                    target_address: 0x1000,
+                    new_session: None,
+                    new_security: None,
+                },
+            )
+        }
+
+        #[tokio::test]
+        async fn send_functional_prefers_doip() {
+            // With a DoIP gateway present, functional requests go to DoIP
+            // (the stub returns an empty result map).
+            let gw = MultiTransportGateway::new(HashMap::default())
+                .with_doip(DoipStub::default())
+                .with_can(can_gateway_with_discovered_ecu1());
+            let (params, payload) = test_send_params();
+            let result = gw
+                .send_functional(
+                    params,
+                    payload,
+                    HashMap::default(),
+                    std::time::Duration::from_millis(100),
+                    false,
+                )
+                .await;
+            assert!(result.expect("DoIP stub accepts the request").is_empty());
+        }
+
+        #[tokio::test]
+        async fn send_functional_over_can_is_not_supported_yet() {
+            // CAN-only operation: the request must fail honestly with
+            // RequestNotSupported (see #417), not pretend every ECU is
+            // offline.
+            let gw = MultiTransportGateway::<DoipStub>::new(HashMap::default())
+                .with_can(can_gateway_with_discovered_ecu1());
+            let (params, payload) = test_send_params();
+            let result = gw
+                .send_functional(
+                    params,
+                    payload,
+                    HashMap::default(),
+                    std::time::Duration::from_millis(100),
+                    false,
+                )
+                .await;
+            assert!(matches!(
+                result,
+                Err(DiagServiceError::RequestNotSupported(_))
+            ));
+        }
+
+        #[tokio::test]
+        async fn send_functional_without_transports_is_offline() {
+            let gw = MultiTransportGateway::<DoipStub>::new(HashMap::default());
+            let (params, payload) = test_send_params();
+            let result = gw
+                .send_functional(
+                    params,
+                    payload,
+                    HashMap::default(),
+                    std::time::Duration::from_millis(100),
+                    false,
+                )
+                .await;
+            assert!(matches!(result, Err(DiagServiceError::EcuOffline(_))));
+        }
+
+        #[tokio::test]
+        async fn undetected_ecu_is_offline() {
+            let doip = DoipStub::default();
+            let gw = MultiTransportGateway::new(HashMap::default()).with_doip(doip);
+
+            let db = RwLock::new(EcuStub);
+            assert!(matches!(
+                gw.ecu_online("ecu1", &db).await,
+                Err(DiagServiceError::EcuOffline(_))
+            ));
+            assert!(gw.ecu_bindings.read().await.is_empty());
+        }
+    }
+}

--- a/cda-comm-doip/src/config.rs
+++ b/cda-comm-doip/src/config.rs
@@ -20,6 +20,11 @@ use serde::{Deserialize, Serialize};
 /// `DoIP` (Diagnostics over IP) transport layer configuration.
 #[derive(Deserialize, Serialize, Clone, Debug, schemars::JsonSchema)]
 pub struct DoipConfig {
+    /// Whether the `DoIP` transport is enabled.
+    /// When `false`, CDA skips `DoIP` initialization entirely (useful for
+    /// CAN-only or DoIP-less test setups).
+    /// Defaults to `true` to preserve the historical DoIP-first behavior.
+    pub enabled: bool,
     /// IP address of the diagnostic tester interface.
     pub tester_address: String,
     /// Subnet mask for the tester network.
@@ -38,12 +43,16 @@ pub struct DoipConfig {
     pub alive_check_interval_secs: u64,
     /// The name of the protocol to use.
     /// Matched case-insensitive against the database.
+    /// The special value `"auto-can"` defers the choice to the MDD-driven
+    /// CAN protocol auto-detection (see `into_db_protocol`; the markers are
+    /// configurable via `database.naming_convention.can_protocol_markers`).
     pub protocol_name: String,
 }
 
 impl Default for DoipConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             tester_address: "127.0.0.1".to_owned(),
             tester_subnet: "255.255.0.0".to_owned(),
             gateway_port: 13400,
@@ -87,6 +96,14 @@ impl ConfigSanity for DoipConfig {
             Ok(())
         }
 
+        // A disabled DoIP transport binds no endpoint (CAN-only operation), so
+        // its address/port/timeout fields are unused and may be left at their
+        // zero/placeholder defaults; validating them would reject a valid
+        // CAN-only configuration.
+        if !self.enabled {
+            return Ok(());
+        }
+
         validate_ip(&self.tester_address, "tester_address")?;
         validate_ip(&self.tester_subnet, "tester_address")?;
         validate_port(self.gateway_port, "gateway_port")?;
@@ -105,7 +122,37 @@ impl ConfigSanity for DoipConfig {
 
 #[cfg(test)]
 mod tests {
+    use cda_interfaces::config::ConfigSanity;
     use doip_definitions::header::ProtocolVersion;
+
+    use super::DoipConfig;
+
+    #[test]
+    fn disabled_doip_skips_field_validation() {
+        // CAN-only operation: DoIP is disabled and its endpoint fields are left
+        // at zero/placeholder defaults. Sanity must accept this instead of
+        // rejecting the unused gateway_port == 0.
+        let config = DoipConfig {
+            enabled: false,
+            gateway_port: 0,
+            tls_port: 0,
+            tester_address: String::new(),
+            tester_subnet: String::new(),
+            send_timeout_ms: 0,
+            ..Default::default()
+        };
+        assert!(config.validate_sanity().is_ok());
+    }
+
+    #[test]
+    fn enabled_doip_still_rejects_zero_port() {
+        let config = DoipConfig {
+            enabled: true,
+            gateway_port: 0,
+            ..Default::default()
+        };
+        assert!(config.validate_sanity().is_err());
+    }
 
     #[test]
     fn protocol_version_from_u8() {

--- a/cda-comm-doip/src/connection_receiver.rs
+++ b/cda-comm-doip/src/connection_receiver.rs
@@ -13,7 +13,7 @@
 
 use std::{sync::Arc, time::Duration};
 
-use cda_interfaces::{EcuConnectivityHandler, HashMap, dlt_ctx};
+use cda_interfaces::{HashMap, dlt_ctx};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     sync::{broadcast, mpsc, watch},
@@ -147,8 +147,6 @@ pub(super) async fn handle_response(
     outtx: &HashMap<u16, broadcast::Sender<Result<DiagnosticResponse, EcuError>>>,
     reset_tx: &mpsc::Sender<ConnectionResetReason>,
     response: Option<Result<DiagnosticResponse, ConnectionError>>,
-    ecu_names: &[String],
-    connectivity_handler: &Arc<dyn EcuConnectivityHandler>,
 ) {
     let Some(result) = response else {
         return;
@@ -158,15 +156,7 @@ pub(super) async fn handle_response(
             handle_ok_response(gateway_name, gateway_ip, outtx, response).await;
         }
         Err(err) => {
-            handle_connection_error(
-                gateway_name,
-                gateway_ip,
-                reset_tx,
-                err,
-                ecu_names,
-                connectivity_handler,
-            )
-            .await;
+            handle_connection_error(gateway_name, gateway_ip, reset_tx, err).await;
         }
     }
 }
@@ -231,11 +221,15 @@ async fn handle_connection_error(
     gateway_ip: &str,
     reset_tx: &mpsc::Sender<ConnectionResetReason>,
     err: ConnectionError,
-    ecu_names: &[String],
-    connectivity_handler: &Arc<dyn EcuConnectivityHandler>,
 ) {
     match err {
         ConnectionError::Closed => {
+            // Connectivity notifications are owned by the connection-reset
+            // task: it serializes disconnected -> (reconnect) -> connected.
+            // Emitting disconnected from here raced the reset task - the
+            // read loop hits Closed repeatedly while a reconnect is already
+            // succeeding, and a late disconnected arriving after the reset
+            // task's connected left healthy ECUs marked Offline for good.
             if let Err(e) = reset_tx
                 .send("Connection has been closed.".to_owned())
                 .await
@@ -247,10 +241,6 @@ async fn handle_connection_error(
                     "Failed to send connection reset request"
                 );
             }
-            // Notify UDS layer that ECUs on this connection are disconnected
-            connectivity_handler
-                .on_gateway_disconnected(ecu_names)
-                .await;
         }
         _ => {
             // for POC purposes we just log the error and do not reset the connection
@@ -294,8 +284,6 @@ where
         mut send_pending_rx,
         reset_tx,
     } = channels;
-    let ecu_names = gateway.ecu_names;
-    let connectivity_handler = gateway.connectivity_handler;
 
     cda_interfaces::spawn_named!(&format!("gateway-receiver-{}", gateway_id.ip), async move {
         'receive: loop {
@@ -338,8 +326,6 @@ where
                             &outtx,
                             &reset_tx,
                             response,
-                            &ecu_names,
-                            &connectivity_handler,
                         ).await;
                     }
                 }

--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -356,6 +356,16 @@ fn spawn_connection_reset_task(
                 let mut reconnect_attempts = 0u32;
                 if let Some(reason) = conn_reset_rx.recv().await {
                     tracing::info!(reason = %reason, "Resetting connection");
+                    // This task owns the connectivity notifications for the
+                    // gateway lifecycle: disconnected here, connected after a
+                    // successful reset. Emitting them from one place keeps
+                    // their order strict - notifications racing in from the
+                    // dying connection's IO tasks used to arrive after the
+                    // reconnect's connected and pinned healthy ECUs Offline.
+                    gateway
+                        .connectivity_handler
+                        .on_gateway_disconnected(&gateway.ecu_names)
+                        .await;
                     let mut conn_guard = conn_reset.lock_connection().await;
 
                     'reconnect: loop {
@@ -397,13 +407,21 @@ fn spawn_connection_reset_task(
                                 if reconnect_attempts
                                     >= gateway.connection.ecu_timeouts.max_retry_attempts
                                 {
+                                    // Do NOT end the task here: it is the only
+                                    // reconnect path for this gateway, and the
+                                    // outage may simply outlast the retry
+                                    // budget (e.g. a restarting gateway). Keep
+                                    // listening so the next reset request - a
+                                    // failed send, or the pending ones already
+                                    // queued - starts a fresh retry round.
                                     tracing::error!(
                                         attempts = reconnect_attempts,
                                         max_attempts =
                                             gateway.connection.ecu_timeouts.max_retry_attempts,
-                                        "Max reconnect attempts reached, giving up"
+                                        "Max reconnect attempts reached, giving up until the next \
+                                         reset request"
                                     );
-                                    return;
+                                    break 'reconnect;
                                 }
                             }
                         }

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -19,8 +19,8 @@ use std::{
 
 use cda_interfaces::{
     DiagServiceError, DoipComParams, DoipGatewaySetupError, EcuAddresses, EcuConnectivityHandler,
-    EcuGateway, HashMap, HashMapExtensions, ServicePayload, TransmissionParameters,
-    UDS_ID_RESPONSE_BITMASK, UdsResponse, dlt_ctx,
+    EcuGateway, HashMap, HashMapExtensions, ServicePayload, TransmissionParameters, UdsResponse,
+    dlt_ctx,
     util::{self, tokio_ext},
 };
 use doip_definitions::{
@@ -96,10 +96,11 @@ impl DiagnosticResponse {
 
         match self {
             Self::Ack((_, previous)) => request.starts_with(previous),
-            Self::Msg(msg) => msg
-                .message
-                .first()
-                .is_some_and(|response_sid| *response_sid == (*sid | UDS_ID_RESPONSE_BITMASK)),
+            // Positive and negative echoes both belong to the request: a
+            // final NRC can overtake the ACK, and ignoring it here consumes
+            // it from the receiver - the later response read then times out
+            // although the ECU answered.
+            Self::Msg(msg) => util::uds_response_matches_request_sid(*sid, &msg.message),
             Self::Pending { request_sid, .. }
             | Self::BusyRepeatRequest { request_sid, .. }
             | Self::TemporarilyNotAvailable { request_sid, .. } => *request_sid == *sid,
@@ -420,27 +421,6 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
         })
     }
 
-    pub async fn shutdown(&mut self) {
-        self.cancel_token.cancel();
-
-        if let Some(vam_listener_handle) = self.vam_listener_handle.lock().await.take() {
-            // Abort and await the VAM listener task so it stops reading from the
-            // shared UDP socket before a new gateway reuses it.
-            vam_listener_handle.abort();
-            let _ = vam_listener_handle.await;
-        }
-
-        // Abort all background tasks (sender, receiver, connection-reset) for each
-        // gateway connection. This immediately drops their TCP socket halves.
-        let connections = self.state.doip_connections.write().await;
-        let mut tasks = self.state.connection_tasks.lock().await;
-        tasks.abort_all();
-        while tasks.join_next().await.is_some() {}
-        drop(tasks);
-        drop(connections);
-        self.state.doip_connections.write().await.clear();
-    }
-
     /// Returns a clone of the UDP socket Arc for reuse in a new gateway instance.
     /// This avoids binding a second socket on the same port during reloads.
     #[must_use]
@@ -503,6 +483,27 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
 }
 
 impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
+    async fn shutdown(&mut self) {
+        self.cancel_token.cancel();
+
+        if let Some(vam_listener_handle) = self.vam_listener_handle.lock().await.take() {
+            // Abort and await the VAM listener task so it stops reading from the
+            // shared UDP socket before a new gateway reuses it.
+            vam_listener_handle.abort();
+            let _ = vam_listener_handle.await;
+        }
+
+        // Abort all background tasks (sender, receiver, connection-reset) for each
+        // gateway connection. This immediately drops their TCP socket halves.
+        let connections = self.state.doip_connections.write().await;
+        let mut tasks = self.state.connection_tasks.lock().await;
+        tasks.abort_all();
+        while tasks.join_next().await.is_some() {}
+        drop(tasks);
+        drop(connections);
+        self.state.doip_connections.write().await.clear();
+    }
+
     async fn get_gateway_network_address(&self, logical_address: u16) -> Option<String> {
         self.state
             .doip_connections

--- a/cda-comm-uds/src/coordinator.rs
+++ b/cda-comm-uds/src/coordinator.rs
@@ -53,6 +53,12 @@ pub struct EcuCoordinatorHandle {
     /// Shared state for direct synchronous reads. The actor is the sole writer
     /// for connectivity; variant detection writes directly.
     pub state: EcuRuntimeState,
+    /// Serializes variant detections for this ECU (held for the duration of
+    /// one `detect_variant` run); see [`Self::begin_detection`].
+    detection_lock: std::sync::Arc<tokio::sync::Mutex<()>>,
+    /// Trigger generation for detections on this handle; see
+    /// [`Self::begin_detection`].
+    detection_generation: std::sync::Arc<std::sync::atomic::AtomicU64>,
 }
 
 impl EcuCoordinatorHandle {
@@ -76,7 +82,12 @@ impl EcuCoordinatorHandle {
             ecu_name,
             suppress_disconnect: false,
         });
-        Self { actor_ref, state }
+        Self {
+            actor_ref,
+            state,
+            detection_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
+            detection_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        }
     }
 
     /// Read the current ECU status (synchronous, no mailbox round-trip).
@@ -97,6 +108,41 @@ impl EcuCoordinatorHandle {
         std_ext::lock_read(&self.state.service_states)
             .get(&sid)
             .cloned()
+    }
+
+    /// Claims the variant-detection slot of this handle (the group
+    /// representative's, for duplicate groups): detection writes the state of
+    /// every group member, so two members must never detect concurrently - a
+    /// reconnect burst would otherwise race concurrent detections
+    /// last-writer-wins, and a stale run against an already replaced
+    /// connection could overwrite the state a successful run just wrote.
+    ///
+    /// Entrants coalesce: every caller bumps the trigger generation before
+    /// waiting for the lock, and a waiter that acquires it only proceeds if
+    /// it is still the newest trigger. This bounds a burst to the in-flight
+    /// run plus one fresh run, instead of draining stale (potentially
+    /// 10s-timeout) detections one at a time.
+    ///
+    /// Returns the guard to hold for the duration of the detection run, or
+    /// `None` when this trigger was superseded by a newer one and the caller
+    /// should skip its run entirely.
+    pub async fn begin_detection(&self) -> Option<tokio::sync::OwnedMutexGuard<()>> {
+        let my_generation = self
+            .detection_generation
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            .wrapping_add(1);
+        let guard = std::sync::Arc::clone(&self.detection_lock)
+            .lock_owned()
+            .await;
+        if self
+            .detection_generation
+            .load(std::sync::atomic::Ordering::SeqCst)
+            == my_generation
+        {
+            Some(guard)
+        } else {
+            None
+        }
     }
 }
 
@@ -211,12 +257,15 @@ impl Message<EcuDisconnected> for EcuCoordinator {
 ///
 /// Only transitions from `Offline` to `Online`. If already `Online`, this is a no-op.
 /// Variant state is cleared to `NotTested` because the ECU may have rebooted while offline
-/// (e.g. into a different session/variant). The pre-send guard will trigger re-detection
-/// on the next UDS request.
+/// (e.g. into a different session/variant).
+///
+/// Replies with `true` when an actual `Offline` -> `Online` transition happened, so the
+/// caller can push a variant re-detection; the pre-send guard alone would leave the ECU
+/// `NotTested` until the next UDS request arrives.
 pub struct EcuConnected;
 
 impl Message<EcuConnected> for EcuCoordinator {
-    type Reply = ();
+    type Reply = bool;
 
     async fn handle(
         &mut self,
@@ -234,12 +283,14 @@ impl Message<EcuConnected> for EcuCoordinator {
             ecu_state.connectivity = Connectivity::Online;
             ecu_state.variant_state = VariantState::NotTested;
             ecu_state.variant_index = None;
+            true
         } else {
             tracing::debug!(
                 ecu = %self.ecu_name,
                 current = ?ecu_state.connectivity,
                 "ECU connected received but already Online..skipping"
             );
+            false
         }
     }
 }
@@ -578,5 +629,44 @@ mod tests {
         tokio::task::yield_now().await;
 
         assert_eq!(handle.ecu_status().variant_state, VariantState::NotDetected);
+    }
+
+    // begin_detection: serialization + trigger coalescing
+
+    #[tokio::test]
+    async fn begin_detection_grants_the_slot_when_uncontended() {
+        let handle = spawn_test_coordinator("TestECU");
+        let guard = handle.begin_detection().await;
+        assert!(guard.is_some(), "sole entrant must get the slot");
+        // Releasing and re-entering works (generation moved on, no stale skip).
+        drop(guard);
+        assert!(handle.begin_detection().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn begin_detection_coalesces_a_burst_to_the_newest_trigger() {
+        let handle = spawn_test_coordinator("TestECU");
+
+        // Entrant 1 runs and holds the slot.
+        let in_flight = handle.begin_detection().await.expect("first entrant");
+
+        // Entrants 2 and 3 queue up behind it, in order (each is polled
+        // until it is parked on the lock before the next one bumps the
+        // generation, so the mutex queue order matches the trigger order).
+        let h2 = handle.clone();
+        let waiter2 = tokio::spawn(async move { h2.begin_detection().await });
+        tokio::task::yield_now().await;
+        let h3 = handle.clone();
+        let waiter3 = tokio::spawn(async move { h3.begin_detection().await });
+        tokio::task::yield_now().await;
+
+        // The in-flight run finishes; the queued triggers resolve.
+        drop(in_flight);
+        let second = waiter2.await.expect("waiter 2 must not panic");
+        let third = waiter3.await.expect("waiter 3 must not panic");
+
+        // The stale intermediate trigger is skipped, the newest one runs.
+        assert!(second.is_none(), "superseded trigger must be skipped");
+        assert!(third.is_some(), "newest trigger must run");
     }
 }

--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -48,7 +48,7 @@ pub struct UdsManager<S: EcuGateway, T: UdsEcuDb> {
     ecus: Arc<HashMap<String, RwLock<T>>>,
     gateway: S,
     data_transfers: Arc<Mutex<HashMap<EcuIdentifier, EcuDataTransfer>>>,
-    ecu_semaphores: Arc<Mutex<HashMap<u16, Arc<Semaphore>>>>,
+    ecu_semaphores: Arc<Mutex<HashMap<String, Arc<Semaphore>>>>,
     tester_present_tasks: Arc<RwLock<HashMap<EcuIdentifier, TesterPresentTask>>>,
     session_reset_tasks: Arc<RwLock<HashMap<EcuIdentifier, JoinHandle<()>>>>,
     security_reset_tasks: Arc<RwLock<HashMap<EcuIdentifier, JoinHandle<()>>>>,
@@ -128,10 +128,21 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
                             processed_duplicates.extend(duplicates.iter().cloned());
                         }
                         deduplicated_ecus.push(ecu_name);
+                    } else {
+                        // A silent drop here once masked a casing mismatch
+                        // between a transport's discovery names and the
+                        // lowercase-keyed ECU map, leaving discovered ECUs
+                        // NotTested until their first request.
+                        tracing::warn!(
+                            ecu_name,
+                            "Variant detection trigger for unknown ECU dropped"
+                        );
                     }
                 }
 
-                vd_uds_clone.start_variant_detection_for_ecus(deduplicated_ecus);
+                vd_uds_clone
+                    .start_variant_detection_for_ecus(deduplicated_ecus)
+                    .await;
             }
         });
 

--- a/cda-comm-uds/src/query.rs
+++ b/cda-comm-uds/src/query.rs
@@ -28,17 +28,18 @@ use cda_interfaces::{
 
 use crate::{UdsManager, util::check_sd_sdg_recursive};
 
-/// Newtype wrapper for a gateway logical address.
+/// Grouping key for the network structure.
 ///
-/// Needed because `&u16` does not implement `From<&u16> -> u16`, which causes
-/// issues with `HashMap::entry_ref`. The newtype allows implementing `From<&GatewayAddress>`.
+/// `DoIP` ECUs group under their gateway's logical address. ECUs the
+/// transport identifies by name (CAN: the arbitration ID pair is the
+/// address, there is no gateway node) each form their own entry - their
+/// logical addresses are unresolved com-param defaults shared by every such
+/// ECU, so grouping by address would collapse unrelated ECUs into one
+/// pseudo-gateway with a single (necessarily wrong) network address.
 #[derive(Eq, Hash, PartialEq)]
-struct GatewayAddress(u16);
-
-impl From<&GatewayAddress> for GatewayAddress {
-    fn from(value: &GatewayAddress) -> Self {
-        GatewayAddress(value.0)
-    }
+enum GatewayKey {
+    Address(u16),
+    Ecu(String),
 }
 
 #[async_trait]
@@ -107,7 +108,7 @@ impl<S: EcuGateway, T: EcuManager> UdsQuery for UdsManager<S, T> {
             }
         }
 
-        let mut gateways: HashMap<GatewayAddress, Gateway> = HashMap::new();
+        let mut gateways: HashMap<GatewayKey, Gateway> = HashMap::new();
 
         for ecu in self.ecus.values() {
             let ecu = ecu.read().await;
@@ -118,9 +119,24 @@ impl<S: EcuGateway, T: EcuManager> UdsQuery for UdsManager<S, T> {
 
             let network_ecu = ecu_to_network_ecu(&*ecu);
 
+            if let Some(network_address) = self.gateway.get_ecu_network_address(&ecu_name).await {
+                // Name-identified ECU (CAN): its own entry, carrying its own
+                // transport address.
+                gateways.insert(
+                    GatewayKey::Ecu(ecu_name.clone()),
+                    Gateway {
+                        name: ecu_name,
+                        network_address,
+                        logical_address: network_ecu.logical_address.clone(),
+                        ecus: vec![network_ecu],
+                    },
+                );
+                continue;
+            }
+
             let gateway_addr = ecu.logical_gateway_address();
             let gateway = gateways
-                .entry(GatewayAddress(gateway_addr))
+                .entry(GatewayKey::Address(gateway_addr))
                 .or_insert(Gateway {
                     name: String::new(),
                     network_address: String::new(),
@@ -142,7 +158,7 @@ impl<S: EcuGateway, T: EcuManager> UdsQuery for UdsManager<S, T> {
                     tracing::warn!(
                         gateway_name = %ecu_name,
                         logical_address = %network_ecu.logical_address,
-                        "No IP address found for gateway"
+                        "No network address found for gateway"
                     );
                 }
             }

--- a/cda-comm-uds/src/state_coordinator.rs
+++ b/cda-comm-uds/src/state_coordinator.rs
@@ -34,6 +34,11 @@ use crate::coordinator::{
 #[derive(Clone)]
 pub struct EcuStateCoordinator {
     handles: Arc<HashMap<String, EcuCoordinatorHandle>>,
+    /// A real `Offline` -> `Online` transition pushes the ECU into this
+    /// channel for variant re-detection; without it a reconnected ECU
+    /// stays `NotTested` until the next UDS request, too late for
+    /// state-only consumers like the network structure.
+    redetect: tokio::sync::mpsc::Sender<Vec<String>>,
 }
 
 impl EcuStateCoordinator {
@@ -41,8 +46,15 @@ impl EcuStateCoordinator {
     ///
     /// Each ECU gets its own actor spawned, sharing the `EcuRuntimeState` from the
     /// `EcuManager` stored in `ecus`.
+    ///
+    /// `redetect` receives reconnected ECUs for variant re-detection; a
+    /// coordinator that swallows reconnects leaves ECUs undetected, so it
+    /// is required. Tests pass a channel and drop the receiver.
     #[must_use]
-    pub fn new(runtime_states: HashMap<String, EcuRuntimeState>) -> Self {
+    pub fn new(
+        runtime_states: HashMap<String, EcuRuntimeState>,
+        redetect: tokio::sync::mpsc::Sender<Vec<String>>,
+    ) -> Self {
         let handles: HashMap<String, EcuCoordinatorHandle> = runtime_states
             .into_iter()
             .map(|(ecu_name, state)| {
@@ -53,6 +65,7 @@ impl EcuStateCoordinator {
 
         Self {
             handles: Arc::new(handles),
+            redetect,
         }
     }
 
@@ -65,7 +78,19 @@ impl EcuStateCoordinator {
         tracing::info!(ecu_name, "ECU connected - setting connectivity to Online");
 
         if let Some(handle) = self.handles.get(ecu_name) {
-            let _ = handle.actor_ref.tell(EcuConnected).await;
+            let transitioned = handle.actor_ref.ask(EcuConnected).await.unwrap_or_default();
+            // Push a re-detection whenever the reconnected ECU has no valid
+            // variant: a real Offline -> Online transition resets it to
+            // NotTested, and a reconnect during variant detection (when
+            // disconnect events are suppressed, so no transition is seen)
+            // can leave a stale offline verdict behind. Triggering on every
+            // such reconnect mirrors the transport announcing the ECU;
+            // detection runs are coalesced downstream.
+            let needs_detection =
+                transitioned || crate::transport::needs_variant_detection(&handle.ecu_status());
+            if needs_detection {
+                let _ = self.redetect.send(vec![ecu_name.to_owned()]).await;
+            }
         }
     }
 
@@ -149,7 +174,8 @@ mod tests {
         let runtime_states: HashMap<String, EcuRuntimeState> =
             HashMap::from_iter([("TestECU".to_string(), runtime_state.clone())]);
 
-        let coordinator = EcuStateCoordinator::new(runtime_states);
+        let (redetect_tx, _redetect_rx) = tokio::sync::mpsc::channel(8);
+        let coordinator = EcuStateCoordinator::new(runtime_states, redetect_tx);
         (coordinator, runtime_state)
     }
 
@@ -201,7 +227,8 @@ mod tests {
         let runtime_state = EcuRuntimeState::new();
         let runtime_states: HashMap<String, EcuRuntimeState> =
             HashMap::from_iter([("TestECU".to_string(), runtime_state.clone())]);
-        let coordinator = EcuStateCoordinator::new(runtime_states);
+        let (redetect_tx, _redetect_rx) = tokio::sync::mpsc::channel(8);
+        let coordinator = EcuStateCoordinator::new(runtime_states, redetect_tx);
 
         coordinator.handle_ecu_connected("TestECU").await;
 

--- a/cda-comm-uds/src/transport.rs
+++ b/cda-comm-uds/src/transport.rs
@@ -183,17 +183,17 @@ impl<S: EcuGateway, T: UdsEcuDb + VariantDetection> UdsManager<S, T> {
 
         let ecu = self.uds_ecu_db(ecu_name)?;
         let (uds_params, transmission_params) = Self::ecu_send_params(ecu).await;
-        let ecu_logical_address = ecu.read().await.logical_address();
         let sent_sid = *payload.data.first().ok_or(DiagServiceError::BadPayload(
             "Cannot sent message without SID".to_owned(),
         ))?;
+        let ecu_sem_key = ecu.read().await.request_lock_key();
 
         let semaphore = {
             Arc::clone(
                 self.ecu_semaphores
                     .lock()
                     .await
-                    .entry(ecu_logical_address)
+                    .entry(ecu_sem_key.clone())
                     .or_insert_with(|| Arc::new(Semaphore::new(1))),
             )
         };
@@ -204,6 +204,7 @@ impl<S: EcuGateway, T: UdsEcuDb + VariantDetection> UdsManager<S, T> {
             .map_err(|_| {
                 tracing::error!(
                     ecu = ecu_name,
+                    request_lock_key = %ecu_sem_key,
                     "Timeout waiting for ecu to become available for requests."
                 );
                 DiagServiceError::Timeout
@@ -718,7 +719,8 @@ mod send_tests {
                 .keys()
                 .map(|name| (name.clone(), EcuRuntimeState::new()))
                 .collect();
-            let state_coordinator = EcuStateCoordinator::new(runtime_states);
+            let (redetect_tx, _redetect_rx) = tokio::sync::mpsc::channel(8);
+            let state_coordinator = EcuStateCoordinator::new(runtime_states, redetect_tx);
             Self {
                 ecus,
                 gateway,
@@ -749,6 +751,8 @@ mod send_tests {
         + Sync;
 
     impl EcuGateway for TestGateway {
+        async fn shutdown(&mut self) {}
+
         async fn get_gateway_network_address(&self, _logical_address: u16) -> Option<String> {
             None
         }

--- a/cda-comm-uds/src/variant.rs
+++ b/cda-comm-uds/src/variant.rs
@@ -18,48 +18,122 @@ use cda_interfaces::{
     DiagComm, DiagServiceError, DynamicPlugin, EcuGateway, EcuManager, EcuState, HashMap,
     HashMapExtensions, PayloadDecoder, UdsVariant, dlt_ctx,
 };
+use tokio::sync::RwLock;
 
 use crate::UdsManager;
+
+/// Result of evaluating every member of a duplicate group against one set of
+/// detection responses.
+#[derive(Debug)]
+enum GroupDetectionResult {
+    /// Exactly this member matched a specific (non-fallback) variant.
+    ExactMatch(String),
+    /// Members are online, but none matched a specific variant.
+    AllFallbacks,
+    /// No member of the group is online.
+    NoOnlineEcu,
+    /// Members are online, but detection failed for all of them.
+    NoDetection,
+}
 
 impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
     #[tracing::instrument(skip_all,
         fields(dlt_context = dlt_ctx!("UDS"))
     )]
-    pub(crate) fn start_variant_detection_for_ecus(&self, ecus: Vec<String>) {
+    pub(crate) async fn start_variant_detection_for_ecus(&self, ecus: Vec<String>) {
+        // detect_variant on any member of a duplicate group evaluates and
+        // writes the state of every member. Different callers pick different
+        // members (the boot path iterates a HashMap, the reconnect path
+        // forwards the gateway ECU list), so map every name to its group
+        // representative before scheduling: one trigger batch then spawns at
+        // most one detection per group. Concurrent detections across trigger
+        // batches are serialized by the coordinator's detection lock inside
+        // detect_variant.
+        let mut representatives = std::collections::BTreeSet::new();
         for ecu_name in ecus {
+            if !self.ecus.contains_key(&ecu_name) {
+                continue;
+            }
+            representatives.insert(self.duplicate_group_representative(&ecu_name).await);
+        }
+
+        for ecu_name in representatives {
             let vd = self.clone();
             cda_interfaces::spawn_named!(&format!("variant-detection-{ecu_name}"), async move {
-                match vd.detect_variant(&ecu_name).await {
-                    Ok(()) => {
-                        tracing::trace!("Variant detection successful");
+                // Retry budget for detections that conclude offline: such a
+                // verdict is usually transient here (the detection raced the
+                // tail of a reconnect churn and its request or response was
+                // lost on a connection that was being replaced), and since it
+                // does not break the now-healthy connection, no further
+                // reconnect event would ever correct it. The delay runs
+                // outside the detection (and its disconnect suppression), so
+                // real connectivity events flow between attempts; genuinely
+                // offline ECUs still settle at Offline after the retries.
+                const OFFLINE_VERDICT_RETRIES: u32 = 3;
+                const OFFLINE_VERDICT_RETRY_DELAY: Duration = Duration::from_secs(1);
+
+                for attempt in 0..=OFFLINE_VERDICT_RETRIES {
+                    if attempt > 0 {
+                        cda_interfaces::util::tokio_ext::sleep_for(OFFLINE_VERDICT_RETRY_DELAY)
+                            .await;
                     }
-                    Err(e) => {
-                        tracing::info!(error = %e, "Variant detection failed");
+                    match vd.detect_variant(&ecu_name).await {
+                        Ok(()) => {
+                            tracing::trace!("Variant detection successful");
+                        }
+                        Err(e) => {
+                            tracing::info!(error = %e, "Variant detection failed");
+                        }
                     }
+                    let offline =
+                        vd.state_coordinator
+                            .get_handle(&ecu_name)
+                            .is_some_and(|handle| {
+                                handle.connectivity() == cda_interfaces::Connectivity::Offline
+                            });
+                    if !offline {
+                        break;
+                    }
+                    tracing::debug!(
+                        ecu_name,
+                        attempt,
+                        "Variant detection concluded offline, retrying"
+                    );
                 }
             });
         }
     }
-}
 
-#[async_trait]
-impl<S: EcuGateway, T: EcuManager> UdsVariant for UdsManager<S, T> {
-    #[tracing::instrument(skip(self), err,
-        fields(
-            dlt_context = dlt_ctx!("UDS")
-        )
-    )]
-    async fn detect_variant(&self, ecu_name: &str) -> Result<(), DiagServiceError> {
-        #[derive(Debug)]
-        enum VariantDetectionResult<'a> {
-            ExactMatch(&'a str),
-            AllFallbacks,
-            NoOnlineEcu,
-            NoDetection,
-        }
+    /// Deterministic representative of the ECU's duplicate group: the
+    /// smallest member name (including the ECU itself) that is present in
+    /// the loaded ECU map.
+    async fn duplicate_group_representative(&self, ecu_name: &str) -> String {
+        let Some(db) = self.ecus.get(ecu_name) else {
+            return ecu_name.to_owned();
+        };
+        db.read()
+            .await
+            .duplicating_ecu_names()
+            .into_iter()
+            .flatten()
+            .filter(|name| self.ecus.contains_key(*name))
+            .map(String::as_str)
+            .chain(std::iter::once(ecu_name))
+            .min()
+            .unwrap_or(ecu_name)
+            .to_owned()
+    }
 
-        let ecu = self.uds_ecu_db(ecu_name)?;
-
+    /// Sends the ECU's variant-detection requests and returns the responses
+    /// that arrived. Disconnect events are suppressed while the requests are
+    /// in flight to prevent a timeout from re-triggering variant detection
+    /// in a loop; gathering stops at the first send failure (no need to
+    /// continue if one fails).
+    async fn gather_detection_responses(
+        &self,
+        ecu_name: &str,
+        ecu: &RwLock<T>,
+    ) -> Result<HashMap<String, <T as PayloadDecoder>::Response>, DiagServiceError> {
         let requests = ecu
             .read()
             .await
@@ -85,77 +159,203 @@ impl<S: EcuGateway, T: EcuManager> UdsVariant for UdsManager<S, T> {
         }
 
         let mut service_responses = HashMap::new();
-        'variant_detection_calls: {
-            // Suppress disconnect events while UDS requests are in-flight to
-            // prevent a timeout from re-triggering variant detection in a loop.
-            self.state_coordinator
-                .suppress_disconnect_handling(ecu_name)
-                .await;
-            for (name, service) in requests {
-                let response = match self
-                    .send_without_variant_guard(
-                        ecu_name,
-                        service,
-                        &(Box::new(()) as DynamicPlugin),
-                        None,
-                        true,
-                        Some(Duration::from_secs(10)),
-                    )
-                    .await
-                {
-                    Ok(response) => response,
-                    Err(e) => {
-                        tracing::debug!(
-                            request_name = %name,
-                            error = %e,
-                            "Failed to send variant detection request"
-                        );
-                        break 'variant_detection_calls; // no need to continue if one fails
-                    }
-                };
-                service_responses.insert(name, response);
+        self.state_coordinator
+            .suppress_disconnect_handling(ecu_name)
+            .await;
+        for (name, service) in requests {
+            match self
+                .send_without_variant_guard(
+                    ecu_name,
+                    service,
+                    &(Box::new(()) as DynamicPlugin),
+                    None,
+                    true,
+                    Some(Duration::from_secs(10)),
+                )
+                .await
+            {
+                Ok(response) => {
+                    service_responses.insert(name, response);
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        request_name = %name,
+                        error = %e,
+                        "Failed to send variant detection request"
+                    );
+                    break;
+                }
             }
         }
-        // Re-enable disconnect events now that UDS sends are complete.
         self.state_coordinator
             .restore_disconnect_handling(ecu_name)
             .await;
 
-        // No responses gathered -> ECU is unreachable.
-        // Call detect_variant with empty responses to set appropriate state
-        // (Disconnected if was online, Offline if never tested).
-        // If this ECU has duplicates, set them all to disconnected as well.
-        if service_responses.is_empty() {
-            ecu.write()
-                .await
-                .detect_variant::<<T as PayloadDecoder>::Response>(HashMap::new())
-                .await
-                .map_err(|e| {
-                    DiagServiceError::VariantDetectionError(format!(
-                        "Failed to detect variant: {e:?}"
-                    ))
-                })?;
+        Ok(service_responses)
+    }
 
-            // Also set all duplicates to the same state
-            if let Some(duplicates) = ecu
-                .read()
-                .await
-                .duplicating_ecu_names()
-                .cloned()
-                .filter(|d| !d.is_empty())
-            {
-                for dup_name in &duplicates {
-                    if let Some(dup_ecu) = self.ecus.get(dup_name) {
-                        let _ = dup_ecu
-                            .write()
-                            .await
-                            .detect_variant::<<T as PayloadDecoder>::Response>(HashMap::new())
-                            .await;
+    /// Marks the ECU and every member of its duplicate group as unreachable
+    /// by running detection with an empty response set (Disconnected if it
+    /// was online before, Offline if never tested).
+    async fn mark_group_unreachable(&self, ecu: &RwLock<T>) -> Result<(), DiagServiceError> {
+        ecu.write()
+            .await
+            .detect_variant::<<T as PayloadDecoder>::Response>(HashMap::new())
+            .await
+            .map_err(|e| {
+                DiagServiceError::VariantDetectionError(format!("Failed to detect variant: {e:?}"))
+            })?;
+
+        if let Some(duplicates) = ecu
+            .read()
+            .await
+            .duplicating_ecu_names()
+            .cloned()
+            .filter(|d| !d.is_empty())
+        {
+            for dup_name in &duplicates {
+                if let Some(dup_ecu) = self.ecus.get(dup_name) {
+                    // Best effort: one failing member must not stop
+                    // marking the rest; the primary error is propagated.
+                    if let Err(e) = dup_ecu
+                        .write()
+                        .await
+                        .detect_variant::<<T as PayloadDecoder>::Response>(HashMap::new())
+                        .await
+                    {
+                        tracing::debug!(
+                            ecu_name = %dup_name,
+                            error = ?e,
+                            "Failed to mark duplicate as unreachable"
+                        );
                     }
                 }
             }
+        }
 
-            return Ok(());
+        Ok(())
+    }
+
+    /// Runs detection for every member of a duplicate group against the same
+    /// responses and derives the group verdict: the first member matching a
+    /// specific variant wins; otherwise the group is all-fallbacks, failed,
+    /// or entirely offline.
+    async fn evaluate_duplicate_group(
+        &self,
+        duplicated_ecus: &cda_interfaces::HashSet<String>,
+        service_responses: &HashMap<String, <T as PayloadDecoder>::Response>,
+    ) -> GroupDetectionResult {
+        // First ECU that is online and fell back to base variant (no specific match).
+        let mut first_fallback = None;
+        // Tracked independently of detection success: an online member
+        // with failed detection must yield NoDetection, not NoOnlineEcu.
+        let mut any_online = false;
+
+        for ecu_name in duplicated_ecus {
+            let Some(ecu) = self.ecus.get(ecu_name) else {
+                continue;
+            };
+
+            if let Err(e) = ecu
+                .write()
+                .await
+                .detect_variant(service_responses.clone())
+                .await
+            {
+                tracing::warn!(
+                    "Variant detection failed for ECU {ecu_name}: {e:?}, marking as undetected"
+                );
+                any_online |= ecu.read().await.ecu_status().connectivity
+                    == cda_interfaces::Connectivity::Online;
+                continue;
+            }
+
+            let status = ecu.read().await.ecu_status();
+            any_online |= status.connectivity == cda_interfaces::Connectivity::Online;
+            if !status.is_online_and_detected() {
+                continue;
+            }
+
+            if status.is_fallback() {
+                first_fallback.get_or_insert(ecu_name);
+            } else {
+                return GroupDetectionResult::ExactMatch(ecu_name.clone());
+            }
+        }
+
+        match (first_fallback, any_online) {
+            (Some(_), true) => GroupDetectionResult::AllFallbacks,
+            (None, true) => GroupDetectionResult::NoDetection,
+            (_, false) => GroupDetectionResult::NoOnlineEcu,
+        }
+    }
+
+    /// Applies a duplicate-group verdict to every member's state.
+    async fn apply_group_result(
+        &self,
+        detection_result: &GroupDetectionResult,
+        duplicated_ecus: &cda_interfaces::HashSet<String>,
+    ) {
+        match detection_result {
+            GroupDetectionResult::ExactMatch(the_chosen_one) => {
+                // Mark all other duplicates, the chosen one keeps its detected variant.
+                for ecu_name in duplicated_ecus {
+                    if ecu_name == the_chosen_one {
+                        continue;
+                    }
+                    if let Some(ecu) = self.ecus.get(ecu_name) {
+                        ecu.write().await.mark_as_duplicate().await;
+                    }
+                }
+            }
+            GroupDetectionResult::AllFallbacks => {
+                // No specific variant found despite online ECUs - mark all as undetected.
+                // Falling back to base variant is only allowed when there are no duplicates.
+                for ecu_name in duplicated_ecus {
+                    if let Some(ecu) = self.ecus.get(ecu_name) {
+                        ecu.write().await.mark_as_no_variant_detected().await;
+                    }
+                }
+            }
+            GroupDetectionResult::NoOnlineEcu | GroupDetectionResult::NoDetection => {}
+        }
+    }
+}
+
+#[async_trait]
+impl<S: EcuGateway, T: EcuManager> UdsVariant for UdsManager<S, T> {
+    #[tracing::instrument(skip(self), err,
+        fields(
+            dlt_context = dlt_ctx!("UDS")
+        )
+    )]
+    async fn detect_variant(&self, ecu_name: &str) -> Result<(), DiagServiceError> {
+        let ecu = self.uds_ecu_db(ecu_name)?;
+
+        // Serialize detections per duplicate group and coalesce trigger
+        // bursts (a detection writes the state of every group member, so
+        // callers claim the group representative's slot); see
+        // [`crate::coordinator::EcuCoordinatorHandle::begin_detection`].
+        // All callers (boot, reconnect, pre-send guard) funnel through here.
+        let group_representative = self.duplicate_group_representative(ecu_name).await;
+        let mut _detection_guard = None;
+        if let Some(handle) = self.state_coordinator.get_handle(&group_representative) {
+            _detection_guard = handle.begin_detection().await;
+            if _detection_guard.is_none() {
+                tracing::debug!(
+                    ecu_name,
+                    "Variant detection superseded by a newer trigger, skipping"
+                );
+                return Ok(());
+            }
+        }
+
+        let service_responses = self.gather_detection_responses(ecu_name, ecu).await?;
+
+        // No responses gathered -> the ECU (and thus its whole duplicate
+        // group, which shares the physical node) is unreachable.
+        if service_responses.is_empty() {
+            return self.mark_group_unreachable(ecu).await;
         }
 
         let Some(mut duplicated_ecus) = ecu
@@ -178,82 +378,15 @@ impl<S: EcuGateway, T: EcuManager> UdsVariant for UdsManager<S, T> {
                 });
         };
 
-        // Detect variants for all duplicated ECUs
+        // Detect variants for all duplicated ECUs; the group verdict decides
+        // each member's final state.
         duplicated_ecus.insert(ecu_name.to_owned());
-
-        let detection_result = {
-            // First ECU that is online and fell back to base variant (no specific match).
-            let mut first_fallback = None;
-            let mut any_online = false;
-
-            let mut result = None;
-            for ecu_name in &duplicated_ecus {
-                let Some(ecu) = self.ecus.get(ecu_name) else {
-                    continue;
-                };
-
-                if let Err(e) = ecu
-                    .write()
-                    .await
-                    .detect_variant(service_responses.clone())
-                    .await
-                {
-                    tracing::warn!(
-                        "Variant detection failed for ECU {ecu_name}: {e:?}, marking as undetected"
-                    );
-                    continue;
-                }
-
-                let status = ecu.read().await.ecu_status();
-                if !status.is_online_and_detected() {
-                    continue;
-                }
-
-                any_online = true;
-
-                if status.is_fallback() {
-                    first_fallback.get_or_insert(ecu_name);
-                } else {
-                    result = Some(VariantDetectionResult::ExactMatch(ecu_name));
-                    break;
-                }
-            }
-
-            let result_fallback_mapper =
-                |first_fallback, any_online| match (first_fallback, any_online) {
-                    (Some(_), true) => VariantDetectionResult::AllFallbacks,
-                    (_, true) => VariantDetectionResult::NoDetection,
-                    _ => VariantDetectionResult::NoOnlineEcu,
-                };
-
-            result.unwrap_or(result_fallback_mapper(first_fallback, any_online))
-        };
-
+        let detection_result = self
+            .evaluate_duplicate_group(&duplicated_ecus, &service_responses)
+            .await;
         tracing::debug!(?detection_result, "ECU variant detection result");
-
-        match &detection_result {
-            VariantDetectionResult::ExactMatch(the_chosen_one) => {
-                // Mark all other duplicates, the chosen one keeps its detected variant.
-                for ecu_name in &duplicated_ecus {
-                    if ecu_name == *the_chosen_one {
-                        continue;
-                    }
-                    if let Some(ecu) = self.ecus.get(ecu_name) {
-                        ecu.write().await.mark_as_duplicate().await;
-                    }
-                }
-            }
-            VariantDetectionResult::AllFallbacks => {
-                // No specific variant found despite online ECUs - mark all as undetected.
-                // Falling back to base variant is only allowed when there are no duplicates.
-                for ecu_name in &duplicated_ecus {
-                    if let Some(ecu) = self.ecus.get(ecu_name) {
-                        ecu.write().await.mark_as_no_variant_detected().await;
-                    }
-                }
-            }
-            VariantDetectionResult::NoOnlineEcu | VariantDetectionResult::NoDetection => {}
-        }
+        self.apply_group_result(&detection_result, &duplicated_ecus)
+            .await;
 
         Ok(())
     }
@@ -306,7 +439,7 @@ impl<S: EcuGateway, T: EcuManager> UdsVariant for UdsManager<S, T> {
             ecus.push(ecu_name.to_owned());
         }
         let cloned = self.clone();
-        cloned.start_variant_detection_for_ecus(ecus);
+        cloned.start_variant_detection_for_ecus(ecus).await;
     }
 
     async fn get_logical_address(&self, ecu_name: &str) -> Result<u16, DiagServiceError> {

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -89,6 +89,8 @@ pub struct EcuManager<S: SecurityPlugin> {
     pub(in crate::diag_kernel) logical_address: u16,
     pub(in crate::diag_kernel) logical_gateway_address: u16,
     pub(in crate::diag_kernel) logical_functional_address: u16,
+    /// See [`Self::doip_addresses_resolved`] for the semantics.
+    pub(in crate::diag_kernel) doip_addresses_resolved: bool,
 
     pub(in crate::diag_kernel) nack_number_of_retries: HashMap<u8, u32>,
     pub(in crate::diag_kernel) diagnostic_ack_timeout: Duration,
@@ -317,23 +319,53 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
     }
 }
 
+/// A `DoIP` logical address plus the provenance duplicate detection needs.
+struct DoipLogicalAddress {
+    /// The address value to use.
+    address: u16,
+    /// `true` when the database lookup failed and `address` is merely the
+    /// com-param default, not an address actually assigned to this ECU.
+    /// CAN-only MDDs carry no `DoIP` addressing, so all their ECUs share the
+    /// default value - which must not be mistaken for an address collision.
+    is_comparam_default: bool,
+}
+
 impl<S: SecurityPlugin> EcuManager<S> {
+    /// Whether gateway and ECU logical address come from the database (or an
+    /// explicit config override) rather than the com-param default fallback.
+    ///
+    /// ECUs whose MDDs carry no `DoIP` addressing (e.g. CAN-only databases) all
+    /// share the fallback values; address-based logic such as duplicate
+    /// detection must not treat that as a real address collision.
+    pub fn doip_addresses_resolved(&self) -> bool {
+        self.doip_addresses_resolved
+    }
+
+    /// Resolve a logical address, keeping track of whether it was actually
+    /// resolved (config override or database hit) as opposed to falling back
+    /// to the com-param default.
     fn resolve_logical_address(
         database: &datatypes::DiagnosticDatabase,
         data_protocol: Option<&datatypes::Protocol<'_>>,
         config: &ComParamConfig<u16>,
         addr_type: &datatypes::LogicalAddressType,
-    ) -> u16 {
+    ) -> DoipLogicalAddress {
         if config.precedence == ComParamPrecedence::Config {
             tracing::debug!(
                 param_name = %config.name,
                 "Using config value (precedence = Config), DB lookup skipped"
             );
-            return config.value;
+            return DoipLogicalAddress {
+                address: config.value,
+                is_comparam_default: false,
+            };
         }
 
         match database.find_logical_address(addr_type, database, data_protocol.map(|v| &**v)) {
-            Ok(address) => address,
+            Ok(address) => DoipLogicalAddress {
+                address,
+                is_comparam_default: false,
+            },
             Err(e) => {
                 tracing::error!(
                     config = ?config,
@@ -341,7 +373,10 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     addr_type =  ?addr_type,
                     error = %e,
                     "Failed to find logical address");
-                config.value
+                DoipLogicalAddress {
+                    address: config.value,
+                    is_comparam_default: true,
+                }
             }
         }
     }
@@ -477,9 +512,11 @@ impl<S: SecurityPlugin> EcuManager<S> {
             database_naming_convention,
             tester_address: database
                 .find_com_param(data_protocol_ref, &com_params.doip.logical_tester_address)?,
-            logical_address: logical_ecu_address,
-            logical_gateway_address,
-            logical_functional_address,
+            logical_address: logical_ecu_address.address,
+            logical_gateway_address: logical_gateway_address.address,
+            logical_functional_address: logical_functional_address.address,
+            doip_addresses_resolved: !logical_gateway_address.is_comparam_default
+                && !logical_ecu_address.is_comparam_default,
             nack_number_of_retries,
             diagnostic_ack_timeout: database
                 .find_com_param(data_protocol_ref, &com_params.doip.diagnostic_ack_timeout)?,
@@ -597,6 +634,8 @@ impl<S: SecurityPlugin> EcuManager<S> {
             logical_address: logical_ecu_address,
             logical_gateway_address: com_params.doip.logical_gateway_address.value,
             logical_functional_address: com_params.doip.logical_functional_address.value,
+            // Functional descriptions use the com-param defaults verbatim.
+            doip_addresses_resolved: false,
             nack_number_of_retries,
             diagnostic_ack_timeout: com_params.doip.diagnostic_ack_timeout.value,
             retry_period: com_params.doip.retry_period.value,

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -18,9 +18,9 @@ use cda_interfaces::{
     Connectivity, DiagServiceError, EcuManagerType, EcuRuntimeState, EcuStateManager, HashMap,
     HashMapExtensions, HashSet, PayloadDecoder, Protocol, VariantState,
     datatypes::{
-        AddressingMode, ComParamConfig, ComParamPrecedence, ComParams, ComplexComParamValue,
-        DatabaseNamingConvention, DiagnosticServiceAffixPosition, RetryPolicy, SdSdg,
-        TesterPresentSendType,
+        AddressingMode, ComParamConfig, ComParamPrecedence, ComParamValue, ComParams,
+        ComplexComParamValue, DatabaseNamingConvention, DiagnosticServiceAffixPosition,
+        RetryPolicy, SdSdg, TesterPresentSendType,
     },
     dlt_ctx,
     util::std_ext,
@@ -91,6 +91,12 @@ pub struct EcuManager<S: SecurityPlugin> {
     pub(in crate::diag_kernel) logical_functional_address: u16,
     /// See [`Self::doip_addresses_resolved`] for the semantics.
     pub(in crate::diag_kernel) doip_addresses_resolved: bool,
+    /// CAN arbitration ID pair from the MDD com-params (or config override),
+    /// when present; see [`Self::resolve_can_id`] for the resolution order.
+    /// `None` when the ECU has no CAN addressing (e.g. a pure `DoIP` ECU);
+    /// when `Some`, both IDs are present and range-validated.
+    pub(in crate::diag_kernel) can_ids: Option<cda_interfaces::CanIds>,
+    pub(in crate::diag_kernel) can_functional_id: Option<cda_interfaces::CanId>,
 
     pub(in crate::diag_kernel) nack_number_of_retries: HashMap<u8, u32>,
     pub(in crate::diag_kernel) diagnostic_ack_timeout: Duration,
@@ -161,6 +167,38 @@ impl<S: SecurityPlugin> cda_interfaces::EcuAddresses for EcuManager<S> {
     fn logical_address_eq<T: cda_interfaces::EcuAddresses>(&self, other: &T) -> bool {
         self.logical_address == other.logical_address()
             && self.logical_gateway_address() == other.logical_gateway_address()
+    }
+
+    fn request_lock_key(&self) -> String {
+        // CAN-only MDDs carry no DoIP addressing: their ECUs all share the
+        // com-param fallback addresses, which must not collapse them onto one
+        // request semaphore. Observed on a real vehicle where every ECU
+        // resolved to 0x0000@0x0000 and all requests serialized globally.
+        // The CAN ID pair is the target identity there - shared by the
+        // candidate descriptions of one physical node (duplicate group).
+        cda_interfaces::request_lock_key_for(
+            self.doip_addresses_resolved,
+            self.logical_gateway_address,
+            self.logical_address,
+            self.can_ids,
+            &self.ecu_name,
+        )
+    }
+}
+
+/// CAN addressing extracted from the MDD com-params (`CP_CanPhysReqId` /
+/// `CP_CanRespUSDTId` / `CP_CanFuncReqId`, preferring the per-ECU
+/// `CP_UniqueRespIdTable` entries), implementing #415.
+/// `None` when neither the database nor the config provides a value; the CAN
+/// gateway then relies on the explicit `[[can.ecu_mappings]]` config block,
+/// which always takes precedence over these values anyway.
+impl<S: SecurityPlugin> cda_interfaces::CanComParamProvider for EcuManager<S> {
+    fn can_ids(&self) -> Option<cda_interfaces::CanIds> {
+        self.can_ids
+    }
+
+    fn can_functional_id(&self) -> Option<cda_interfaces::CanId> {
+        self.can_functional_id
     }
 }
 
@@ -319,6 +357,28 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
     }
 }
 
+/// Reads a CAN arbitration ID sub-parameter out of a resolved
+/// unique-response-ID table. Values appear as decimal or `0x`-prefixed hex
+/// strings depending on the authoring tool; unparseable values are treated
+/// as absent (with a warning) so the scalar com-param fallback still runs.
+fn can_id_from_table(entries: &ComplexComParamValue, param_name: &str) -> Option<u32> {
+    let ComParamValue::Simple(simple) = entries.get(param_name)? else {
+        return None;
+    };
+    match cda_interfaces::util::parse_u32_maybe_hex(simple.value.trim()) {
+        Ok(id) => Some(id),
+        Err(e) => {
+            tracing::warn!(
+                param_name,
+                value = %simple.value,
+                error = %e,
+                "Unparseable CAN ID in unique-response-ID table, treating as absent"
+            );
+            None
+        }
+    }
+}
+
 /// A `DoIP` logical address plus the provenance duplicate detection needs.
 struct DoipLogicalAddress {
     /// The address value to use.
@@ -339,6 +399,73 @@ impl<S: SecurityPlugin> EcuManager<S> {
     /// detection must not treat that as a real address collision.
     pub fn doip_addresses_resolved(&self) -> bool {
         self.doip_addresses_resolved
+    }
+
+    /// Looks up the unique-response-ID table (`CP_UniqueRespIdTable` by
+    /// default) that carries the per-ECU CAN addressing as sub-parameters.
+    /// `None` when the database has no such table for the protocol (the
+    /// scalar com-param fallback in [`Self::resolve_can_id`] still applies).
+    ///
+    /// A multi-row table collapses to one entry per sub-parameter name here
+    /// (per-ECU MDDs carry a single row; shared multi-ECU descriptions are
+    /// out of scope).
+    fn resolve_can_id_table(
+        database: &datatypes::DiagnosticDatabase,
+        data_protocol: Option<&datatypes::Protocol<'_>>,
+        com_params: &ComParams,
+    ) -> Option<ComplexComParamValue> {
+        match datatypes::lookup(
+            database,
+            data_protocol.map(|v| &**v),
+            &com_params.can.unique_resp_id_table_name,
+        ) {
+            Ok(ComParamValue::Complex(entries)) => Some(entries),
+            Ok(ComParamValue::Simple(_)) => {
+                tracing::warn!(
+                    table = %com_params.can.unique_resp_id_table_name,
+                    "Unique-response-ID table is a simple com-param, expected a complex table; \
+                     ignoring it for CAN addressing"
+                );
+                None
+            }
+            // Most commonly NotFound (no CAN addressing in this database).
+            Err(_) => None,
+        }
+    }
+
+    /// Resolves one CAN arbitration ID with the precedence
+    /// config override (`precedence = "Config"`) > unique-response-ID-table
+    /// sub-parameter > top-level scalar com-param > `None`.
+    fn resolve_can_id(
+        database: &datatypes::DiagnosticDatabase,
+        data_protocol: Option<&datatypes::Protocol<'_>>,
+        table: Option<&ComplexComParamValue>,
+        config: &ComParamConfig<Option<u32>>,
+    ) -> Option<u32> {
+        if config.precedence == ComParamPrecedence::Config {
+            tracing::debug!(
+                param_name = %config.name,
+                "Using config value (precedence = Config), DB lookup skipped"
+            );
+            return config.value;
+        }
+
+        if let Some(id) = table.and_then(|entries| can_id_from_table(entries, &config.name)) {
+            return Some(id);
+        }
+
+        // Top-level scalar com-param; a missing entry falls back to the
+        // config value (`None` by default) inside find_com_param.
+        database
+            .find_com_param(data_protocol, config)
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    param_name = %config.name,
+                    error = %e,
+                    "Failed to read CAN ID com-param, treating as absent"
+                );
+                None
+            })
     }
 
     /// Resolve a logical address, keeping track of whether it was actually
@@ -499,6 +626,53 @@ impl<S: SecurityPlugin> EcuManager<S> {
             .map(datatypes::map_nack_number_of_retries)
             .collect::<Result<HashMap<u8, u32>, DiagServiceError>>()?;
 
+        // Per-ECU CAN addressing lives in the unique-response-ID table (one
+        // row per ECU description); resolve it once and let all three ID
+        // lookups read from it before falling back to scalar com-params.
+        let can_id_table = Self::resolve_can_id_table(&database, data_protocol_ref, com_params);
+        let can_request_id = Self::resolve_can_id(
+            &database,
+            data_protocol_ref,
+            can_id_table.as_ref(),
+            &com_params.can.physical_request_id,
+        );
+        let can_response_id = Self::resolve_can_id(
+            &database,
+            data_protocol_ref,
+            can_id_table.as_ref(),
+            &com_params.can.physical_response_id,
+        );
+        // Out-of-range IDs are treated as absent (with a warning) so one
+        // bad value cannot fail the ECU load; [[can.ecu_mappings]] overrides.
+        let can_ids = can_request_id
+            .zip(can_response_id)
+            .and_then(|(request, response)| {
+                cda_interfaces::CanIds::try_from_raw(request, response)
+                    .inspect_err(|e| {
+                        tracing::warn!(
+                            error = %e,
+                            "Invalid CAN addressing in MDD com-params, treating as absent"
+                        );
+                    })
+                    .ok()
+            });
+        let can_functional_id = Self::resolve_can_id(
+            &database,
+            data_protocol_ref,
+            can_id_table.as_ref(),
+            &com_params.can.functional_id,
+        )
+        .and_then(|id| {
+            cda_interfaces::CanId::try_from(id)
+                .inspect_err(|e| {
+                    tracing::warn!(
+                        error = %e,
+                        "Invalid functional CAN ID in MDD com-params, treating as absent"
+                    );
+                })
+                .ok()
+        });
+
         let ecu_name = database
             .ecu_data()?
             .ecu_name()
@@ -517,6 +691,8 @@ impl<S: SecurityPlugin> EcuManager<S> {
             logical_functional_address: logical_functional_address.address,
             doip_addresses_resolved: !logical_gateway_address.is_comparam_default
                 && !logical_ecu_address.is_comparam_default,
+            can_ids,
+            can_functional_id,
             nack_number_of_retries,
             diagnostic_ack_timeout: database
                 .find_com_param(data_protocol_ref, &com_params.doip.diagnostic_ack_timeout)?,
@@ -636,6 +812,13 @@ impl<S: SecurityPlugin> EcuManager<S> {
             logical_functional_address: com_params.doip.logical_functional_address.value,
             // Functional descriptions use the com-param defaults verbatim.
             doip_addresses_resolved: false,
+            // Functional descriptions are not physical CAN nodes.
+            can_ids: None,
+            can_functional_id: com_params
+                .can
+                .functional_id
+                .value
+                .and_then(|id| cda_interfaces::CanId::try_from(id).ok()),
             nack_number_of_retries,
             diagnostic_ack_timeout: com_params.doip.diagnostic_ack_timeout.value,
             retry_period: com_params.doip.retry_period.value,
@@ -960,5 +1143,53 @@ mod tests {
                 .variant_index
                 .is_some()
         );
+    }
+
+    // can_id_from_table: reading CAN IDs out of a resolved
+    // unique-response-ID table
+
+    fn table_with(entries: &[(&str, &str)]) -> ComplexComParamValue {
+        entries
+            .iter()
+            .map(|(name, value)| {
+                (
+                    (*name).to_owned(),
+                    ComParamValue::Simple(cda_interfaces::datatypes::ComParamSimpleValue {
+                        value: (*value).to_owned(),
+                        unit: None,
+                    }),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn can_id_from_table_parses_hex_and_decimal() {
+        // Real smart453 values: request 0x79B, response 0x7BB. Authoring
+        // tools emit either 0x-prefixed hex or plain decimal.
+        let table = table_with(&[
+            ("CP_CanPhysReqId", "0x79B"),
+            ("CP_CanRespUSDTId", "1979"),
+            ("CP_Padded", " 0x7DF "),
+        ]);
+        assert_eq!(can_id_from_table(&table, "CP_CanPhysReqId"), Some(0x79B));
+        assert_eq!(can_id_from_table(&table, "CP_CanRespUSDTId"), Some(1979));
+        assert_eq!(can_id_from_table(&table, "CP_Padded"), Some(0x7DF));
+    }
+
+    #[test]
+    fn can_id_from_table_treats_missing_and_invalid_as_absent() {
+        let table = table_with(&[("CP_CanPhysReqId", "not-a-number")]);
+        // Unparseable value: absent, so the scalar com-param fallback runs.
+        assert_eq!(can_id_from_table(&table, "CP_CanPhysReqId"), None);
+        assert_eq!(can_id_from_table(&table, "CP_CanRespUSDTId"), None);
+
+        // A nested complex sub-value is not an ID either.
+        let mut nested = table_with(&[]);
+        nested.insert(
+            "CP_CanPhysReqId".to_owned(),
+            ComParamValue::Complex(table_with(&[("inner", "0x123")])),
+        );
+        assert_eq!(can_id_from_table(&nested, "CP_CanPhysReqId"), None);
     }
 }

--- a/cda-core/src/diag_kernel/mod.rs
+++ b/cda-core/src/diag_kernel/mod.rs
@@ -249,6 +249,18 @@ impl TryInto<u32> for DiagDataValue {
     }
 }
 
+/// Data type used to expose a RESERVED parameter, which has no semantic type
+/// of its own: blocks up to 32 bits are exposed as `UInt32`; anything wider
+/// cannot be represented numerically and is treated as raw bytes instead.
+/// Shared between the encode and decode paths so they cannot drift.
+pub(in crate::diag_kernel) fn reserved_param_data_type(bit_length: u32) -> datatypes::DataType {
+    if bit_length > 32 {
+        datatypes::DataType::ByteField
+    } else {
+        datatypes::DataType::UInt32
+    }
+}
+
 pub fn into_db_protocol<'db>(
     database: &'db datatypes::DiagnosticDatabase,
     protocol: &cda_interfaces::Protocol,
@@ -256,13 +268,64 @@ pub fn into_db_protocol<'db>(
     let protocol_name = protocol.to_string();
     let all_protocols = database.protocols()?;
 
-    // Try exact match first.
-    if let Some(p) = all_protocols.iter().find(|p| {
-        p.diag_layer()
-            .and_then(|dl| dl.short_name())
-            .is_some_and(|sn| sn.eq_ignore_ascii_case(&protocol_name))
-    }) {
-        return Ok(datatypes::Protocol(*p));
+    let find_by_name = |name: &str| {
+        all_protocols
+            .iter()
+            .find(|p| {
+                datatypes::protocol_short_name(p).is_some_and(|sn| sn.eq_ignore_ascii_case(name))
+            })
+            .map(|p| datatypes::Protocol(*p))
+    };
+    // CAN protocol naming is OEM-specific and therefore configurable via the
+    // database naming convention (database.naming_convention.can_protocol_*).
+    let naming_convention = &database.config().naming_convention;
+
+    // CAN handling, part 1: auto-detection. The sentinel `"auto-can"` scans
+    // the MDD's protocols for a CAN-named one (per the configured markers).
+    // This lets a CAN-only setup work without a per-ECU `[ecu.<name>]
+    // protocol = "UDS_CAN"` override. There is deliberately no silent
+    // fallback: using an arbitrary protocol would run the ECU with the wrong
+    // com-param set (timings, addressing) and produce failures far from the
+    // root cause.
+    if protocol_name == "auto-can" {
+        if let Some(p) = all_protocols.iter().find(|p| {
+            datatypes::protocol_short_name(p).is_some_and(|sn| {
+                let up = sn.to_ascii_uppercase();
+                naming_convention
+                    .can_protocol_markers
+                    .iter()
+                    .any(|marker| up.contains(&marker.to_ascii_uppercase()))
+            })
+        }) {
+            tracing::info!("Auto-detected CAN protocol from MDD; using it as the default");
+            return Ok(datatypes::Protocol(*p));
+        }
+        return Err(DiagServiceError::InvalidDatabase(
+            "Protocol auto-detection found no CAN protocol in the database; configure an explicit \
+             protocol name for this ECU"
+                .to_owned(),
+        ));
+    }
+
+    // Exact match against the configured protocol name.
+    if let Some(p) = find_by_name(&protocol_name) {
+        return Ok(p);
+    }
+
+    // CAN handling, part 2: when the configured name is one of the known CAN
+    // protocol names but the database uses a sibling name, try the other
+    // aliases in order. On a miss, fall through to the strict handling below
+    // instead of picking an arbitrary protocol.
+    if naming_convention
+        .can_protocol_aliases
+        .iter()
+        .any(|alias| alias.eq_ignore_ascii_case(&protocol_name))
+        && let Some(p) = naming_convention
+            .can_protocol_aliases
+            .iter()
+            .find_map(|alias| find_by_name(alias))
+    {
+        return Ok(p);
     }
 
     // Fallback: when ignore_protocol is enabled and only one distinct protocol

--- a/cda-core/src/diag_kernel/mod.rs
+++ b/cda-core/src/diag_kernel/mod.rs
@@ -602,6 +602,28 @@ mod tests {
     }
 
     #[test]
+    fn test_oversized_numeric_payload_is_an_error() {
+        // Numeric decode must stay strict: a payload longer than the numeric
+        // type indicates a malformed response (or an MDD defect that has to
+        // be handled at the declaration layer), never a silent type change.
+        for data_type in [DataType::UInt32, DataType::Int32, DataType::Float32] {
+            assert!(
+                DiagDataValue::new(data_type, &[0u8; 5]).is_err(),
+                "5 bytes must not decode as {data_type:?}"
+            );
+        }
+        assert!(DiagDataValue::new(DataType::Float64, &[0u8; 9]).is_err());
+    }
+
+    #[test]
+    fn test_short_numeric_payload_is_padded() {
+        match DiagDataValue::new(DataType::UInt32, &[0x00, 0x01, 0x01]) {
+            Ok(DiagDataValue::UInt32(v)) => assert_eq!(v, 0x0101),
+            other => panic!("expected UInt32, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_mixed_interval_types() {
         let value = DiagDataValue::Int32(50);
 

--- a/cda-core/src/diag_kernel/operations.rs
+++ b/cda-core/src/diag_kernel/operations.rs
@@ -19,7 +19,7 @@ use cda_database::datatypes::{
 };
 use cda_interfaces::{
     DiagServiceError,
-    util::{decode_hex, tracing::print_hex},
+    util::{decode_hex, tracing::print_hex, try_strip_hex_prefix},
 };
 
 use crate::diag_kernel::{
@@ -774,7 +774,7 @@ fn decode_hex_with_optional_prefix(value: &str) -> Result<Vec<u8>, DiagServiceEr
         .split([' ', ','])
         .filter(|v: &&str| !v.is_empty())
         .map(|value| {
-            if let Some(stripped) = value.to_lowercase().strip_prefix("0x") {
+            if let Some(stripped) = try_strip_hex_prefix(value) {
                 decode_hex(stripped)
             } else {
                 decode_hex(value)

--- a/cda-core/src/diag_kernel/payload_decode.rs
+++ b/cda-core/src/diag_kernel/payload_decode.rs
@@ -1714,14 +1714,7 @@ fn map_param_reserved_from_uds(
         DiagServiceError::InvalidDatabase("Expected Reserved specific data".to_owned()),
     )?;
 
-    // RESERVED parameters have no semantic type of their own. Blocks up to 32
-    // bits are exposed as UInt32; anything wider cannot be represented
-    // numerically and is exposed as raw bytes instead.
-    let data_type = if r.bit_length() > 32 {
-        datatypes::DataType::ByteField
-    } else {
-        datatypes::DataType::UInt32
-    };
+    let data_type = super::reserved_param_data_type(r.bit_length());
     let coded_type = datatypes::DiagCodedType::new_high_low_byte_order(
         data_type,
         datatypes::DiagCodedTypeVariant::StandardLength(datatypes::StandardLengthType {

--- a/cda-core/src/diag_kernel/payload_decode.rs
+++ b/cda-core/src/diag_kernel/payload_decode.rs
@@ -1714,8 +1714,16 @@ fn map_param_reserved_from_uds(
         DiagServiceError::InvalidDatabase("Expected Reserved specific data".to_owned()),
     )?;
 
+    // RESERVED parameters have no semantic type of their own. Blocks up to 32
+    // bits are exposed as UInt32; anything wider cannot be represented
+    // numerically and is exposed as raw bytes instead.
+    let data_type = if r.bit_length() > 32 {
+        datatypes::DataType::ByteField
+    } else {
+        datatypes::DataType::UInt32
+    };
     let coded_type = datatypes::DiagCodedType::new_high_low_byte_order(
-        datatypes::DataType::UInt32,
+        data_type,
         datatypes::DiagCodedTypeVariant::StandardLength(datatypes::StandardLengthType {
             bit_length: r.bit_length(),
             bit_mask: None,
@@ -1734,7 +1742,7 @@ fn map_param_reserved_from_uds(
         DiagDataTypeContainer::RawContainer(DiagDataTypeContainerRaw {
             data: param_data,
             bit_len,
-            data_type: datatypes::DataType::UInt32,
+            data_type,
             compu_method: None,
         }),
     );

--- a/cda-core/src/diag_kernel/payload_encode.rs
+++ b/cda-core/src/diag_kernel/payload_encode.rs
@@ -405,13 +405,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     "Expected Reserved specific data".to_owned(),
                 ))?;
         let bit_length = reserved_param.bit_length();
-        // Mirror the decode side: reserved blocks wider than 32 bits are
-        // treated as byte fields (UInt32 cannot represent them).
-        let data_type = if bit_length > 32 {
-            datatypes::DataType::ByteField
-        } else {
-            datatypes::DataType::UInt32
-        };
+        let data_type = super::reserved_param_data_type(bit_length);
         let coded_type = datatypes::DiagCodedType::new_high_low_byte_order(
             data_type,
             datatypes::DiagCodedTypeVariant::StandardLength(datatypes::StandardLengthType {

--- a/cda-core/src/diag_kernel/payload_encode.rs
+++ b/cda-core/src/diag_kernel/payload_encode.rs
@@ -405,8 +405,15 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     "Expected Reserved specific data".to_owned(),
                 ))?;
         let bit_length = reserved_param.bit_length();
+        // Mirror the decode side: reserved blocks wider than 32 bits are
+        // treated as byte fields (UInt32 cannot represent them).
+        let data_type = if bit_length > 32 {
+            datatypes::DataType::ByteField
+        } else {
+            datatypes::DataType::UInt32
+        };
         let coded_type = datatypes::DiagCodedType::new_high_low_byte_order(
-            datatypes::DataType::UInt32,
+            data_type,
             datatypes::DiagCodedTypeVariant::StandardLength(datatypes::StandardLengthType {
                 bit_length,
                 bit_mask: None,

--- a/cda-core/src/diag_kernel/variant_detection.rs
+++ b/cda-core/src/diag_kernel/variant_detection.rs
@@ -14,7 +14,7 @@
 use cda_database::datatypes;
 use cda_interfaces::{
     DiagComm, DiagCommType, DiagServiceError, HashMap, datatypes::DatabaseNamingConvention,
-    diagservices::DiagServiceResponse, dlt_ctx,
+    diagservices::DiagServiceResponse, dlt_ctx, util::byte_field_matches_hex_pattern,
 };
 type DiagServiceId = String;
 
@@ -128,7 +128,12 @@ pub(super) fn evaluate_variant<T: DiagServiceResponse + Sized>(
                                         .iter()
                                         .find(|(name, _)| **name == expected_param)
                                         .map(|(_name, value)| {
-                                            let matches = value.replace('"', "") == expected_value;
+                                            let received = value.replace('"', "");
+                                            let matches = received == expected_value
+                                                || byte_field_matches_hex_pattern(
+                                                    &received,
+                                                    expected_value,
+                                                );
                                             tracing::debug!(
                                                 service = %service,
                                                 parameter = %expected_param,

--- a/cda-database/src/datatypes/comparam.rs
+++ b/cda-database/src/datatypes/comparam.rs
@@ -14,11 +14,16 @@
 use cda_interfaces::{
     DiagServiceError, HashMap,
     datatypes::{ComParamSimpleValue, ComParamValue, Unit},
+    util::try_strip_hex_prefix,
 };
 
 use crate::flatbuf::diagnostic_description::dataformat;
 
-pub(super) fn lookup(
+/// Lookup a COM parameter by name and return its raw value
+///
+/// # Errors
+/// Returns an error if the COM parameter is not found or cannot be resolved
+pub fn lookup(
     ecu_data: &crate::datatypes::DiagnosticDatabase,
     protocol: Option<&dataformat::Protocol>,
     param_name: &str,
@@ -26,7 +31,7 @@ pub(super) fn lookup(
     let ignore_protocol = ecu_data.config().ignore_protocol;
 
     let protocol_name: Option<&str> = match protocol {
-        Some(proto) => Some(proto.diag_layer().and_then(|dl| dl.short_name()).ok_or(
+        Some(proto) => Some(crate::datatypes::protocol_short_name(proto).ok_or(
             DiagServiceError::InvalidDatabase("Protocol has no short name".to_owned()),
         )?),
         None if ignore_protocol => None,
@@ -58,7 +63,8 @@ pub(super) fn lookup(
                     && (ignore_protocol
                         || cp_ref
                             .protocol()
-                            .and_then(|p| p.diag_layer().and_then(|dl| dl.short_name()))
+                            .as_ref()
+                            .and_then(|p| crate::datatypes::protocol_short_name(p))
                             .is_some_and(|sn| {
                                 protocol_name.is_some_and(|pn| sn.eq_ignore_ascii_case(pn))
                             }))
@@ -259,7 +265,7 @@ pub fn map_nack_number_of_retries<K: AsRef<str>>(
     (name, value): (K, &u32),
 ) -> Result<(u8, u32), DiagServiceError> {
     let name = name.as_ref();
-    let key_result = if let Some(hex_str) = name.strip_prefix("0x") {
+    let key_result = if let Some(hex_str) = try_strip_hex_prefix(name) {
         u8::from_str_radix(hex_str, 16)
     } else {
         name.parse::<u8>()

--- a/cda-database/src/datatypes/data_operation.rs
+++ b/cda-database/src/datatypes/data_operation.rs
@@ -12,7 +12,10 @@
  */
 
 //
-use cda_interfaces::{DiagServiceError, dlt_ctx, util::decode_hex};
+use cda_interfaces::{
+    DiagServiceError, dlt_ctx,
+    util::{decode_hex, try_strip_hex_prefix},
+};
 
 use crate::{
     datatypes::{self, DataType},
@@ -278,7 +281,7 @@ impl TryInto<Vec<u8>> for &Limit {
                         reason = "Expected behavior when converting from float to u8"
                     )]
                     Ok((float_value as u8).to_be_bytes().to_vec())
-                } else if let Some(stripped) = value.to_lowercase().strip_prefix("0x") {
+                } else if let Some(stripped) = try_strip_hex_prefix(value) {
                     decode_hex(stripped)
                 } else {
                     decode_hex(value)

--- a/cda-database/src/datatypes/mod.rs
+++ b/cda-database/src/datatypes/mod.rs
@@ -33,6 +33,12 @@ use crate::{
     mdd_data::{self, read_ecudata},
 };
 
+/// Short-name of a protocol layer, the key used for all protocol matching.
+#[must_use]
+pub fn protocol_short_name<'db>(p: &dataformat::Protocol<'db>) -> Option<&'db str> {
+    p.diag_layer().and_then(|dl| dl.short_name())
+}
+
 #[cfg(feature = "database-builder")]
 pub mod database_builder;
 
@@ -748,7 +754,7 @@ impl DiagnosticDatabase {
         let protocols = self.protocols()?;
         let seen: HashSet<&str> = protocols
             .iter()
-            .filter_map(|p| p.diag_layer().and_then(|dl| dl.short_name()))
+            .filter_map(|p| protocol_short_name(p))
             .collect();
         Ok(seen.len())
     }

--- a/cda-interfaces/src/can_id.rs
+++ b/cda-interfaces/src/can_id.rs
@@ -1,0 +1,181 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Validated CAN arbitration identifiers, shared by MDD extraction,
+//! duplicate grouping, request serialization and the CAN transport.
+//! Not feature-gated: CAN addressing is carried in every build, and
+//! feature-gated types in this crate break under feature unification.
+
+use std::fmt;
+
+/// A CAN arbitration identifier, validated on construction: 11-bit standard
+/// (`<= 0x7FF`) or 29-bit extended (`<= 0x1FFF_FFFF`, e.g. ISO 15765-4
+/// normal fixed addressing such as `0x18DA10F1`).
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum CanId {
+    /// 11-bit identifier, sent in the standard frame format.
+    Standard(u16),
+    /// 29-bit identifier, sent in the extended frame format.
+    Extended(u32),
+}
+
+/// Error for a value outside both the 11-bit and the 29-bit CAN ID range.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct InvalidCanId(pub u32);
+
+impl fmt::Display for InvalidCanId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CAN ID {:#X} out of range: must be an 11-bit standard (<= 0x7FF) or 29-bit extended \
+             (<= 0x1FFFFFFF) identifier",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for InvalidCanId {}
+
+impl CanId {
+    /// The raw identifier value.
+    #[must_use]
+    pub fn raw(self) -> u32 {
+        match self {
+            Self::Standard(id) => u32::from(id),
+            Self::Extended(id) => id,
+        }
+    }
+
+    /// Whether this is an 11-bit standard identifier.
+    #[must_use]
+    pub fn is_standard(self) -> bool {
+        matches!(self, Self::Standard(_))
+    }
+}
+
+impl TryFrom<u32> for CanId {
+    type Error = InvalidCanId;
+
+    fn try_from(id: u32) -> Result<Self, Self::Error> {
+        if id <= 0x7FF {
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "the range check makes the cast lossless"
+            )]
+            Ok(Self::Standard(id as u16))
+        } else if id <= 0x1FFF_FFFF {
+            Ok(Self::Extended(id))
+        } else {
+            Err(InvalidCanId(id))
+        }
+    }
+}
+
+impl fmt::Display for CanId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:#05X}", self.raw())
+    }
+}
+
+/// Physical CAN arbitration IDs of an ECU (request/response pair).
+///
+/// These always appear together: a CAN ECU is addressable only when both
+/// IDs are known. The pair is resolved from the MDD com-params or from an
+/// explicit `[[can.ecu_mappings]]` config entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CanIds {
+    /// Physical request CAN ID (tester -> ECU).
+    pub request: CanId,
+    /// Physical response CAN ID (ECU -> tester).
+    pub response: CanId,
+}
+
+impl CanIds {
+    /// Validates a raw request/response pair into a [`CanIds`].
+    ///
+    /// # Errors
+    /// Returns the first out-of-range value as [`InvalidCanId`].
+    pub fn try_from_raw(request: u32, response: u32) -> Result<Self, InvalidCanId> {
+        Ok(Self {
+            request: CanId::try_from(request)?,
+            response: CanId::try_from(response)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_from_dispatches_standard_and_extended() {
+        // 11-bit range -> standard frame format
+        assert!(matches!(CanId::try_from(0x000), Ok(CanId::Standard(_))));
+        assert!(matches!(CanId::try_from(0x7E0), Ok(CanId::Standard(_))));
+        assert!(matches!(CanId::try_from(0x7FF), Ok(CanId::Standard(_))));
+        // 29-bit range -> extended frame format (ISO 15765-4 normal fixed
+        // addressing lives here, e.g. 0x18DA10F1 physical / 0x18DB33F1
+        // functional)
+        assert!(matches!(CanId::try_from(0x800), Ok(CanId::Extended(_))));
+        assert!(matches!(
+            CanId::try_from(0x18DA_10F1),
+            Ok(CanId::Extended(_))
+        ));
+        assert!(matches!(
+            CanId::try_from(0x1FFF_FFFF),
+            Ok(CanId::Extended(_))
+        ));
+        // beyond 29 bits -> error
+        assert!(CanId::try_from(0x2000_0000).is_err());
+        assert!(CanId::try_from(u32::MAX).is_err());
+    }
+
+    #[test]
+    fn raw_round_trips_and_classification_matches() {
+        let standard = CanId::try_from(0x7E0).expect("valid standard ID");
+        assert_eq!(standard.raw(), 0x7E0);
+        assert!(standard.is_standard());
+
+        let extended = CanId::try_from(0x18DA_10F1).expect("valid extended ID");
+        assert_eq!(extended.raw(), 0x18DA_10F1);
+        assert!(!extended.is_standard());
+    }
+
+    #[test]
+    fn display_uses_the_log_convention() {
+        assert_eq!(
+            CanId::try_from(0x7E0).expect("valid ID").to_string(),
+            "0x7E0"
+        );
+        assert_eq!(CanId::try_from(0x1).expect("valid ID").to_string(), "0x001");
+        assert_eq!(
+            CanId::try_from(0x18DA_10F1).expect("valid ID").to_string(),
+            "0x18DA10F1"
+        );
+    }
+
+    #[test]
+    fn can_ids_pair_validates_both_sides() {
+        let ids = CanIds::try_from_raw(0x79B, 0x7BB).expect("valid pair");
+        assert_eq!(ids.request.raw(), 0x79B);
+        assert_eq!(ids.response.raw(), 0x7BB);
+        assert_eq!(
+            CanIds::try_from_raw(0x2000_0000, 0x7BB),
+            Err(InvalidCanId(0x2000_0000))
+        );
+        assert_eq!(
+            CanIds::try_from_raw(0x79B, u32::MAX),
+            Err(InvalidCanId(u32::MAX))
+        );
+    }
+}

--- a/cda-interfaces/src/com_param_handling.rs
+++ b/cda-interfaces/src/com_param_handling.rs
@@ -77,3 +77,16 @@ pub trait DoipComParams: Send + Sync + 'static {
     #[must_use]
     fn connection_retry_attempts(&self) -> u32;
 }
+
+/// Provider for CAN-specific communication parameters from MDD.
+pub trait CanComParamProvider: Send + Sync + 'static {
+    /// Physical request/response CAN ID pair for addressing this ECU.
+    /// `None` when the ECU has no CAN addressing (e.g. a pure `DoIP` ECU);
+    /// when `Some`, both IDs are present and range-validated.
+    #[must_use]
+    fn can_ids(&self) -> Option<crate::CanIds>;
+
+    /// Functional CAN ID for broadcast requests
+    #[must_use]
+    fn can_functional_id(&self) -> Option<crate::CanId>;
+}

--- a/cda-interfaces/src/datatypes/com_params.rs
+++ b/cda-interfaces/src/datatypes/com_params.rs
@@ -27,6 +27,7 @@ pub struct ComParams {
     pub uds: UdsComParams,
     /// DoIP-specific communication parameters.
     pub doip: DoipComParams,
+    pub can: CanComParams,
 }
 
 pub type ComParamName = String;
@@ -329,6 +330,27 @@ pub struct DoipComParams {
     pub connection_retry_attempts: ComParamConfig<u32>,
 }
 
+/// Defines the Communication parameters which are used in CAN bus communication
+#[derive(Deserialize, Serialize, Clone, Debug, schemars::JsonSchema)]
+pub struct CanComParams {
+    /// Physical request CAN ID (tester -> ECU)
+    pub physical_request_id: ComParamConfig<Option<u32>>,
+
+    /// Physical response CAN ID (ECU -> tester)
+    pub physical_response_id: ComParamConfig<Option<u32>>,
+
+    /// Functional CAN ID for broadcast requests
+    pub functional_id: ComParamConfig<Option<u32>>,
+
+    /// Name of the COMPLEX com-param table carrying the per-ECU CAN
+    /// addressing (ISO 22900/ODX `CP_UniqueRespIdTable`). Its sub-parameters
+    /// are matched against the `name`s of the ID parameters above and take
+    /// precedence over top-level scalar com-params of the same names.
+    /// OEM databases using a different table name configure it here (mirrors
+    /// `DoipComParams::logical_response_id_table_name`).
+    pub unique_resp_id_table_name: String,
+}
+
 /// Strategy for retrying after specific negative response codes.
 #[derive(Deserialize, Serialize, Clone, Debug, schemars::JsonSchema, PartialEq)]
 pub enum RetryPolicy {
@@ -586,6 +608,35 @@ impl Default for DoipComParams {
                 precedence: ComParamPrecedence::Database,
             },
         }
+    }
+}
+
+impl Default for CanComParams {
+    fn default() -> Self {
+        Self {
+            physical_request_id: ComParamConfig {
+                name: "CP_CanPhysReqId".to_owned(),
+                value: None,
+                precedence: ComParamPrecedence::Database,
+            },
+            physical_response_id: ComParamConfig {
+                name: "CP_CanRespUSDTId".to_owned(), // USDT = User Specific Diagnostic Test
+                value: None,
+                precedence: ComParamPrecedence::Database,
+            },
+            functional_id: ComParamConfig {
+                name: "CP_CanFuncReqId".to_owned(),
+                value: None,
+                precedence: ComParamPrecedence::Database,
+            },
+            unique_resp_id_table_name: "CP_UniqueRespIdTable".to_owned(),
+        }
+    }
+}
+
+impl DeserializableCompParam for Option<u32> {
+    fn parse_from_db(input: &str, _unit: Option<&Unit>) -> Result<Self, String> {
+        crate::util::parse_u32_maybe_hex(input).map(Some)
     }
 }
 

--- a/cda-interfaces/src/datatypes/database_naming_convention.rs
+++ b/cda-interfaces/src/datatypes/database_naming_convention.rs
@@ -74,6 +74,17 @@ pub struct DatabaseNamingConvention {
     // it will be validated in the validate sanity function
     #[serde(deserialize_with = "serde_ext::normalized_u8_key_map::deserialize")]
     pub service_affixes: HashMap<String, (DiagnosticServiceAffixPosition, Vec<String>)>,
+    /// Protocol short-names that identify diagnostics-over-CAN in the MDD,
+    /// matched case-insensitively. When the configured protocol name is one
+    /// of these but the database has no layer of exactly that name, protocol
+    /// resolution tries the other entries in order. OEM databases with
+    /// different protocol names configure their own list.
+    #[serde(default = "default_can_protocol_aliases")]
+    pub can_protocol_aliases: Vec<String>,
+    /// Case-insensitive substrings that mark a protocol short-name as
+    /// diagnostics-over-CAN during `"auto-can"` protocol detection.
+    #[serde(default = "default_can_protocol_markers")]
+    pub can_protocol_markers: Vec<String>,
     /// Affixes used to derive a service lookup name from a [`DiagCommAction`].
     ///
     /// These are applied when a [`crate::DiagComm`] has no explicit `lookup_name`
@@ -345,10 +356,29 @@ impl Default for DatabaseNamingConvention {
                     ),
                 ),
             ]),
+            can_protocol_aliases: [
+                "UDS_CAN",
+                "ISO_11898_2_DWCAN",
+                "ISO_11898_3_DWFTCAN",
+                "CAN",
+                "ISO_15765_2",
+                "ISO_15765_3",
+            ]
+            .map(str::to_owned)
+            .to_vec(),
+            can_protocol_markers: ["CAN", "ISO_11898"].map(str::to_owned).to_vec(),
             semantics: Semantics::default(),
             action_affixes: DiagCommActionAffixes::default(),
         }
     }
+}
+
+fn default_can_protocol_aliases() -> Vec<String> {
+    DatabaseNamingConvention::default().can_protocol_aliases
+}
+
+fn default_can_protocol_markers() -> Vec<String> {
+    DatabaseNamingConvention::default().can_protocol_markers
 }
 
 /// Position of a naming affix relative to the diagnostic service name.
@@ -428,6 +458,7 @@ mod tests {
             service_affixes: HashMap::default(),
             semantics: Semantics::default(),
             action_affixes: DiagCommActionAffixes::default(),
+            ..Default::default()
         }
     }
 
@@ -521,6 +552,7 @@ mod tests {
             service_affixes: HashMap::default(),
             action_affixes: DiagCommActionAffixes::default(),
             semantics: Semantics::default(),
+            ..Default::default()
         };
         assert_eq!(conv.trim_short_name_affixes("PRE_data"), "data");
         assert_eq!(conv.trim_long_name_affixes("Data POST"), "Data");

--- a/cda-interfaces/src/ecugateway.rs
+++ b/cda-interfaces/src/ecugateway.rs
@@ -126,4 +126,24 @@ pub trait EcuGateway: Clone + Send + Sync + 'static {
     ) -> impl Future<
         Output = Result<HashMap<String, Result<UdsResponse, DiagServiceError>>, DiagServiceError>,
     > + Send;
+
+    /// Stops the gateway, aborting its background tasks and releasing its
+    /// transport resources. Completes only after the owned tasks have
+    /// terminated, so callers (e.g. the runtime database reload, which reuses
+    /// the `DoIP` UDP socket) can rely on the transport being quiescent.
+    fn shutdown(&mut self) -> impl Future<Output = ()> + Send;
+
+    /// Network address of a specific ECU, looked up by name.
+    ///
+    /// Fallback for ECUs whose logical addresses are unresolved com-param
+    /// defaults (CAN-only databases all share the fallback `0x0000`, so the
+    /// address-based [`Self::get_gateway_network_address`] cannot identify
+    /// them). Transports whose addressing is genuinely logical-address-based
+    /// (`DoIP`) keep the default `None`.
+    fn get_ecu_network_address(
+        &self,
+        _ecu_name: &str,
+    ) -> impl Future<Output = Option<String>> + Send {
+        std::future::ready(None)
+    }
 }

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -450,6 +450,59 @@ pub trait EcuAddresses: Send + Sync + 'static {
     fn ecu_name(&self) -> String;
     #[must_use]
     fn logical_address_eq<T: EcuAddresses>(&self, other: &T) -> bool;
+
+    /// Stable key used to serialize requests that must not overlap on the same
+    /// transport target; see [`request_lock_key_for`] for the semantics.
+    ///
+    /// This default assumes the gateway/logical address pair is genuinely
+    /// resolved. Implementations that can carry unresolved fallback addresses
+    /// (all ECUs of a CAN-only database share the com-param default) must
+    /// override it with [`request_lock_key_for`], their resolved-ness flag
+    /// and their CAN IDs, otherwise unrelated ECUs end up serialized behind
+    /// one semaphore.
+    #[must_use]
+    fn request_lock_key(&self) -> String {
+        request_lock_key_for(
+            true,
+            self.logical_gateway_address(),
+            self.logical_address(),
+            None,
+            "",
+        )
+    }
+}
+
+/// Builds the key under which requests to the same transport target are
+/// serialized (the per-ECU request semaphore).
+///
+/// A transport target is shared by every candidate description of the same
+/// physical node (a duplicate group), and concurrent requests to one node
+/// must never overlap - on CAN they would even corrupt each other's
+/// segmented transfers via doubled flow control. In priority order:
+///
+/// 1. Resolved `DoIP` gateway/logical address pair - the established key;
+///    duplicate-group ECUs share their pair on purpose.
+/// 2. The CAN arbitration ID pair from the MDD com-params - the target
+///    identity for ECUs without `DoIP` addressing (CAN-only databases);
+///    candidate models sharing one pair share the key.
+/// 3. The unique ECU name - when nothing identifies the target, the shared
+///    com-param fallback addresses must NOT collapse unrelated ECUs onto one
+///    semaphore.
+#[must_use]
+pub fn request_lock_key_for(
+    addresses_resolved: bool,
+    logical_gateway_address: u16,
+    logical_address: u16,
+    can_ids: Option<crate::CanIds>,
+    ecu_name: &str,
+) -> String {
+    if addresses_resolved {
+        format!("logical:0x{logical_gateway_address:04X}@0x{logical_address:04X}")
+    } else if let Some(ids) = can_ids {
+        format!("can:{:#X}@{:#X}", ids.request.raw(), ids.response.raw())
+    } else {
+        format!("ecu:{}", ecu_name.to_lowercase())
+    }
 }
 
 /// Encodes UDS request payloads from structured data.
@@ -1102,5 +1155,98 @@ mod tests {
         // Response: positive with wrong DID
         let response = make_payload(vec![0x6E, 0xF2, 0x00]);
         assert!(!response.has_matching_echo_bytes(&request));
+    }
+
+    // request_lock_key_for: the per-ECU request-serialization key
+
+    #[test]
+    fn resolved_addresses_share_the_key_per_target() {
+        // Duplicate-group ECUs share their resolved address pair on purpose:
+        // both names map onto the same key, serializing requests to the
+        // shared physical node.
+        let a = request_lock_key_for(true, 0x1000, 0x0712, None, "R0_13_453");
+        let b = request_lock_key_for(true, 0x1000, 0x0712, None, "R_MID453");
+        assert_eq!(a, b);
+        assert_eq!(a, "logical:0x1000@0x0712");
+        // Distinct resolved addresses keep distinct keys.
+        assert_ne!(a, request_lock_key_for(true, 0x1000, 0x0713, None, "OTHER"));
+        // Resolved DoIP addressing outranks CAN IDs: the established key
+        // stays stable when an MDD carries both.
+        assert_eq!(
+            request_lock_key_for(
+                true,
+                0x1000,
+                0x0712,
+                Some(crate::CanIds::try_from_raw(0x712, 0x732).expect("valid pair")),
+                "R0_13_453"
+            ),
+            a
+        );
+    }
+
+    #[test]
+    fn can_ids_share_the_key_per_node() {
+        // CAN-only duplicate group: R0_13_453 and R_MID453 both derive
+        // 0x712/0x732 from their MDDs - one physical radio, two candidate
+        // descriptions. They must share the key so their requests serialize.
+        let a = request_lock_key_for(
+            false,
+            0,
+            0,
+            Some(crate::CanIds::try_from_raw(0x712, 0x732).expect("valid pair")),
+            "R0_13_453",
+        );
+        let b = request_lock_key_for(
+            false,
+            0,
+            0,
+            Some(crate::CanIds::try_from_raw(0x712, 0x732).expect("valid pair")),
+            "R_MID453",
+        );
+        assert_eq!(a, b);
+        assert_eq!(a, "can:0x712@0x732");
+        // Distinct nodes keep distinct keys.
+        assert_ne!(
+            a,
+            request_lock_key_for(
+                false,
+                0,
+                0,
+                Some(crate::CanIds::try_from_raw(0x79B, 0x7BB).expect("valid pair")),
+                "BMS453"
+            )
+        );
+    }
+
+    #[test]
+    fn unresolved_addresses_without_can_ids_key_by_name() {
+        // Neither resolved DoIP addressing nor CAN IDs: the shared com-param
+        // fallback addresses must not collapse unrelated ECUs onto one
+        // semaphore, so the unique name is the key.
+        let a = request_lock_key_for(false, 0, 0, None, "BMS453");
+        let b = request_lock_key_for(false, 0, 0, None, "BIC453");
+        assert_ne!(a, b);
+        assert_eq!(a, "ecu:bms453");
+        // Case-insensitive: the ECU map is lowercase-keyed, config casing may
+        // differ.
+        assert_eq!(
+            request_lock_key_for(false, 0, 0, None, "Bms453"),
+            request_lock_key_for(false, 0, 0, None, "BMS453")
+        );
+        // The three key namespaces can never collide.
+        assert_ne!(
+            request_lock_key_for(false, 0x1000, 0x0712, None, "ecu1"),
+            request_lock_key_for(true, 0x1000, 0x0712, None, "ecu1")
+        );
+        assert_ne!(
+            request_lock_key_for(
+                false,
+                0,
+                0,
+                Some(crate::CanIds::try_from_raw(0x1000, 0x0712).expect("valid pair")),
+                "ecu1"
+            ),
+            request_lock_key_for(true, 0x1000, 0x0712, None, "ecu1")
+        );
     }
 }

--- a/cda-interfaces/src/lib.rs
+++ b/cda-interfaces/src/lib.rs
@@ -19,6 +19,8 @@ use std::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+mod can_id;
+pub use can_id::*;
 mod com_param_handling;
 pub use com_param_handling::*;
 pub mod datatypes;
@@ -117,7 +119,7 @@ impl From<DiagCommType> for DiagCommAction {
 pub enum DiagCommType {
     /// Service Prefix `0x2E`
     Configurations,
-    /// Service Prefix `0x22`
+    /// Service Prefixes `0x21` (KWP2000), `0x22` (UDS)
     Data,
     /// Service Prefixes `0x14`, `0x19`
     Faults,
@@ -133,7 +135,9 @@ impl TryFrom<u8> for DiagCommType {
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             service_ids::WRITE_DATA_BY_IDENTIFIER => Ok(DiagCommType::Configurations),
-            service_ids::READ_DATA_BY_IDENTIFIER => Ok(DiagCommType::Data),
+            service_ids::READ_DATA_BY_LOCAL_IDENTIFIER | service_ids::READ_DATA_BY_IDENTIFIER => {
+                Ok(DiagCommType::Data)
+            }
             service_ids::CLEAR_DIAGNOSTIC_INFORMATION | service_ids::READ_DTC_INFORMATION => {
                 Ok(DiagCommType::Faults)
             }
@@ -195,6 +199,9 @@ pub mod service_ids {
     pub const ECU_RESET: u8 = 0x11;
     pub const CLEAR_DIAGNOSTIC_INFORMATION: u8 = 0x14;
     pub const READ_DTC_INFORMATION: u8 = 0x19;
+    /// KWP2000 `ReadDataByLocalIdentifier` (legacy, used by some older ECUs
+    /// that are not fully UDS-compliant)
+    pub const READ_DATA_BY_LOCAL_IDENTIFIER: u8 = 0x21;
     pub const READ_DATA_BY_IDENTIFIER: u8 = 0x22;
     pub const SECURITY_ACCESS: u8 = 0x27;
     pub const COMMUNICATION_CONTROL: u8 = 0x28;
@@ -223,7 +230,10 @@ pub const DEFAULT_SUBFUNCTION_MASK: u8 = 0x7F;
 
 const CONFIGURATIONS_PREFIXES: [u8; 1] = [service_ids::WRITE_DATA_BY_IDENTIFIER];
 
-const DATA_PREFIXES: [u8; 1] = [service_ids::READ_DATA_BY_IDENTIFIER];
+const DATA_PREFIXES: [u8; 2] = [
+    service_ids::READ_DATA_BY_LOCAL_IDENTIFIER,
+    service_ids::READ_DATA_BY_IDENTIFIER,
+];
 
 const FAULTS_PREFIXES: [u8; 2] = [
     service_ids::CLEAR_DIAGNOSTIC_INFORMATION,

--- a/cda-interfaces/src/util.rs
+++ b/cda-interfaces/src/util.rs
@@ -448,9 +448,95 @@ pub fn try_extract_sid_from_payload(payload: &[u8]) -> Result<u8, DiagServiceErr
     Ok(sid)
 }
 
+/// Parse a `u32` given either as decimal (`2015`) or `0x`-prefixed hex
+/// (`0x7DF`), as CAN IDs appear in MDD com-params and config files.
+/// # Errors
+/// Returns the integer parse error message when `input` is neither.
+pub fn parse_u32_maybe_hex(input: &str) -> Result<u32, String> {
+    if let Some(hex_str) = input
+        .strip_prefix("0x")
+        .or_else(|| input.strip_prefix("0X"))
+    {
+        u32::from_str_radix(hex_str, 16).map_err(|e| format!("{e:?}"))
+    } else {
+        input.parse::<u32>().map_err(|e| format!("{e:?}"))
+    }
+}
+
+/// Normalize a display-hex value for comparison: per whitespace-separated
+/// token, strip a `0x`/`0X` prefix and uppercase, then concatenate.
+/// Example: `"0x04 0x80"` and `"0480"` both normalize to `"0480"`.
+#[must_use]
+pub fn normalize_hex(value: &str) -> String {
+    value
+        .split_whitespace()
+        .map(|token| {
+            token
+                .trim_start_matches("0x")
+                .trim_start_matches("0X")
+                .to_ascii_uppercase()
+        })
+        .collect()
+}
+
+/// Compare a byte-field parameter against a variant pattern's expected value.
+///
+/// A decoded `ByteField` serializes as space-separated `0x`-prefixed bytes
+/// (e.g. `"0x04 0x80"`), while variant patterns in real-world MDDs carry the
+/// expected coded value as a bare hex string (e.g. `"0480"`). Those can never
+/// be equal verbatim, so byte-field values get compared on normalized hex.
+///
+/// The normalization applies only when the received value is exactly the
+/// byte-field serialization: ASCII values (which may legitimately contain
+/// `0x` or differ only in case) keep the strict comparison of the caller.
+#[must_use]
+pub fn byte_field_matches_hex_pattern(received: &str, expected: &str) -> bool {
+    fn is_byte_field_repr(value: &str) -> bool {
+        !value.is_empty()
+            && value.split(' ').all(|token| {
+                token.len() == 4
+                    && token
+                        .strip_prefix("0x")
+                        .or_else(|| token.strip_prefix("0X"))
+                        .is_some_and(|hex| hex.chars().all(|c| c.is_ascii_hexdigit()))
+            })
+    }
+
+    is_byte_field_repr(received) && normalize_hex(received) == normalize_hex(expected)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn byte_field_matches_bare_hex_pattern() {
+        // Single byte, as serialized by DiagDataValue::ByteField.
+        assert!(byte_field_matches_hex_pattern("0x04", "04"));
+        // Multi byte against a contiguous hex pattern.
+        assert!(byte_field_matches_hex_pattern("0x04 0x80", "0480"));
+        // Hex digit case differences must not matter.
+        assert!(byte_field_matches_hex_pattern("0xAB 0xCD", "abcd"));
+        // Patterns written with prefixes/spaces normalize the same way.
+        assert!(byte_field_matches_hex_pattern("0x04 0x80", "0x04 0x80"));
+    }
+
+    #[test]
+    fn non_byte_field_values_never_match_via_normalization() {
+        // ASCII values keep the strict comparison - no hex reinterpretation.
+        assert!(!byte_field_matches_hex_pattern("DA1", "da1"));
+        // A value merely containing 0x is not a byte-field serialization.
+        assert!(!byte_field_matches_hex_pattern("v0x10", "v10"));
+        // Tokens must be exactly 0x + two hex digits.
+        assert!(!byte_field_matches_hex_pattern("0x123", "123"));
+        assert!(!byte_field_matches_hex_pattern("", ""));
+    }
+
+    #[test]
+    fn byte_field_mismatch_stays_a_mismatch() {
+        assert!(!byte_field_matches_hex_pattern("0x04 0x80", "0470"));
+        assert!(!byte_field_matches_hex_pattern("0x04", "0400"));
+    }
     #[test]
     fn test_extract_bits_standard_length_cases() {
         let result = extract_bits(4, 5, &[0b_1100_0011, 0b_1010_1000]).unwrap();

--- a/cda-interfaces/src/util.rs
+++ b/cda-interfaces/src/util.rs
@@ -158,8 +158,9 @@ pub mod serde_ext {
         }
 
         fn normalize_key(s: &str) -> Result<String, String> {
+            use crate::util::try_strip_hex_prefix;
             let s = s.trim();
-            if let Some(hex) = s.to_lowercase().strip_prefix("0x") {
+            if let Some(hex) = try_strip_hex_prefix(s) {
                 u8::from_str_radix(hex, 16)
             } else {
                 s.parse::<u8>()
@@ -448,15 +449,46 @@ pub fn try_extract_sid_from_payload(payload: &[u8]) -> Result<u8, DiagServiceErr
     Ok(sid)
 }
 
+/// Whether `response` belongs to a request with SID `request_sid`: its
+/// positive response (SID with the response bit set) or a negative
+/// response (`7F <SID> <NRC>`). Used to tell the answer apart from
+/// unrelated traffic on a shared channel.
+#[must_use]
+pub fn uds_response_matches_request_sid(request_sid: u8, response: &[u8]) -> bool {
+    if response.first() == Some(&crate::service_ids::NEGATIVE_RESPONSE) {
+        response.get(1) == Some(&request_sid)
+    } else {
+        response.first() == Some(&(request_sid | crate::UDS_ID_RESPONSE_BITMASK))
+    }
+}
+
+/// Strip a single `0x` or `0X` prefix from `s`, returning the remainder.
+/// Returns the original slice when no hex prefix is present.
+#[must_use]
+pub fn strip_hex_prefix(s: &str) -> &str {
+    s.strip_prefix("0x")
+        .or_else(|| s.strip_prefix("0X"))
+        .unwrap_or(s)
+}
+
+/// Strip a single `0x` or `0X` prefix from `s`, returning `Some(remainder)`
+/// when present, or `None` when no prefix is found.
+#[must_use]
+pub fn try_strip_hex_prefix(s: &str) -> Option<&str> {
+    let rest = strip_hex_prefix(s);
+    if rest.len() == s.len() {
+        None
+    } else {
+        Some(rest)
+    }
+}
+
 /// Parse a `u32` given either as decimal (`2015`) or `0x`-prefixed hex
 /// (`0x7DF`), as CAN IDs appear in MDD com-params and config files.
 /// # Errors
 /// Returns the integer parse error message when `input` is neither.
 pub fn parse_u32_maybe_hex(input: &str) -> Result<u32, String> {
-    if let Some(hex_str) = input
-        .strip_prefix("0x")
-        .or_else(|| input.strip_prefix("0X"))
-    {
+    if let Some(hex_str) = try_strip_hex_prefix(input) {
         u32::from_str_radix(hex_str, 16).map_err(|e| format!("{e:?}"))
     } else {
         input.parse::<u32>().map_err(|e| format!("{e:?}"))
@@ -470,12 +502,7 @@ pub fn parse_u32_maybe_hex(input: &str) -> Result<u32, String> {
 pub fn normalize_hex(value: &str) -> String {
     value
         .split_whitespace()
-        .map(|token| {
-            token
-                .trim_start_matches("0x")
-                .trim_start_matches("0X")
-                .to_ascii_uppercase()
-        })
+        .map(|token| strip_hex_prefix(token).to_ascii_uppercase())
         .collect()
 }
 
@@ -495,9 +522,7 @@ pub fn byte_field_matches_hex_pattern(received: &str, expected: &str) -> bool {
         !value.is_empty()
             && value.split(' ').all(|token| {
                 token.len() == 4
-                    && token
-                        .strip_prefix("0x")
-                        .or_else(|| token.strip_prefix("0X"))
+                    && try_strip_hex_prefix(token)
                         .is_some_and(|hex| hex.chars().all(|c| c.is_ascii_hexdigit()))
             })
     }
@@ -508,6 +533,23 @@ pub fn byte_field_matches_hex_pattern(received: &str, expected: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn uds_response_matching_accepts_only_echoes_of_the_request() {
+        // Positive response: request SID with the response bit set.
+        assert!(uds_response_matches_request_sid(0x22, &[0x62, 0xF1, 0x90]));
+        // Negative response echoing the request SID.
+        assert!(uds_response_matches_request_sid(0x22, &[0x7F, 0x22, 0x31]));
+        // Unrelated positive response (different SID).
+        assert!(!uds_response_matches_request_sid(0x22, &[0x50, 0x03]));
+        // Unrelated negative response: an ECU NRC-ing the broadcast
+        // keep-alive (7F 3E 12) lands on the response ID mid-exchange and
+        // must not be taken as the answer to a 0x22 request.
+        assert!(!uds_response_matches_request_sid(0x22, &[0x7F, 0x3E, 0x12]));
+        // Degenerate frames.
+        assert!(!uds_response_matches_request_sid(0x22, &[]));
+        assert!(!uds_response_matches_request_sid(0x22, &[0x7F]));
+    }
 
     #[test]
     fn byte_field_matches_bare_hex_pattern() {

--- a/cda-main/Cargo.toml
+++ b/cda-main/Cargo.toml
@@ -31,6 +31,7 @@ path = "src/lib.rs"
 
 [dependencies]
 cda-core = { workspace = true }
+cda-comm-can = { workspace = true }
 cda-comm-doip = { workspace = true }
 cda-comm-uds = { workspace = true }
 cda-database = { workspace = true }
@@ -85,8 +86,18 @@ chrono = { workspace = true }
 default = ["health", "openssl", "config-optional"]
 tokio-tracing = ["cda-interfaces/tokio-tracing", "cda-tracing/tokio-tracing"]
 openssl = ["cda-comm-doip/openssl"]
-openssl-vendored = ["openssl", "cda-comm-doip/openssl-vendored"]
+openssl-vendored = [
+  "openssl",
+  "cda-comm-doip/openssl-vendored",
+]
 mbedtls = ["cda-comm-doip/mbedtls"]
+can = ["cda-comm-can/can"]
+# Userspace ISO-TP over raw CAN (`rawcan:<ifname>` interface scheme):
+# vcan suffices, no can_isotp kernel module needed.
+can-isotp-userspace = ["can", "cda-comm-can/can-isotp-userspace"]
+# CAN frames over a socketcand daemon (`socketcand:<host>:<port>:<bus>`
+# interface scheme): the client needs no kernel CAN; also available off-Linux.
+can-socketcand = ["can-isotp-userspace", "cda-comm-can/can-socketcand"]
 dlt-tracing = ["cda-tracing/dlt-tracing"]
 integration-tests = []
 

--- a/cda-main/src/config/configfile.rs
+++ b/cda-main/src/config/configfile.rs
@@ -11,6 +11,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// `CanConfig` is always available: the `config` module of cda-comm-can is not
+// gated on the `can` feature, only the SocketCAN transport code is. This keeps
+// the configuration schema (and all public function signatures that mention
+// `CanConfig`) identical across feature combinations, which matters because
+// cargo feature unification can otherwise produce mismatched signatures
+// between crates (e.g. integration-tests vs. opensovd_cda_lib under
+// `--all-features`). A `[can]` section in a non-`can` build is rejected with
+// an actionable error in `Configuration::validate_sanity` instead.
+pub use cda_comm_can::{
+    TransportType,
+    config::{CanConfig, CanEcuMapping, TransportOverride},
+};
 pub use cda_comm_doip::config::DoipConfig;
 pub use cda_database::DatabaseConfig;
 use cda_interfaces::{
@@ -62,6 +74,10 @@ pub struct Configuration {
     pub server: ServerConfig,
     /// `DoIP` (Diagnostics over IP) transport layer settings.
     pub doip: DoipConfig,
+    /// Optional CAN bus transport configuration.
+    /// When enabled, the adapter can communicate with ECUs over CAN bus.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub can: Option<CanConfig>,
     /// Diagnostic database loading and naming settings.
     pub database: DatabaseConfig,
     /// Logging, file output, and tracing backend settings.
@@ -136,6 +152,7 @@ impl Default for Configuration {
                 tester_address: "10.2.1.240".to_owned(),
                 ..Default::default()
             },
+            can: None,
             logging: cda_tracing::LoggingConfig::default(),
             com_params: ComParams::default(),
             flat_buf: FlatbBufConfig::default(),
@@ -172,10 +189,116 @@ impl Default for Configuration {
     }
 }
 
+impl Configuration {
+    /// A CDA without any transport cannot talk to a single ECU; refuse to
+    /// start instead of serving a healthy-looking API that can do nothing.
+    fn validate_transport_presence(&self) -> Result<(), ConfigSanityError> {
+        // CAN support is compile-time optional. The config type itself parses
+        // in every build (see the `CanConfig` re-export above), so reject a
+        // configured [can] section here with an actionable message instead of
+        // failing later during gateway setup.
+        #[cfg(not(feature = "can"))]
+        if self.can.is_some() {
+            return Err(ConfigSanityError::InvalidValue {
+                field: "can".to_owned(),
+                reason: "[can] is configured, but this binary was built without CAN support. \
+                         Rebuild with `--features can` or remove the [can] section."
+                    .to_owned(),
+            });
+        }
+
+        if !self.doip.enabled && self.can.is_none() {
+            return Err(ConfigSanityError::InvalidValue {
+                field: "doip.enabled".to_owned(),
+                reason: "No transport configured: doip.enabled = false and no [can] section. \
+                         Enable DoIP or configure CAN."
+                    .to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    /// CAN ECU mappings must be unambiguous: a duplicate ECU name silently
+    /// loses one mapping, two ECUs sharing an arbitration-ID pair open two
+    /// ISO-TP sockets on identical IDs (cross-talk with undefined delivery),
+    /// and `request_id == response_id` makes an ECU answer itself. All three
+    /// are config footguns that are expensive to debug from the bus side.
+    fn validate_can_mappings(&self) -> Result<(), ConfigSanityError> {
+        let Some(ref can) = self.can else {
+            return Ok(());
+        };
+
+        let mut names = cda_interfaces::HashSet::default();
+        let mut id_pairs = cda_interfaces::HashSet::default();
+        for mapping in &can.ecu_mappings {
+            if mapping.request_id == mapping.response_id {
+                return Err(ConfigSanityError::InvalidValue {
+                    field: "can.ecu_mappings".to_owned(),
+                    reason: format!(
+                        "ECU '{}' uses the same CAN ID {:#X} as request_id and response_id",
+                        mapping.ecu_name, mapping.request_id
+                    ),
+                });
+            }
+            if !names.insert(mapping.ecu_name.to_lowercase()) {
+                return Err(ConfigSanityError::InvalidValue {
+                    field: "can.ecu_mappings".to_owned(),
+                    reason: format!(
+                        "Duplicate mapping for ECU '{}' (names are matched case-insensitively)",
+                        mapping.ecu_name
+                    ),
+                });
+            }
+            if !id_pairs.insert((mapping.request_id, mapping.response_id)) {
+                return Err(ConfigSanityError::InvalidValue {
+                    field: "can.ecu_mappings".to_owned(),
+                    reason: format!(
+                        "ECU '{}' reuses the CAN ID pair {:#X}/{:#X} of another mapping",
+                        mapping.ecu_name, mapping.request_id, mapping.response_id
+                    ),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Transport pins must be satisfiable: a pin to a transport that cannot
+    /// serve the ECU would only surface as `EcuOffline` at runtime.
+    fn validate_transport_overrides(&self) -> Result<(), ConfigSanityError> {
+        let Some(ref can) = self.can else {
+            return Ok(());
+        };
+        for transport_override in &can.transport_overrides {
+            match transport_override.transport {
+                // A pin to CAN is validated at gateway setup, not here: the
+                // ECU may get its CAN addressing from the MDD com-params,
+                // which the config layer cannot see.
+                cda_comm_can::TransportType::Can => {}
+                cda_comm_can::TransportType::DoIP => {
+                    if !self.doip.enabled {
+                        return Err(ConfigSanityError::InvalidValue {
+                            field: "can.transport_overrides".to_owned(),
+                            reason: format!(
+                                "Pins ECU '{}' to DoIP, but doip.enabled = false",
+                                transport_override.ecu_name
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
 impl ConfigSanity for Configuration {
     fn validate_sanity(&self) -> Result<(), ConfigSanityError> {
         self.database.naming_convention.validate_sanity()?;
         self.doip.validate_sanity()?;
+        self.validate_transport_presence()?;
+        self.validate_can_mappings()?;
+        self.validate_transport_overrides()?;
+
         // Add more checks for Configuration fields here if needed
         Ok(())
     }
@@ -283,6 +406,134 @@ description_database = "teapot"
                 DiagnosticServiceAffixPosition::Prefix,
                 vec!["Control_".to_string()]
             ))
+        );
+        Ok(())
+    }
+
+    /// A `[can]` section must parse in every build (the config type is not
+    /// feature-gated), but `validate_sanity` must reject it when the binary
+    /// was built without CAN support.
+    #[tokio::test]
+    async fn can_section_parses_and_sanity_depends_on_feature()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let config_str = r#"
+[can]
+interface = "vcan0"
+"#;
+        let figment = Figment::from(Serialized::defaults(Configuration::default()))
+            .merge(Toml::string(config_str));
+        let config: Configuration = figment.extract()?;
+        let can = config.can.as_ref().expect("can section should be parsed");
+        assert_eq!(can.interface, "vcan0");
+
+        #[cfg(feature = "can")]
+        config
+            .validate_sanity()
+            .expect("can section should pass sanity with can feature");
+        #[cfg(not(feature = "can"))]
+        {
+            let err = config
+                .validate_sanity()
+                .expect_err("can section should fail sanity without can feature");
+            assert!(
+                err.to_string().contains("--features can"),
+                "error should tell the user how to enable CAN support, got: {err}"
+            );
+        }
+        Ok(())
+    }
+
+    /// Ambiguous `[[can.ecu_mappings]]` configurations must be rejected:
+    /// duplicate ECU names, reused arbitration-ID pairs, and
+    /// `request_id == response_id` all lead to silent misbehavior on the bus.
+    #[cfg(feature = "can")]
+    #[tokio::test]
+    async fn can_ecu_mappings_sanity_rejects_ambiguity() -> Result<(), Box<dyn std::error::Error>> {
+        async fn config_with_mappings(
+            mappings: &str,
+        ) -> Result<Configuration, Box<dyn std::error::Error>> {
+            let config_str = format!(
+                r#"
+[can]
+interface = "vcan0"
+{mappings}"#
+            );
+            let figment = Figment::from(Serialized::defaults(Configuration::default()))
+                .merge(Toml::string(&config_str));
+            Ok(figment.extract()?)
+        }
+
+        let valid = config_with_mappings(
+            r#"
+[[can.ecu_mappings]]
+ecu_name = "ECU1"
+request_id = 0x7E0
+response_id = 0x7E8
+
+[[can.ecu_mappings]]
+ecu_name = "ECU2"
+request_id = 0x7E1
+response_id = 0x7E9
+"#,
+        )
+        .await?;
+        valid
+            .validate_sanity()
+            .expect("distinct mappings should pass sanity");
+
+        let duplicate_name = config_with_mappings(
+            r#"
+[[can.ecu_mappings]]
+ecu_name = "ECU1"
+request_id = 0x7E0
+response_id = 0x7E8
+
+[[can.ecu_mappings]]
+ecu_name = "ecu1"
+request_id = 0x7E1
+response_id = 0x7E9
+"#,
+        )
+        .await?;
+        let err = duplicate_name
+            .validate_sanity()
+            .expect_err("case-insensitive duplicate ECU name should fail sanity");
+        assert!(err.to_string().contains("Duplicate mapping"), "got: {err}");
+
+        let duplicate_pair = config_with_mappings(
+            r#"
+[[can.ecu_mappings]]
+ecu_name = "ECU1"
+request_id = 0x7E0
+response_id = 0x7E8
+
+[[can.ecu_mappings]]
+ecu_name = "ECU2"
+request_id = 0x7E0
+response_id = 0x7E8
+"#,
+        )
+        .await?;
+        let err = duplicate_pair
+            .validate_sanity()
+            .expect_err("reused CAN ID pair should fail sanity");
+        assert!(err.to_string().contains("CAN ID pair"), "got: {err}");
+
+        let self_answering = config_with_mappings(
+            r#"
+[[can.ecu_mappings]]
+ecu_name = "ECU1"
+request_id = 0x7E0
+response_id = 0x7E0
+"#,
+        )
+        .await?;
+        let err = self_answering
+            .validate_sanity()
+            .expect_err("request_id == response_id should fail sanity");
+        assert!(
+            err.to_string().contains("request_id and response_id"),
+            "got: {err}"
         );
         Ok(())
     }

--- a/cda-main/src/config/generate.rs
+++ b/cda-main/src/config/generate.rs
@@ -11,7 +11,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::{collections::BTreeMap, fmt::Write};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Write,
+};
 
 use cda_interfaces::{FunctionalDescriptionConfig, datatypes::FaultConfig};
 
@@ -62,9 +65,50 @@ precedence = "Config"
 [doip.routing_activation_timeout.value]
 secs = 42
 nanos = 0
+
+[can.physical_request_id]
+name = "CP_CanPhysReqId"
+precedence = "Config"
+value = 2014
+
+[can.physical_response_id]
+name = "CP_CanRespUSDTId"
+precedence = "Config"
+value = 2024
+
+[can.functional_id]
+name = "CP_CanFuncReqId"
+precedence = "Config"
+value = 2015
 "#,
     )
     .expect("valid partial com_params TOML");
+
+    // Top-level CAN bus transport configuration. Populated with example
+    // values so the optional `can` field appears in the generated
+    // reference config (and `reference_config_covers_all_schema_fields`
+    // stays green as new CAN fields are added to the schema).
+    // `CanConfig` is compiled regardless of the `can` feature, so this is
+    // not feature-gated: the generated reference config (and the guard
+    // tests below) are identical in every build.
+    //
+    // We deliberately leave `ecu_mappings` empty: that field is a
+    // `Vec<CanEcuMapping>` with non-optional fields, and the generated
+    // reference config comments out all values, so a non-empty list
+    // would emit commented-out required fields that the TOML parser
+    // then sees as missing (failing `generate_reference_config_parses_as_valid_config`).
+    config.can = Some(cda_comm_can::config::CanConfig {
+        interface: "vcan0".to_owned(),
+        ..Default::default()
+    });
+
+    // Set the global `com_params.can.*.value` to `Some(...)` so the
+    // generated reference config emits those leaves (otherwise the
+    // `reference_config_covers_all_schema_fields` test would flag
+    // `com_params.can.functional_id.value` etc. as missing).
+    config.com_params.can.functional_id.value = Some(0x7DF);
+    config.com_params.can.physical_request_id.value = Some(0x7E0);
+    config.com_params.can.physical_response_id.value = Some(0x7E8);
 
     config.ecu.insert(
         "FLXC1000".to_owned(),
@@ -135,11 +179,51 @@ pub fn generate_reference_config() -> Result<String, GenerateConfigError> {
     let formatted_toml = format_selected_hex_literals(&default_toml);
 
     let desc_map = build_description_map(&schema_json);
+    // Section paths that exist in the *default* configuration. Sections the
+    // reference instance adds on top (optional sections like `[can]`, or
+    // example entries like `[ecu.FLXC1000]`) get their headers commented out:
+    // a bare header of a typed optional section would otherwise deserialize
+    // as `Some(<empty table>)` and fail on missing required fields when a
+    // user loads the reference file verbatim.
+    let default_sections = {
+        let default_value = toml::Value::try_from(crate::config::default_config())
+            .map_err(GenerateConfigError::TomlValue)?;
+        let mut sections = BTreeSet::new();
+        collect_table_paths(&default_value, "", &mut sections);
+        sections
+    };
 
     Ok(format!(
         "{SPDX_HEADER}{}",
-        process_toml(&formatted_toml, &desc_map)
+        process_toml(&formatted_toml, &desc_map, &default_sections)
     ))
+}
+
+/// Collect the dotted paths of all tables (and tables inside arrays) in a
+/// TOML value, i.e. every path that may appear as a `[section]` /
+/// `[[section]]` header.
+fn collect_table_paths(value: &toml::Value, path: &str, sections: &mut BTreeSet<String>) {
+    match value {
+        toml::Value::Table(table) => {
+            if !path.is_empty() {
+                sections.insert(path.to_owned());
+            }
+            for (key, child) in table {
+                let child_path = if path.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{path}.{key}")
+                };
+                collect_table_paths(child, &child_path, sections);
+            }
+        }
+        toml::Value::Array(items) => {
+            for item in items {
+                collect_table_paths(item, path, sections);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Recursively sort all tables in a TOML value by key to ensure deterministic output.
@@ -382,12 +466,23 @@ fn is_toml_section_header(trimmed: &str) -> bool {
     }
 }
 
-/// Post-process the raw TOML string: comment out value lines, inject descriptions.
-fn process_toml(raw_toml: &str, desc_map: &BTreeMap<String, String>) -> String {
+/// Post-process the raw TOML string: comment out value lines (and section
+/// headers that do not exist in the default configuration), inject
+/// descriptions.
+fn process_toml(
+    raw_toml: &str,
+    desc_map: &BTreeMap<String, String>,
+    default_sections: &BTreeSet<String>,
+) -> String {
     raw_toml
         .lines()
         .scan(Vec::<String>::new(), |section_stack, line| {
-            Some(format_toml_line(line, section_stack, desc_map))
+            Some(format_toml_line(
+                line,
+                section_stack,
+                desc_map,
+                default_sections,
+            ))
         })
         .collect()
 }
@@ -396,6 +491,7 @@ fn format_toml_line(
     line: &str,
     section_stack: &mut Vec<String>,
     desc_map: &BTreeMap<String, String>,
+    default_sections: &BTreeSet<String>,
 ) -> String {
     let trimmed = line.trim();
 
@@ -406,6 +502,16 @@ fn format_toml_line(
     if is_toml_section_header(trimmed) {
         let section_name = trimmed.trim_start_matches('[').trim_end_matches(']');
         *section_stack = section_name.split('.').map(String::from).collect();
+
+        // Headers of sections absent from the default configuration are
+        // commented out like the values: an uncommented header of a typed
+        // optional section (e.g. `[can]`) would deserialize as an empty
+        // table and fail on missing required fields.
+        let header_line = if default_sections.contains(section_name) {
+            line.to_owned()
+        } else {
+            format!("# {}", line.trim_start())
+        };
 
         return desc_map
             .get(section_name)
@@ -418,7 +524,7 @@ fn format_toml_line(
                     format!("# {l}")
                 }
             })
-            .chain(std::iter::once(line.to_owned()))
+            .chain(std::iter::once(header_line))
             .fold(String::new(), |mut acc, l| {
                 let _ = writeln!(acc, "{l}");
                 acc
@@ -532,6 +638,11 @@ mod tests {
         };
 
         let reference = generate_reference_config().unwrap();
+        // This mirrors the user's load path (`load_config`): defaults merged
+        // with the reference file. It guards against the generator emitting
+        // anything a verbatim copy of the reference config cannot load -
+        // e.g. a bare `[can]` header, which would deserialize the optional
+        // typed section as an empty table and fail on `interface`.
         let config: crate::config::configfile::Configuration =
             Figment::from(Serialized::defaults(crate::config::default_config()))
                 .merge(Toml::string(&reference))
@@ -540,6 +651,34 @@ mod tests {
         config
             .validate_sanity()
             .expect("parsed reference config should pass sanity validation");
+    }
+
+    /// The committed CAN example config must stay loadable through the real
+    /// config pipeline (figment defaults + file) and pass sanity validation,
+    /// so schema changes cannot silently break the documented setup.
+    #[cfg(feature = "can")]
+    #[test]
+    fn can_example_config_parses_as_valid_config() {
+        use figment::{
+            Figment,
+            providers::{Format, Serialized, Toml},
+        };
+
+        let example_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("opensovd-cda-can.toml");
+        let config: crate::config::configfile::Configuration =
+            Figment::from(Serialized::defaults(crate::config::default_config()))
+                .merge(Toml::file(&example_path))
+                .extract()
+                .expect("opensovd-cda-can.toml should be parseable as a valid Configuration");
+        assert!(
+            config.can.is_some(),
+            "the CAN example config must configure the [can] section"
+        );
+        config
+            .validate_sanity()
+            .expect("CAN example config should pass sanity validation");
     }
 
     /// Collect all leaf property paths from the JSON Schema.

--- a/cda-main/src/error.rs
+++ b/cda-main/src/error.rs
@@ -111,6 +111,24 @@ impl From<DoipGatewaySetupError> for AppError {
     }
 }
 
+#[cfg(feature = "can")]
+impl From<cda_comm_can::error::CanGatewaySetupError> for AppError {
+    fn from(value: cda_comm_can::error::CanGatewaySetupError) -> Self {
+        use cda_comm_can::error::CanGatewaySetupError;
+        match value {
+            CanGatewaySetupError::InterfaceOpenFailed(_, _) => {
+                Self::InitializationFailed(value.to_string())
+            }
+            CanGatewaySetupError::InvalidConfiguration(_) | CanGatewaySetupError::NoEcuMappings => {
+                Self::ConfigurationError {
+                    message: value.to_string(),
+                    source: None,
+                }
+            }
+        }
+    }
+}
+
 impl From<TracingSetupError> for AppError {
     fn from(value: TracingSetupError) -> Self {
         match value {

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -11,15 +11,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// The `run_with_ext` async state machine grows with every enabled transport;
+// with `--all-features` its layout computation overflows rustc's default
+// query depth (128) on stable 1.97. Default limit otherwise.
+#![recursion_limit = "256"]
+
 use std::{future::Future, path::PathBuf, sync::Arc};
 
+#[cfg(feature = "can")]
+use cda_comm_can::CanDiagGateway;
+use cda_comm_can::{MultiTransportGateway, TransportType, config::CanConfig};
 use cda_comm_doip::{DoipDiagGateway, config::DoipConfig};
 use cda_comm_uds::{UdsManager, state_coordinator::EcuStateCoordinator};
 use cda_core::EcuManager;
 use cda_database::FileManager;
 use cda_interfaces::{
-    DoipGatewaySetupError, EcuConnectivityHandler, FunctionalDescriptionConfig, HashMap,
-    HashMapExtensions, UdsQuery, UdsVariant, config::ConfigSanity, datatypes::FaultConfig, dlt_ctx,
+    EcuConnectivityHandler, FunctionalDescriptionConfig, HashMap, HashMapExtensions, UdsQuery,
+    UdsVariant, config::ConfigSanity, datatypes::FaultConfig, dlt_ctx,
 };
 use cda_plugin_security::{
     DefaultSecurityPlugin, DefaultSecurityPluginData, SecurityPlugin, SecurityPluginLoader,
@@ -126,7 +134,7 @@ pub struct AppArgs {
 pub struct VehicleData<S: SecurityPlugin> {
     pub file_managers: FileManagerMap,
     pub uds_manager: UdsManagerType<S>,
-    pub diagnostic_gateway: DoipDiagGateway<EcuManager<S>>,
+    pub diagnostic_gateway: MultiTransportGateway<DoipDiagGateway<EcuManager<S>>>,
     pub locks: Arc<cda_sovd::Locks>,
     pub update_guard: cda_sovd::UpdateGuardState,
     pub databases: Arc<DatabaseMap<S>>,
@@ -136,7 +144,7 @@ pub struct VehicleData<S: SecurityPlugin> {
 
 pub struct VehicleComponents<S: SecurityPlugin> {
     pub uds_manager: UdsManagerType<S>,
-    pub diagnostic_gateway: DoipDiagGateway<EcuManager<S>>,
+    pub diagnostic_gateway: MultiTransportGateway<DoipDiagGateway<EcuManager<S>>>,
     pub databases: Arc<DatabaseMap<S>>,
     pub file_managers: FileManagerMap,
     pub variant_detection_handle: tokio::task::JoinHandle<()>,
@@ -425,11 +433,15 @@ where
 /// # Errors
 /// Returns [`AppError`] if tracing setup, webserver startup, data loading, or route setup fails.
 pub async fn run_with_config(config: Configuration) -> Result<(), AppError> {
-    run_with_config_ext::<DefaultSecurityPluginData, DefaultSecurityPlugin, _, _>(
-        config,
-        vec![],
-        |_| async { Ok(()) },
-    )
+    // Boxed: the composed runtime future exceeds clippy::large_futures'
+    // threshold, and this once-per-process startup future is not worth
+    // keeping on the caller's stack.
+    Box::pin(run_with_config_ext::<
+        DefaultSecurityPluginData,
+        DefaultSecurityPlugin,
+        _,
+        _,
+    >(config, vec![], |_| async { Ok(()) }))
     .await
 }
 
@@ -615,18 +627,28 @@ pub async fn load_vehicle_data<
     };
 
     let update_guard = cda_sovd::UpdateGuardState::new();
-    let doip_socket =
-        cda_comm_doip::create_udp_vir_socket(&config.doip.tester_address, config.doip.gateway_port)
-            .map_err(|e| {
-                AppError::InitializationFailed(format!("Failed to create DoIP socket: {e}"))
-            })?;
+    // In CAN-only operation (doip.enabled = false) no DoIP socket is bound at
+    // all: binding one anyway could collide with another DoIP stack on the
+    // host for no benefit.
+    let doip_socket = if config.doip.enabled {
+        let socket = cda_comm_doip::create_udp_vir_socket(
+            &config.doip.tester_address,
+            config.doip.gateway_port,
+        )
+        .map_err(|e| {
+            AppError::InitializationFailed(format!("Failed to create DoIP socket: {e}"))
+        })?;
+        Some(Arc::new(Mutex::new(socket)))
+    } else {
+        None
+    };
     let components = create_vehicle_components::<F, S>(
         config,
         &mdd_paths,
         clonable_shutdown_signal,
         health_providers.as_ref(),
         update_guard.busy_handle(),
-        Arc::new(Mutex::new(doip_socket)),
+        doip_socket,
     )
     .await?;
 
@@ -643,7 +665,17 @@ pub async fn load_vehicle_data<
     })
 }
 
-pub type UdsManagerType<S> = UdsManager<DoipDiagGateway<EcuManager<S>>, EcuManager<S>>;
+pub type UdsManagerType<S> =
+    UdsManager<MultiTransportGateway<DoipDiagGateway<EcuManager<S>>>, EcuManager<S>>;
+
+/// The transport sections of the configuration, bundled for
+/// [`create_diagnostic_gateway`] so its signature stays within clippy's
+/// argument budget as transports are added.
+pub struct TransportConfigs<'a> {
+    pub doip: &'a DoipConfig,
+    /// `None` disables the CAN transport (no `[can]` section).
+    pub can: Option<&'a CanConfig>,
+}
 
 #[allow(
     clippy::implicit_hasher,
@@ -656,7 +688,7 @@ pub type UdsManagerType<S> = UdsManager<DoipDiagGateway<EcuManager<S>>, EcuManag
     )
 )]
 pub fn create_uds_manager<S: SecurityPlugin>(
-    gateway: DoipDiagGateway<EcuManager<S>>,
+    gateway: MultiTransportGateway<DoipDiagGateway<EcuManager<S>>>,
     databases: Arc<HashMap<String, RwLock<EcuManager<S>>>>,
     variant_detection_receiver: mpsc::Receiver<Vec<String>>,
     state_coordinator: EcuStateCoordinator,
@@ -693,7 +725,7 @@ pub async fn create_vehicle_components<
     shutdown_signal: F,
     health_providers: Option<&HealthProviders>,
     update_in_progress: Arc<std::sync::atomic::AtomicBool>,
-    doip_socket: Arc<tokio::sync::Mutex<cda_comm_doip::socket::DoIPUdpSocket>>,
+    doip_socket: Option<Arc<tokio::sync::Mutex<cda_comm_doip::socket::DoIPUdpSocket>>>,
 ) -> Result<VehicleComponents<S>, AppError> {
     let db_provider = health_providers.map(|h| &h.database);
     let doip_provider = health_providers.map(|h| &h.doip);
@@ -712,12 +744,15 @@ pub async fn create_vehicle_components<
         }
         states
     };
-    let state_coordinator = EcuStateCoordinator::new(runtime_states);
+    let state_coordinator = EcuStateCoordinator::new(runtime_states, variant_detection_tx.clone());
     let connectivity_handler: Arc<dyn EcuConnectivityHandler> = Arc::new(state_coordinator.clone());
 
     let diagnostic_gateway = create_diagnostic_gateway(
         Arc::clone(&databases),
-        &config.doip,
+        TransportConfigs {
+            doip: &config.doip,
+            can: config.can.as_ref(),
+        },
         variant_detection_tx,
         connectivity_handler,
         shutdown_signal,
@@ -751,30 +786,118 @@ pub async fn create_vehicle_components<
 }
 
 #[tracing::instrument(
-    skip(databases, variant_detection, connectivity_handler, shutdown_signal, doip_health_provider, doip_socket),
+    skip(databases, transports, variant_detection, connectivity_handler, shutdown_signal, doip_health_provider, doip_socket),
     fields(
         database_count = databases.len(),
         dlt_context = dlt_ctx!("MAIN"),
     )
 )]
 /// # Errors
-/// Returns [`DoipGatewaySetupError`] if `DoIP` gateway initialization fails.
+/// Returns [`AppError`] if the initialization of any configured transport
+/// fails. Transport init failure is always fatal: a CDA that starts without
+/// one of its configured transports cannot be told apart from a healthy one,
+/// and a supervisor restart is what actually recovers transient causes.
 pub async fn create_diagnostic_gateway<S: SecurityPlugin>(
     databases: Arc<DatabaseMap<S>>,
+    transports: TransportConfigs<'_>,
+    variant_detection: mpsc::Sender<Vec<String>>,
+    connectivity_handler: Arc<dyn EcuConnectivityHandler>,
+    shutdown_signal: impl Future<Output = ()> + Send + 'static,
+    doip_health_provider: Option<&Arc<cda_health::StatusHealthProvider>>,
+    // `None` is only valid in CAN-only operation (doip.enabled = false); when
+    // DoIP is enabled the caller owns socket creation so the runtime-update
+    // reload path can hand the existing socket over (never two sockets bound
+    // to the same DoIP port).
+    doip_socket: Option<Arc<Mutex<cda_comm_doip::socket::DoIPUdpSocket>>>,
+) -> Result<MultiTransportGateway<DoipDiagGateway<EcuManager<S>>>, AppError> {
+    let TransportConfigs {
+        doip: doip_config,
+        can: can_config,
+    } = transports;
+    // Build the multi-transport gateway skeleton, then populate the configured
+    // transports. ECUs route over CAN or DoIP per `transport_overrides`,
+    // defaulting to DoIP-preferred with CAN fallback.
+    let transport_overrides: HashMap<String, TransportType> = can_config
+        .map(|c| {
+            c.transport_overrides
+                .iter()
+                .map(|o| (o.ecu_name.to_lowercase(), o.transport))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut gateway =
+        MultiTransportGateway::<DoipDiagGateway<EcuManager<S>>>::new(transport_overrides);
+
+    // Fail clearly when CAN is configured on a build without CAN support.
+    // (validate_sanity rejects this too; kept as defense in depth for direct
+    // callers of this function.)
+    #[cfg(not(feature = "can"))]
+    if can_config.is_some() {
+        return Err(AppError::ConfigurationError {
+            message: "[can] is configured, but this binary was built without CAN support. Rebuild \
+                      with `--features can` or remove the [can] section."
+                .to_owned(),
+            source: None,
+        });
+    }
+
+    if let Some(doip) = init_doip_gateway(
+        &databases,
+        doip_config,
+        variant_detection.clone(),
+        connectivity_handler,
+        shutdown_signal,
+        doip_health_provider,
+        doip_socket,
+    )
+    .await?
+    {
+        gateway = gateway.with_doip(doip);
+    }
+
+    #[cfg(feature = "can")]
+    if let Some(can_cfg) = can_config {
+        gateway = gateway.with_can(init_can_gateway(&databases, can_cfg, variant_detection).await?);
+    }
+
+    Ok(gateway)
+}
+
+/// Initializes the `DoIP` transport, reporting the attempt on the health
+/// provider. Returns `Ok(None)` when `DoIP` is disabled by config; in that
+/// CAN-only operation (`validate_sanity` rejects configs with no transport
+/// at all) the health provider is marked `Up` immediately so readiness
+/// (/health/ready) does not wait forever on an intentionally disabled
+/// transport.
+async fn init_doip_gateway<S: SecurityPlugin>(
+    databases: &Arc<DatabaseMap<S>>,
     doip_config: &DoipConfig,
     variant_detection: mpsc::Sender<Vec<String>>,
     connectivity_handler: Arc<dyn EcuConnectivityHandler>,
     shutdown_signal: impl Future<Output = ()> + Send + 'static,
     doip_health_provider: Option<&Arc<cda_health::StatusHealthProvider>>,
-    doip_socket: Arc<Mutex<cda_comm_doip::socket::DoIPUdpSocket>>,
-) -> Result<DoipDiagGateway<EcuManager<S>>, DoipGatewaySetupError> {
+    doip_socket: Option<Arc<Mutex<cda_comm_doip::socket::DoIPUdpSocket>>>,
+) -> Result<Option<DoipDiagGateway<EcuManager<S>>>, AppError> {
+    if !doip_config.enabled {
+        tracing::info!("DoIP transport disabled by config (doip.enabled = false)");
+        if let Some(provider) = doip_health_provider {
+            provider.update_status(cda_health::Status::Up).await;
+        }
+        return Ok(None);
+    }
+
+    let doip_socket = doip_socket.ok_or_else(|| {
+        AppError::InitializationFailed(
+            "doip.enabled = true but no DoIP socket was provided".to_owned(),
+        )
+    })?;
     if let Some(provider) = doip_health_provider {
         provider.update_status(cda_health::Status::Starting).await;
     }
-
     let result = DoipDiagGateway::new(
         doip_config,
-        databases,
+        Arc::clone(databases),
         variant_detection,
         connectivity_handler,
         shutdown_signal,
@@ -789,7 +912,31 @@ pub async fn create_diagnostic_gateway<S: SecurityPlugin>(
     if let Some(provider) = doip_health_provider {
         provider.update_status(status).await;
     }
-    result
+    match result {
+        Ok(d) => {
+            tracing::info!("DoIP gateway initialized");
+            Ok(Some(d))
+        }
+        // Fatal; main reports the error on exit.
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Initializes the CAN transport. Like for `DoIP`, an init failure is fatal.
+#[cfg(feature = "can")]
+async fn init_can_gateway<S: SecurityPlugin>(
+    databases: &Arc<DatabaseMap<S>>,
+    can_cfg: &CanConfig,
+    variant_detection: mpsc::Sender<Vec<String>>,
+) -> Result<CanDiagGateway, AppError> {
+    match CanDiagGateway::new(can_cfg, databases, variant_detection).await {
+        Ok(c) => {
+            tracing::info!(interface = %can_cfg.interface, "CAN gateway initialized");
+            Ok(c)
+        }
+        // Fatal; main reports the error on exit.
+        Err(e) => Err(e.into()),
+    }
 }
 
 /// # Panics

--- a/cda-main/src/mdd.rs
+++ b/cda-main/src/mdd.rs
@@ -385,6 +385,19 @@ async fn mark_duplicate_ecus_by_address<S: SecurityPlugin>(
     let mut ecus_by_address: HashMap<u16, HashMap<u16, Vec<String>>> = HashMap::new();
     for (name, db_lock) in databases {
         let db = db_lock.read().await;
+        if !db.doip_addresses_resolved() {
+            // The addresses are com-param fallback values (e.g. a CAN-only
+            // MDD without DoIP addressing, or a functional description). All
+            // such ECUs share the same defaults, which is no evidence of an
+            // actual address collision - grouping them would spuriously mark
+            // unrelated ECUs as duplicates and suppress base-variant
+            // fallback for all of them.
+            tracing::debug!(
+                ecu_name = %name,
+                "Skipping duplicate detection - no resolved DoIP addressing"
+            );
+            continue;
+        }
         let logical_address = db.logical_address();
         let gateway_address = db.logical_gateway_address();
         ecus_by_address

--- a/cda-main/src/mdd.rs
+++ b/cda-main/src/mdd.rs
@@ -377,56 +377,72 @@ pub(crate) fn handle_ecu_config_keys<S: SecurityPlugin>(
     Ok(())
 }
 
-/// Scans `databases` for ECUs sharing the same logical and gateway address and marks them as
-/// duplicates of each other by calling `set_duplicating_ecu_names` on each affected manager.
+/// The transport target an ECU description talks to, as far as duplicate
+/// detection is concerned: several ECU descriptions sharing one target are
+/// candidate models of the same physical node (e.g. the radio variants of a
+/// vehicle), and variant detection decides which one is actually installed.
+#[derive(Hash, PartialEq, Eq)]
+enum DuplicateTargetKey {
+    /// Resolved `DoIP` gateway/logical address pair.
+    Doip { gateway: u16, logical: u16 },
+    /// CAN arbitration ID pair from the MDD com-params, for ECUs without
+    /// resolved `DoIP` addressing (e.g. CAN-only databases).
+    Can(cda_interfaces::CanIds),
+}
+
+/// Scans `databases` for ECUs sharing the same transport target - the
+/// resolved `DoIP` gateway/logical address pair, or (for ECUs without `DoIP`
+/// addressing) the CAN arbitration ID pair from the MDD com-params - and
+/// marks them as duplicates of each other by calling
+/// `set_duplicating_ecu_names` on each affected manager.
 async fn mark_duplicate_ecus_by_address<S: SecurityPlugin>(
     databases: &HashMap<String, RwLock<EcuManager<S>>>,
 ) {
-    let mut ecus_by_address: HashMap<u16, HashMap<u16, Vec<String>>> = HashMap::new();
+    use cda_interfaces::CanComParamProvider as _;
+
+    let mut ecus_by_target: HashMap<DuplicateTargetKey, Vec<String>> = HashMap::new();
     for (name, db_lock) in databases {
         let db = db_lock.read().await;
-        if !db.doip_addresses_resolved() {
-            // The addresses are com-param fallback values (e.g. a CAN-only
-            // MDD without DoIP addressing, or a functional description). All
-            // such ECUs share the same defaults, which is no evidence of an
-            // actual address collision - grouping them would spuriously mark
-            // unrelated ECUs as duplicates and suppress base-variant
-            // fallback for all of them.
+        let key = if db.doip_addresses_resolved() {
+            DuplicateTargetKey::Doip {
+                gateway: db.logical_gateway_address(),
+                logical: db.logical_address(),
+            }
+        } else if let Some(ids) = db.can_ids() {
+            DuplicateTargetKey::Can(ids)
+        } else {
+            // Without resolved DoIP addressing the addresses are com-param
+            // fallback values shared by every such ECU (e.g. a functional
+            // description), and without CAN IDs there is no other target
+            // identity - no evidence of an actual collision, so grouping
+            // would spuriously mark unrelated ECUs as duplicates and
+            // suppress base-variant fallback for all of them.
             tracing::debug!(
                 ecu_name = %name,
-                "Skipping duplicate detection - no resolved DoIP addressing"
+                "Skipping duplicate detection - neither resolved DoIP addressing nor CAN IDs"
             );
             continue;
-        }
-        let logical_address = db.logical_address();
-        let gateway_address = db.logical_gateway_address();
-        ecus_by_address
-            .entry(gateway_address)
-            .or_default()
-            .entry(logical_address)
-            .or_default()
-            .push(name.clone());
+        };
+        ecus_by_target.entry(key).or_default().push(name.clone());
     }
 
-    for logical_map in ecus_by_address.values() {
-        for ecu_names in logical_map.values() {
-            if ecu_names.len() <= 1 {
+    for ecu_names in ecus_by_target.values() {
+        if ecu_names.len() <= 1 {
+            continue;
+        }
+
+        for ecu_name in ecu_names {
+            let Some(db_lock) = databases.get(ecu_name) else {
                 continue;
-            }
+            };
 
-            for ecu_name in ecu_names {
-                let Some(db_lock) = databases.get(ecu_name) else {
-                    continue;
-                };
-
-                let mut db = db_lock.write().await;
-                let duplicates: HashSet<String> = ecu_names
-                    .iter()
-                    .filter(|&name| name != ecu_name)
-                    .cloned()
-                    .collect();
-                db.set_duplicating_ecu_names(duplicates);
-            }
+            let mut db = db_lock.write().await;
+            let duplicates: HashSet<String> = ecu_names
+                .iter()
+                .filter(|&name| name != ecu_name)
+                .cloned()
+                .collect();
+            db.set_duplicating_ecu_names(duplicates);
         }
     }
 }

--- a/cda-main/src/update/mod.rs
+++ b/cda-main/src/update/mod.rs
@@ -14,10 +14,11 @@
 use std::{future::Future, path::PathBuf, sync::Arc};
 
 use async_trait::async_trait;
+use cda_comm_can::MultiTransportGateway;
 use cda_comm_doip::DoipDiagGateway;
 use cda_core::EcuManager;
 use cda_interfaces::{
-    UdsQuery,
+    EcuGateway, UdsQuery,
     datatypes::ComponentsConfig,
     runtime_update_api::{ReloadError, RuntimeFilesUpdateSecurityHandler},
 };
@@ -41,7 +42,7 @@ where
     pub lock_provider: Arc<cda_sovd::SovdLockStateProvider>,
     pub shutdown_signal: F,
     pub uds_manager: RwLock<UdsManagerType<S>>,
-    pub doip_gateway: RwLock<DoipDiagGateway<EcuManager<S>>>,
+    pub doip_gateway: RwLock<MultiTransportGateway<DoipDiagGateway<EcuManager<S>>>>,
     pub ecu_execution_registry: cda_sovd::EcuExecutionRegistry,
     pub update_guard: cda_sovd::UpdateGuardState,
     pub health: Option<crate::HealthProviders>,
@@ -62,7 +63,7 @@ where
     lock_provider: Arc<cda_sovd::SovdLockStateProvider>,
     shutdown_signal: F,
     uds_manager: RwLock<UdsManagerType<S>>,
-    doip_gateway: RwLock<DoipDiagGateway<EcuManager<S>>>,
+    doip_gateway: RwLock<MultiTransportGateway<DoipDiagGateway<EcuManager<S>>>>,
     update_guard: cda_sovd::UpdateGuardState,
     ecu_execution_registry: cda_sovd::EcuExecutionRegistry,
     health: Option<crate::HealthProviders>,
@@ -120,7 +121,13 @@ where
         self.uds_manager.write().await.shutdown().await;
         let doip_socket = {
             let mut gw = self.doip_gateway.write().await;
-            let socket = gw.udp_socket();
+            // `None` in CAN-only operation (no DoIP transport configured);
+            // `create_vehicle_components` only needs the socket when DoIP is
+            // enabled.
+            let socket = gw.doip().map(DoipDiagGateway::udp_socket);
+            // Shut down all transports and await their task termination, so
+            // the VAM listener has stopped reading from the shared UDP socket
+            // before the replacement gateway reuses it.
             gw.shutdown().await;
             socket
         };
@@ -215,7 +222,7 @@ pub struct RuntimeUpdateContext<
     pub security_handler: Arc<T>,
     pub ecu_execution_registry: cda_sovd::EcuExecutionRegistry,
     pub uds_manager: UdsManagerType<S>,
-    pub doip_gateway: DoipDiagGateway<EcuManager<S>>,
+    pub doip_gateway: MultiTransportGateway<DoipDiagGateway<EcuManager<S>>>,
     pub health: Option<crate::HealthProviders>,
     pub variant_detection_handle: Option<tokio::task::JoinHandle<()>>,
 }

--- a/deny.toml
+++ b/deny.toml
@@ -80,6 +80,7 @@ allow-git = [
   "https://github.com/theswiftfox/doip-definitions.git",
   "https://github.com/theswiftfox/doip-sockets.git",
   "https://github.com/theswiftfox/mimalloc.git",
+  "https://github.com/MarkSchmitt/tokio-socketcan-isotp.git",
 ]
 
 [sources.allow-org]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -85,6 +85,11 @@ cda-build = { workspace = true }
 # We need the health endpoint to check if the CDA is online
 default = ["opensovd_cda_lib/health"]
 integration-tests = []
+# Variant of the integration tests that exercises the CAN transport
+# (`CDA_INTEGRATION_TEST_USE_CAN=true`). Compiles in `can-socketcand` so the
+# CDA-side socketcand backend is actually wired in; the ECU simulator reaches
+# the same vcan bus through a socketcand daemon.
+can-integration-tests = ["integration-tests", "opensovd_cda_lib/can-socketcand"]
 
 # Integration tests are only compiled when the feature is enabled.
 [[test]]

--- a/integration-tests/tests/sovd/custom_routes.rs
+++ b/integration-tests/tests/sovd/custom_routes.rs
@@ -142,17 +142,23 @@ async fn test_custom_demo_endpoint() {
         cda_comm_doip::create_udp_vir_socket(&doip_config.tester_address, doip_config.gateway_port)
             .expect("Failed to create DoIP socket");
 
-    let state_coordinator = EcuStateCoordinator::new(HashMap::new());
+    let (redetect_tx, _redetect_rx) = tokio::sync::mpsc::channel(8);
+    let state_coordinator = EcuStateCoordinator::new(HashMap::new(), redetect_tx);
     let connectivity_handler: Arc<dyn EcuConnectivityHandler> = Arc::new(state_coordinator.clone());
 
+    // This test runtime is DoIP-only: no CAN config, socket present because
+    // DoIP is enabled.
     let gateway = opensovd_cda_lib::create_diagnostic_gateway(
         Arc::clone(&databases),
-        &doip_config,
+        opensovd_cda_lib::TransportConfigs {
+            doip: &doip_config,
+            can: None,
+        },
         variant_tx,
         connectivity_handler,
         shutdown_signal.clone(),
         None,
-        Arc::new(tokio::sync::Mutex::new(doip_socket)),
+        Some(Arc::new(tokio::sync::Mutex::new(doip_socket))),
     )
     .await
     .expect("Failed to create gateway");

--- a/integration-tests/tests/sovd/ecu.rs
+++ b/integration-tests/tests/sovd/ecu.rs
@@ -31,9 +31,38 @@ use crate::{
             QueryParams, auth_header, extract_field_from_json, response_to_json, response_to_t,
             send_cda_request,
         },
-        runtime::{TestRuntime, restart_cda, setup_integration_test, start_ecu_sim, stop_ecu_sim},
+        runtime::{
+            TestRuntime, restart_cda, setup_integration_test, skip_for_can, skip_for_doip,
+            start_ecu_sim_for_mode, stop_ecu_sim,
+        },
     },
 };
+
+/// Reads the Identification DID from the ECU over its transport. Unlike the
+/// component listing (served from the loaded MDD even when the ECU is dead),
+/// this request only succeeds if the ECU actually answers on the bus, so it
+/// proves end-to-end liveness.
+async fn assert_ecu_answers_on_bus(runtime: &TestRuntime, ecu_endpoint: &str) {
+    let auth = auth_header(&runtime.config, None)
+        .await
+        .expect("auth header should be obtainable");
+    let response = send_cda_request(
+        &runtime.config,
+        &format!("{ecu_endpoint}/data/identification"),
+        StatusCode::OK,
+        Method::GET,
+        None,
+        Some(&auth),
+        None,
+    )
+    .await
+    .expect("live Identification read over the bus should succeed");
+    let json = response_to_json(&response).expect("data response should be JSON");
+    assert!(
+        json.to_string().contains("Identification"),
+        "data response should contain the Identification parameter: {json}"
+    );
+}
 
 /// This ECU is missing comm parameters and thus must be configured via the configuration file.
 /// The test verifies that the ECU is reachable and reports the correct name and state.
@@ -59,6 +88,8 @@ async fn test_tmcc3000_ecu_online() {
         "tmcc3000",
         "Component name should be tmcc3000"
     );
+
+    assert_ecu_answers_on_bus(runtime, sovd::ECU_TMCC3000_ENDPOINT).await;
 }
 
 /// HOVR4000 uses a non-default protocol (`DMC_DoIP`) in its MDD. The global
@@ -87,6 +118,8 @@ async fn test_hovr4000_per_ecu_protocol_override() {
         "hovr4000",
         "Component name should be hovr4000"
     );
+
+    assert_ecu_answers_on_bus(runtime, sovd::ECU_HOVR4000_ENDPOINT).await;
 }
 
 /// JGWT5000 has a non-default protocol (`DMC_DoIP`) in its MDD but no per-ECU
@@ -114,11 +147,94 @@ async fn test_jgwt5000_ignore_protocol_with_db_protocol() {
         "jgwt5000",
         "Component name should be jgwt5000"
     );
+
+    assert_ecu_answers_on_bus(runtime, sovd::ECU_JGWT5000_ENDPOINT).await;
+}
+
+/// A CAN-only ECU must be usable purely from configuration: TMCC3000's MDD
+/// carries no `DoIP` addressing and its CAN request/response IDs come
+/// exclusively from `[[can.ecu_mappings]]` plus the per-ECU protocol
+/// handling in the test config (in mixed mode additionally a transport
+/// override pins it to CAN). The test asserts the ECU is actually served
+/// over a CAN network address and answers a live read on the bus.
+#[tokio::test]
+async fn test_can_only_ecu_from_configuration() {
+    if skip_for_doip(
+        "test_can_only_ecu_from_configuration",
+        "needs the CAN transport (pure-CAN or mixed mode)",
+    ) {
+        return;
+    }
+    let (runtime, _lock) = setup_integration_test(false).await.unwrap();
+
+    // Live read proves the ECU answers on the bus at all.
+    assert_ecu_answers_on_bus(runtime, sovd::ECU_TMCC3000_ENDPOINT).await;
+
+    // The network structure must serve TMCC3000 behind a CAN network address
+    // (can:// scheme) carrying the configured request/response CAN IDs.
+    let response = send_cda_request(
+        &runtime.config,
+        "apps/sovd2uds/data/networkstructure",
+        StatusCode::OK,
+        Method::GET,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("network structure should be readable");
+    let json = response_to_json(&response).expect("network structure should be JSON");
+    let gateways: Vec<&serde_json::Value> = json
+        .get("data")
+        .and_then(|d| d.as_array())
+        .map(|structures| {
+            structures
+                .iter()
+                .flat_map(|ns| ns.get("Gateways").and_then(|g| g.as_array()))
+                .flatten()
+                .collect()
+        })
+        .unwrap_or_default();
+    let tmcc3000_gateway = gateways
+        .iter()
+        .find(|gw| {
+            gw.get("Ecus")
+                .and_then(|ecus| ecus.as_array())
+                .is_some_and(|ecus| {
+                    ecus.iter().any(|ecu| {
+                        ecu.get("Qualifier")
+                            .and_then(|q| q.as_str())
+                            .is_some_and(|q| q.eq_ignore_ascii_case("tmcc3000"))
+                    })
+                })
+        })
+        .unwrap_or_else(|| panic!("TMCC3000 missing from network structure: {json}"));
+    let network_address = tmcc3000_gateway
+        .get("NetworkAddress")
+        .and_then(|a| a.as_str())
+        .expect("gateway should have a network address");
+    assert!(
+        network_address.starts_with("can://"),
+        "TMCC3000 should be served over CAN, got network address {network_address}"
+    );
+    assert!(
+        network_address.contains("0x730") && network_address.contains("0x738"),
+        "CAN address should carry the configured request/response IDs: {network_address}"
+    );
 }
 
 #[allow(clippy::too_many_lines, reason = "Makes sense to keep test together")]
 #[tokio::test]
 async fn test_ecu_session_switching() {
+    // TODO(can): SecurityAccess seed/key/lock sequencing is not yet reliable
+    // over the CAN transport. Re-enable once the CAN session/security path
+    // is hardened, see #444
+    if skip_for_can(
+        "test_ecu_session_switching",
+        "SecurityAccess sequencing not yet supported over CAN",
+    ) {
+        return;
+    }
     let (runtime, _lock) = setup_integration_test(true).await.unwrap();
     let auth = auth_header(&runtime.config, None).await.unwrap();
     let ecu_endpoint = sovd::ECU_FLXC1000_ENDPOINT;
@@ -348,6 +464,15 @@ async fn test_ecu_session_switching() {
 
 #[tokio::test]
 async fn test_variant_detection_duplicates() {
+    // DoIP-only: relies on spontaneous VAM announcements and restarts the sim's
+    // DoIP entities (which has no CAN-hub equivalent), so it cannot run over the
+    // CAN transport.
+    if skip_for_can(
+        "test_variant_detection_duplicates",
+        "depends on DoIP VAM announcements and sim restart",
+    ) {
+        return;
+    }
     let (runtime, _lock) = setup_integration_test(true).await.unwrap();
     let auth = auth_header(&runtime.config, None).await.unwrap();
 
@@ -453,7 +578,7 @@ async fn test_variant_detection_duplicates() {
 
     // restart sim and wait for ECUs to come online,
     // status should be detected without manual variant detection
-    start_ecu_sim(&runtime.ecu_sim).await.unwrap();
+    start_ecu_sim_for_mode(&runtime.ecu_sim).await.unwrap();
 
     // wait in loop, to check if the CDA receives the spontaneous VAM when is online
     for attempt in 0..=5 {
@@ -789,6 +914,15 @@ async fn test_boot_variant_service_inheritance() {
 
 #[tokio::test]
 async fn test_ecu_session_reset_on_lock_reacquire() {
+    // TODO(can): session expiry depends on TesterPresent keepalive cadence,
+    // which is not yet reliable over the CAN transport (per-transaction
+    // sockets + busy-poll dispatcher are too slow), see #444
+    if skip_for_can(
+        "test_ecu_session_reset_on_lock_reacquire",
+        "session-expiry keepalive timing not yet reliable over CAN",
+    ) {
+        return;
+    }
     let (runtime, _lock) = setup_integration_test(true).await.unwrap();
     let auth = auth_header(&runtime.config, None).await.unwrap();
     let ecu_endpoint = sovd::ECU_FLXC1000_ENDPOINT;
@@ -1156,18 +1290,31 @@ async fn test_operation_sdg_retrieval() {
     assert_eq!(sd.get("value").unwrap().as_str(), Some("5000"));
 }
 
+/// Polls until the ECU reaches the expected state, then asserts.
+///
+/// ECU states are updated asynchronously (variant detection tasks probe each
+/// ECU on its transport, with per-probe timeouts), so a one-shot check races
+/// the startup/detection loop - especially in mixed mode where undetected
+/// CAN-mapped ECUs cost a probe timeout each before the loop moves on.
 async fn validate_ecu_state(
     runtime: &TestRuntime,
     auth: &HeaderMap,
     ecu: &str,
     expected_state: sovd_interfaces::components::ecu::State,
 ) {
-    let ecu_status = ecu_status(&runtime.config, auth, ecu)
+    let started = std::time::Instant::now();
+    let mut status = ecu_status(&runtime.config, auth, ecu)
         .await
         .expect("failed to get ecu status");
+    while status.variant.state != expected_state && started.elapsed() < Duration::from_secs(10) {
+        cda_interfaces::util::tokio_ext::sleep_for(Duration::from_millis(200)).await;
+        status = ecu_status(&runtime.config, auth, ecu)
+            .await
+            .expect("failed to get ecu status");
+    }
     assert_eq!(
-        ecu_status.variant.state, expected_state,
-        "ECU {ecu} state does not match {ecu_status:?}"
+        status.variant.state, expected_state,
+        "ECU {ecu} state does not match {status:?}"
     );
 }
 

--- a/integration-tests/tests/sovd/mod.rs
+++ b/integration-tests/tests/sovd/mod.rs
@@ -388,8 +388,10 @@ where
         // Run cleanup inside catch_unwind so a failure here never triggers
         // a double-panic (which the runtime turns into SIGABRT).
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            // Run on a dedicated thread to avoid nesting a new runtime
-            // inside the existing tokio runtime (which would abort).
+            // Drive the cleanup future on a dedicated thread: a nested
+            // runtime on a tokio worker thread panics (see
+            // https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#method.block_on),
+            // and a second panic while unwinding aborts the process.
             std::thread::scope(|s| {
                 s.spawn(|| {
                     if let Ok(rt) = tokio::runtime::Builder::new_current_thread()

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -32,8 +32,8 @@ use http::{Method, StatusCode};
 use opensovd_cda_lib::{
     cda_version,
     config::configfile::{
-        Configuration, DatabaseConfig, EcuComParams, EcuConfig, RuntimeUpdateConfig, ServerConfig,
-        StrictConfig,
+        CanConfig, CanEcuMapping, Configuration, DatabaseConfig, EcuComParams, EcuConfig,
+        RuntimeUpdateConfig, ServerConfig, StrictConfig, TransportOverride, TransportType,
     },
 };
 use sovd_interfaces::apps::sovd2uds::data::network_structure::get::Response as NetworkStructureResponse;
@@ -64,6 +64,19 @@ static ECU_SIM_PROCESS: LazyLock<Mutex<Option<std::process::Child>>> =
 const CDA_INTEGRATION_TEST_USE_DOCKER: &str = "CDA_INTEGRATION_TEST_USE_DOCKER";
 const CDA_INTEGRATION_TEST_TESTER_ADDRESS: &str = "CDA_INTEGRATION_TEST_TESTER_ADDRESS";
 const CDA_INTEGRATION_TEST_COVERAGE: &str = "CDA_INTEGRATION_TEST_COVERAGE";
+const CDA_INTEGRATION_TEST_USE_CAN: &str = "CDA_INTEGRATION_TEST_USE_CAN";
+/// Mixed mode: `DoIP` and CAN run simultaneously. TMCC3000/HOVR4000/JGWT5000
+/// are pinned to CAN, FLXC1000 to `DoIP`, the remaining ECUs bind at first
+/// detection.
+const CDA_INTEGRATION_TEST_USE_MIXED: &str = "CDA_INTEGRATION_TEST_USE_MIXED";
+/// Port of the socketcand daemon that fronts the shared (v)can bus. CDA and the
+/// ecu-sim both connect to it as rawmode clients.
+const SOCKETCAND_PORT: u16 = 29536;
+/// Name of the CAN bus exposed by socketcand.
+const CAN_BUS_NAME: &str = "vcan0";
+/// socketcand host CDA + ecu-sim use *inside* their containers: the socketcand
+/// service is reachable by its compose service name over the bridge network.
+const CAN_DOCKER_SOCKETCAND_HOST: &str = "socketcand";
 
 const MAIN_HEALTH_COMPONENT_KEY: &str = "main";
 
@@ -123,6 +136,9 @@ async fn initialize_runtime() -> Result<TestRuntime, TestingError> {
     let (cda_port, gateway_port, sim_control_port) = if use_docker() {
         (
             find_available_tcp_port(&host)?,
+            // gateway_port is written to `.env` as SIM_GATEWAY_PORT but the JVM
+            // reads SIM_DOIP_PORT, so this allocation is currently dead (kept as
+            // a pre-existing behaviour; cleanup tracked separately).
             find_available_tcp_port(&host)?,
             find_available_tcp_port(&host)?,
         )
@@ -130,7 +146,13 @@ async fn initialize_runtime() -> Result<TestRuntime, TestingError> {
         (20002, 13400, 8181) // default ports for local usage
     };
 
-    let config = cda_test_config(host.clone(), cda_port, gateway_port)?;
+    let config = if use_mixed() {
+        cda_test_config_mixed(host.clone(), cda_port, gateway_port)?
+    } else if use_can() {
+        cda_test_config_can(host.clone(), cda_port)?
+    } else {
+        cda_test_config(host.clone(), cda_port, gateway_port)?
+    };
     config.validate_sanity().map_err(|e| {
         TestingError::SetupError(format!("Configuration sanity check failed: {e:?}"))
     })?;
@@ -145,7 +167,11 @@ async fn initialize_runtime() -> Result<TestRuntime, TestingError> {
         write_config_toml(&test_container_dir()?, config.clone())?;
         start_docker_compose(cda_port, gateway_port, sim_control_port)?;
     } else {
-        start_ecu_sim(&ecu_sim).await?;
+        if can_infra() {
+            start_ecu_sim_can(&ecu_sim).await?;
+        } else {
+            start_ecu_sim_doip(&ecu_sim).await?;
+        }
         start_cda(config.clone());
     }
 
@@ -162,16 +188,91 @@ fn cda_test_config(
     cda_port: u16,
     gateway_port: u16,
 ) -> Result<Configuration, TestingError> {
-    let config = Configuration {
+    let mut config = base_test_config(host, cda_port, per_ecu_configs_for_doip())?;
+    enable_doip(&mut config, gateway_port);
+    Ok(config)
+}
+
+/// CAN-only configuration: no `DoIP` transport, so no gateway port either.
+fn cda_test_config_can(host: String, cda_port: u16) -> Result<Configuration, TestingError> {
+    let mut config = base_test_config(host, cda_port, per_ecu_configs_for_can())?;
+    config.can = Some(test_can_config(vec![]));
+    Ok(config)
+}
+
+/// Mixed `DoIP`+CAN configuration: both transports are live. The three ECUs
+/// that already have CAN-style per-ECU configs are pinned to CAN; FLXC1000 is
+/// pinned to `DoIP` so the session/security/variant tests (which target it)
+/// run deterministically over `DoIP`; the remaining ECUs are left unpinned to
+/// exercise sticky first-detection binding.
+fn cda_test_config_mixed(
+    host: String,
+    cda_port: u16,
+    gateway_port: u16,
+) -> Result<Configuration, TestingError> {
+    let mut ecu = per_ecu_configs_for_doip();
+    // Pinned-to-CAN ECUs use the CAN-style protocol handling.
+    for (name, cfg) in per_ecu_configs_for_can() {
+        ecu.insert(name, cfg);
+    }
+    let mut config = base_test_config(host, cda_port, ecu)?;
+    enable_doip(&mut config, gateway_port);
+    let pins = [
+        ("TMCC3000", TransportType::Can),
+        ("HOVR4000", TransportType::Can),
+        ("JGWT5000", TransportType::Can),
+        ("FLXC1000", TransportType::DoIP),
+    ]
+    .into_iter()
+    .map(|(ecu_name, transport)| TransportOverride {
+        ecu_name: ecu_name.to_owned(),
+        transport,
+    })
+    .collect();
+    config.can = Some(test_can_config(pins));
+    Ok(config)
+}
+
+/// Turns on the `DoIP` transport of a [`base_test_config`].
+fn enable_doip(config: &mut Configuration, gateway_port: u16) {
+    config.doip.enabled = true;
+    config.doip.gateway_port = gateway_port;
+}
+
+fn test_can_config(transport_overrides: Vec<TransportOverride>) -> CanConfig {
+    CanConfig {
+        interface: format!("socketcand:127.0.0.1:{SOCKETCAND_PORT}:{CAN_BUS_NAME}"),
+        ecu_mappings: can_ecu_mappings(),
+        transport_overrides,
+        response_timeout_ms: 2000,
+        probe_timeout_ms: 500,
+        // The suites ran with the keep-alive since its introduction; keep
+        // it on (the default is off for resident operation).
+        keepalive_interval_ms: 2000,
+        ..CanConfig::default()
+    }
+}
+
+/// Transport-less base of every test configuration (server, database,
+/// com-params, ...). The `DoIP` section is present but disabled; callers add
+/// their transports via [`enable_doip`] and/or by setting `config.can`.
+fn base_test_config(
+    host: String,
+    cda_port: u16,
+    ecu: HashMap<String, EcuConfig>,
+) -> Result<Configuration, TestingError> {
+    Ok(Configuration {
         server: opensovd_cda_lib::config::configfile::ServerConfig {
             address: host.clone(),
             port: cda_port,
         },
         doip: opensovd_cda_lib::config::configfile::DoipConfig {
             tester_address: host,
-            gateway_port,
+            enabled: false,
+            gateway_port: 0,
             ..Default::default()
         },
+        can: None,
         database: DatabaseConfig {
             path: mdd_file_path()?,
             naming_convention: DatabaseNamingConvention::default(),
@@ -189,6 +290,13 @@ fn cda_test_config(
             // are unaffected because the DB value takes precedence.
             let mut p = ComParams::default();
             p.doip.logical_functional_address.value = 0xFFFF;
+            // Faster reconnect ladder against the local simulator: with the
+            // production default of 5s, recovering from a simulated gateway
+            // restart (several failed reconnect rounds while the entities are
+            // down) can take longer than the 30s `wait_for_ecus_online`
+            // budget. Precedence Config so the MDD cannot override it.
+            p.doip.connection_retry_delay.value = std::time::Duration::from_secs(1);
+            p.doip.connection_retry_delay.precedence = ComParamPrecedence::Config;
             p
         },
         flat_buf: FlatbBufConfig::default(),
@@ -206,80 +314,120 @@ fn cda_test_config(
             user_memory_scope: "Development".to_owned(),
             ..Default::default()
         },
-        ecu: {
-            let mut map = HashMap::new();
-            map.insert(
-                "TMCC3000".to_owned(),
-                EcuConfig {
-                    ignore_protocol: Some(true),
-                    com_params: Some(
-                        EcuComParams::try_from(ComParams {
-                            doip: DoipComParams {
-                                logical_gateway_address: ComParamConfig {
-                                    name: "logical_gateway_address".to_string(),
-                                    value: 0x3000,
-                                    precedence: ComParamPrecedence::Config,
-                                },
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        })
-                        .expect("Failed to create EcuConfig for TMCC3000"),
-                    ),
-                    ..Default::default()
-                },
-            );
-            map.insert(
-                "HOVR4000".to_owned(),
-                EcuConfig {
-                    com_params: Some(
-                        EcuComParams::try_from(ComParams {
-                            doip: DoipComParams {
-                                logical_gateway_address: ComParamConfig {
-                                    name: "logical_gateway_address".to_string(),
-                                    value: 0x4000,
-                                    precedence: ComParamPrecedence::Config,
-                                },
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        })
-                        .expect("Failed to create EcuConfig for HOVR4000"),
-                    ),
-                    protocol: Some("DMC_DoIP".to_owned()),
-                    ignore_protocol: Some(false),
-                },
-            );
-            map.insert(
-                "JGWT5000".to_owned(),
-                EcuConfig {
-                    ignore_protocol: Some(true),
-                    com_params: Some(
-                        EcuComParams::try_from(ComParams {
-                            doip: DoipComParams {
-                                logical_gateway_address: ComParamConfig {
-                                    name: "logical_gateway_address".to_string(),
-                                    value: 0x5000,
-                                    precedence: ComParamPrecedence::Config,
-                                },
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        })
-                        .expect("Failed to create EcuConfig for JGWT5000"),
-                    ),
-                    ..Default::default()
-                },
-            );
-            map
-        },
+        ecu,
         runtime_update_config: RuntimeUpdateConfig {
             init_storage_from_database_path: true,
             ..RuntimeUpdateConfig::default()
         },
         strict: StrictConfig::default(),
-    };
-    Ok(config)
+    })
+}
+
+fn per_ecu_configs_for_doip() -> HashMap<String, EcuConfig> {
+    let mut map = HashMap::new();
+    map.insert(
+        "TMCC3000".to_owned(),
+        EcuConfig {
+            ignore_protocol: Some(true),
+            com_params: Some(
+                EcuComParams::try_from(ComParams {
+                    doip: DoipComParams {
+                        logical_gateway_address: ComParamConfig {
+                            name: "logical_gateway_address".to_string(),
+                            value: 0x3000,
+                            precedence: ComParamPrecedence::Config,
+                        },
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .expect("Failed to create EcuConfig for TMCC3000"),
+            ),
+            ..Default::default()
+        },
+    );
+    map.insert(
+        "HOVR4000".to_owned(),
+        EcuConfig {
+            com_params: Some(
+                EcuComParams::try_from(ComParams {
+                    doip: DoipComParams {
+                        logical_gateway_address: ComParamConfig {
+                            name: "logical_gateway_address".to_string(),
+                            value: 0x4000,
+                            precedence: ComParamPrecedence::Config,
+                        },
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .expect("Failed to create EcuConfig for HOVR4000"),
+            ),
+            protocol: Some("DMC_DoIP".to_owned()),
+            ignore_protocol: Some(false),
+        },
+    );
+    map.insert(
+        "JGWT5000".to_owned(),
+        EcuConfig {
+            ignore_protocol: Some(true),
+            com_params: Some(
+                EcuComParams::try_from(ComParams {
+                    doip: DoipComParams {
+                        logical_gateway_address: ComParamConfig {
+                            name: "logical_gateway_address".to_string(),
+                            value: 0x5000,
+                            precedence: ComParamPrecedence::Config,
+                        },
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .expect("Failed to create EcuConfig for JGWT5000"),
+            ),
+            ..Default::default()
+        },
+    );
+    map
+}
+
+fn per_ecu_configs_for_can() -> HashMap<String, EcuConfig> {
+    // For CAN we let the MDD's protocol layer win where it exists, and
+    // fall back to `ignore_protocol = true` for the protocol-less MDDs
+    // (TMCC3000, JGWT5000).
+    let mut map = HashMap::new();
+    for name in ["TMCC3000", "HOVR4000", "JGWT5000"] {
+        map.insert(
+            name.to_owned(),
+            EcuConfig {
+                ignore_protocol: Some(true),
+                ..Default::default()
+            },
+        );
+    }
+    map
+}
+
+fn can_ecu_mappings() -> Vec<CanEcuMapping> {
+    // The Kotlin sim assigns each example ECU a distinct (rxId, txId)
+    // pair. CDA must mirror the same mapping on its side so that the
+    // per-ECU ISO-TP sockets connect to the right arbitration IDs.
+    let pairs: &[(&str, u32, u32)] = &[
+        ("FLXC1000", 0x700, 0x708),
+        ("TMC1001", 0x710, 0x718),
+        ("FSNR2000", 0x720, 0x728),
+        ("TMCC3000", 0x730, 0x738),
+        ("HOVR4000", 0x740, 0x748),
+        ("JGWT5000", 0x750, 0x758),
+    ];
+    pairs
+        .iter()
+        .map(|(name, req, resp)| CanEcuMapping {
+            ecu_name: (*name).to_owned(),
+            request_id: *req,
+            response_id: *resp,
+        })
+        .collect()
 }
 
 pub(crate) fn host() -> String {
@@ -461,6 +609,7 @@ fn start_docker_compose(
         .arg("--build-arg")
         .arg("SOURCE_GIT_SHA=unknown")
         .env("DOCKER_BUILDKIT", "1")
+        .env("COMPOSE_PROFILES", compose_profiles())
         .current_dir(&test_container_dir);
 
     let status = cmd
@@ -482,7 +631,10 @@ fn docker_compose_up(container: Option<String>) -> Result<(), TestingError> {
         append_coverage_compose_files(&mut cmd);
     }
 
-    cmd.arg("up").arg("-d").env("DOCKER_BUILDKIT", "1");
+    cmd.arg("up")
+        .arg("-d")
+        .env("DOCKER_BUILDKIT", "1")
+        .env("COMPOSE_PROFILES", compose_profiles());
 
     if let Some(container_name) = container {
         cmd.arg(container_name);
@@ -508,6 +660,7 @@ fn docker_compose_down(container: Option<String>) -> Result<(), TestingError> {
     cmd.arg("down")
         .arg("--remove-orphans")
         .env("DOCKER_BUILDKIT", "1")
+        .env("COMPOSE_PROFILES", compose_profiles())
         .current_dir(&test_container_dir);
 
     if let Some(container_name) = container {
@@ -536,10 +689,15 @@ fn dump_docker_logs() {
 
     tracing::error!("========== Docker Compose Logs ==========");
 
+    // Set the active compose profiles so profile-gated services (e.g. the
+    // `socketcand` daemon under the `can` profile) are included in the dump -
+    // without this only the default services (cda, ecu-sim) are known here, and
+    // the socketcand side stays invisible when debugging CAN failures.
     let output = std::process::Command::new("docker")
         .arg("compose")
         .arg("logs")
         .arg("--no-color")
+        .env("COMPOSE_PROFILES", compose_profiles())
         .current_dir(&test_container_dir)
         .output();
 
@@ -616,6 +774,13 @@ fn write_config_toml(
     "0.0.0.0".clone_into(&mut config.server.address);
     "/app/odx".clone_into(&mut config.database.path);
 
+    // In docker the socketcand daemon runs in its own service, reachable by
+    // service name over the bridge network (not the host loopback used locally).
+    if let Some(can) = config.can.as_mut() {
+        can.interface =
+            format!("socketcand:{CAN_DOCKER_SOCKETCAND_HOST}:{SOCKETCAND_PORT}:{CAN_BUS_NAME}");
+    }
+
     let config_path = test_container_dir.join("cda-test-config.toml");
     let toml_content = toml::to_string_pretty(&config).map_err(|e| {
         TestingError::SetupError(format!("Failed to serialize config to TOML: {e}"))
@@ -661,6 +826,45 @@ fn write_config_toml(
     Ok(())
 }
 
+/// Build the docker-compose `.env` file contents. Pure (no I/O, no env
+/// lookups) so the exact bytes fed to compose can be unit-tested.
+fn docker_env_content(
+    can: bool,
+    cda_port: u16,
+    gateway_port: u16,
+    sim_control_port: u16,
+) -> String {
+    let mut env_content = format!(
+        "# Auto-generated environment file for integration tests\n# ECU Simulator Control \
+         Port\nSIM_CONTROL_PORT={sim_control_port}\n# ECU Simulator Gateway \
+         Port\nSIM_GATEWAY_PORT={gateway_port}\n# CDA Service Port\nCDA_PORT={cda_port}\n",
+    );
+
+    if can {
+        use std::fmt::Write as _;
+
+        // Point the ecu-sim at the socketcand service over the compose bridge,
+        // and compile the CDA image with the socketcand transport.
+        //
+        // NOTE: emit one short `writeln!` per line rather than a single long
+        // literal: rustfmt's `format_strings` rewraps long literals at the
+        // column limit and can mangle an `\n` escape at the wrap point into a
+        // stray backslash in the emitted file. Short lines are never
+        // rewrapped, so this stays correct across `cargo fmt`.
+        let _ = writeln!(env_content, "# socketcand daemon the ecu-sim connects to");
+        let _ = writeln!(
+            env_content,
+            "SIM_CAN_SOCKETCAND_HOST={CAN_DOCKER_SOCKETCAND_HOST}"
+        );
+        let _ = writeln!(env_content, "SIM_CAN_SOCKETCAND_PORT={SOCKETCAND_PORT}");
+        let _ = writeln!(env_content, "SIM_CAN_SOCKETCAND_BUS={CAN_BUS_NAME}");
+        let _ = writeln!(env_content, "# Extra cargo features for the CDA image");
+        let _ = writeln!(env_content, "CDA_FEATURES=can-socketcand");
+    }
+
+    env_content
+}
+
 fn write_docker_env_file(
     test_container_dir: &std::path::Path,
     cda_port: u16,
@@ -668,11 +872,7 @@ fn write_docker_env_file(
     sim_control_port: u16,
 ) -> Result<(), TestingError> {
     let env_file_path = test_container_dir.join(".env");
-    let env_content = format!(
-        "# Auto-generated environment file for integration tests\n# ECU Simulator Control \
-         Port\nSIM_CONTROL_PORT={sim_control_port}\n# ECU Simulator Gateway \
-         Port\nSIM_GATEWAY_PORT={gateway_port}\n# CDA Service Port\nCDA_PORT={cda_port}\n",
-    );
+    let env_content = docker_env_content(can_infra(), cda_port, gateway_port, sim_control_port);
 
     std::fs::write(&env_file_path, env_content)
         .map_err(|e| TestingError::ProcessFailed(format!("Failed to write .env file: {e}")))?;
@@ -681,7 +881,7 @@ fn write_docker_env_file(
     Ok(())
 }
 
-pub(crate) async fn start_ecu_sim(sim: &EcuSim) -> Result<(), TestingError> {
+pub(crate) async fn start_ecu_sim_doip(sim: &EcuSim) -> Result<(), TestingError> {
     if use_docker() {
         docker_compose_up(Some("ecu-sim".to_owned()))?;
     } else {
@@ -702,6 +902,71 @@ pub(crate) async fn start_ecu_sim(sim: &EcuSim) -> Result<(), TestingError> {
 
         *ECU_SIM_PROCESS.lock().await = Some(child);
     }
+    wait_for_ecu_sim_ready(&sim.host, sim.control_port).await
+}
+
+/// Starts the ecu-sim the same way the current test mode originally started
+/// it: with the CAN stack when CAN infrastructure is in use (pure-CAN and
+/// mixed runs), plain `DoIP` otherwise. Tests that restart the sim must use
+/// this so the sim comes back on the same transports.
+///
+/// In docker mode the compose service carries its CAN configuration in the
+/// generated `.env`, so restarting the container restores the right
+/// transports for every mode; `start_ecu_sim_can` only implements the local
+/// (non-docker) jar path.
+pub(crate) async fn start_ecu_sim_for_mode(sim: &EcuSim) -> Result<(), TestingError> {
+    if !use_docker() && can_infra() {
+        start_ecu_sim_can(sim).await
+    } else {
+        start_ecu_sim_doip(sim).await
+    }
+}
+
+pub(crate) async fn start_ecu_sim_can(sim: &EcuSim) -> Result<(), TestingError> {
+    // Local (non-docker) CAN path: spawn the same `ecu-sim-all.jar` as the DoIP
+    // path but with `SIM_CAN_SOCKETCAND_*` set so the JVM connects to a
+    // socketcand daemon. The daemon and its (v)can bus must already be running
+    // locally (e.g. `socketcand -i vcan0` on 127.0.0.1:29536). In docker mode
+    // the daemon runs in its own compose service (see `write_docker_env_file` /
+    // docker-compose.yml), not here.
+    let ecu_sim_dir = ecu_sim_dir()?;
+    if !ecu_sim_dir.exists() {
+        return Err(TestingError::PathNotFound(format!(
+            "ecu-sim run script not found at {}",
+            ecu_sim_dir.display()
+        )));
+    }
+    let jar = ecu_sim_dir.join("build/libs/ecu-sim-all.jar");
+    if !jar.exists() {
+        return Err(TestingError::PathNotFound(format!(
+            "ecu-sim-all.jar not found at {}. Run `./gradlew shadowJar` in the ecu-sim directory \
+             first.",
+            jar.display()
+        )));
+    }
+
+    // Use `java` from PATH by default; CDA_INTEGRATION_TEST_JAVA_BIN
+    // overrides it for systems where the required JDK (>= 21) is not the
+    // default one.
+    let java_bin =
+        std::env::var("CDA_INTEGRATION_TEST_JAVA_BIN").unwrap_or_else(|_| "java".to_owned());
+    let child = std::process::Command::new(&java_bin)
+        .arg("-jar")
+        .arg(&jar)
+        .env("SIM_DOIP_PORT", "13400")
+        .env("SIM_REST_PORT", sim.control_port.to_string())
+        .env("SIM_NETWORK_INTERFACE", "127.0.0.1")
+        .env("SIM_CAN_SOCKETCAND_HOST", "127.0.0.1")
+        .env("SIM_CAN_SOCKETCAND_PORT", SOCKETCAND_PORT.to_string())
+        .env("SIM_CAN_SOCKETCAND_BUS", CAN_BUS_NAME)
+        .spawn()
+        .map_err(|e| {
+            TestingError::ProcessFailed(format!(
+                "Failed to start ecu-sim CAN sim with {java_bin}: {e}"
+            ))
+        })?;
+
+    *ECU_SIM_PROCESS.lock().await = Some(child);
     wait_for_ecu_sim_ready(&sim.host, sim.control_port).await
 }
 
@@ -752,6 +1017,51 @@ fn use_docker() -> bool {
 
 fn coverage_mode() -> bool {
     std::env::var(CDA_INTEGRATION_TEST_COVERAGE).is_ok_and(|s| s == "true")
+}
+
+pub(crate) fn use_can() -> bool {
+    std::env::var(CDA_INTEGRATION_TEST_USE_CAN).is_ok_and(|s| s == "true")
+}
+
+fn use_mixed() -> bool {
+    std::env::var(CDA_INTEGRATION_TEST_USE_MIXED).is_ok_and(|s| s == "true")
+}
+
+/// Whether the CAN infrastructure (socketcand + sim CAN stack) is needed:
+/// true in pure-CAN and in mixed mode.
+pub(crate) fn can_infra() -> bool {
+    use_can() || use_mixed()
+}
+
+/// Compose profiles to activate: the `can` profile (which includes the
+/// socketcand service) whenever CAN infrastructure is needed (pure-CAN and
+/// mixed runs), so `DoIP`-only runs need no vcan module.
+fn compose_profiles() -> &'static str {
+    if can_infra() { "can" } else { "" }
+}
+
+/// Guard, returning `true` (and logging a skip notice), for tests that cannot
+/// run in the pure-CAN suite: either they exercise `DoIP`-only mechanisms
+/// (`VAM`, sim restart) or they depend on session/security timing not yet
+/// reliable over the CAN transport. Each gated call site documents its
+/// specific reason. In MIXED mode these tests DO run: the ECUs they target
+/// (FLXC1000/FLXCNG1000) are served over `DoIP` there.
+pub(crate) fn skip_for_can(test_name: &str, reason: &str) -> bool {
+    if use_can() {
+        eprintln!("[can] skipping {test_name}: {reason}");
+        return true;
+    }
+    false
+}
+
+/// Guard for tests that need the CAN infrastructure (pure-CAN or mixed
+/// mode); mirrors [`skip_for_can`].
+pub(crate) fn skip_for_doip(test_name: &str, reason: &str) -> bool {
+    if !can_infra() {
+        eprintln!("[doip] skipping {test_name}: {reason}");
+        return true;
+    }
+    false
 }
 
 async fn wait_for_http_ready(
@@ -1083,5 +1393,66 @@ fn check_command_success(
         Ok(())
     } else {
         Err(TestingError::ProcessFailed(error_msg.to_owned()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn docker_env_can_socketcand_lines_are_well_formed() {
+        let content = docker_env_content(true, 20002, 13400, 8181);
+
+        // Guards against string-literal mangling (e.g. a stray backslash in a
+        // value), which would silently keep the ecu-sim off the CAN bus.
+        assert!(
+            content.contains("SIM_CAN_SOCKETCAND_HOST=socketcand\n"),
+            "host line malformed:\n{content}"
+        );
+        assert!(
+            !content.contains("socketcand\\"),
+            "host value has a stray backslash:\n{content}"
+        );
+        assert!(
+            content.contains(&format!("SIM_CAN_SOCKETCAND_PORT={SOCKETCAND_PORT}\n")),
+            "port line malformed:\n{content}"
+        );
+        assert!(
+            content.contains(&format!("SIM_CAN_SOCKETCAND_BUS={CAN_BUS_NAME}\n")),
+            "bus line malformed:\n{content}"
+        );
+        assert!(
+            content.contains("CDA_FEATURES=can-socketcand\n"),
+            "features line malformed:\n{content}"
+        );
+        // Every line is a comment or a well-formed KEY=VALUE line.
+        for line in content
+            .lines()
+            .filter(|l| !l.is_empty() && !l.trim_start().starts_with('#'))
+        {
+            let (key, _) = line
+                .split_once('=')
+                .unwrap_or_else(|| panic!("not KEY=VALUE: {line:?}"));
+            assert_eq!(key, key.trim(), "key has stray whitespace: {line:?}");
+            assert!(
+                key.chars()
+                    .all(|c| c.is_ascii_uppercase() || c == '_' || c.is_ascii_digit()),
+                "unexpected key {key:?} in line {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn docker_env_without_can_has_no_socketcand_vars() {
+        let content = docker_env_content(false, 20002, 13400, 8181);
+        assert!(
+            !content.contains("SOCKETCAND"),
+            "unexpected CAN vars:\n{content}"
+        );
+        assert!(
+            !content.contains("CDA_FEATURES"),
+            "unexpected CDA_FEATURES:\n{content}"
+        );
     }
 }

--- a/opensovd-cda-can.toml
+++ b/opensovd-cda-can.toml
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Example configuration for CAN bus transport
+# This enables CAN communication while keeping DoIP disabled.
+# Requires a binary built with the `can` cargo feature, e.g.
+#   CDA_CONFIG_FILE=opensovd-cda-can.toml cargo run -p opensovd-cda --features can
+
+flash_files_path = "./flash"
+
+[server]
+address = "0.0.0.0"
+port = 20002
+
+[database]
+path = "./mdds"
+fallback_to_base_variant = true
+
+# DoIP is disabled. The block is still required (Configuration.doip is
+# non-Option), but CDA skips DoIP initialization when enabled = false.
+# Set enabled = true and fill in tester_address if you want DoIP as well.
+[doip]
+enabled = false
+tester_address = "127.0.0.1"
+tester_subnet = "255.255.0.0"
+gateway_port = 13400
+send_timeout_ms = 1000
+
+# CAN bus configuration
+[can]
+# CAN interface name (e.g., "vxcan0", "can0", "vcan0")
+interface = "vxcan0"
+
+# Response timeout in milliseconds (default: 5000ms)
+response_timeout_ms = 2000
+
+# Functional-broadcast TesterPresent keep-alive interval in milliseconds.
+# The default (0) disables the broadcast for resident on-board operation.
+# This file is the external-tester example, so it enables the keep-alive:
+# it holds ECUs awake for the diagnostic session, making discovery work
+# even on a quiet bus.
+keepalive_interval_ms = 2000
+
+# Probe timeout in milliseconds for ECU discovery (default: 100ms)
+probe_timeout_ms = 100
+
+# Extra rounds through the probe sequence for ECUs that did not answer,
+# self-healing transiently lost exchanges inside the transport
+# (default: 0 = probe each ECU once per discovery)
+# probe_retries = 0
+
+# Delay between probe retry rounds in milliseconds (default: 100ms)
+# probe_retry_delay_ms = 100
+
+# Whether the built-in TesterPresent probe heads the discovery probe
+# sequence (default: true). Set to false for fleets whose ECUs never answer
+# TesterPresent; [[can.probe_fallbacks]] must then be non-empty and is used
+# as the complete probe sequence.
+# default_probes = true
+
+# CAN ID mappings. CDA extracts CAN addressing from the MDD com-params
+# (per-ECU CP_UniqueRespIdTable entries first, then top-level
+# CP_CanPhysReqId / CP_CanRespUSDTId scalars); an [[can.ecu_mappings]]
+# entry OVERRIDES whatever the MDD provides for that ECU. The example
+# MDDs in testcontainer/odx/ (e.g. FLXC1000) do not carry CAN addressing
+# com-params, so a fallback request/response ID pair is required here.
+# 0x7E0/0x7E8 are the OBD-II request/response IDs and work as a generic
+# default for the test/example MDDs.
+[[can.ecu_mappings]]
+ecu_name = "FLXC1000"
+request_id = 0x7E0
+response_id = 0x7E8
+
+# CAN ECUs need a protocol override: the global default protocol name
+# (doip.protocol_name, "UDS_Ethernet_DoIP_DOBT") is DoIP-specific and will
+# not match the diag layers in a CAN MDD, which makes the ECU fail to load.
+# Any name from database.naming_convention.can_protocol_aliases (default:
+# UDS_CAN, ISO_11898_2_DWCAN, ISO_11898_3_DWFTCAN, CAN, ISO_15765_2,
+# ISO_15765_3) engages the CAN alias chain in protocol resolution: on an
+# exact-match miss the other aliases are tried in order. Alternatively
+# "auto-can" picks the first protocol whose name matches the configured
+# CAN markers (database.naming_convention.can_protocol_markers).
+[ecu.FLXC1000]
+protocol = "UDS_CAN"
+
+# Optional: explicit CAN ID mappings
+# Use this to override CAN IDs from MDD files or when MDD doesn't contain them
+# [[can.ecu_mappings]]
+# ecu_name = "MyECU"
+# request_id = 0x7E0    # Physical request CAN ID
+# response_id = 0x7E8   # Physical response CAN ID
+#
+# [[can.ecu_mappings]]
+# ecu_name = "AnotherECU"
+# request_id = 0x700
+# response_id = 0x708
+
+# Optional: per-ECU transport selection overrides
+#
+# By default, DoIP is used when a DoIP gateway is available, falling back to CAN.
+# Use transport_overrides to force specific ECUs onto a particular transport.
+# This is useful when:
+#   - An ECU is CAN-only and has no DoIP logical address
+#   - The MDD contains DoIP COM params for a gateway device, but you want to
+#     talk to the ECU directly over CAN
+#   - You want to test CAN communication for an ECU that is also reachable via DoIP
+#
+# Supported transport spellings: "can" / "Can" / "CAN" and
+# "doip" / "DoIP" / "DOIP" (exact aliases, other casings are rejected).
+# ECU names are matched case-insensitively.
+#
+# [[can.transport_overrides]]
+# ecu_name = "CanOnlyEcu"
+# transport = "can"
+#
+# [[can.transport_overrides]]
+# ecu_name = "ForceDoipEcu"
+# transport = "doip"
+
+[logging.otel]
+enabled = false
+
+# Uncomment to enable OpenTelemetry tracing
+# [logging.otel]
+# enabled = true
+# endpoint = "http://localhost:4317"

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -12,6 +12,60 @@
 # Path to the directory containing flash files.
 # flash_files_path = "."
 
+# Optional CAN bus transport configuration.
+# When enabled, the adapter can communicate with ECUs over CAN bus.
+# [can]
+# default_probes = true
+# ecu_mappings = []
+# interface = "vcan0"
+# keepalive_interval_ms = 0
+# probe_fallbacks = []
+# probe_retries = 0
+# probe_retry_delay_ms = 100
+# probe_timeout_ms = 100
+# response_timeout_ms = 5000
+# transport_overrides = []
+
+# Defines the Communication parameters which are used in CAN bus communication
+[com_params.can]
+# Name of the COMPLEX com-param table carrying the per-ECU CAN
+# addressing (ISO 22900/ODX `CP_UniqueRespIdTable`). Its sub-parameters
+# are matched against the `name`s of the ID parameters above and take
+# precedence over top-level scalar com-params of the same names.
+# OEM databases using a different table name configure it here (mirrors
+# `DoipComParams::logical_response_id_table_name`).
+# unique_resp_id_table_name = "CP_UniqueRespIdTable"
+
+# Functional CAN ID for broadcast requests
+[com_params.can.functional_id]
+# Communication parameter identifier (`CP_xxx` name from the database).
+# name = "CP_CanFuncReqId"
+# Controls whether a com-parameter value is resolved from the MDD database
+# or forced from the configuration file.
+# precedence = "Database"
+# Value used when the database does not provide one, or precedence is set to `Config`.
+# value = 2015
+
+# Physical request CAN ID (tester -> ECU)
+[com_params.can.physical_request_id]
+# Communication parameter identifier (`CP_xxx` name from the database).
+# name = "CP_CanPhysReqId"
+# Controls whether a com-parameter value is resolved from the MDD database
+# or forced from the configuration file.
+# precedence = "Database"
+# Value used when the database does not provide one, or precedence is set to `Config`.
+# value = 2016
+
+# Physical response CAN ID (ECU -> tester)
+[com_params.can.physical_response_id]
+# Communication parameter identifier (`CP_xxx` name from the database).
+# name = "CP_CanRespUSDTId"
+# Controls whether a com-parameter value is resolved from the MDD database
+# or forced from the configuration file.
+# precedence = "Database"
+# Value used when the database does not provide one, or precedence is set to `Config`.
+# value = 2024
+
 # DoIP-specific communication parameters.
 [com_params.doip]
 # Only the ID of this com param is needed right now
@@ -429,6 +483,25 @@
 # Common affixes (e.g. `read`, `write`) should be placed first for performance, but compound
 # affixes must precede their base forms for correct matching.
 [database.naming_convention]
+# Protocol short-names that identify diagnostics-over-CAN in the MDD,
+# matched case-insensitively. When the configured protocol name is one
+# of these but the database has no layer of exactly that name, protocol
+# resolution tries the other entries in order. OEM databases with
+# different protocol names configure their own list.
+# can_protocol_aliases = [
+#     "UDS_CAN",
+#     "ISO_11898_2_DWCAN",
+#     "ISO_11898_3_DWFTCAN",
+#     "CAN",
+#     "ISO_15765_2",
+#     "ISO_15765_3",
+# ]
+# Case-insensitive substrings that mark a protocol short-name as
+# diagnostics-over-CAN during `"auto-can"` protocol detection.
+# can_protocol_markers = [
+#     "CAN",
+#     "ISO_11898",
+# ]
 # Semantic ID used to identify the distinguishing parameter of a service.
 # configuration_service_parameter_semantic_id = "ID"
 # Functional class name used to filter varcoding services.
@@ -534,10 +607,18 @@
 # The alive check is only sent when no diagnostic communication has occurred
 # for this duration. Set to 0 to disable the alive check.
 # alive_check_interval_secs = 1800
+# Whether the `DoIP` transport is enabled.
+# When `false`, CDA skips `DoIP` initialization entirely (useful for
+# CAN-only or DoIP-less test setups).
+# Defaults to `true` to preserve the historical DoIP-first behavior.
+# enabled = true
 # UDP/TCP port for `DoIP` gateway discovery and communication.
 # gateway_port = 13400
 # The name of the protocol to use.
 # Matched case-insensitive against the database.
+# The special value `"auto-can"` defers the choice to the MDD-driven
+# CAN protocol auto-detection (see `into_db_protocol`; the markers are
+# configurable via `database.naming_convention.can_protocol_markers`).
 # protocol_name = "UDS_Ethernet_DoIP_DOBT"
 # Whether to request a diagnostic message positive acknowledgement.
 # send_diagnostic_message_ack = true
@@ -550,19 +631,34 @@
 # TLS port for secure `DoIP` communication.
 # tls_port = 3496
 
-[ecu.FLXC1000.com_params.doip.routing_activation_timeout]
+# [ecu.FLXC1000.com_params.can.functional_id]
+# name = "CP_CanFuncReqId"
+# precedence = "Config"
+# value = 2015
+
+# [ecu.FLXC1000.com_params.can.physical_request_id]
+# name = "CP_CanPhysReqId"
+# precedence = "Config"
+# value = 2014
+
+# [ecu.FLXC1000.com_params.can.physical_response_id]
+# name = "CP_CanRespUSDTId"
+# precedence = "Config"
+# value = 2024
+
+# [ecu.FLXC1000.com_params.doip.routing_activation_timeout]
 # name = "CP_DoIPRoutingActivationTimeout"
 # precedence = "Config"
 
-[ecu.FLXC1000.com_params.doip.routing_activation_timeout.value]
+# [ecu.FLXC1000.com_params.doip.routing_activation_timeout.value]
 # nanos = 0
 # secs = 42
 
-[ecu.FLXC1000.com_params.uds.timeout_default]
+# [ecu.FLXC1000.com_params.uds.timeout_default]
 # name = "CP_P6Max"
 # precedence = "Config"
 
-[ecu.FLXC1000.com_params.uds.timeout_default.value]
+# [ecu.FLXC1000.com_params.uds.timeout_default.value]
 # nanos = 0
 # secs = 5
 

--- a/testcontainer/cda/Dockerfile
+++ b/testcontainer/cda/Dockerfile
@@ -37,6 +37,7 @@ COPY cda-interfaces/Cargo.toml ./cda-interfaces/Cargo.toml
 COPY cda-core/Cargo.toml ./cda-core/Cargo.toml
 COPY cda-comm-doip/Cargo.toml ./cda-comm-doip/Cargo.toml
 COPY cda-comm-uds/Cargo.toml ./cda-comm-uds/Cargo.toml
+COPY cda-comm-can/Cargo.toml ./cda-comm-can/Cargo.toml
 COPY cda-database/Cargo.toml ./cda-database/Cargo.toml
 COPY cda-plugin-security/Cargo.toml ./cda-plugin-security/Cargo.toml
 COPY cda-plugin-runtime-update/Cargo.toml ./cda-plugin-runtime-update/Cargo.toml
@@ -83,6 +84,10 @@ ARG SOURCE_DATE_EPOCH
 ARG SOURCE_GIT_SHA
 ARG BUILD_PROFILE=release
 ARG RUSTFLAGS=
+# Optional extra cargo features for the opensovd-cda binary, e.g.
+# "can-socketcand" to compile in the socketcand-backed CAN transport used by
+# the CAN integration tests.
+ARG CDA_FEATURES=""
 
 WORKDIR /app
 # Copy pre-built dependencies from the cacher stage
@@ -95,6 +100,7 @@ COPY cda-interfaces ./cda-interfaces
 COPY cda-core ./cda-core
 COPY cda-comm-doip ./cda-comm-doip
 COPY cda-comm-uds ./cda-comm-uds
+COPY cda-comm-can ./cda-comm-can
 COPY cda-database ./cda-database
 COPY cda-plugin-security ./cda-plugin-security
 COPY cda-plugin-runtime-update ./cda-plugin-runtime-update
@@ -119,10 +125,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     export SOURCE_GIT_SHA=${SOURCE_GIT_SHA} && \
     export RUSTFLAGS="$RUSTFLAGS"; \
     if [ "$BUILD_PROFILE" = "dev" ]; then \
-        cargo build --profile dev --bin opensovd-cda && \
+        cargo build --profile dev --bin opensovd-cda ${CDA_FEATURES:+--features "$CDA_FEATURES"} && \
         cp target/debug/opensovd-cda /tmp/opensovd-cda; \
     else \
-        cargo build --release --bin opensovd-cda && \
+        cargo build --release --bin opensovd-cda ${CDA_FEATURES:+--features "$CDA_FEATURES"} && \
         cp target/release/opensovd-cda /tmp/opensovd-cda; \
     fi
 

--- a/testcontainer/docker-compose.yml
+++ b/testcontainer/docker-compose.yml
@@ -10,6 +10,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
 services:
+  # socketcand daemon fronting a shared vcan bus. Only started for the CAN
+  # integration tests (compose profile `can`); requires the `vcan` kernel
+  # module on the host. CDA and the ecu-sim both connect to it over TCP.
+  socketcand:
+    build:
+      context: ./socketcand
+    privileged: true
+    cap_add:
+      - NET_ADMIN
+    profiles:
+      - can
+    networks:
+      - testcontainer-net
+    healthcheck:
+      test: ["CMD-SHELL", "ss -ltn | grep -q 29536 || exit 1"]
+      interval: 1s
+      timeout: 5s
+      retries: 15
+      start_period: 10s
+    restart: unless-stopped
+
   ecu-sim:
     build:
       context: ./ecu-sim
@@ -20,6 +41,11 @@ services:
     environment:
       - USE_MULTIPLE_IPS=true
       - SIM_NETWORK_INTERFACE=eth0
+      # When a socketcand host is set the sim serves its ECUs over CAN/ISO-TP
+      # via that daemon. Empty/unset disables the CAN path (DoIP-only).
+      - SIM_CAN_SOCKETCAND_HOST=${SIM_CAN_SOCKETCAND_HOST:-}
+      - SIM_CAN_SOCKETCAND_PORT=${SIM_CAN_SOCKETCAND_PORT:-29536}
+      - SIM_CAN_SOCKETCAND_BUS=${SIM_CAN_SOCKETCAND_BUS:-vcan0}
     ports:
       - "${SIM_CONTROL_PORT:-8181}:8181"
     networks:
@@ -39,6 +65,8 @@ services:
       args:
         - SOURCE_DATE_EPOCH
         - SOURCE_GIT_SHA
+        # Extra cargo features for the CDA image; "can-socketcand" for CAN tests.
+        - CDA_FEATURES=${CDA_FEATURES:-}
     ports:
       - "${CDA_PORT:-20002}:20002"
     volumes:

--- a/testcontainer/ecu-sim/settings.gradle.kts
+++ b/testcontainer/ecu-sim/settings.gradle.kts
@@ -13,10 +13,15 @@
 
 rootProject.name = "ecu-sim"
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
-            version("kotlinVersion", "2.2.10")
+            // must match the kotlin-stdlib 2.3.x pulled in by doip-sim-ecu-dsl
+            version("kotlinVersion", "2.3.21")
             version("ktorVersion", "3.2.3")
             version("shadow", "8.1.1")
             version("ktlint", "14.0.1")
@@ -35,7 +40,10 @@ dependencyResolutionManagement {
                 "ktor-server-content-negotiation",
             ).versionRef("ktorVersion")
 
-            library("doip-sim-dsl", "io.github.doip-sim-ecu:doip-sim-ecu-dsl:0.22.0")
+            library(
+                "doip-sim-dsl",
+                "io.github.doip-sim-ecu:doip-sim-ecu-dsl:0.23.2-beta",
+            )
             library("logback-classic", "ch.qos.logback:logback-classic:1.5.18")
             library("auth0-jwt", "com.auth0:java-jwt:4.5.0")
             library("google-guava", "com.google.guava:guava:33.4.8-jre")

--- a/testcontainer/ecu-sim/src/main/kotlin/Main.kt
+++ b/testcontainer/ecu-sim/src/main/kotlin/Main.kt
@@ -13,6 +13,9 @@
 
 import ecu.addCanEcu
 import ecu.addDoipEntity
+import ecu.addSimCanEcu
+import ecu.canNetwork
+import library.can.socketcand.SocketcandTransport
 import webserver.startEmbeddedWebserver
 
 fun main() {
@@ -22,6 +25,11 @@ fun main() {
     val doipPort = System.getenv("SIM_DOIP_PORT")?.toInt() ?: 13400
     val portRest = System.getenv("SIM_REST_PORT")?.toInt() ?: 8181
     val networkInterfaceEnv = System.getenv("SIM_NETWORK_INTERFACE") ?: "0.0.0.0"
+    // CAN is enabled when a socketcand host is configured; the simulator then
+    // reaches the shared CAN bus through a socketcand daemon over TCP.
+    val socketcandHost = System.getenv("SIM_CAN_SOCKETCAND_HOST")?.takeIf { it.isNotBlank() }
+    val socketcandPort = System.getenv("SIM_CAN_SOCKETCAND_PORT")?.toInt() ?: 29536
+    val socketcandBus = System.getenv("SIM_CAN_SOCKETCAND_BUS") ?: "vcan0"
 
     network {
         networkInterface = networkInterfaceEnv
@@ -72,5 +80,28 @@ fun main() {
         }
     }
     start()
+
+    if (socketcandHost != null) {
+        println("CAN via socketcand at $socketcandHost:$socketcandPort bus $socketcandBus")
+        canNetwork({
+            SocketcandTransport(
+                host = socketcandHost,
+                port = socketcandPort,
+                busName = socketcandBus,
+                reconnect = true,
+            )
+        }) {
+            // Each example ECU gets a distinct (rxId, txId) pair so the right
+            // SimEcu instance answers on the bus. The integration test config
+            // (`[[can.ecu_mappings]]` in runtime.rs) mirrors this assignment.
+            addSimCanEcu("FLXC1000", rxId = 0x700, txId = 0x708)
+            addSimCanEcu("TMC1001", rxId = 0x710, txId = 0x718)
+            addSimCanEcu("FSNR2000", rxId = 0x720, txId = 0x728)
+            addSimCanEcu("TMCC3000", rxId = 0x730, txId = 0x738)
+            addSimCanEcu("HOVR4000", rxId = 0x740, txId = 0x748)
+            addSimCanEcu("JGWT5000", rxId = 0x750, txId = 0x758)
+        }
+    }
+
     startEmbeddedWebserver(port = portRest)
 }

--- a/testcontainer/ecu-sim/src/main/kotlin/can/CanNetworking.kt
+++ b/testcontainer/ecu-sim/src/main/kotlin/can/CanNetworking.kt
@@ -1,0 +1,206 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package can
+
+import SimEcu
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import library.UdsMessage
+import library.can.CanTransport
+import library.can.CanUdsMessage
+import library.can.isotp.IsoTpEndpoint
+import library.can.isotp.IsoTpOptions
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Serves existing [SimEcu] instances over UDS/ISO-TP on a single CAN bus,
+ * using the doip-sim-ecu-dsl CAN library (PR#164): one [IsoTpEndpoint] per ECU
+ * on a shared [CanTransport] (here socketcand).
+ *
+ * The ECUs are the *same* instances as the DoIP entities defined in the
+ * `network { ... }` block - looked up by name via [addSimCanEcu] - so anything
+ * the REST control plane changes (state, interceptors, `/reset`) is observed on
+ * both the DoIP and the CAN path, because there is only one [SimEcu] behind a
+ * given name. ISO-TP segmentation/reassembly and the raw-frame transport are
+ * provided entirely by the library; this class only wires endpoints to ECUs and
+ * dispatches reassembled requests through `SimEcu.onIncomingUdsMessage`.
+ */
+class CanNetworking(
+    private val transportFactory: () -> CanTransport,
+) {
+    private val log = LoggerFactory.getLogger(CanNetworking::class.java)
+    private val started = AtomicBoolean(false)
+    private val ecusByName = ConcurrentHashMap<String, CanEcu>()
+    private val endpoints = mutableListOf<IsoTpEndpoint>()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @Volatile
+    private var transport: CanTransport? = null
+
+    private data class CanEcu(
+        val name: String,
+        val ecu: SimEcu,
+        val rxId: Int,
+        val txId: Int,
+    )
+
+    fun addEcu(
+        name: String,
+        ecu: SimEcu,
+        rxId: Int,
+        txId: Int,
+    ) {
+        require(!started.get()) { "Cannot add ECUs after start()" }
+        require(ecusByName[name] == null) { "ECU '$name' already registered on this network" }
+        ecusByName[name] = CanEcu(name, ecu, rxId, txId)
+    }
+
+    fun start() {
+        if (!started.compareAndSet(false, true)) return
+        val transport = transportFactory()
+        this.transport = transport
+
+        // Attach the endpoints before connecting the transport, so no frame
+        // received right after connecting can be lost.
+        ecusByName.values.forEach { canEcu ->
+            lateinit var endpoint: IsoTpEndpoint
+            endpoint =
+                IsoTpEndpoint(
+                    transport = transport,
+                    physicalRxId = canEcu.rxId,
+                    functionalRxId = null,
+                    txId = canEcu.txId,
+                    options = IsoTpOptions(),
+                ) { payload, functional ->
+                    dispatchRequest(canEcu, endpoint, payload, functional)
+                }
+            endpoint.start(scope)
+            endpoints.add(endpoint)
+            log.info(
+                "ECU '{}' listening on 0x{} (responding on 0x{})",
+                canEcu.name,
+                canEcu.rxId.toString(16),
+                canEcu.txId.toString(16),
+            )
+        }
+
+        // Connect the transport in the background rather than blocking the
+        // caller: the simulator's HTTP control server must come up regardless of
+        // whether socketcand is reachable yet (in docker the daemon may still be
+        // starting). `SocketcandTransport.start` only auto-reconnects *after* a
+        // successful initial connect, so retry that initial connect here until
+        // the daemon is up; the endpoints are already subscribed to the frame
+        // flow, so nothing is lost.
+        scope.launch {
+            var attempt = 0
+            while (isActive) {
+                try {
+                    transport.start(scope)
+                    log.info("CAN network connected via {}", transport.name)
+                    break
+                } catch (e: Exception) {
+                    attempt++
+                    log.warn(
+                        "CAN transport '{}' initial connect failed (attempt {}), retrying: {}",
+                        transport.name,
+                        attempt,
+                        e.message,
+                    )
+                    delay(minOf(5000L, 500L * attempt))
+                }
+            }
+        }
+    }
+
+    /**
+     * The [IsoTpEndpoint] handler runs on the endpoint's frame-processing
+     * coroutine and must not block, so the (blocking) DSL handler chain is run
+     * on a separate coroutine. It uses the scope's [Dispatchers.IO] (not
+     * [Dispatchers.Default]): `CanUdsMessage.respond` performs the ISO-TP
+     * transmission via a blocking `runBlocking`, and a multi-frame response
+     * blocks its thread until flow control arrives - on the small Default pool
+     * concurrent operations would starve it (and the simulator's HTTP server).
+     * The response is written back through [IsoTpEndpoint.outputChannel] by
+     * [CanUdsMessage.respond], which emits raw UDS (no DoIP framing).
+     */
+    private fun dispatchRequest(
+        canEcu: CanEcu,
+        endpoint: IsoTpEndpoint,
+        payload: ByteArray,
+        functional: Boolean,
+    ) {
+        val request =
+            CanUdsMessage(
+                targetAddressType = if (functional) UdsMessage.FUNCTIONAL else UdsMessage.PHYSICAL,
+                message = payload,
+                output = endpoint.outputChannel,
+                requestCanId = canEcu.rxId,
+                responseCanId = canEcu.txId,
+            )
+        scope.launch {
+            try {
+                canEcu.ecu.onIncomingUdsMessage(request)
+            } catch (e: Exception) {
+                log.error("ECU '${canEcu.name}' handler threw", e)
+            }
+        }
+    }
+
+    /**
+     * The CAN ECUs share their [SimEcu] with the DoIP entities, which are reset
+     * via the DoIP `networkInstances()`; the ISO-TP endpoints keep no
+     * cross-message state that needs clearing here.
+     */
+    fun reset() = Unit
+
+    fun stop() {
+        if (!started.compareAndSet(true, false)) return
+        endpoints.forEach { it.stop() }
+        endpoints.clear()
+        transport?.close()
+        transport = null
+        scope.cancel()
+    }
+
+    fun findEcuByName(
+        name: String,
+        ignoreCase: Boolean = true,
+    ): SimEcu? = ecusByName.values.firstOrNull { name.equals(it.name, ignoreCase) }?.ecu
+
+    fun isStarted(): Boolean = started.get()
+}
+
+/**
+ * Global registry of all [CanNetworking] instances, mirroring the
+ * `doip-sim-ecu-dsl` `networkInstances()` global.
+ */
+object CanNetworks {
+    private val networks: MutableList<CanNetworking> = mutableListOf()
+
+    fun add(network: CanNetworking) = synchronized(networks) { networks.add(network) }
+
+    fun all(): List<CanNetworking> = synchronized(networks) { networks.toList() }
+
+    fun findEcuByName(
+        name: String,
+        ignoreCase: Boolean = true,
+    ): SimEcu? = all().firstNotNullOfOrNull { it.findEcuByName(name, ignoreCase) }
+}

--- a/testcontainer/ecu-sim/src/main/kotlin/ecu/EcuFunctions.kt
+++ b/testcontainer/ecu-sim/src/main/kotlin/ecu/EcuFunctions.kt
@@ -18,6 +18,10 @@ import DoipEntityDataHandler
 import NetworkingData
 import RequestsData
 import addDtcRequests
+import can.CanNetworking
+import can.CanNetworks
+import library.can.CanTransport
+import networkInstances
 
 private fun generateDefaultEcuState() = EcuState()
 
@@ -63,6 +67,36 @@ fun DoipEntityData.addCanEcu(
     }
 }
 
+/**
+ * Attach an existing [SimEcu] (defined in the `network { ... }` DoIP block) to a
+ * [CanNetworking] so the *same* ECU instance is reachable over both DoIP and
+ * CAN. Sharing one instance is what makes the REST control plane work across
+ * transports: an interceptor or state change applied via `findByEcuName` (which
+ * resolves the DoIP-side instance) is observed by CAN traffic too, because there
+ * is only one [SimEcu] behind the name.
+ *
+ * The ECU must already exist; define it with [addDoipEntity] / [addCanEcu] in
+ * the `network { ... }` block before calling this.
+ */
+fun CanNetworking.addSimCanEcu(
+    name: String,
+    rxId: Int,
+    txId: Int,
+) {
+    val ecu =
+        networkInstances().firstNotNullOfOrNull { it.findEcuByName(name, true) }
+            ?: error(
+                "No ECU named '$name' found in the DoIP network; define it in the " +
+                    "network { ... } block before attaching it to a CAN network",
+            )
+    addEcu(
+        name = name,
+        ecu = ecu,
+        rxId = rxId,
+        txId = txId,
+    )
+}
+
 fun RequestsData.addAllFunctionality() {
     addSessionRequests()
     addResetRequests()
@@ -74,4 +108,24 @@ fun RequestsData.addAllFunctionality() {
     addDiagnosticRequests()
     addFlashRequests()
     addDtcRequests()
+}
+
+/**
+ * Top-level builder for a CAN network. Mirrors the DSL's `network { ... }`
+ * but operates on a [CanNetworking] instead of [NetworkingData].
+ *
+ * [transportFactory] creates the raw-frame [CanTransport] the network's ISO-TP
+ * endpoints run on (e.g. a `SocketcandTransport`); it is invoked once, on
+ * [CanNetworking.start]. Multiple CAN networks are supported (one process-global
+ * registry per `CanNetworks`); the integration tests use a single network.
+ */
+fun canNetwork(
+    transportFactory: () -> CanTransport,
+    block: CanNetworking.() -> Unit,
+): CanNetworking {
+    val net = CanNetworking(transportFactory)
+    net.block()
+    CanNetworks.add(net)
+    net.start()
+    return net
 }

--- a/testcontainer/ecu-sim/src/main/kotlin/webserver/WebserverRoutes.kt
+++ b/testcontainer/ecu-sim/src/main/kotlin/webserver/WebserverRoutes.kt
@@ -46,6 +46,10 @@ fun findByEcuName(ecuName: String): SimEcu? {
             return ecu
         }
     }
+    val canEcu = can.CanNetworks.findEcuByName(ecuName, true)
+    if (canEcu != null) {
+        return canEcu
+    }
     throw NotFoundException()
 }
 
@@ -60,6 +64,10 @@ fun Route.addStateRoutes() {
         networkInstances().forEach { network ->
             network.reset()
         }
+        // The CAN networks share their SimEcu instances with the DoIP entities
+        // reset above; the ISO-TP endpoints keep no cross-message state, so this
+        // is a no-op kept for symmetry.
+        can.CanNetworks.all().forEach { net -> net.reset() }
         call.respond(HttpStatusCode.NoContent)
     }
 

--- a/testcontainer/first_steps.md
+++ b/testcontainer/first_steps.md
@@ -135,3 +135,37 @@ This returns all DTCs stored in the ECU's fault memory, including their status f
 ```sh
 docker compose down
 ```
+
+## Local CAN Setup (Optional)
+
+The CAN integration suites run against a virtual CAN bus. To prepare one
+locally (requires root and the `vcan` kernel module):
+
+```sh
+sudo modprobe vcan
+sudo ip link add dev vcan0 type vcan
+sudo ip link set up vcan0
+```
+
+The pure-CAN and mixed suites are then run with:
+
+```sh
+CDA_INTEGRATION_TEST_USE_CAN=true cargo test --locked -p integration-tests \
+  --features can-integration-tests --test integration_tests -- --test-threads=1
+CDA_INTEGRATION_TEST_USE_MIXED=true cargo test --locked -p integration-tests \
+  --features can-integration-tests --test integration_tests -- --test-threads=1
+```
+
+## Quick API Access
+
+Fetch a token and read data from an ECU (the test credentials work against
+the integration-test configuration):
+
+```sh
+TOKEN=$(curl -s -X POST http://localhost:20002/vehicle/v15/authorize \
+  -H "Content-Type: application/json" \
+  -d '{"client_id": "test", "client_secret": "test"}' | jq -r '.access_token')
+
+curl -s http://localhost:20002/vehicle/v15/components/<ecu>/data \
+  -H "Authorization: Bearer $TOKEN" | jq .
+```

--- a/testcontainer/socketcand/Dockerfile
+++ b/testcontainer/socketcand/Dockerfile
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM debian:trixie-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git ca-certificates build-essential meson ninja-build pkg-config \
+        libconfig-dev libsocketcan-dev iproute2 \
+    && git clone --depth 1 https://github.com/linux-can/socketcand.git /tmp/socketcand \
+    && cd /tmp/socketcand \
+    && meson setup -Dlibconfig=true --buildtype=release build \
+    && meson compile -C build \
+    && meson install -C build \
+    && ldconfig \
+    && rm -rf /tmp/socketcand /var/lib/apt/lists/*
+
+# Create the vcan bus at start (needs the `vcan` kernel module loaded on the
+# host plus NET_ADMIN), then serve it over rawmode TCP on the default port
+# 29536. The bus name `vcan0` is what clients pass in `< open vcan0 >`.
+# `-n` disables the UDP discovery beacon (clients connect by host:port).
+#
+# NOTE: socketcand's `-l` takes an *interface name* (default `eth0`), NOT an IP
+# address - passing `-l 0.0.0.0` makes it look up a non-existent interface and
+# die with "bind: Cannot assign requested address". `eth0` is the container's
+# interface on the compose bridge network, so clients reach it by service name.
+CMD ["/bin/sh", "-c", "ip link add dev vcan0 type vcan && ip link set up vcan0 && exec socketcand -n -i vcan0 -l eth0"]


### PR DESCRIPTION
Adds CAN (ISO-TP / ISO 15765-2) as a second diagnostic transport next to DoIP, behind the optional `can` cargo feature. Closes #195, closes #415.

## Structure

6 commits, each compiling on its own: four standalone diag-kernel/DoIP fixes flushed out during CAN bring-up, one squashed feature commit carrying the entire CAN transport (gateway, MDD-based addressing, duplicate groups, rediscovery, keep-alive, containerized CAN test environment), and the coverage CI wiring.

## Features

- Three interchangeable ISO-TP backends, selected by the interface string: kernel `can-isotp` sockets (`can0`), userspace ISO-TP over CAN_RAW (`rawcan:vcan0`, no `can_isotp` module needed), and CAN frames via a socketcand daemon (`socketcand:host:port:bus`, works off-Linux).
- **CAN addressing from the MDD com-params** (#415): per-ECU `CP_UniqueRespIdTable` entries first, scalar `CP_CanPhysReqId`/`CP_CanRespUSDTId` second; `[[can.ecu_mappings]]` and com-param config overrides win. ECUs sharing a derived ID pair form a duplicate group (candidate models of one physical node), resolved by variant detection like DoIP address twins.
- 11-bit standard and 29-bit extended CAN IDs (ISO 15765-4 normal fixed addressing), validated once via a shared `CanId` type.
- ECU discovery by probing (TesterPresent by default, configurable probe sequence incl. opt-out via `default_probes`), background rediscovery of absent/slept ECUs, fail-fast transport init.
- Functional-broadcast TesterPresent keep-alive with configurable interval; `keepalive_interval_ms = 0` disables it for resident/on-board deployments so network management can put ECUs to sleep - sleeping ECUs are then recovered autonomously by rediscovery on wake.
- `MultiTransportGateway`: explicit per-ECU pins via `[[can.transport_overrides]]` win; otherwise sticky first-detection binding (DoIP preferred). DoIP-only, CAN-only (`doip.enabled = false`, no DoIP socket bound), and mixed operation.
- KWP2000 `READ_DATA_BY_LOCAL_IDENTIFIER` (0x21) alongside UDS 0x22.

## Testing

- Three CI integration jobs (DoIP, pure CAN, mixed DoIP+CAN), all coverage-instrumented and merged into one report. All green.
- Real-vehicle validation on a smart453 (26 CAN-only KWP2000-over-ISO-TP ECUs, arm64 device on the OBD-II port): with **zero ID configuration**, 20/26 ECUs discovered purely from MDD extraction, correct variants incl. duplicate-group resolution, live data reads; 29-bit support confirmed in-vehicle by @FEVLuM. Both keep-alive modes tested on the vehicle, including the ignition-off sleep arc and autonomous recovery after wake.

## Running it

```
export CDA_CONFIG_FILE="opensovd-cda-can.toml"
RUST_LOG=debug ./opensovd-cda
```

If your MDDs carry CAN com-params, no per-ECU ID configuration is needed; otherwise add `[[can.ecu_mappings]]` entries (see `opensovd-cda-can.toml`).

## Known limitations / follow-ups

- ECU discovery probes sequentially; startup scales with ECU count x probe timeout. #416
- Functional addressing over CAN (`send_functional`) returns an honest `RequestNotSupported`. #417
- Setup-time validation for CAN ECUs sharing the fallback logical address in response routing. #418 (duplicate detection and the request semaphore already exclude/handle them)
- Session/security over CAN (SecurityAccess sequencing, keep-alive payload from com-params - KWP wants `3E 01/02`). #444
- Per-request ISO-TP sockets; persistent sockets for flashing-grade throughput. #455

Refactoring and process follow-ups from the reviews: #442 (transport orchestration layer), #443 (all-data-services integration test), #445 (overall completion deadline in `send_with_raw_payload`), #446 (test-harness port-allocation cleanup), #451 (blocking clippy), #452 (compile-time optional DoIP), #453 (typed parse errors), #454 (shared BackgroundTask). Upstreaming the `tokio-socketcan-isotp` feature work is tracked on the fork (MarkSchmitt/tokio-socketcan-isotp#1).

---

- [x] I have tested my changes locally (CI: DoIP + CAN + mixed suites; plus real-vehicle validation)
- [x] I have added or updated documentation (`testcontainer/first_steps.md`, example configs; docs/ pages still open)
- [x] I have linked related issues or discussions (#195)
- [x] I have added or updated tests (CAN + mixed integration suites, unit tests for the fixes)

Closes #415
Closes #195 
---
Mark Schmitt [mark.schmitt@mercedes-benz.com](mailto:mark.schmitt@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)

