### PR TITLE
Bump CICD again to fix pr-comment workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,7 @@ jobs:
 
   coverage:
     name: Coverage
-    uses: eclipse-opensovd/cicd-workflows/.github/workflows/coverage.yml@79d646fae2da95f76eef7463899add4846859a74
+    uses: eclipse-opensovd/cicd-workflows/.github/workflows/coverage.yml@685151a2a184d4967bf4c75e02b54947938559e3
     with:
       rust-version: "1.88.0"
       cargo-extra-args: "--features integration-tests"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,7 +57,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Format and Clippy - Nightly toolchain pinned
         continue-on-error: true
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@79d646fae2da95f76eef7463899add4846859a74
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@685151a2a184d4967bf4c75e02b54947938559e3
         with:
           toolchain: nightly-2025-07-14
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -68,7 +68,7 @@ jobs:
           reporter: github-check
       - name: Format and Clippy - Nightly toolchain latest
         continue-on-error: true
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@79d646fae2da95f76eef7463899add4846859a74
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@685151a2a184d4967bf4c75e02b54947938559e3
         with:
           toolchain: nightly
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -46,7 +46,7 @@ jobs:
           # to avoid rate limiting, passing the default token.
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Format and Clippy - Stable toolchain
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@79d646fae2da95f76eef7463899add4846859a74
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@685151a2a184d4967bf4c75e02b54947938559e3
         with:
           toolchain: 1.88.0
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
           rustfmt-enable-reviewdog: "false"
           error-on-unformatted: "false"
       - name: Format and Clippy - Nightly toolchain pinned
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@79d646fae2da95f76eef7463899add4846859a74
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@685151a2a184d4967bf4c75e02b54947938559e3
         with:
           toolchain: nightly-2025-07-14
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
       - name: Format and Clippy - Nightly toolchain latest
         id: nightly-clippy
         continue-on-error: true
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@79d646fae2da95f76eef7463899add4846859a74
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@685151a2a184d4967bf4c75e02b54947938559e3
         with:
           toolchain: nightly
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -22,8 +22,9 @@ on:
 jobs:
   post:
     if: github.event.workflow_run.event == 'pull_request'
-    uses: eclipse-opensovd/cicd-workflows/.github/workflows/post-pr-comments.yml@79d646fae2da95f76eef7463899add4846859a74
+    uses: eclipse-opensovd/cicd-workflows/.github/workflows/post-pr-comments.yml@685151a2a184d4967bf4c75e02b54947938559e3
     with:
       run-id: ${{ github.event.workflow_run.id }}
     permissions:
+      actions: read
       pull-requests: write


### PR DESCRIPTION
Use latest CICD workflow and set actions: read permission for pr-comment workflow.

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)