### PR TITLE
tests: replace raw override with more generic interceptors

### DIFF
--- a/integration-tests/tests/sovd/data.rs
+++ b/integration-tests/tests/sovd/data.rs
@@ -50,9 +50,15 @@ async fn test_wrong_did_in_response_returns_504() {
     // Normal request:  22 F1 90  (ReadDataByIdentifier, DID=0xF190)
     // Normal response: 62 F1 90 <VIN data>
     // Override response: 62 F2 00 41 42 43 (correct SID, wrong DID 0xF200, fake data "ABC")
-    ecusim::set_raw_response_override(&runtime.ecu_sim, "FLXC1000", "22f190", "62f20041424344")
-        .await
-        .expect("Failed to install raw response override");
+    ecusim::set_interceptor(
+        &runtime.ecu_sim,
+        "FLXC1000",
+        "did_mismatch",
+        "22f190",
+        "62f20041424344",
+    )
+    .await
+    .expect("Failed to install interceptor");
 
     // Attempt to read the VIN data from FLXC1000.
     // CDA should detect the DID mismatch and return 504 Gateway Timeout.
@@ -76,8 +82,8 @@ async fn test_wrong_did_in_response_returns_504() {
 }
 
 async fn cleanup(ecu_sim: &EcuSim) {
-    // Clean up: remove the override so other tests are not affected.
-    ecusim::clear_raw_response_override(ecu_sim, "FLXC1000")
+    // Clean up: remove the interceptor so other tests are not affected.
+    ecusim::clear_interceptor(ecu_sim, "FLXC1000", "did_mismatch")
         .await
-        .expect("Failed to clear raw response override");
+        .expect("Failed to clear interceptor");
 }

--- a/integration-tests/tests/util/ecusim.rs
+++ b/integration-tests/tests/util/ecusim.rs
@@ -280,31 +280,35 @@ pub(crate) async fn stop_and_clear_recording(
     crate::util::http::response_to_t(&response)
 }
 
-/// Install a raw UDS response override on the ECU simulator.
+/// Install a named inbound interceptor on the ECU simulator.
 ///
 /// When installed, any incoming UDS request whose hex representation matches
-/// `request_hex` will receive `response_hex` as a raw response (no auto-prefix).
-/// This is useful for testing malformed ECU responses (e.g., wrong DID echo bytes).
-pub(crate) async fn set_raw_response_override(
+/// the `request` regex pattern will receive `response` as a raw hex response.
+/// If `response` is empty, the ECU will suppress its response (simulating offline).
+/// The `[]` sequence in `request` is treated as a wildcard (`.*`).
+pub(crate) async fn set_interceptor(
     sim: &EcuSim,
     ecu: &str,
-    request_hex: &str,
-    response_hex: &str,
+    name: &str,
+    request: &str,
+    response: &str,
 ) -> Result<(), TestingError> {
     let mut url = sim_endpoint(sim)?;
     url.path_segments_mut()
         .map_err(|()| TestingError::InvalidUrl("cannot modify URL path".to_owned()))?
+        .push("interceptor")
         .push(ecu)
-        .push("override");
+        .push("inbound")
+        .push(name);
 
     let body = serde_json::json!({
-        "requestHex": request_hex,
-        "responseHex": response_hex
+        "request": request,
+        "response": response
     })
     .to_string();
 
     crate::util::http::send_request(
-        StatusCode::NO_CONTENT,
+        StatusCode::ACCEPTED,
         http::Method::PUT,
         Some(&body),
         None,
@@ -314,16 +318,19 @@ pub(crate) async fn set_raw_response_override(
     Ok(())
 }
 
-/// Remove a previously installed raw response override from the ECU simulator.
-pub(crate) async fn clear_raw_response_override(
+/// Remove a previously installed named interceptor from the ECU simulator.
+pub(crate) async fn clear_interceptor(
     sim: &EcuSim,
     ecu: &str,
+    name: &str,
 ) -> Result<(), TestingError> {
     let mut url = sim_endpoint(sim)?;
     url.path_segments_mut()
         .map_err(|()| TestingError::InvalidUrl("cannot modify URL path".to_owned()))?
+        .push("interceptor")
         .push(ecu)
-        .push("override");
+        .push("inbound")
+        .push(name);
 
     crate::util::http::send_request(
         StatusCode::NO_CONTENT,

--- a/testcontainer/ecu-sim/src/main/kotlin/webserver/EmbeddedWebserver.kt
+++ b/testcontainer/ecu-sim/src/main/kotlin/webserver/EmbeddedWebserver.kt
@@ -81,7 +81,7 @@ fun Application.appModule() {
         addFlashTransferRoutes()
         addRecordingRoutes()
         addDtcFaultsRoutes()
-        addRawResponseOverrideRoutes()
+        addInterceptorRoutes()
         addJwtAuthServerMockRoutes()
 
         post("/shutdown") {

--- a/testcontainer/ecu-sim/src/main/kotlin/webserver/WebserverRoutes.kt
+++ b/testcontainer/ecu-sim/src/main/kotlin/webserver/WebserverRoutes.kt
@@ -182,46 +182,72 @@ private suspend fun SimEcu.dtcFaultsByApplicationCall(call: ApplicationCall) =
     }
 
 /**
- * DTO for configuring a raw UDS response override.
- * When installed, any incoming request matching [requestHex] will receive
- * [responseHex] as a raw UDS response (bytes sent as-is, no auto-prefix).
+ * DTO for configuring an inbound interceptor.
+ * [request] is a hex pattern for matching incoming UDS requests (supports `[]` as wildcard for `.*`).
+ * [response] is the hex response to send back (empty string = suppress response / simulate ECU offline).
+ * [removeAfterNRequest] optionally auto-removes the interceptor after N matched requests.
  */
 @Serializable
-data class RawResponseOverrideDto(
-    val requestHex: String,
-    val responseHex: String,
+data class SimpleInterceptorDto(
+    val request: String,
+    val response: String,
+    val removeAfterNRequest: Int? = null,
 )
 
 /**
- * Routes to install/remove raw UDS response overrides on ECUs.
- * This is used in integration tests to simulate malformed ECU responses
- * (e.g., responses with incorrect DID echo bytes).
+ * Routes to install/remove named inbound interceptors on ECUs.
+ * This is used in integration tests to simulate custom ECU responses
+ * (e.g., malformed responses, suppressed responses, or temporary overrides).
  *
- * - PUT /{ecu}/override: Install a raw response override
- * - DELETE /{ecu}/override: Remove the override
+ * - PUT /interceptor/{ecu}/inbound/{interceptorName}: Install or replace a named interceptor
+ * - DELETE /interceptor/{ecu}/inbound/{interceptorName}: Remove a named interceptor
  */
-fun Route.addRawResponseOverrideRoutes() {
-    put("/{ecu}/override") {
+fun Route.addInterceptorRoutes() {
+    put("/interceptor/{ecu}/inbound/{interceptorName}") {
         val ecu = findByEcuName(call) ?: return@put
-        val dto = call.receive<RawResponseOverrideDto>()
-        val requestPattern = dto.requestHex.replace(" ", "").lowercase()
-        val responseBytes = dto.responseHex.replace(" ", "").decodeHex()
+        val interceptorName = call.parameters["interceptorName"].orEmpty()
+        if (interceptorName.isBlank()) {
+            call.respond(HttpStatusCode.BadRequest, "interceptorName must not be blank")
+            return@put
+        }
+        val dto = call.receive<SimpleInterceptorDto>()
+        val regex =
+            Regex(
+                dto.request
+                    .uppercase()
+                    .replace(" ", "")
+                    .replace("[]", ".*"),
+            )
+        val removeAfterNRequest = dto.removeAfterNRequest
+        var matchCount = 0
 
-        ecu.addOrReplaceEcuInterceptor("RAW_OVERRIDE", alsoCallWhenEcuIsBusy = false) {
-            val incomingHex = this.message.toHexString(separator = "").lowercase()
-            if (incomingHex == requestPattern) {
-                respond(responseBytes)
+        ecu.addOrReplaceEcuInterceptor(interceptorName, alsoCallWhenEcuIsBusy = false) {
+            val incomingHex = this.message.toHexString(separator = "").uppercase()
+            if (incomingHex.matches(regex)) {
+                matchCount += 1
+                if (dto.response.isNotBlank()) {
+                    respond(dto.response.replace(" ", "").decodeHex())
+                }
+                // If response is blank, suppress response (ECU offline simulation)
+                if (removeAfterNRequest != null && matchCount >= removeAfterNRequest) {
+                    ecu.removeInterceptor(interceptorName)
+                }
                 true
             } else {
                 false
             }
         }
-        call.respond(HttpStatusCode.NoContent)
+        call.respond(HttpStatusCode.Accepted)
     }
 
-    delete("/{ecu}/override") {
+    delete("/interceptor/{ecu}/inbound/{interceptorName}") {
         val ecu = findByEcuName(call) ?: return@delete
-        ecu.removeInterceptor("RAW_OVERRIDE")
+        val interceptorName = call.parameters["interceptorName"].orEmpty()
+        if (interceptorName.isBlank()) {
+            call.respond(HttpStatusCode.BadRequest, "interceptorName must not be blank")
+            return@delete
+        }
+        ecu.removeInterceptor(interceptorName)
         call.respond(HttpStatusCode.NoContent)
     }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
Replaces the override endpoint with a more generic interceptor concept, which enables additional feature, like multiple interceptors at the same time, removability after N requests, and pattern matching.


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
