### PR TITLE
cicd: update workflow sha to b5496db

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,7 @@ jobs:
 
   coverage:
     name: Coverage
-    uses: eclipse-opensovd/cicd-workflows/.github/workflows/coverage.yml@e5e7addf1d63b31646b52c30cacacd5934b623e1
+    uses: eclipse-opensovd/cicd-workflows/.github/workflows/coverage.yml@b5496db6e121cc417071b31688935a51ccb94f06
     with:
       rust-version: "1.88.0"
       cargo-extra-args: "--features integration-tests"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,7 +57,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Format and Clippy - Nightly toolchain pinned
         continue-on-error: true
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@e5e7addf1d63b31646b52c30cacacd5934b623e1
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@b5496db6e121cc417071b31688935a51ccb94f06
         with:
           toolchain: nightly-2025-07-14
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -68,7 +68,7 @@ jobs:
           reporter: github-check
       - name: Format and Clippy - Nightly toolchain latest
         continue-on-error: true
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@e5e7addf1d63b31646b52c30cacacd5934b623e1
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@b5496db6e121cc417071b31688935a51ccb94f06
         with:
           toolchain: nightly
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -46,7 +46,7 @@ jobs:
           # to avoid rate limiting, passing the default token.
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Format and Clippy - Stable toolchain
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@e5e7addf1d63b31646b52c30cacacd5934b623e1
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@b5496db6e121cc417071b31688935a51ccb94f06
         with:
           toolchain: 1.88.0
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
           rustfmt-enable-reviewdog: "false"
           error-on-unformatted: "false"
       - name: Format and Clippy - Nightly toolchain pinned
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@e5e7addf1d63b31646b52c30cacacd5934b623e1
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@b5496db6e121cc417071b31688935a51ccb94f06
         with:
           toolchain: nightly-2025-07-14
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
       - name: Format and Clippy - Nightly toolchain latest
         id: nightly-clippy
         continue-on-error: true
-        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@e5e7addf1d63b31646b52c30cacacd5934b623e1
+        uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@b5496db6e121cc417071b31688935a51ccb94f06
         with:
           toolchain: nightly
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   post:
     if: github.event.workflow_run.event == 'pull_request'
-    uses: eclipse-opensovd/cicd-workflows/.github/workflows/post-pr-comments.yml@e5e7addf1d63b31646b52c30cacacd5934b623e1
+    uses: eclipse-opensovd/cicd-workflows/.github/workflows/post-pr-comments.yml@b5496db6e121cc417071b31688935a51ccb94f06
     with:
       run-id: ${{ github.event.workflow_run.id }}
     permissions:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -33,6 +33,6 @@ jobs:
         with:
           submodules: false
       - name: Run checks
-        uses: eclipse-opensovd/cicd-workflows/pre-commit-action@e5e7addf1d63b31646b52c30cacacd5934b623e1
+        uses: eclipse-opensovd/cicd-workflows/pre-commit-action@b5496db6e121cc417071b31688935a51ccb94f06
         with:
           rust-toolchain: "1.88"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       - id: conventional-pre-commit
         stages: [commit-msg]
   - repo: https://github.com/eclipse-opensovd/cicd-workflows
-    rev: e5e7addf1d63b31646b52c30cacacd5934b623e1
+    rev: b5496db6e121cc417071b31688935a51ccb94f06
     hooks:
       - id: reuse-annotate
       - id: no-unicode-check


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
The workflow shas referencing the cicd workflow repository are updated to the newest commit. This is done to apply the changes of #320.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
This commit is used as reference: https://github.com/eclipse-opensovd/cicd-workflows/commit/b5496db6e121cc417071b31688935a51ccb94f06

## Notes for Reviewers

Veronika Neumann [veronika.neumann@mercedes-benz.com](mailto:veronika.neumann@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
