### PR TITLE
bugfix: check if DID of received response matches

### DIFF
--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -380,6 +380,17 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsMana
                                 // if we received a response matching our sent SID, return it
                                 // other responses are logged as warnings and ignored.
                                 if !msg.data.is_empty() && msg.is_response_for_sid(sent_sid) {
+                                    // Validate that echo bytes (e.g. DID) in the response
+                                    // match those in the request (ISO 14229-1).
+                                    if !msg.has_matching_echo_bytes(&payload.data) {
+                                        tracing::warn!(
+                                            "Response has correct SID but mismatched echo bytes \
+                                             (e.g. DID). Request: {:02X?}, Response: {:02X?}",
+                                            payload.data,
+                                            msg.data
+                                        );
+                                        continue 'read_uds_messages;
+                                    }
                                     tracing::debug!("Received expected UDS message: {:?}", msg);
                                     break 'read_uds_messages Ok(msg);
                                 }

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -185,6 +185,84 @@ impl ServicePayload {
     pub fn is_suppress_positive_response(&self) -> bool {
         self.data.get(1).is_some_and(|&b| b & 0x80 != 0)
     }
+
+    /// Validates that a positive response echoes back the expected identifier bytes
+    /// from the original request, as required by ISO 14229-1.
+    ///
+    /// Per ISO 14229-1, a positive response "parameter is an echo of [the identifier]
+    /// from the request message." Specifically:
+    /// - `ReadDataByIdentifier` (0x22): 2-byte `dataIdentifier` echo (Table 189)
+    /// - `WriteDataByIdentifier` (0x2E): 2-byte `dataIdentifier` echo (Table 280)
+    /// - `InputOutputControlByIdentifier` (0x2F): 2-byte `dataIdentifier` echo (Table 401)
+    /// - `RoutineControl` (0x31): 1-byte `routineControlType` (bits 6-0 of `SubFunction`,
+    ///   suppress-positive-response bit masked out) + 2-byte `routineIdentifier` (Table 428)
+    ///
+    /// Returns `true` if:
+    /// - The service does not require echo validation (no echo bytes defined), or
+    /// - The echoed bytes in the response match those in the request.
+    ///
+    /// Returns `false` if the echoed bytes do not match.
+    #[must_use]
+    pub fn has_matching_echo_bytes(&self, request_data: &[u8]) -> bool {
+        let Some(&sent_sid) = request_data.first() else {
+            return true;
+        };
+
+        // Only validate positive responses; negative responses are handled separately.
+        if !self.is_positive_response_for_sid(sent_sid) {
+            return true;
+        }
+
+        let echo_len = Self::echo_byte_count(sent_sid);
+        if echo_len == 0 {
+            return true;
+        }
+
+        // Check that we have enough bytes in both request and response.
+        // Echo bytes start at index 1 (after SID/response SID byte).
+        let Some(request_echo) = request_data.get(1..1usize.saturating_add(echo_len)) else {
+            return true; // Request too short to have echo bytes; skip validation.
+        };
+        let Some(response_echo) = self.data.get(1..1usize.saturating_add(echo_len)) else {
+            return false; // Response too short to contain expected echo bytes.
+        };
+
+        // For RoutineControl, the subfunction byte (index 1 of the request) may have the
+        // suppress-positive-response bit (0x80) set; the response never includes this bit.
+        // We mask it out for comparison.
+        if sent_sid == service_ids::ROUTINE_CONTROL {
+            let request_subfn =
+                request_echo.first().copied().unwrap_or(0) & crate::DEFAULT_SUBFUNCTION_MASK;
+            let response_subfn = response_echo.first().copied().unwrap_or(0);
+            if request_subfn != response_subfn {
+                return false;
+            }
+            // Compare remaining bytes (routine identifier) directly.
+            return request_echo.get(1..) == response_echo.get(1..);
+        }
+
+        request_echo == response_echo
+    }
+
+    /// Returns the number of echo bytes (after the response SID) that a positive response
+    /// for the given request SID must echo back from the request, per ISO 14229-1.
+    ///
+    /// The echo byte counts are derived from the positive response message definitions in
+    /// ISO 14229-1 (Tables 188, 279, 401, 428). Returns 0 for services where the spec does
+    /// not define echoed identifier bytes.
+    #[must_use]
+    pub const fn echo_byte_count(sent_sid: u8) -> usize {
+        match sent_sid {
+            // ReadDataByIdentifier, WriteDataByIdentifier,
+            // InputOutputControlByIdentifier: 2-byte DID
+            service_ids::READ_DATA_BY_IDENTIFIER
+            | service_ids::WRITE_DATA_BY_IDENTIFIER
+            | service_ids::INPUT_OUTPUT_CONTROL_BY_IDENTIFIER => 2,
+            // RoutineControl: 1-byte subfunction + 2-byte RoutineIdentifier
+            service_ids::ROUTINE_CONTROL => 3,
+            _ => 0,
+        }
+    }
 }
 
 /// Trait to provide communication parameters for an ECU.
@@ -613,5 +691,201 @@ impl std::fmt::Display for EcuState {
             EcuState::Disconnected => write!(f, "Disconnected"),
             EcuState::NoVariantDetected => write!(f, "NoVariantDetected"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service_ids;
+
+    fn make_payload(data: Vec<u8>) -> ServicePayload {
+        ServicePayload {
+            data,
+            source_address: 0x1000,
+            target_address: 0x0001,
+            new_session: None,
+            new_security: None,
+        }
+    }
+
+    // echo_byte_count
+
+    #[test]
+    fn echo_byte_count_read_data_by_identifier() {
+        assert_eq!(
+            ServicePayload::echo_byte_count(service_ids::READ_DATA_BY_IDENTIFIER),
+            2
+        );
+    }
+
+    #[test]
+    fn echo_byte_count_write_data_by_identifier() {
+        assert_eq!(
+            ServicePayload::echo_byte_count(service_ids::WRITE_DATA_BY_IDENTIFIER),
+            2
+        );
+    }
+
+    #[test]
+    fn echo_byte_count_io_control_by_identifier() {
+        assert_eq!(
+            ServicePayload::echo_byte_count(service_ids::INPUT_OUTPUT_CONTROL_BY_IDENTIFIER),
+            2
+        );
+    }
+
+    #[test]
+    fn echo_byte_count_routine_control() {
+        assert_eq!(
+            ServicePayload::echo_byte_count(service_ids::ROUTINE_CONTROL),
+            3
+        );
+    }
+
+    #[test]
+    fn echo_byte_count_other_services_returns_zero() {
+        assert_eq!(
+            ServicePayload::echo_byte_count(service_ids::SESSION_CONTROL),
+            0
+        );
+        assert_eq!(ServicePayload::echo_byte_count(service_ids::ECU_RESET), 0);
+        assert_eq!(
+            ServicePayload::echo_byte_count(service_ids::TESTER_PRESENT),
+            0
+        );
+    }
+
+    // has_matching_echo_bytes: ReadDataByIdentifier
+
+    #[test]
+    fn rdbi_matching_did_returns_true() {
+        // Request: ReadDataByIdentifier DID 0xF190
+        let request = vec![0x22, 0xF1, 0x90];
+        // Response: positive (0x62) with matching DID
+        let response = make_payload(vec![0x62, 0xF1, 0x90, 0x01, 0x02, 0x03]);
+        assert!(response.has_matching_echo_bytes(&request));
+    }
+
+    #[test]
+    fn rdbi_mismatched_did_returns_false() {
+        // Request: ReadDataByIdentifier DID 0xF190
+        let request = vec![0x22, 0xF1, 0x90];
+        // Response: positive (0x62) with WRONG DID (0xF200 instead of 0xF190)
+        let response = make_payload(vec![0x62, 0xF2, 0x00, 0x01, 0x02, 0x03]);
+        assert!(!response.has_matching_echo_bytes(&request));
+    }
+
+    #[test]
+    fn rdbi_mismatched_did_single_byte_difference_returns_false() {
+        // Request: ReadDataByIdentifier DID 0xF190
+        let request = vec![0x22, 0xF1, 0x90];
+        // Response: DID 0xF191 (off by one)
+        let response = make_payload(vec![0x62, 0xF1, 0x91, 0xAA]);
+        assert!(!response.has_matching_echo_bytes(&request));
+    }
+
+    #[test]
+    fn rdbi_response_too_short_for_echo_returns_false() {
+        // Request: ReadDataByIdentifier DID 0xF190
+        let request = vec![0x22, 0xF1, 0x90];
+        // Response: only has SID + 1 byte (missing second DID byte)
+        let response = make_payload(vec![0x62, 0xF1]);
+        assert!(!response.has_matching_echo_bytes(&request));
+    }
+
+    // has_matching_echo_bytes: negative response passthrough
+
+    #[test]
+    fn negative_response_always_returns_true() {
+        // Negative responses are validated by is_negative_response_for_sid, not echo bytes.
+        let request = vec![0x22, 0xF1, 0x90];
+        // Negative response: 0x7F, original SID, NRC
+        let response = make_payload(vec![0x7F, 0x22, 0x31]);
+        assert!(response.has_matching_echo_bytes(&request));
+    }
+
+    // has_matching_echo_bytes: services without echo validation
+
+    #[test]
+    fn session_control_no_echo_validation() {
+        let request = vec![0x10, 0x03]; // DiagnosticSessionControl - extendedSession
+        // Response has different subfunction - but no echo validation for this SID
+        let response = make_payload(vec![0x50, 0x01, 0x00, 0x19]);
+        assert!(response.has_matching_echo_bytes(&request));
+    }
+
+    // has_matching_echo_bytes: RoutineControl
+
+    #[test]
+    fn routine_control_matching_returns_true() {
+        // Request: RoutineControl Start (0x01) + RoutineID 0x1001
+        let request = vec![0x31, 0x01, 0x10, 0x01];
+        // Response: positive (0x71) with matching subfunction and RoutineID
+        let response = make_payload(vec![0x71, 0x01, 0x10, 0x01, 0xAA]);
+        assert!(response.has_matching_echo_bytes(&request));
+    }
+
+    #[test]
+    fn routine_control_suppress_positive_response_bit_masked() {
+        // Request: RoutineControl Start with suppressPosRsp (0x81) + RoutineID 0x1001
+        let request = vec![0x31, 0x81, 0x10, 0x01];
+        // Response: positive (0x71) with subfunction 0x01 (bit 7 cleared)
+        let response = make_payload(vec![0x71, 0x01, 0x10, 0x01]);
+        assert!(response.has_matching_echo_bytes(&request));
+    }
+
+    #[test]
+    fn routine_control_wrong_routine_id_returns_false() {
+        // Request: RoutineControl Start + RoutineID 0x1001
+        let request = vec![0x31, 0x01, 0x10, 0x01];
+        // Response: correct subfunction but wrong RoutineID (0x2002)
+        let response = make_payload(vec![0x71, 0x01, 0x20, 0x02]);
+        assert!(!response.has_matching_echo_bytes(&request));
+    }
+
+    #[test]
+    fn routine_control_wrong_subfunction_returns_false() {
+        // Request: RoutineControl Start (0x01) + RoutineID 0x1001
+        let request = vec![0x31, 0x01, 0x10, 0x01];
+        // Response: subfunction 0x02 (Stop) with correct RoutineID
+        let response = make_payload(vec![0x71, 0x02, 0x10, 0x01]);
+        assert!(!response.has_matching_echo_bytes(&request));
+    }
+
+    // has_matching_echo_bytes: edge cases
+
+    #[test]
+    fn empty_request_data_returns_true() {
+        let response = make_payload(vec![0x62, 0xF1, 0x90, 0x01]);
+        assert!(response.has_matching_echo_bytes(&[]));
+    }
+
+    #[test]
+    fn request_too_short_for_echo_returns_true() {
+        // Request has SID but no DID bytes (malformed, but we don't fail)
+        let request = vec![0x22];
+        let response = make_payload(vec![0x62, 0xF1, 0x90, 0x01]);
+        assert!(response.has_matching_echo_bytes(&request));
+    }
+
+    // has_matching_echo_bytes: WriteDataByIdentifier
+
+    #[test]
+    fn wdbi_matching_did_returns_true() {
+        // Request: WriteDataByIdentifier DID 0xF190 + data
+        let request = vec![0x2E, 0xF1, 0x90, 0xAA, 0xBB];
+        // Response: positive (0x6E) with matching DID
+        let response = make_payload(vec![0x6E, 0xF1, 0x90]);
+        assert!(response.has_matching_echo_bytes(&request));
+    }
+
+    #[test]
+    fn wdbi_mismatched_did_returns_false() {
+        // Request: WriteDataByIdentifier DID 0xF190
+        let request = vec![0x2E, 0xF1, 0x90, 0xAA];
+        // Response: positive with wrong DID
+        let response = make_payload(vec![0x6E, 0xF2, 0x00]);
+        assert!(!response.has_matching_echo_bytes(&request));
     }
 }

--- a/integration-tests/tests/sovd/data.rs
+++ b/integration-tests/tests/sovd/data.rs
@@ -12,10 +12,13 @@
 
 use http::{Method, StatusCode};
 
-use crate::util::{
-    ecusim,
-    http::{auth_header, send_cda_request},
-    runtime::setup_integration_test,
+use crate::{
+    sovd::hook_cleanup,
+    util::{
+        ecusim,
+        http::{auth_header, send_cda_request},
+        runtime::{EcuSim, setup_integration_test},
+    },
 };
 
 /// Tests that CDA correctly rejects ECU responses where the DID (Data Identifier)
@@ -31,6 +34,13 @@ use crate::util::{
 #[tokio::test]
 async fn test_wrong_did_in_response_returns_504() {
     let (runtime, _lock) = setup_integration_test(true).await.unwrap();
+
+    let cleanup_sim = runtime.ecu_sim.clone();
+    hook_cleanup(move || {
+        let sim = cleanup_sim.clone();
+        async move { cleanup(&sim).await }
+    });
+
     let auth = auth_header(&runtime.config, None).await.unwrap();
 
     // Install a raw response override on FLXC1000:
@@ -62,8 +72,12 @@ async fn test_wrong_did_in_response_returns_504() {
         "Expected 504 Gateway Timeout when ECU responds with wrong DID, got: {result:?}"
     );
 
+    cleanup(&runtime.ecu_sim).await;
+}
+
+async fn cleanup(ecu_sim: &EcuSim) {
     // Clean up: remove the override so other tests are not affected.
-    ecusim::clear_raw_response_override(&runtime.ecu_sim, "FLXC1000")
+    ecusim::clear_raw_response_override(ecu_sim, "FLXC1000")
         .await
         .expect("Failed to clear raw response override");
 }

--- a/integration-tests/tests/sovd/data.rs
+++ b/integration-tests/tests/sovd/data.rs
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+use http::{Method, StatusCode};
+
+use crate::util::{
+    ecusim,
+    http::{auth_header, send_cda_request},
+    runtime::setup_integration_test,
+};
+
+/// Tests that CDA correctly rejects ECU responses where the DID (Data Identifier)
+/// in the positive response does not match the DID that was requested.
+///
+/// According to ISO 14229-1, a `ReadDataByIdentifier` positive response must echo
+/// the same DID bytes as the request. If the ECU responds with a different DID,
+/// the response is invalid and CDA should treat it as if no valid response was
+/// received (timeout → HTTP 504 Gateway Timeout).
+///
+/// This test verifies that the CDA correctly ignores an invalid DID and returns
+/// HTTP 504 if no further correct message is received within the timeout period.
+#[tokio::test]
+async fn test_wrong_did_in_response_returns_504() {
+    let (runtime, _lock) = setup_integration_test(true).await.unwrap();
+    let auth = auth_header(&runtime.config, None).await.unwrap();
+
+    // Install a raw response override on FLXC1000:
+    // When the ECU receives ReadDataByIdentifier for DID 0xF190 (VIN),
+    // respond with correct SID (0x62) but WRONG DID (0xF200) + fake data.
+    //
+    // Normal request:  22 F1 90  (ReadDataByIdentifier, DID=0xF190)
+    // Normal response: 62 F1 90 <VIN data>
+    // Override response: 62 F2 00 41 42 43 (correct SID, wrong DID 0xF200, fake data "ABC")
+    ecusim::set_raw_response_override(&runtime.ecu_sim, "FLXC1000", "22f190", "62f20041424344")
+        .await
+        .expect("Failed to install raw response override");
+
+    // Attempt to read the VIN data from FLXC1000.
+    // CDA should detect the DID mismatch and return 504 Gateway Timeout.
+    let result = send_cda_request(
+        &runtime.config,
+        "components/flxc1000/data/vindataidentifier",
+        StatusCode::GATEWAY_TIMEOUT,
+        Method::GET,
+        None,
+        Some(&auth),
+        None,
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "Expected 504 Gateway Timeout when ECU responds with wrong DID, got: {result:?}"
+    );
+
+    // Clean up: remove the override so other tests are not affected.
+    ecusim::clear_raw_response_override(&runtime.ecu_sim, "FLXC1000")
+        .await
+        .expect("Failed to clear raw response override");
+}

--- a/integration-tests/tests/sovd/mod.rs
+++ b/integration-tests/tests/sovd/mod.rs
@@ -28,6 +28,7 @@ use crate::util::{
 };
 
 mod custom_routes;
+mod data;
 mod ecu;
 mod faults;
 mod flash_download;

--- a/integration-tests/tests/sovd/mod.rs
+++ b/integration-tests/tests/sovd/mod.rs
@@ -333,3 +333,20 @@ pub(crate) async fn get_ecu_component(
     // everything as Sd, we also fail on silent changes in the interface, which is desirable
     response_to_json(&response)
 }
+
+pub(crate) fn hook_cleanup<F, Fut>(cleanup_fn: F)
+where
+    F: Fn() -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + 'static,
+{
+    std::panic::set_hook(Box::new(move |_| {
+        // Create a new runtime to drive the future to completion.
+        // Don't use Handle::current().block_on() here — it will
+        // deadlock if the panic happens on an async worker thread.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to build runtime in panic hook");
+        rt.block_on(cleanup_fn());
+    }));
+}

--- a/integration-tests/tests/util/ecusim.rs
+++ b/integration-tests/tests/util/ecusim.rs
@@ -279,3 +279,59 @@ pub(crate) async fn stop_and_clear_recording(
             .await?;
     crate::util::http::response_to_t(&response)
 }
+
+/// Install a raw UDS response override on the ECU simulator.
+///
+/// When installed, any incoming UDS request whose hex representation matches
+/// `request_hex` will receive `response_hex` as a raw response (no auto-prefix).
+/// This is useful for testing malformed ECU responses (e.g., wrong DID echo bytes).
+pub(crate) async fn set_raw_response_override(
+    sim: &EcuSim,
+    ecu: &str,
+    request_hex: &str,
+    response_hex: &str,
+) -> Result<(), TestingError> {
+    let mut url = sim_endpoint(sim)?;
+    url.path_segments_mut()
+        .map_err(|()| TestingError::InvalidUrl("cannot modify URL path".to_owned()))?
+        .push(ecu)
+        .push("override");
+
+    let body = serde_json::json!({
+        "requestHex": request_hex,
+        "responseHex": response_hex
+    })
+    .to_string();
+
+    crate::util::http::send_request(
+        StatusCode::NO_CONTENT,
+        http::Method::PUT,
+        Some(&body),
+        None,
+        url,
+    )
+    .await?;
+    Ok(())
+}
+
+/// Remove a previously installed raw response override from the ECU simulator.
+pub(crate) async fn clear_raw_response_override(
+    sim: &EcuSim,
+    ecu: &str,
+) -> Result<(), TestingError> {
+    let mut url = sim_endpoint(sim)?;
+    url.path_segments_mut()
+        .map_err(|()| TestingError::InvalidUrl("cannot modify URL path".to_owned()))?
+        .push(ecu)
+        .push("override");
+
+    crate::util::http::send_request(
+        StatusCode::NO_CONTENT,
+        http::Method::DELETE,
+        None,
+        None,
+        url,
+    )
+    .await?;
+    Ok(())
+}

--- a/integration-tests/tests/util/http.rs
+++ b/integration-tests/tests/util/http.rs
@@ -166,7 +166,7 @@ pub(crate) async fn send_cda_request(
     headers: Option<&HeaderMap>,
     query_params: Option<&QueryParams>,
 ) -> Result<Response, TestingError> {
-    let base_url = format!("http://{}:{}", &config.server.address, config.server.port);
+    let base_url = format!("http://{}:{}", config.server.address, config.server.port);
     let url_params = query_params
         .unwrap_or(&QueryParams::default())
         .to_query_string();

--- a/integration-tests/tests/util/http.rs
+++ b/integration-tests/tests/util/http.rs
@@ -19,6 +19,7 @@ use serde::de::DeserializeOwned;
 
 use crate::util::TestingError;
 
+#[derive(Debug)]
 pub(crate) struct Response {
     #[allow(dead_code)]
     status: StatusCode,

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -61,6 +61,7 @@ pub(crate) struct TestRuntime {
     pub(crate) ecu_sim: EcuSim,
 }
 
+#[derive(Clone)]
 pub(crate) struct EcuSim {
     pub(crate) host: String,
     pub(crate) control_port: u16,

--- a/testcontainer/ecu-sim/src/main/kotlin/webserver/EmbeddedWebserver.kt
+++ b/testcontainer/ecu-sim/src/main/kotlin/webserver/EmbeddedWebserver.kt
@@ -81,6 +81,7 @@ fun Application.appModule() {
         addFlashTransferRoutes()
         addRecordingRoutes()
         addDtcFaultsRoutes()
+        addRawResponseOverrideRoutes()
         addJwtAuthServerMockRoutes()
 
         post("/shutdown") {

--- a/testcontainer/ecu-sim/src/main/kotlin/webserver/WebserverRoutes.kt
+++ b/testcontainer/ecu-sim/src/main/kotlin/webserver/WebserverRoutes.kt
@@ -29,6 +29,8 @@ import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.put
+import kotlinx.serialization.Serializable
+import library.decodeHex
 import library.toHexString
 import networkInstances
 import org.slf4j.MDC
@@ -178,3 +180,48 @@ private suspend fun SimEcu.dtcFaultsByApplicationCall(call: ApplicationCall) =
         )
         null
     }
+
+/**
+ * DTO for configuring a raw UDS response override.
+ * When installed, any incoming request matching [requestHex] will receive
+ * [responseHex] as a raw UDS response (bytes sent as-is, no auto-prefix).
+ */
+@Serializable
+data class RawResponseOverrideDto(
+    val requestHex: String,
+    val responseHex: String,
+)
+
+/**
+ * Routes to install/remove raw UDS response overrides on ECUs.
+ * This is used in integration tests to simulate malformed ECU responses
+ * (e.g., responses with incorrect DID echo bytes).
+ *
+ * - PUT /{ecu}/override: Install a raw response override
+ * - DELETE /{ecu}/override: Remove the override
+ */
+fun Route.addRawResponseOverrideRoutes() {
+    put("/{ecu}/override") {
+        val ecu = findByEcuName(call) ?: return@put
+        val dto = call.receive<RawResponseOverrideDto>()
+        val requestPattern = dto.requestHex.replace(" ", "").lowercase()
+        val responseBytes = dto.responseHex.replace(" ", "").decodeHex()
+
+        ecu.addOrReplaceEcuInterceptor("RAW_OVERRIDE", alsoCallWhenEcuIsBusy = false) {
+            val incomingHex = this.message.toHexString(separator = "").lowercase()
+            if (incomingHex == requestPattern) {
+                respond(responseBytes)
+                true
+            } else {
+                false
+            }
+        }
+        call.respond(HttpStatusCode.NoContent)
+    }
+
+    delete("/{ecu}/override") {
+        val ecu = findByEcuName(call) ?: return@delete
+        ecu.removeInterceptor("RAW_OVERRIDE")
+        call.respond(HttpStatusCode.NoContent)
+    }
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

If the DID of a response is not matching the sent request, the cda previously was still returning this as a positive response. With this PR the received message is now checked for matching DID and if it does not match, a warning is logged and the message discarded.

In addition the PR
- Adds tests for DID matching in unit test & integration test.
- Extends SIM to allow overwriting the response via endpoint


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)