### PR TITLE
Fix documentation links + improve project setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ https://www.apache.org/licenses/LICENSE-2.0
 # Contributing
 
 Welcome to the OpenSOVD community. Start here for info on how to contribute and help improve our project.
-Please observe our [Community Code of Conduct](./CODE_OF_CONDUCT.md).
+Please observe our [Community Code of Conduct](https://github.com/eclipse-opensovd/opensovd/blob/main/CODE_OF_CONDUCT.md).
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ $env:OPENSSL_INCLUDE_DIR="C:\Program Files\OpenSSL-Win64\include"
 
 ### pre commit
 ```shell
-uv run https://raw.githubusercontent.com/eclipse-opensovd/cicd-workflows/main/run_checks.py
+uv run https://raw.githubusercontent.com/eclipse-opensovd/cicd-workflows/4116addc88b6c523bc6d729b1b4e198ccb04ce3d/run_checks.py
 ```
+Install this command as documented here: https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
 
 ### codestyle
 
@@ -255,4 +256,4 @@ In a second terminal window start `tokio-console` and it should automatically co
 
 ### architecture
 
-see [overview](docs/architecture/index.adoc)
+see [overview](https://eclipse-opensovd.github.io/classic-diagnostic-adapter/03_architecture/index.html)

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -8,6 +8,7 @@
 # terms of the Apache License Version 2.0 which is available at
 # https://www.apache.org/licenses/LICENSE-2.0
 
+unstable_features = true # needed for `group_imports` feature
 max_width = 100
 
 # in case rustfmt stopps working again, enable these options


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
The link to the architecture overview in the README.md leads to a 404.
This change points it to the rendered documentation to fix this.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
Frank Märkle [frank.maerkle@mercedes-benz.com](mailto:frank.maerkle@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
