### PR TITLE
fix: update deprecated github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       PKG_CONFIG_PATH: "/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
       - name: Install Rust toolchain
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
       - name: Set up Docker Buildx
@@ -160,7 +160,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
       - name: Install Rust toolchain

--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
       - name: Set up Docker Buildx
@@ -59,7 +59,7 @@ jobs:
             ghcr.io/${{ github.repository }}/sphinxdoc:latest \
             bash -c "sphinx-build -W -b html /docs /docs/_build/html"
       - name: Upload documentation (html)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         id: upload-docs-html
         with:
           if-no-files-found: 'error'
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
       - name: Install Rust toolchain
@@ -87,7 +87,7 @@ jobs:
       - name: Add redirect
         run: echo '<meta http-equiv="refresh" content="0;url=cda_plugin_security/index.html">' > target/doc/index.html
       - name: Upload documentation (rustdoc)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         id: upload-rustdoc
         with:
           if-no-files-found: 'error'
@@ -106,19 +106,19 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Download Sphinx documentation
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cda-docs
           path: pages/
       - name: Download Rustdoc documentation
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: rustdoc
           path: pages/rustdoc/
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: pages/
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
       - name: Install Rust toolchain
@@ -45,7 +45,7 @@ jobs:
     name: "Nightly Lint and Format"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
       - name: Setup DLT tracing lib

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -33,7 +33,7 @@ jobs:
       IS_FORK: ${{ github.event.pull_request.head.repo.fork == true }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
       - name: Setup DLT tracing lib

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
       - name: Run checks


### PR DESCRIPTION
## Summary
Since some jobs are using deprecated actions based on node 20, the versions of the corresponding actions are updated.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
Fixes #320 partly, the same updates will be done in the cicd repository as well

## Notes for Reviewers
Veronika Neumann [veronika.neumann@mercedes-benz.com](mailto:veronika.neumann@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
