### PR TITLE
ci: add release and conventional-commits workflows

### DIFF
--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+
+name: Conventional Commits
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-commits:
+    uses: eclipse-opensovd/cicd-workflows/.github/workflows/conventional-commits.yml@df0f51a

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+      release: ${{ steps.check.outputs.release }}
+    steps:
+      - uses: actions/checkout@v6
+        if: github.event_name == 'schedule'
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            LAST_SHA=$(git rev-parse nightly 2>/dev/null || echo "")
+            if [[ "$LAST_SHA" == "${{ github.sha }}" ]]; then
+              echo "No changes since last nightly, skipping"
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              echo "release=none" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "release=nightly" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "release=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+            echo "release=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "release=none" >> "$GITHUB_OUTPUT"
+          fi
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: prepare
+    if: needs.prepare.outputs.should_run == 'true'
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - os: windows-2025
+            target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    env:
+      RUSTFLAGS: "-L /usr/local/lib"
+      PKG_CONFIG_PATH: "/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.88.0
+          target: ${{ matrix.target }}
+          cache-shared-key: release
+
+      - name: Setup DLT tracing lib
+        if: runner.os == 'Linux'
+        uses: eclipse-opensovd/dlt-tracing-lib/.github/actions/setup-dlt@main
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "34.1"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup OpenSSL (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          echo "OPENSSL_DIR=$env:OPENSSL_DIR" >> $env:GITHUB_ENV
+          echo "OPENSSL_LIB_DIR=$env:OPENSSL_DIR\lib\VC\$env:RUNNER_ARCH\MD" >> $env:GITHUB_ENV
+          echo "OPENSSL_INCLUDE_DIR=$env:OPENSSL_DIR\include" >> $env:GITHUB_ENV
+        env:
+          OPENSSL_DIR: C:\Program Files\OpenSSL
+
+      - run: cargo build --locked --release --target ${{ matrix.target }}
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: opensovd-cda-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/opensovd-cda${{ runner.os == 'Windows' && '.exe' || '' }}
+
+  release:
+    needs: [prepare, build]
+    if: needs.prepare.outputs.release != 'none'
+    uses: eclipse-opensovd/cicd-workflows/.github/workflows/release.yml@df0f51a
+    with:
+      version: ${{ needs.prepare.outputs.release }}
+      artifact-pattern: "opensovd-cda-*"
+      binary-name: "opensovd-cda"
+      delete-existing: ${{ needs.prepare.outputs.release == 'nightly' || needs.prepare.outputs.release == 'latest' }}
+    permissions:
+      contents: write
+      attestations: write
+      id-token: write


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 The Eclipse OpenSOVD contributors
SPDX-License-Identifier: Apache-2.0
-->

## Summary

- Add `conventional-commits.yaml` workflow that validates PR titles and commit subjects by calling the reusable workflow from `eclipse-opensovd/cicd-workflows`
- Add `release.yaml` workflow that builds cross-platform binaries (Linux x86_64/aarch64, Windows x86_64) and publishes GitHub Releases with changelog, SHA-512 checksums, and build provenance attestation via the reusable release workflow from `eclipse-opensovd/cicd-workflows`

Both workflows are pinned to `adc06c32` (eclipse-opensovd/cicd-workflows#40 HEAD).

## Checklist

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

- eclipse-opensovd/cicd-workflows#40 (adds reusable conventional-commits and release workflows)
- Extracted from #328 to keep that PR focused on pre-commit migration and lint fixes

## Notes for Reviewers

Once eclipse-opensovd/cicd-workflows#40 merges to main, the SHA pins here should be updated to the merge commit on main.

---
Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)