### PR TITLE
feat(config): add config-optional build feature

### DIFF
--- a/cda-main/Cargo.toml
+++ b/cda-main/Cargo.toml
@@ -80,7 +80,7 @@ reqwest = { workspace = true }
 chrono = { workspace = true }
 
 [features]
-default = ["health", "openssl"]
+default = ["health", "openssl", "config-optional"]
 tokio-tracing = ["cda-interfaces/tokio-tracing", "cda-tracing/tokio-tracing"]
 openssl = ["cda-comm-doip/openssl"]
 openssl-vendored = ["openssl", "cda-comm-doip/openssl-vendored"]
@@ -89,4 +89,5 @@ dlt-tracing = ["cda-tracing/dlt-tracing"]
 integration-tests = []
 
 health = []
+config-optional = []
 systemd-notify = ["dep:cda-extra", "cda-extra/systemd-notify"]

--- a/cda-main/src/main.rs
+++ b/cda-main/src/main.rs
@@ -108,12 +108,7 @@ async fn main() -> Result<(), AppError> {
         return generate_config_cmd(output.as_ref());
     }
 
-    let mut config =
-        opensovd_cda_lib::config::load_config(args.config.as_deref()).unwrap_or_else(|e| {
-            println!("Failed to load configuration: {e}");
-            println!("Using default values");
-            opensovd_cda_lib::config::default_config()
-        });
+    let mut config = load_config_or_default(args.config.as_deref())?;
     config.validate_sanity()?;
 
     args.update_config(&mut config);
@@ -246,6 +241,31 @@ async fn main() -> Result<(), AppError> {
         .map_err(|e| AppError::RuntimeError(format!("Webserver task join error: {e}")))?;
 
     Ok(())
+}
+
+#[cfg(feature = "config-optional")]
+#[allow(clippy::unnecessary_wraps)] // signature must match the `not(feature)` variant
+fn load_config_or_default(config_path: Option<&str>) -> Result<Configuration, AppError> {
+    Ok(
+        opensovd_cda_lib::config::load_config(config_path).unwrap_or_else(|e| {
+            println!("Failed to load configuration: {e}");
+            println!("Using default values");
+            opensovd_cda_lib::config::default_config()
+        }),
+    )
+}
+
+/// Without `config-optional`, a missing or invalid configuration is a hard error.
+#[cfg(not(feature = "config-optional"))]
+fn load_config_or_default(config_path: Option<&str>) -> Result<Configuration, AppError> {
+    opensovd_cda_lib::config::load_config(config_path).map_err(|e| {
+        println!("Failed to load configuration: {e}");
+        println!(
+            "Provide a configuration file or build with the 'config-optional' feature to allow \
+             starting without one."
+        );
+        AppError::ConfigurationError(e)
+    })
 }
 
 fn generate_config_cmd(output: Option<&PathBuf>) -> Result<(), AppError> {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Resolves #251 — Make startup without any configuration an optional build-time feature.

Supersedes #316 (renamed feature flag for readability).

### Changes

- Adds `config-optional` Cargo feature flag (default-enabled for backward compatibility)
- Extracts config loading into `load_config_or_default()` with dual `#[cfg]` implementations
- When feature enabled: current behavior preserved (fallback to built-in defaults)
- When feature disabled: missing/invalid config → hard error with descriptive message

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

Resolves #251
Supersedes #316

## Notes for Reviewers

Minimal change: only `Cargo.toml` and `main.rs` touched. The original `config_file_path()` helper from #316 is no longer needed since `load_config()` now accepts an `Option<&str>` path from clap args.

---
Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)