### PR TITLE
docs: add persistence API requirements and architecture

### DIFF
--- a/docs/02_requirements/01_general.rst
+++ b/docs/02_requirements/01_general.rst
@@ -91,6 +91,42 @@ Storage Access
     A default implementation for local file system access, utilizing the Storage Access Abstraction must be provided.
 
 
+Persistence
+^^^^^^^^^^^
+
+.. req:: Persistence API
+    :id: req~system-persistence-api
+    :links: arch~system-persistence-api
+    :reqtype: functional
+    :status: draft
+
+    The CDA shall provide a persistence API for durable key-value storage. Data shall be organized into Buckets, where
+    each Bucket represents a named, logically separated collection of key-value pairs. The API shall support
+    creating and opening Buckets, as well as performing get, set, delete, and contains operations on entries within
+    a Bucket.
+
+    The API shall provide a flush operation that explicitly persists all buffered data to the underlying storage media.
+    This allows callers to guarantee durability at defined points, such as during shutdown or for security-critical
+    data that must not be lost.
+
+    The concrete persistence implementation shall be provided by an exchangeable provider, allowing different storage
+    backends to be used without changing consuming code.
+
+
+.. req:: Default redb Persistence Provider
+    :id: req~system-default-redb-persistence-provider
+    :links: arch~system-default-redb-persistence-provider
+    :reqtype: functional
+    :status: draft
+
+    A default persistence provider implementation using `redb`_ shall be provided. This provider shall implement the
+    persistence API, mapping Buckets to redb tables and storing key-value pairs with ACID transaction guarantees.
+
+    .. _redb: https://www.redb.org
+
+    Writes to the underlying storage media shall be minimized to reduce wear on flash-based storage typically found
+    in embedded devices.
+
 
 Systemd Watchdog Integration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/03_architecture/01_general.rst
+++ b/docs/03_architecture/01_general.rst
@@ -103,6 +103,67 @@ Storage Access
     if it does not exist. If the collection already exists, it simply returns it.
 
 
+Persistence
+-----------
+
+.. arch:: Persistence API
+    :id: arch~system-persistence-api
+    :status: draft
+
+    The Persistence API provides a durable key-value storage abstraction. Data is organized into Buckets, each
+    representing a named, logically separated set of key-value pairs. The API is accessed through an exchangeable
+    provider, enabling different storage backends without affecting consuming code.
+
+    .. uml::
+
+        @startuml
+        package "Persistence API" {
+            +enum PersistenceError {
+                BucketNotFound(String)
+                KeyNotFound(String)
+                IoError(String)
+                Other(String)
+            }
+
+            +interface Persistence {
+                +get(bucket: String, key: String) -> Result<String, PersistenceError>
+                +set(bucket: String, key: String, value: String) -> Result<(), PersistenceError>
+                +delete(bucket: String, key: String) -> Result<(), PersistenceError>
+                +contains(bucket: String, key: String) -> Result<bool, PersistenceError>
+                +list_keys(bucket: String) -> Result<Vec<String>, PersistenceError>
+                +flush() -> Result<(), PersistenceError>
+            }
+
+            Persistence ..> PersistenceError
+        }
+        @enduml
+
+    The ``Persistence`` interface is the single access point for all persistence operations. Callers specify the
+    target Bucket by name alongside the key for each operation. Bucket management (creation, lifecycle) is handled
+    transparently by the provider implementation.
+
+    The ``flush`` operation explicitly persists all buffered data to the underlying storage media. Providers that
+    buffer writes in memory shall guarantee that all data is durable after a successful flush call.
+
+    Providers are exchangeable at compile time, allowing the use of alternative backends (e.g., an in-memory
+    provider for testing purposes) without modifying consuming code.
+
+
+.. arch:: Default redb Persistence Provider
+    :id: arch~system-default-redb-persistence-provider
+    :status: draft
+
+    The default persistence provider uses `redb`_ as its storage backend. It implements the ``Persistence``
+    interface with the following characteristics:
+
+    .. _redb: https://www.redb.org
+
+    * All write operations (set, delete) are performed within ACID transactions, ensuring durability and consistency.
+    * The database file path is configurable.
+    * On unexpected interruption (power-off, crash), redb guarantees that uncommitted transactions are rolled back
+      on the next open, preserving data integrity.
+
+
 Systemd Watchdog Integration
 ----------------------------
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
Add requirement and architecture for a durable key-value persistence API with Bucket-based data organization, flush support, and an exchangeable provider pattern. Include default redb provider with ACID guarantees and write minimization for embedded flash storage.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [x] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
