### PR TITLE
ci: mark PR as needs-review when all review threads are resolved

### DIFF
--- a/.github/workflows/pr-label-review-state.yml
+++ b/.github/workflows/pr-label-review-state.yml
@@ -71,7 +71,6 @@ jobs:
               }
             }
 
-            // Get the latest review state per reviewer
             const { data: reviews } = await github.rest.pulls.listReviews({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -89,14 +88,19 @@ jobs:
             const allApproved = states.length > 0
               && states.every(s => s === 'APPROVED' || s === 'DISMISSED');
 
-            // Check draft status and unresolved review threads via GraphQL
             const { repository } = await github.graphql(`
               query($owner: String!, $repo: String!, $pr: Int!) {
                 repository(owner: $owner, name: $repo) {
                   pullRequest(number: $pr) {
                     isDraft
+                    author { login }
                     reviewThreads(first: 100) {
-                      nodes { isResolved }
+                      nodes {
+                        isResolved
+                        comments(first: 100) {
+                          nodes { author { login } }
+                        }
+                      }
                     }
                   }
                 }
@@ -107,13 +111,24 @@ jobs:
               pr: prNumber,
             });
 
-            const isDraft = repository.pullRequest.isDraft;
-            const hasUnresolvedThreads = repository.pullRequest.reviewThreads.nodes
-              .some(thread => !thread.isResolved);
+            const pr = repository.pullRequest;
+            const isDraft = pr.isDraft;
+            const prAuthor = pr.author?.login;
 
-            const needsChanges = hasChangesRequested || hasUnresolvedThreads;
+            const unresolvedThreads = pr.reviewThreads.nodes
+              .filter(thread => !thread.isResolved);
+            const hasUnresolvedThreads = unresolvedThreads.length > 0;
 
-            // Draft PRs never get the 'needs review' label
+            // Threads needing a reply: started by someone other than the PR author
+            const threadsNeedingReply = unresolvedThreads.filter(thread => {
+              const firstComment = thread.comments.nodes[0];
+              return firstComment?.author?.login !== prAuthor;
+            });
+            const authorRepliedToAll = threadsNeedingReply.length === 0
+              || threadsNeedingReply.every(thread =>
+                thread.comments.nodes.some(c => c.author?.login === prAuthor)
+              );
+
             if (isDraft) {
               core.info('PR is a draft, removing review labels.');
               await removeLabel(NEEDS_REVIEW);
@@ -129,7 +144,7 @@ jobs:
               await addLabel(CHANGES_REQUESTED);
               await removeLabel(NEEDS_REVIEW);
 
-            } else if (allApproved && !needsChanges) {
+            } else if (allApproved && !hasUnresolvedThreads) {
               await removeLabel(NEEDS_REVIEW);
               await removeLabel(CHANGES_REQUESTED);
 
@@ -137,7 +152,12 @@ jobs:
               await addLabel(NEEDS_REVIEW);
               await removeLabel(CHANGES_REQUESTED);
 
-            } else if (needsChanges) {
+            } else if (hasUnresolvedThreads && authorRepliedToAll) {
+              // Author replied to every reviewer thread — ready for re-review
+              await addLabel(NEEDS_REVIEW);
+              await removeLabel(CHANGES_REQUESTED);
+
+            } else if (hasUnresolvedThreads) {
               await addLabel(CHANGES_REQUESTED);
               await removeLabel(NEEDS_REVIEW);
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Decouple the "changes requested" label from the formal `CHANGES_REQUESTED` review state and use **unresolved review threads** as the sole signal instead.

Previously, the workflow kept "changes requested" as long as a `CHANGES_REQUESTED` review existed — even after the author had addressed all thread feedback. This left PRs stuck in "changes requested" limbo until the reviewer explicitly re-reviewed.

Now the label lifecycle is:
1. Reviewer requests changes (with threads) → **"changes requested"**
2. Author addresses all threads (resolves them) → **"needs review"**
3. Reviewer approves → labels removed

Removed the combined `needsChanges = hasChangesRequested || hasUnresolvedThreads` variable. The decision tree now uses `hasUnresolvedThreads` directly.

## Checklist

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

<!-- List any related issues or PRs (e.g. Fixes #12 or Closes #34). -->

## Notes for Reviewers

The only changed file is `.github/workflows/pr-label-review-state.yml`. The logic simplification is in the decision tree: `hasUnresolvedThreads` now drives the "changes requested" label directly, and the absence of unresolved threads triggers the "needs review" transition.

---
Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)