### PR TITLE
fix(sovd): return 401 for unauthenticated requests to unregistered ECU paths

### DIFF
--- a/cda-sovd/src/sovd/error.rs
+++ b/cda-sovd/src/sovd/error.rs
@@ -18,7 +18,7 @@ use axum::{
         Request,
         rejection::{JsonRejection, QueryRejection},
     },
-    http::{StatusCode, Uri},
+    http::{HeaderMap, StatusCode, Uri, header},
     middleware::Next,
     response::{IntoResponse, Response},
 };
@@ -409,7 +409,10 @@ pub(crate) async fn sovd_method_not_allowed_handler(
     }
 }
 
-pub(crate) async fn sovd_not_found_handler(uri: Uri) -> impl IntoResponse {
+pub(crate) async fn sovd_not_found_handler(headers: HeaderMap, uri: Uri) -> impl IntoResponse {
+    if !headers.contains_key(header::AUTHORIZATION) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
     (
         StatusCode::NOT_FOUND,
         Json(
@@ -423,4 +426,5 @@ pub(crate) async fn sovd_not_found_handler(uri: Uri) -> impl IntoResponse {
             },
         ),
     )
+        .into_response()
 }

--- a/cda-sovd/src/sovd/mod.rs
+++ b/cda-sovd/src/sovd/mod.rs
@@ -459,9 +459,10 @@ async fn get_components<T: UdsEcu + SchemaProvider + Clone>(
     WithRejection(Query(query), _): WithRejection<Query<IncludeSchemaQuery>, ApiError>,
 ) -> Response {
     fn ecu_to_resource(ecu: String) -> Resource {
+        let ecu_lower = ecu.to_lowercase();
         Resource {
-            href: format!("http://localhost:20002/Vehicle/v15/components/{ecu}"),
-            id: Some(ecu.to_lowercase()),
+            href: format!("http://localhost:20002/vehicle/v15/components/{ecu_lower}"),
+            id: Some(ecu_lower),
             name: ecu,
         }
     }
@@ -510,7 +511,7 @@ fn docs_components(op: TransformOperation) -> TransformOperation {
         .response_with::<200, Json<sovd_interfaces::ResourceResponse>, _>(|res| {
             res.example(sovd_interfaces::ResourceResponse {
                 items: vec![sovd_interfaces::Resource {
-                    href: "http://localhost:20002/Vehicle/v15/components/my_ecu".into(),
+                    href: "http://localhost:20002/vehicle/v15/components/my_ecu".into(),
                     id: Some("my_ecu".into()),
                     name: "My ECU".into(),
                 }],


### PR DESCRIPTION
Summary
The fallback 404 handler was returning 404 unconditionally for any unmatched route, including unauthenticated requests. This allowed clients to probe ECU existence — 401 meant the ECU was registered, 404 meant it wasn't.

Fix: sovd_not_found_handler now checks for the Authorization header and returns 401 (no body) when absent, per SOVD 6.15.6. Authenticated requests to genuinely missing resources still receive 404.

Also corrected the href casing in the GET /vehicle/v15/components response (/Vehicle/ → /vehicle/) to be consistent with actual registered routes.

Checklist
 I have tested my changes locally
 I have linked related issues or discussions
Related
Closes #302

Notes for Reviewers
The original issue reported 404 for a valid ECU path without a token, this was not reproducible (that path already returns 401 correctly). The fix targets the related case: unregistered paths returning 404 before any auth check runs. Steps to verify:


# Before fix: 404. After fix: 401
curl http://localhost:20002/vehicle/v15/components/doesnotexist/operations

# Unchanged — still 401
curl http://localhost:20002/vehicle/v15/components/flxc1000/operations

# Unchanged — still 200
curl -H "Authorization: Bearer $TOKEN" http://localhost:20002/vehicle/v15/components/flxc1000/operations