### PR TITLE
Enable string_slice Clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ unwrap_used = "deny"
 arithmetic_side_effects = "deny"
 separated_literal_suffix = "deny"
 disallowed_methods = "deny"
+string_slice = "deny"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(nightly)'] }

--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -3046,7 +3046,11 @@ fn sae_to_dtc_code(sae_dtc: &str) -> Result<DtcCode, DiagServiceError> {
         }
     };
 
-    let hex_part = &sae_dtc[2..];
+    let hex_part = sae_dtc.get(2..).ok_or_else(|| {
+        DiagServiceError::InvalidRequest(format!(
+            "Invalid SAE dtc code '{sae_dtc}', missing hex part"
+        ))
+    })?;
     let code = DtcCode::from_str_radix(hex_part, 16).map_err(|_| {
         DiagServiceError::InvalidRequest(format!(
             "Invalid hex characters in SAE dtc code '{sae_dtc}'"
@@ -3094,5 +3098,106 @@ fn check_sd_sdg_recursive(expected: &SdBoolMappings, sd_sdg: &SdSdg) -> bool {
         SdSdg::Sdg { sdgs, .. } => sdgs
             .iter()
             .any(|sdsdg| check_sd_sdg_recursive(expected, sdsdg)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //Tests for SAE/ISO Diagnostic Trouble Code (DTC) conversion. (https://autodtcs.com/codes/#google_vignette)
+    //
+    // System
+    // 00 - Powertrain (P)
+    // 01 - Chassis (C)
+    // 10 - Body (B)
+    // 11 - Network Communications (U)
+    //
+    // Group:
+    // 00 - SAE/ISO Controlled (0)
+    // 01 - Manufacturer Controlled (1)
+    // 10 - For (P) SAE/ISO / Rest Manufacturer Controlled (2)
+    // 11 - SAE/ISO Controlled (3)
+    //
+    // You'll see bitfield shifts in some of the expected values below. That's because
+    // `sae_to_dtc_code` packs its result as `(system << 22) | (group << 20) | code`,
+    // so the system and group bits live at fixed positions in the u32. We rebuild the
+    // expected value the same way to make sure each field lands in the right slot.
+    // This allows us to compare the expected result with the received response
+
+    use super::*;
+
+    #[test]
+    fn test_sae_to_dtc_code_powertrain() {
+        // P0420 - "Catalyst System Efficiency Below Threshold (Bank 1)"
+        // Format: "P000420" -> system=0 (P), group=0, hex=0x00420
+        assert_eq!(sae_to_dtc_code("P000420").unwrap(), 0x00420);
+
+        // P0301 - "Cylinder 1 Misfire Detected"
+        assert_eq!(sae_to_dtc_code("P000301").unwrap(), 0x00301);
+    }
+
+    #[test]
+    fn test_sae_to_dtc_code_chassis() {
+        // C0035 - "Left Front Wheel Speed Sensor Circuit"
+        // Format: "C000035" -> system=1 (C), group=0, hex=0x00035
+        assert_eq!(sae_to_dtc_code("C000035").unwrap(), (1u32 << 22) | 0x00035);
+    }
+
+    #[test]
+    fn test_sae_to_dtc_code_body_generic() {
+        // B0001 - "Driver Frontal Stage 1 Deployment Control"
+        // Extended format: "B000001" -> system=2 (B), group=0, hex=0x00001
+        assert_eq!(sae_to_dtc_code("B000001").unwrap(), (2u32 << 22) | 0x00001);
+    }
+
+    #[test]
+    fn test_sae_to_dtc_code_body_manufacturer() {
+        // B1000 - Manufacturer-specific Body code (e.g., "ECU Defective")
+        // Extended format: "B100000" -> system=2 (B), group=1, hex=0x00000
+        assert_eq!(
+            sae_to_dtc_code("B100000").unwrap(),
+            (2u32 << 22) | (1u32 << 20)
+        );
+    }
+
+    #[test]
+    fn test_sae_to_dtc_code_network() {
+        // U0001 - "High Speed CAN Communication Bus"
+        // Format: "U000001" -> system=3 (U), group=0, hex=0x00001
+        assert_eq!(sae_to_dtc_code("U000001").unwrap(), (3u32 << 22) | 0x00001);
+    }
+
+    #[test]
+    fn test_sae_to_dtc_code_lowercase() {
+        // Function should handle lowercase input (calls .to_lowercase() internally)
+        // P0420 in lowercase
+        assert_eq!(sae_to_dtc_code("p000420").unwrap(), 0x00420);
+    }
+
+    #[test]
+    fn test_sae_to_dtc_code_invalid_length() {
+        // Standard 5-char SAE format is too short for this function
+        assert!(sae_to_dtc_code("P0420").is_err());
+        // Too long
+        assert!(sae_to_dtc_code("P00042000").is_err());
+        // Empty
+        assert!(sae_to_dtc_code("").is_err());
+    }
+
+    #[test]
+    fn test_sae_to_dtc_code_invalid_system() {
+        // 'X' is not a valid system letter (must be P/C/B/U)
+        assert!(sae_to_dtc_code("X000420").is_err());
+    }
+
+    #[test]
+    fn test_sae_to_dtc_code_invalid_group() {
+        // '9' is not a valid group digit (must be 0-3)
+        assert!(sae_to_dtc_code("P900420").is_err());
+    }
+
+    #[test]
+    fn test_sae_to_dtc_code_invalid_hex() {
+        // 'Z' is not a valid hex character
+        assert!(sae_to_dtc_code("P00042Z").is_err());
     }
 }

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -8857,8 +8857,11 @@ mod tests {
         if let ParameterTypeMetadata::CodedConst { coded_value } = &did_param.param_type {
             // Verify the coded value can be parsed as a DID
             // "0xF190" should parse to 61840
-            let did_value = if coded_value.starts_with("0x") || coded_value.starts_with("0X") {
-                u16::from_str_radix(&coded_value[2..], 16).ok()
+            let did_value = if let Some(hex_part) = coded_value
+                .strip_prefix("0x")
+                .or_else(|| coded_value.strip_prefix("0X"))
+            {
+                u16::from_str_radix(hex_part, 16).ok()
             } else {
                 coded_value.parse::<u16>().ok()
             };

--- a/cda-interfaces/src/datatypes/database_naming_convention.rs
+++ b/cda-interfaces/src/datatypes/database_naming_convention.rs
@@ -80,12 +80,18 @@ impl DatabaseNamingConvention {
             if self.long_name_affix_position == DiagnosticServiceAffixPosition::Prefix
                 && long_name_lowercase.starts_with(affix)
             {
-                return long_name[affix.len()..].to_string();
+                return long_name
+                    .get(affix.len()..)
+                    .unwrap_or(long_name)
+                    .to_string();
             }
             if self.long_name_affix_position == DiagnosticServiceAffixPosition::Suffix
                 && long_name_lowercase.ends_with(affix)
             {
-                return long_name[..long_name.len().saturating_sub(affix.len())].to_string();
+                return long_name
+                    .get(..long_name.len().saturating_sub(affix.len()))
+                    .unwrap_or(long_name)
+                    .to_string();
             }
         }
         long_name.to_string()
@@ -102,12 +108,18 @@ impl DatabaseNamingConvention {
             if self.short_name_affix_position == DiagnosticServiceAffixPosition::Prefix
                 && short_name_lowercase.starts_with(affix)
             {
-                return short_name[affix.len()..].to_string();
+                return short_name
+                    .get(affix.len()..)
+                    .unwrap_or(short_name)
+                    .to_string();
             }
             if self.short_name_affix_position == DiagnosticServiceAffixPosition::Suffix
                 && short_name_lowercase.ends_with(affix)
             {
-                return short_name[..short_name.len().saturating_sub(affix.len())].to_string();
+                return short_name
+                    .get(..short_name.len().saturating_sub(affix.len()))
+                    .unwrap_or(short_name)
+                    .to_string();
             }
         }
         short_name.to_string()
@@ -124,12 +136,18 @@ impl DatabaseNamingConvention {
             if *position == DiagnosticServiceAffixPosition::Prefix
                 && short_name_lowercase.starts_with(affix_lowercase.as_str())
             {
-                return short_name[affix.len()..].to_string();
+                return short_name
+                    .get(affix.len()..)
+                    .unwrap_or(&short_name)
+                    .to_string();
             }
             if *position == DiagnosticServiceAffixPosition::Suffix
                 && short_name_lowercase.ends_with(affix_lowercase.as_str())
             {
-                return short_name[..short_name.len().saturating_sub(affix.len())].to_string();
+                return short_name
+                    .get(..short_name.len().saturating_sub(affix.len()))
+                    .unwrap_or(&short_name)
+                    .to_string();
             }
         }
         short_name

--- a/cda-interfaces/src/diagservices.rs
+++ b/cda-interfaces/src/diagservices.rs
@@ -80,7 +80,7 @@ impl std::fmt::Display for UdsPayloadData {
                 let dbg = format!("{hash_map:?}");
                 write!(f, "ParameterMap: ")?;
                 if dbg.len() > 40 {
-                    write!(f, "{} ...", &dbg[..40])
+                    write!(f, "{} ...", dbg.get(..40).unwrap_or(&dbg))
                 } else {
                     write!(f, "{dbg}")
                 }

--- a/cda-interfaces/src/util.rs
+++ b/cda-interfaces/src/util.rs
@@ -238,14 +238,18 @@ pub fn decode_hex(value: &str) -> Result<Vec<u8>, DiagServiceError> {
             "Non-hex character found".to_owned(),
         ));
     }
+
     let value = if value.len().is_multiple_of(2) {
         value
     } else {
-        &format!(
-            "{}0{}",
-            &value[..value.len().saturating_sub(1)],
-            &value[value.len().saturating_sub(1)..]
-        )
+        // Odd length: pad the last character with a leading '0'
+        let first_part = value.get(..value.len().saturating_sub(1)).ok_or_else(|| {
+            DiagServiceError::ParameterConversionError("Invalid hex string length".to_owned())
+        })?;
+        let last_char = value.get(value.len().saturating_sub(1)..).ok_or_else(|| {
+            DiagServiceError::ParameterConversionError("Invalid hex string length".to_owned())
+        })?;
+        &format!("{first_part}0{last_char}")
     };
 
     hex::decode(value).map_err(|e| {
@@ -361,7 +365,10 @@ pub fn set_bit_checked(
 #[inline]
 #[must_use]
 pub fn starts_with_ignore_ascii_case(text: &str, prefix: &str) -> bool {
-    text.len() >= prefix.len() && text[..prefix.len()].eq_ignore_ascii_case(prefix)
+    text.len() >= prefix.len()
+        && text
+            .get(..prefix.len())
+            .is_some_and(|s| s.eq_ignore_ascii_case(prefix))
 }
 
 /// Fast ASCII-only case-insensitive substring check without allocations.
@@ -386,7 +393,9 @@ pub fn contains_ignore_ascii_case(text: &str, needle: &str) -> bool {
 #[must_use]
 pub fn ends_with_ignore_ascii_case(text: &str, suffix: &str) -> bool {
     text.len() >= suffix.len()
-        && text[text.len().saturating_sub(suffix.len())..].eq_ignore_ascii_case(suffix)
+        && text
+            .get(text.len().saturating_sub(suffix.len())..)
+            .is_some_and(|s| s.eq_ignore_ascii_case(suffix))
 }
 
 /// Tries to extract the SID from positive and negative responses
@@ -478,11 +487,54 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_hex() {
-        let result = decode_hex("A3F").unwrap();
-        assert_eq!(result, vec![0xA3, 0x0F]);
+    fn test_decode_hex_even_length() {
         let result = decode_hex("0A3F").unwrap();
         assert_eq!(result, vec![0x0A, 0x3F]);
+
+        let result = decode_hex("ABCD").unwrap();
+        assert_eq!(result, vec![0xAB, 0xCD]);
+    }
+
+    #[test]
+    fn test_decode_hex_odd_length() {
+        // Odd length: last char gets padded with leading '0'
+        // "A3F" -> "A30F" -> [0xA3, 0x0F]
+        let result = decode_hex("A3F").unwrap();
+        assert_eq!(result, vec![0xA3, 0x0F]);
+
+        let result = decode_hex("F").unwrap();
+        assert_eq!(result, vec![0x0F]);
+    }
+
+    #[test]
+    fn test_decode_hex_case_insensitive() {
+        let result = decode_hex("abcd").unwrap();
+        assert_eq!(result, vec![0xAB, 0xCD]);
+
+        let result = decode_hex("AbCd").unwrap();
+        assert_eq!(result, vec![0xAB, 0xCD]);
+    }
+
+    #[test]
+    fn test_decode_hex_empty() {
+        let result = decode_hex("").unwrap();
+        assert_eq!(result, Vec::<u8>::new());
+    }
+
+    #[test]
+    fn test_decode_hex_invalid_chars() {
+        assert!(decode_hex("G123").is_err());
+        assert!(decode_hex("12 34").is_err());
+        assert!(decode_hex("0x10").is_err());
+        assert!(decode_hex("12-34").is_err());
+    }
+
+    #[test]
+    fn test_decode_hex_boundary_values() {
+        let result = decode_hex("00").unwrap();
+        assert_eq!(result, vec![0x00]);
+        let result = decode_hex("FF").unwrap();
+        assert_eq!(result, vec![0xFF]);
     }
 
     #[test]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->
## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
Enable string_slice Clippy lint + Fix lint warnings.
I also decide  to  add  a  few  missing  tests for  `decode_hex` function
## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
-->
[Issue](https://github.com/eclipse-opensovd/classic-diagnostic-adapter/issues/333)
## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
