### PR TITLE
 Improve shutdown_signal handling

### DIFF
--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -25,6 +25,7 @@ use doip_definitions::{
     header::ProtocolVersion,
     payload::{DiagnosticMessage, DiagnosticMessageNack, DoipPayload, GenericNack},
 };
+use futures::FutureExt;
 use thiserror::Error;
 use tokio::sync::{Mutex, RwLock, broadcast, mpsc};
 
@@ -162,7 +163,7 @@ impl<T: EcuAddressProvider + DoipComParamProvider> DoipDiagGateway<T> {
         shutdown_signal: F,
     ) -> Result<Self, DoipGatewaySetupError>
     where
-        F: Future<Output = ()> + Clone + Send + 'static,
+        F: Future<Output = ()> + Send + 'static,
     {
         let DoipConfig {
             protocol_version,
@@ -199,12 +200,14 @@ impl<T: EcuAddressProvider + DoipComParamProvider> DoipDiagGateway<T> {
         )?;
         let mask = create_netmask(tester_ip, tester_subnet)?;
 
+        let shared_shutdown_signal = shutdown_signal.shared();
+
         let gateways = vir_vam::get_vehicle_identification::<T, F>(
             &mut socket,
             mask,
             gateway_port,
             &ecus,
-            shutdown_signal.clone(),
+            shared_shutdown_signal.clone(),
         )
         .await
         .map_err(|err| {
@@ -271,7 +274,7 @@ impl<T: EcuAddressProvider + DoipComParamProvider> DoipDiagGateway<T> {
             gateway.clone(),
             variant_detection,
             send_timeout,
-            shutdown_signal,
+            shared_shutdown_signal,
         )
         .await;
 

--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -19,7 +19,6 @@ use doip_definitions::{
     header::PayloadType,
     payload::{DoipPayload, VehicleIdentificationRequest},
 };
-use futures::FutureExt;
 use tokio::sync::{Mutex, RwLock, mpsc};
 
 use crate::{
@@ -57,7 +56,7 @@ where
     let vam_timeout = Duration::from_secs(1); // not the actual timeout from the spec ...
 
     tokio::select! {
-        _ = &mut shutdown_signal => {
+        () = &mut shutdown_signal => {
             tracing::info!("Shutdown signal received");
         },
         () = cda_interfaces::util::tokio_ext::sleep_for(vam_timeout) => {

--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -19,6 +19,7 @@ use doip_definitions::{
     header::PayloadType,
     payload::{DoipPayload, VehicleIdentificationRequest},
 };
+use futures::FutureExt;
 use tokio::sync::{Mutex, RwLock, mpsc};
 
 use crate::{
@@ -32,11 +33,11 @@ pub(crate) async fn get_vehicle_identification<T, F>(
     netmask: u32,
     gateway_port: u16,
     ecus: &Arc<HashMap<String, RwLock<T>>>,
-    shutdown_signal: F,
+    mut shutdown_signal: futures::future::Shared<F>,
 ) -> Result<Vec<DoipTarget>, DiagServiceError>
 where
     T: EcuAddressProvider,
-    F: Future<Output = ()> + Clone + Send + 'static,
+    F: Future<Output = ()> + Send + 'static,
 {
     // send VIR
     tracing::info!("Broadcasting VIR");
@@ -56,7 +57,7 @@ where
     let vam_timeout = Duration::from_secs(1); // not the actual timeout from the spec ...
 
     tokio::select! {
-        () = shutdown_signal.clone() => {
+        _ = &mut shutdown_signal => {
             tracing::info!("Shutdown signal received");
         },
         () = cda_interfaces::util::tokio_ext::sleep_for(vam_timeout) => {
@@ -106,10 +107,10 @@ pub(crate) async fn listen_for_vams<T, F>(
     gateway: DoipDiagGateway<T>,
     variant_detection: mpsc::Sender<Vec<String>>,
     send_timeout: Duration,
-    shutdown_signal: F,
+    mut shutdown_signal: futures::future::Shared<F>,
 ) where
     T: EcuAddressProvider + DoipComParamProvider,
-    F: Future<Output = ()> + Clone + Send + 'static,
+    F: Future<Output = ()> + Send + 'static,
 {
     #[derive(Debug)]
     struct DoipMessageContext {
@@ -283,9 +284,8 @@ pub(crate) async fn listen_for_vams<T, F>(
 
             loop {
                 let mut socket = broadcast_socket.lock().await;
-                let signal = shutdown_signal.clone();
                 tokio::select! {
-                    () = signal => {
+                    () = &mut shutdown_signal => {
                         break
                     },
                     Some(Ok((doip_msg, source_addr))) = socket.recv() => {

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -678,7 +678,7 @@ pub async fn create_diagnostic_gateway<S: SecurityPlugin>(
     databases: Arc<DatabaseMap<S>>,
     doip_config: &DoipConfig,
     variant_detection: mpsc::Sender<Vec<String>>,
-    shutdown_signal: impl Future<Output = ()> + Send + Clone + 'static,
+    shutdown_signal: impl Future<Output = ()> + Send + 'static,
     health: Option<&cda_health::HealthState>,
 ) -> Result<DoipDiagGateway<EcuManager<S>>, DoipGatewaySetupError> {
     let doip_health_provider = if let Some(health_state) = health {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

Implement a way to avoid cloning the shutdown signal.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

[Issue](https://github.com/eclipse-opensovd/classic-diagnostic-adapter/issues/6)


## Notes for Reviewers

I haven't used UNPIN because it doesn't allow us to pass a signal to a spawned process.
