### PR TITLE
Introduce cargo aliases for formatting and lints.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+
+[alias]
+format = "fmt -- --check --config error_on_unformatted=true,error_on_line_overflow=true,format_strings=true,group_imports=StdExternalCrate,imports_granularity=Crate"
+lint = "clippy --all-targets --all-features -- -D warnings"

--- a/CODESTYLE.md
+++ b/CODESTYLE.md
@@ -14,8 +14,7 @@ https://www.apache.org/licenses/LICENSE-2.0
 
 ## Linting & Clippy
 
-- **Clippy**: Always run with `clippy::pedantic` enabled for stricter linting.
-  - Example: `cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic`
+- **Clippy**: Run with `cargo lint` alias to use recommended configuration.
 - **Allow/Forbid**: Use `#[allow(...)]` only when necessary, and always document the reason.
   - Example: `#[allow(clippy::ref_option)] // Not compatible with serde derive`
 - **Warnings**: Treat all warnings as errors.
@@ -32,9 +31,9 @@ This repository follows most of the defaults in rustfmt, with some opinionated u
   - Enable formatting of strings.
 
 As we do not want to require nightly rust for the entire repository, these settings are not yet included in `rustfmt.toml` (but will be once stabilized).
-Instead, run this command to apply the correct formatting:
+Instead, run this alias to apply the correct formatting:
 ```sh
-cargo +nightly fmt -- --check --config error_on_unformatted=true,error_on_line_overflow=true,format_strings=true,group_imports=StdExternalCrate,imports_granularity=Crate
+cargo +nightly format
 ```
 
 It is recommended to configure your IDE to use nightly rustfmt with these settings as well.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
Allow running `cargo +nightly format` and `cargo lint` to run `cargo fmt` and `cargo clippy` with appropriate command-line arguments.
This makes it easier to remember the commands and easier to modify them in the future.

I also removed `-W clippy::pedantic` from the lint command, as this is already configured in the workspace `Cargo.toml`.


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->
N/A

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
I wasn't able to test, if the sample configuration for VSCode could also use this alias, since VSCode crashes on my system on startup. But I don't believe, this would be possible, since VSCode calls the format command for individual files, which can't be passed into `cargo fmt`, not even with `cargo fmt --` or `cargo fmt -- --`.


---

Frank Märkle [frank.maerkle@mercedes-benz.com](mailto:frank.maerkle@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
