### PR TITLE
fix: update copyright header format and normalize newlines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,16 @@ jobs:
         uses: eclipse-opensovd/dlt-tracing-lib/.github/actions/setup-dlt@main
       - name: Build all features
         run: cargo build --locked --verbose --all-features
+      - name: Verify generated files are up to date
+        run: |
+          if ! git diff --exit-code cda-database/src/flatbuf/diagnostic_description.rs cda-database/src/proto/fileformat.rs; then
+            echo ""
+            echo "::error::Generated files are out of date."
+            echo "Regenerate flatbuffers with: cargo build -p cda-database --features gen-flatbuffers"
+            echo "Regenerate protos with: cargo build -p cda-database --features gen-protos"
+            exit 1
+          fi
+          echo "Generated files are up to date."
       - name: Verify reference config is up to date
         run: |
           cargo run --locked --all-features -- generate-config --output /tmp/opensovd-cda.toml

--- a/cda-database/build.rs
+++ b/cda-database/build.rs
@@ -12,7 +12,8 @@
 
 #[cfg(any(feature = "gen-protos", feature = "gen-flatbuffers"))]
 const COPYRIGHT_HEADER: &str = r"/*
- * Copyright (c) 2025 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,8 +21,6 @@ const COPYRIGHT_HEADER: &str = r"/*
  * This program and the accompanying materials are made available under the
  * terms of the Apache License Version 2.0 which is available at
  * https://www.apache.org/licenses/LICENSE-2.0
- *
- * SPDX-License-Identifier: Apache-2.0
  */
 
 ";
@@ -30,6 +29,14 @@ fn prepend_copyright(file_path: &str) -> std::io::Result<()> {
     let content = std::fs::read_to_string(file_path)?;
     let new_content = format!("{COPYRIGHT_HEADER}{content}");
     std::fs::write(file_path, new_content)?;
+    Ok(())
+}
+
+#[cfg(feature = "gen-flatbuffers")]
+fn normalize_trailing_newline(file_path: &str) -> std::io::Result<()> {
+    let content = std::fs::read_to_string(file_path)?;
+    let normalized = format!("{}\n", content.trim_end_matches('\n'));
+    std::fs::write(file_path, normalized)?;
     Ok(())
 }
 
@@ -163,6 +170,7 @@ fn generate_flatbuffers() -> std::io::Result<()> {
     let final_file = format!("{output_dir}{schema_name}.rs");
     std::fs::rename(generated_file, &final_file)?;
     prepend_copyright(&final_file)?;
+    normalize_trailing_newline(&final_file)?;
 
     Ok(())
 }


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
Move SPDX identifiers to the top of the copyright block per project conventions and add a normalize_trailing_newline helper to ensure consistent file endings in generated flatbuffer sources.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->



Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)