### PR TITLE
ci: automate PR review state labels

### DIFF
--- a/.github/workflows/pr-label-review-state.yml
+++ b/.github/workflows/pr-label-review-state.yml
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+
+name: PR Review Labels
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, review_requested, ready_for_review, converted_to_draft]
+  pull_request_review:
+    types: [submitted, dismissed]
+  pull_request_review_comment:
+    types: [created, deleted]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  update-review-labels:
+    runs-on: ubuntu-latest
+    name: "Update review state labels"
+    steps:
+      - name: Update review state labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request?.number
+              || context.payload.review?.pull_request?.number;
+
+            if (!prNumber) {
+              core.info('No PR number found, skipping.');
+              return;
+            }
+
+            const NEEDS_REVIEW = 'needs review';
+            const CHANGES_REQUESTED = 'changes requested';
+
+            async function addLabel(label) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  labels: [label],
+                });
+                core.info(`Added label: "${label}"`);
+              } catch (e) {
+                core.warning(`Failed to add label "${label}": ${e.message}`);
+              }
+            }
+
+            async function removeLabel(label) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  name: label,
+                });
+                core.info(`Removed label: "${label}"`);
+              } catch (e) {
+                if (e.status !== 404) {
+                  core.warning(`Failed to remove label "${label}": ${e.message}`);
+                }
+              }
+            }
+
+            // Get the latest review state per reviewer
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const latestByReviewer = {};
+            for (const review of reviews) {
+              if (review.state === 'COMMENTED') continue;
+              latestByReviewer[review.user.login] = review.state;
+            }
+
+            const states = Object.values(latestByReviewer);
+            const hasChangesRequested = states.includes('CHANGES_REQUESTED');
+            const allApproved = states.length > 0
+              && states.every(s => s === 'APPROVED' || s === 'DISMISSED');
+
+            // Check draft status and unresolved review threads via GraphQL
+            const { repository } = await github.graphql(`
+              query($owner: String!, $repo: String!, $pr: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pr) {
+                    isDraft
+                    reviewThreads(first: 100) {
+                      nodes { isResolved }
+                    }
+                  }
+                }
+              }
+            `, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pr: prNumber,
+            });
+
+            const isDraft = repository.pullRequest.isDraft;
+            const hasUnresolvedThreads = repository.pullRequest.reviewThreads.nodes
+              .some(thread => !thread.isResolved);
+
+            const needsChanges = hasChangesRequested || hasUnresolvedThreads;
+
+            // Draft PRs never get the 'needs review' label
+            if (isDraft) {
+              core.info('PR is a draft, removing review labels.');
+              await removeLabel(NEEDS_REVIEW);
+              await removeLabel(CHANGES_REQUESTED);
+              return;
+            }
+
+            const eventName = context.eventName;
+            const action = context.payload.action;
+
+            if (eventName === 'pull_request_review' && action === 'submitted'
+                && context.payload.review.state === 'changes_requested') {
+              await addLabel(CHANGES_REQUESTED);
+              await removeLabel(NEEDS_REVIEW);
+
+            } else if (allApproved && !needsChanges) {
+              await removeLabel(NEEDS_REVIEW);
+              await removeLabel(CHANGES_REQUESTED);
+
+            } else if (eventName === 'pull_request_target' && action === 'synchronize') {
+              await addLabel(NEEDS_REVIEW);
+              await removeLabel(CHANGES_REQUESTED);
+
+            } else if (needsChanges) {
+              await addLabel(CHANGES_REQUESTED);
+              await removeLabel(NEEDS_REVIEW);
+
+            } else {
+              await addLabel(NEEDS_REVIEW);
+              await removeLabel(CHANGES_REQUESTED);
+            }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 The Eclipse OpenSOVD contributors
SPDX-License-Identifier: Apache-2.0
-->

## Summary

- Adds a GitHub Actions workflow that automatically manages `needs review` and `changes requested` labels based on PR review events
- Eliminates manual label management that was inconsistently applied

| Event | Result |
|-------|--------|
| PR opened / review requested | Adds `needs review` |
| Review: changes requested | Swaps to `changes requested` |
| New push after review | Resets to `needs review` |
| All reviewers approved | Removes both labels |
| Review dismissed | Re-evaluates based on remaining reviews |

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions

## Related

N/A

## Notes for Reviewers

- Uses `pull_request_target` for fork PR compatibility (required for write access to labels on fork PRs)
- Only calls GitHub API via `actions/github-script` — no checkout needed, no security risk from fork code execution
- Idempotent label operations (gracefully handles labels already present/absent)
- Evaluates latest review per reviewer to prevent label thrashing from comment-only reviews


This is added here and not in CICD because I want to test it here only. If it works, we can go into the architecture group and discuss if this is something we want globally. 

---
Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)