### PR TITLE
feat(database): add strict_parameter_validation config flag, Rejects requests with undefined parameters (400) when enabled

### DIFF
--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -103,6 +103,23 @@ impl VariantData {
     }
 }
 
+/// Configuration options passed to [`EcuManager::new`].
+///
+/// Grouping these together keeps the constructor signature manageable and
+/// makes call sites self-documenting.
+#[derive(Copy, Clone)]
+pub struct EcuManagerConfig {
+    /// Whether this ECU represents a physical ECU (`Ecu`) or a functional
+    /// group description (`FunctionalDescription`).
+    pub type_: EcuManagerType,
+    /// When `true`, variant detection failures fall back to the base variant
+    /// instead of returning an error.
+    pub fallback_to_base_variant: bool,
+    /// When `true`, requests containing parameters not defined in the service
+    /// are rejected with a `BadPayload` error (400 Bad Request).
+    pub strict_parameter_validation: bool,
+}
+
 // Allowed because this holds a bunch of config values.
 #[allow(clippy::struct_excessive_bools)]
 pub struct EcuManager<S: SecurityPlugin> {
@@ -129,6 +146,7 @@ pub struct EcuManager<S: SecurityPlugin> {
     variant_index: Option<usize>,
     variant: EcuVariant,
     fallback_to_base_variant: bool,
+    strict_parameter_validation: bool,
     duplicating_ecu_names: Option<HashSet<String>>,
 
     protocol: Protocol,
@@ -2039,28 +2057,25 @@ impl<S: SecurityPlugin> EcuManager<S> {
         protocol: Protocol,
         com_params: &ComParams,
         database_naming_convention: DatabaseNamingConvention,
-        type_: EcuManagerType,
+        config: EcuManagerConfig,
         func_description_config: &cda_interfaces::FunctionalDescriptionConfig,
-        fallback_to_base_variant: bool,
     ) -> Result<Self, DiagServiceError> {
-        match type_ {
+        match config.type_ {
             EcuManagerType::Ecu => Self::new_ecu_description(
                 database,
                 protocol,
                 com_params,
                 database_naming_convention,
-                type_,
+                config,
                 func_description_config,
-                fallback_to_base_variant,
             ),
             EcuManagerType::FunctionalDescription => Self::new_functional_description(
                 database,
                 protocol,
                 com_params,
                 database_naming_convention,
-                type_,
+                config,
                 func_description_config,
-                fallback_to_base_variant,
             ),
         }
     }
@@ -2072,9 +2087,8 @@ impl<S: SecurityPlugin> EcuManager<S> {
         protocol: Protocol,
         com_params: &ComParams,
         database_naming_convention: DatabaseNamingConvention,
-        type_: EcuManagerType,
+        config: EcuManagerConfig,
         func_description_config: &cda_interfaces::FunctionalDescriptionConfig,
-        fallback_to_base_variant: bool,
     ) -> Result<Self, DiagServiceError> {
         let variant_detection =
             variant_detection::prepare_variant_detection(&database, &database_naming_convention)?;
@@ -2141,7 +2155,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         Ok(Self {
             db_cache: DbCache::default(),
             ecu_name,
-            description_type: type_,
+            description_type: config.type_,
             database_naming_convention,
             tester_address: database
                 .find_com_param(data_protocol_ref, &com_params.doip.logical_tester_address)?,
@@ -2178,7 +2192,8 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 state: EcuState::NotTested,
                 logical_address: logical_ecu_address,
             },
-            fallback_to_base_variant,
+            fallback_to_base_variant: config.fallback_to_base_variant,
+            strict_parameter_validation: config.strict_parameter_validation,
             duplicating_ecu_names: None,
             protocol,
             fg_protocol_position: func_description_config.protocol_position.clone(),
@@ -2243,9 +2258,8 @@ impl<S: SecurityPlugin> EcuManager<S> {
         protocol: Protocol,
         com_params: &ComParams,
         database_naming_convention: DatabaseNamingConvention,
-        type_: EcuManagerType,
+        config: EcuManagerConfig,
         func_description_config: &cda_interfaces::FunctionalDescriptionConfig,
-        fallback_to_base_variant: bool,
     ) -> Result<Self, DiagServiceError> {
         // Functional group description: use defaults for all com params
         let logical_ecu_address = com_params.doip.logical_ecu_address.value;
@@ -2267,7 +2281,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
             diag_database: database,
             db_cache: DbCache::default(),
             ecu_name,
-            description_type: type_,
+            description_type: config.type_,
             database_naming_convention,
             tester_address: com_params.doip.logical_tester_address.value,
             logical_address: logical_ecu_address,
@@ -2295,7 +2309,8 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 state: EcuState::NotTested,
                 logical_address: logical_ecu_address,
             },
-            fallback_to_base_variant,
+            fallback_to_base_variant: config.fallback_to_base_variant,
+            strict_parameter_validation: config.strict_parameter_validation,
             duplicating_ecu_names: None,
             protocol,
             fg_protocol_position: func_description_config.protocol_position.clone(),
@@ -3483,6 +3498,20 @@ impl<S: SecurityPlugin> EcuManager<S> {
         Ok(())
     }
 
+    fn reject_unexpected_keys<'e, 'k>(
+        expected: impl Iterator<Item = &'e str>,
+        provided: impl Iterator<Item = &'k str>,
+    ) -> Result<(), DiagServiceError> {
+        let expected_names: HashSet<&str> = expected.collect();
+        let unexpected: Vec<&str> = provided.filter(|k| !expected_names.contains(k)).collect();
+        if !unexpected.is_empty() {
+            return Err(DiagServiceError::BadPayload(format!(
+                "Unexpected parameters in request: {unexpected:?}"
+            )));
+        }
+        Ok(())
+    }
+
     fn map_mux_to_uds(
         &self,
         mux_dop: &datatypes::MuxDop,
@@ -3561,6 +3590,13 @@ impl<S: SecurityPlugin> EcuManager<S> {
                         )
                     })?;
 
+                if self.strict_parameter_validation {
+                    Self::reject_unexpected_keys(
+                        ["Selector", case_name].into_iter(),
+                        value.keys().map(String::as_str),
+                    )?;
+                }
+
                 if let Some(struct_) = struct_ {
                     let struct_data = value.get(case_name).ok_or_else(|| {
                         DiagServiceError::BadPayload(format!(
@@ -3596,20 +3632,27 @@ impl<S: SecurityPlugin> EcuManager<S> {
             )));
         };
 
-        structure
+        let params: Vec<_> = structure
             .params()
             .into_iter()
             .flatten()
             .map(datatypes::Parameter)
-            .try_for_each(|param| {
-                let short_name = param.short_name().ok_or_else(|| {
-                    DiagServiceError::InvalidDatabase(
-                        "Unable to find short name for param".to_owned(),
-                    )
-                })?;
+            .collect();
 
-                self.map_param_to_uds(&param, value.get(short_name), payload, struct_byte_pos)
-            })
+        if self.strict_parameter_validation {
+            Self::reject_unexpected_keys(
+                params.iter().filter_map(|p| p.short_name()),
+                value.keys().map(String::as_str),
+            )?;
+        }
+
+        params.into_iter().try_for_each(|param| {
+            let short_name = param.short_name().ok_or_else(|| {
+                DiagServiceError::InvalidDatabase("Unable to find short name for param".to_owned())
+            })?;
+
+            self.map_param_to_uds(&param, value.get(short_name), payload, struct_byte_pos)
+        })
     }
 
     fn process_parameter_map(
@@ -3618,6 +3661,13 @@ impl<S: SecurityPlugin> EcuManager<S> {
         json_values: &HashMap<String, serde_json::Value>,
         uds: &mut Vec<u8>,
     ) -> Result<(), DiagServiceError> {
+        if self.strict_parameter_validation {
+            Self::reject_unexpected_keys(
+                mapped_params.iter().filter_map(|p| p.short_name()),
+                json_values.keys().map(String::as_str),
+            )?;
+        }
+
         for param in mapped_params {
             // When BYTE-POSITION is omitted (ISO 22901-1 §7.4.8) the
             // parameter follows a variable-length PARAM-LENGTH-INFO field
@@ -3648,6 +3698,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
             };
             self.map_param_to_uds(param, json_values.get(short_name), uds, parent_byte_pos)?;
         }
+
         Ok(())
     }
 
@@ -5735,14 +5786,17 @@ mod tests {
             Protocol::default(),
             &ComParams::default(),
             DatabaseNamingConvention::default(),
-            EcuManagerType::Ecu,
+            super::EcuManagerConfig {
+                type_: EcuManagerType::Ecu,
+                fallback_to_base_variant: true,
+                strict_parameter_validation: false,
+            },
             &cda_interfaces::FunctionalDescriptionConfig {
                 description_database: "functional_groups".to_owned(),
                 enabled_functional_groups: None,
                 protocol_position:
                     cda_interfaces::datatypes::DiagnosticServiceAffixPosition::Suffix,
             },
-            true,
         )
         .expect("Failed to create EcuManager");
 
@@ -5767,14 +5821,17 @@ mod tests {
             Protocol::default(),
             &ComParams::default(),
             DatabaseNamingConvention::default(),
-            EcuManagerType::Ecu,
+            super::EcuManagerConfig {
+                type_: EcuManagerType::Ecu,
+                fallback_to_base_variant: false,
+                strict_parameter_validation: false,
+            },
             &cda_interfaces::FunctionalDescriptionConfig {
                 description_database: "functional_groups".to_owned(),
                 enabled_functional_groups: None,
                 protocol_position:
                     cda_interfaces::datatypes::DiagnosticServiceAffixPosition::Suffix,
             },
-            false,
         )
         .unwrap()
     }
@@ -8074,6 +8131,134 @@ mod tests {
             assert!(
                 e.to_string()
                     .contains("Required parameter 'param2' missing")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_process_parameter_map_unexpected_params_lenient() {
+        let (ecu_manager, service, _, _) = create_ecu_manager_with_struct_service(1);
+
+        let struct_value = json!({"param1": 0x1234u32, "param2": 1.0f32, "param3": "hello"});
+        // bogus_param is at the top-level service parameter map, not defined in the service
+        let payload_data = UdsPayloadData::ParameterMap(
+            [
+                ("main_param".to_string(), struct_value),
+                ("bogus_param".to_string(), json!("should be ignored")),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        // Lenient mode (default): unexpected params are ignored, request succeeds
+        let result = ecu_manager
+            .create_uds_payload(&service, &skip_sec_plugin!(), Some(payload_data), None)
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "Expected success in lenient mode, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_process_parameter_map_unexpected_params_strict() {
+        let (mut ecu_manager, service, _, _) = create_ecu_manager_with_struct_service(1);
+        ecu_manager.strict_parameter_validation = true;
+
+        let struct_value = json!({"param1": 0x1234u32, "param2": 1.0f32, "param3": "hello"});
+        // bogus_param is at the top-level service parameter map, not defined in the service
+        let payload_data = UdsPayloadData::ParameterMap(
+            [
+                ("main_param".to_string(), struct_value),
+                ("bogus_param".to_string(), json!("should be rejected")),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        // Strict mode: unexpected params cause a BadPayload error
+        let result = ecu_manager
+            .create_uds_payload(&service, &skip_sec_plugin!(), Some(payload_data), None)
+            .await;
+
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(
+                e.to_string().contains("Unexpected parameters in request"),
+                "Expected unexpected parameter error, got: {e}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_process_parameter_map_nested_unexpected_params_strict() {
+        let (mut ecu_manager, service, _, _) = create_ecu_manager_with_struct_service(1);
+        ecu_manager.strict_parameter_validation = true;
+
+        // bogus_nested is inside the struct value, not defined in the struct's sub-params
+        let struct_value = json!({"param1": 0x1234u32, "param2": 1.0f32, "param3": "hello", "bogus_nested": "reject me"});
+        let payload_data = UdsPayloadData::ParameterMap(
+            [("main_param".to_string(), struct_value)]
+                .into_iter()
+                .collect(),
+        );
+
+        // Strict mode: unexpected nested params cause a BadPayload error
+        let result = ecu_manager
+            .create_uds_payload(&service, &skip_sec_plugin!(), Some(payload_data), None)
+            .await;
+
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(
+                e.to_string().contains("Unexpected parameters in request"),
+                "Expected unexpected parameter error for nested param, got: {e}"
+            );
+        }
+    }
+
+    /// Strict mode must reject unexpected keys inside a Mux parameter object.
+    ///
+    /// `map_mux_to_uds` only reads `"Selector"` and the matched case name;
+    /// any extra keys must be rejected when `strict_parameter_validation` is
+    /// enabled, mirroring the behaviour of `map_struct_to_uds` and
+    /// `process_parameter_map`.
+    #[tokio::test]
+    async fn test_map_mux_to_uds_unexpected_params_strict() {
+        let (mut ecu_manager, service, _) = create_ecu_manager_with_mux_service(None, None, None);
+        ecu_manager.strict_parameter_validation = true;
+
+        // Valid mux payload with an extra key "bogus_mux_key" at the mux
+        // object level.  "Selector" and "mux_1_case_1" are the only
+        // legitimate keys for this request.
+        let test_value = json!({
+            "mux_1_param": {
+                "Selector": 5,
+                "mux_1_case_1": {
+                    "mux_1_case_1_param_1": 13.37f32,
+                    "mux_1_case_1_param_2": 7
+                },
+                "bogus_mux_key": "should be rejected"
+            }
+        });
+
+        let payload_data =
+            UdsPayloadData::ParameterMap(serde_json::from_value(test_value).unwrap());
+
+        let result = ecu_manager
+            .create_uds_payload(&service, &skip_sec_plugin!(), Some(payload_data), None)
+            .await;
+
+        assert!(
+            result.is_err(),
+            "Expected strict mode to reject unexpected mux-level key 'bogus_mux_key', but the \
+             request succeeded"
+        );
+        if let Err(e) = result {
+            assert!(
+                e.to_string().contains("Unexpected parameters in request"),
+                "Expected 'Unexpected parameters in request' error, got: {e}"
             );
         }
     }

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -129,6 +129,7 @@ pub struct EcuManager<S: SecurityPlugin> {
     variant_index: Option<usize>,
     variant: EcuVariant,
     fallback_to_base_variant: bool,
+    strict_parameter_validation: bool,
     duplicating_ecu_names: Option<HashSet<String>>,
 
     protocol: Protocol,
@@ -2006,6 +2007,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
     ///
     /// Will return `Err` if the ECU database cannot be loaded correctly due to different reasons,
     /// like the format being incompatible or required information missing from the database.
+    #[allow(clippy::too_many_arguments)]
     #[tracing::instrument(skip_all,
         fields(
             dlt_context = dlt_ctx!("CORE"),
@@ -2019,6 +2021,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         type_: EcuManagerType,
         func_description_config: &cda_interfaces::FunctionalDescriptionConfig,
         fallback_to_base_variant: bool,
+        strict_parameter_validation: bool,
     ) -> Result<Self, DiagServiceError> {
         match type_ {
             EcuManagerType::Ecu => Self::new_ecu_description(
@@ -2029,6 +2032,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 type_,
                 func_description_config,
                 fallback_to_base_variant,
+                strict_parameter_validation,
             ),
             EcuManagerType::FunctionalDescription => Self::new_functional_description(
                 database,
@@ -2038,12 +2042,13 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 type_,
                 func_description_config,
                 fallback_to_base_variant,
+                strict_parameter_validation,
             ),
         }
     }
 
     // allow keeping the function together as it makes sense structurally
-    #[allow(clippy::too_many_lines)]
+    #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
     fn new_ecu_description(
         database: datatypes::DiagnosticDatabase,
         protocol: Protocol,
@@ -2052,6 +2057,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         type_: EcuManagerType,
         func_description_config: &cda_interfaces::FunctionalDescriptionConfig,
         fallback_to_base_variant: bool,
+        strict_parameter_validation: bool,
     ) -> Result<Self, DiagServiceError> {
         let variant_detection =
             variant_detection::prepare_variant_detection(&database, &database_naming_convention)?;
@@ -2149,6 +2155,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 logical_address: logical_ecu_address,
             },
             fallback_to_base_variant,
+            strict_parameter_validation,
             duplicating_ecu_names: None,
             protocol,
             fg_protocol_position: func_description_config.protocol_position.clone(),
@@ -2200,6 +2207,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_functional_description(
         database: datatypes::DiagnosticDatabase,
         protocol: Protocol,
@@ -2208,6 +2216,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
         type_: EcuManagerType,
         func_description_config: &cda_interfaces::FunctionalDescriptionConfig,
         fallback_to_base_variant: bool,
+        strict_parameter_validation: bool,
     ) -> Result<Self, DiagServiceError> {
         // Functional group description: use defaults for all com params
         let logical_ecu_address = com_params.doip.logical_ecu_address.default;
@@ -2258,6 +2267,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 logical_address: logical_ecu_address,
             },
             fallback_to_base_variant,
+            strict_parameter_validation,
             duplicating_ecu_names: None,
             protocol,
             fg_protocol_position: func_description_config.protocol_position.clone(),
@@ -3610,6 +3620,28 @@ impl<S: SecurityPlugin> EcuManager<S> {
             };
             self.map_param_to_uds(param, json_values.get(short_name), uds, parent_byte_pos)?;
         }
+
+        let expected_names: HashSet<&str> = mapped_params
+            .iter()
+            .filter_map(|p| p.short_name())
+            .collect();
+        let unexpected: Vec<&str> = json_values
+            .keys()
+            .filter(|k| !expected_names.contains(k.as_str()))
+            .map(String::as_str)
+            .collect();
+        if !unexpected.is_empty() {
+            tracing::warn!(
+                unexpected_parameters = ?unexpected,
+                "Request contains parameters not defined in the service"
+            );
+            if self.strict_parameter_validation {
+                return Err(DiagServiceError::BadPayload(format!(
+                    "Unexpected parameters in request: {unexpected:?}"
+                )));
+            }
+        }
+
         Ok(())
     }
 
@@ -5705,6 +5737,7 @@ mod tests {
                     cda_interfaces::datatypes::DiagnosticServiceAffixPosition::Suffix,
             },
             true,
+            false,
         )
         .expect("Failed to create EcuManager");
 
@@ -5736,6 +5769,7 @@ mod tests {
                 protocol_position:
                     cda_interfaces::datatypes::DiagnosticServiceAffixPosition::Suffix,
             },
+            false,
             false,
         )
         .unwrap()
@@ -8036,6 +8070,62 @@ mod tests {
             assert!(
                 e.to_string()
                     .contains("Required parameter 'param2' missing")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_process_parameter_map_unexpected_params_lenient() {
+        let (ecu_manager, service, _, _) = create_ecu_manager_with_struct_service(1);
+
+        let struct_value = json!({"param1": 0x1234u32, "param2": 1.0f32, "param3": "hello"});
+        // bogus_param is at the top-level service parameter map, not defined in the service
+        let payload_data = UdsPayloadData::ParameterMap(
+            [
+                ("main_param".to_string(), struct_value),
+                ("bogus_param".to_string(), json!("should be ignored")),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        // Lenient mode (default): unexpected params are ignored, request succeeds
+        let result = ecu_manager
+            .create_uds_payload(&service, &skip_sec_plugin!(), Some(payload_data), None)
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "Expected success in lenient mode, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_process_parameter_map_unexpected_params_strict() {
+        let (mut ecu_manager, service, _, _) = create_ecu_manager_with_struct_service(1);
+        ecu_manager.strict_parameter_validation = true;
+
+        let struct_value = json!({"param1": 0x1234u32, "param2": 1.0f32, "param3": "hello"});
+        // bogus_param is at the top-level service parameter map, not defined in the service
+        let payload_data = UdsPayloadData::ParameterMap(
+            [
+                ("main_param".to_string(), struct_value),
+                ("bogus_param".to_string(), json!("should be rejected")),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        // Strict mode: unexpected params cause a BadPayload error
+        let result = ecu_manager
+            .create_uds_payload(&service, &skip_sec_plugin!(), Some(payload_data), None)
+            .await;
+
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(
+                e.to_string().contains("Unexpected parameters in request"),
+                "Expected unexpected parameter error, got: {e}"
             );
         }
     }

--- a/cda-core/src/lib.rs
+++ b/cda-core/src/lib.rs
@@ -12,4 +12,7 @@
 
 mod diag_kernel;
 
-pub use diag_kernel::{diagservices::*, ecumanager::EcuManager};
+pub use diag_kernel::{
+    diagservices::*,
+    ecumanager::{EcuManager, EcuManagerConfig},
+};

--- a/cda-database/src/lib.rs
+++ b/cda-database/src/lib.rs
@@ -46,6 +46,11 @@ pub struct DatabaseConfig {
     /// attempting a lookup with this flag set against a multi-protocol database
     /// returns `DiagServiceError::InvalidDatabase`.
     pub ignore_protocol: bool,
+    /// When `true`, requests that contain parameters not defined in the service
+    /// are rejected with a `BadPayload` error (400 Bad Request).
+    /// When `false` (default), unexpected parameters trigger a warning log but
+    /// are otherwise ignored.
+    pub strict_parameter_validation: bool,
     /// When `true`, the application will exit with an error if any key under
     /// `[ecu.<name>]` in the configuration does not match a loaded MDD database.
     ///

--- a/cda-database/src/lib.rs
+++ b/cda-database/src/lib.rs
@@ -22,6 +22,8 @@ pub use mdd_data::{
 };
 use serde::{Deserialize, Serialize};
 
+// Allowed because this holds a set of independent configuration flags.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Deserialize, Serialize, Clone, Debug, Default, schemars::JsonSchema)]
 pub struct DatabaseConfig {
     /// Path to load the databases from, this must be a directory.
@@ -44,4 +46,9 @@ pub struct DatabaseConfig {
     /// attempting a lookup with this flag set against a multi-protocol database
     /// returns `DiagServiceError::InvalidDatabase`.
     pub ignore_protocol: bool,
+    /// When `true`, requests that contain parameters not defined in the service
+    /// are rejected with a `BadPayload` error (400 Bad Request).
+    /// When `false` (default), unexpected parameters trigger a warning log but
+    /// are otherwise ignored.
+    pub strict_parameter_validation: bool,
 }

--- a/cda-main/src/config/configfile.rs
+++ b/cda-main/src/config/configfile.rs
@@ -203,6 +203,7 @@ impl Default for Configuration {
                 exit_no_database_loaded: false,
                 fallback_to_base_variant: true,
                 ignore_protocol: false,
+                strict_parameter_validation: false,
                 strict_ecu_config: false,
             },
             flash_files_path: ".".to_owned(),

--- a/cda-main/src/config/configfile.rs
+++ b/cda-main/src/config/configfile.rs
@@ -76,6 +76,7 @@ impl Default for Configuration {
                 exit_no_database_loaded: false,
                 fallback_to_base_variant: true,
                 ignore_protocol: false,
+                strict_parameter_validation: false,
             },
             flash_files_path: ".".to_owned(),
             server: ServerConfig {

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -14,7 +14,7 @@ use std::{fs::ReadDir, future::Future, path::PathBuf, sync::Arc};
 
 use cda_comm_doip::{DoipDiagGateway, config::DoipConfig};
 use cda_comm_uds::UdsManager;
-use cda_core::{DiagServiceResponseStruct, EcuManager};
+use cda_core::{DiagServiceResponseStruct, EcuManager, EcuManagerConfig};
 use cda_database::{FileManager, ProtoLoadConfig, update_mdd_uncompressed};
 use cda_health::{HealthState, StatusHealthProvider};
 use cda_interfaces::{
@@ -74,6 +74,7 @@ struct EcuLoadContext<'a> {
     protocol: &'a Protocol,
     com_params: &'a Arc<ComParams>,
     fallback_to_base_variant: bool,
+    strict_parameter_validation: bool,
 }
 
 /// Result of building an ECU manager and associated metadata.
@@ -278,6 +279,7 @@ pub async fn load_databases<S: SecurityPlugin>(
     let database_naming_convention = config.database.naming_convention.clone();
     let func_description_cfg = config.functional_description.clone();
     let fallback_to_base_variant = config.database.fallback_to_base_variant;
+    let strict_parameter_validation = config.database.strict_parameter_validation;
     let database_config = config.database.clone();
     let strict_ecu_config = database_config.strict_ecu_config;
     let protocol = cda_interfaces::Protocol::new(config.doip.protocol_name.clone());
@@ -350,6 +352,7 @@ pub async fn load_databases<S: SecurityPlugin>(
                         flat_buf_settings,
                         func_description_cfg,
                         fallback_to_base_variant,
+                        strict_parameter_validation,
                         database_config,
                     )
                     .await;
@@ -626,9 +629,12 @@ fn create_ecu_manager<S: SecurityPlugin>(
         protocol,
         effective_com_params,
         ctx.database_naming_convention.clone(),
-        ecu_type,
+        EcuManagerConfig {
+            type_: ecu_type,
+            fallback_to_base_variant: ctx.fallback_to_base_variant,
+            strict_parameter_validation: ctx.strict_parameter_validation,
+        },
         ctx.func_description_cfg,
-        ctx.fallback_to_base_variant,
     )
     .map_err(|e| {
         tracing::error!(
@@ -742,6 +748,7 @@ async fn load_database<S: SecurityPlugin>(
     flat_buf_settings: FlatbBufConfig,
     func_description_cfg: FunctionalDescriptionConfig,
     fallback_to_base_variant: bool,
+    strict_parameter_validation: bool,
     database_config: cda_database::DatabaseConfig,
 ) {
     for (mddfile, _) in paths {
@@ -779,6 +786,7 @@ async fn load_database<S: SecurityPlugin>(
                     protocol: &protocol,
                     com_params: &com_params,
                     fallback_to_base_variant,
+                    strict_parameter_validation,
                 };
 
                 if let Some(result) = load_ecu_from_file(proto_data, &ctx, per_ecu_cfg) {

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -252,6 +252,7 @@ pub async fn load_databases<S: SecurityPlugin>(
     let database_naming_convention = config.database.naming_convention.clone();
     let func_description_cfg = config.functional_description.clone();
     let fallback_to_base_variant = config.database.fallback_to_base_variant;
+    let strict_parameter_validation = config.database.strict_parameter_validation;
     let database_config = config.database.clone();
     let protocol = cda_interfaces::Protocol::new(config.doip.protocol_name.clone());
     let com_params = config.com_params.clone();
@@ -326,6 +327,7 @@ pub async fn load_databases<S: SecurityPlugin>(
                         flat_buf_settings,
                         func_description_cfg,
                         fallback_to_base_variant,
+                        strict_parameter_validation,
                         database_config,
                     )
                     .await;
@@ -462,6 +464,7 @@ async fn load_database<S: SecurityPlugin>(
     flat_buf_settings: FlatbBufConfig,
     func_description_cfg: FunctionalDescriptionConfig,
     fallback_to_base_variant: bool,
+    strict_parameter_validation: bool,
     database_config: cda_database::DatabaseConfig,
 ) {
     for (mddfile, _) in paths {
@@ -531,6 +534,7 @@ async fn load_database<S: SecurityPlugin>(
                     ecu_type,
                     &func_description_cfg,
                     fallback_to_base_variant,
+                    strict_parameter_validation,
                 ) {
                     Ok(manager) => manager,
                     Err(e) => {

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -171,6 +171,7 @@ fn cda_test_config(
             exit_no_database_loaded: true,
             fallback_to_base_variant: true,
             ignore_protocol: false,
+            strict_parameter_validation: false,
             strict_ecu_config: false,
         },
         logging: LoggingConfig::default(),

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -136,6 +136,7 @@ async fn initialize_runtime() -> Result<TestRuntime, TestingError> {
             exit_no_database_loaded: true,
             fallback_to_base_variant: true,
             ignore_protocol: false,
+            strict_parameter_validation: false,
         },
         logging: LoggingConfig::default(),
         flash_files_path: flash_files_path()?,

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -328,6 +328,10 @@
 # ignore_protocol = false
 # Path to load the databases from, this must be a directory.
 # path = "."
+# When `true`, requests that contain parameters not defined in the service
+# are rejected with a 400 Bad Request error listing the unexpected parameter names.
+# When `false` (default), unexpected parameters trigger a warning log but are otherwise ignored.
+# strict_parameter_validation = false
 
 # Holds configuration for diagnostic service naming conventions.
 #

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -401,6 +401,11 @@
 # This helps catch typos in ECU names early. When `false` (default),
 # unmatched per-ECU config entries only produce a warning.
 # strict_ecu_config = false
+# When `true`, requests that contain parameters not defined in the service
+# are rejected with a `BadPayload` error (400 Bad Request).
+# When `false` (default), unexpected parameters trigger a warning log but
+# are otherwise ignored.
+# strict_parameter_validation = false
 
 # Holds configuration for diagnostic service naming conventions.
 #

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -329,8 +329,9 @@
 # Path to load the databases from, this must be a directory.
 # path = "."
 # When `true`, requests that contain parameters not defined in the service
-# are rejected with a 400 Bad Request error listing the unexpected parameter names.
-# When `false` (default), unexpected parameters trigger a warning log but are otherwise ignored.
+# are rejected with a `BadPayload` error (400 Bad Request).
+# When `false` (default), unexpected parameters trigger a warning log but
+# are otherwise ignored.
 # strict_parameter_validation = false
 
 # Holds configuration for diagnostic service naming conventions.


### PR DESCRIPTION
Summary
Adds a new opt-in config flag database.strict_parameter_validation (default: false).

When false: requests containing parameters not defined in the service proceed normally. S warning is logged but the request is forwarded to the ECU.

When true: the request is rejected immediately with 400 Bad Request listing the unexpected parameter names, before any UDS payload is built or sent to the ECU.

Checklist
 I have tested my changes locally
 I have updated documentation
 I have linked related issues
 I have updated tests
Related
Closes #215

Notes for Reviewers
The flag is opt-in and defaults to false to preserve existing behavior. The check runs at the end of process_parameter_map in EcuManager after the existing parameter mapping loop, unexpected keys are detected by diffing the request's parameter map keys against the set of short_names defined in the ODX service.

The opensovd-cda.toml reference config documents the flag with its default. The integration test setup in runtime.rs explicitly sets false to keep existing tests unaffected.

To enable strict mode, set strict_parameter_validation = true under [database] in opensovd-cda.toml and restart the application. With strict mode on, a request containing an undefined parameter will be rejected before reaching the ECU with 400 Bad Request and a message of the form: "Bad payload: Unexpected parameters in request: [\"bogus_extra_param\"]".

Example
Request:

curl -X PUT http://localhost:20002/vehicle/v15/components/flxc1000/data/VINDataIdentifier \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"data": {"VIN": "SCEDT26T8BD005261", "bogus_extra_param": "unexpected"}}'
Expected response (strict_parameter_validation = true):

{
  "message": "Bad payload: Unexpected parameters in request: [\"bogus_extra_param\"]",
  "error_code": "vendor-specific",
  "vendor_code": "bad-request"
}
HTTP 400 Bad Request

Expected response (strict_parameter_validation = false):

Request goes through to the ECU normally, bogus_extra_param is silently ignored. Warning appears in logs.