### PR TITLE
feat(ci): add CI workflow for FlatBuffers and Protobuf schema backward compatibility

### DIFF
--- a/.github/workflows/schema_compatibility.yml
+++ b/.github/workflows/schema_compatibility.yml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+
+name: Schema Backward Compatibility
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'cda-database/src/flatbuf/**'
+      - 'cda-database/proto/**'
+
+permissions:
+  contents: read
+
+jobs:
+  flatbuffers-compat:
+    name: FlatBuffers Backward Compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install flatc v25.9.23
+        uses: Nugine/setup-flatc@v1
+        with:
+          version: "25.9.23"
+
+      - name: Check FlatBuffers schema backward compatibility
+        run: |
+          git show origin/main:cda-database/src/flatbuf/diagnostic_description.fbs \
+            > /tmp/main_diagnostic_description.fbs
+          flatc --conform /tmp/main_diagnostic_description.fbs \
+            cda-database/src/flatbuf/diagnostic_description.fbs
+
+  protobuf-compat:
+    name: Protobuf Backward Compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check Protobuf schema backward compatibility
+        uses: bufbuild/buf-action@v1
+        with:
+          input: cda-database/proto
+          breaking_against: '.git#branch=origin/main,subdir=cda-database/proto'
+          lint: false
+          format: false
+          push: false
+          pr_comment: false

--- a/cda-database/proto/buf.yaml
+++ b/cda-database/proto/buf.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+
+version: v2


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
Adds a GitHub Actions workflow that runs on PRs to main when schema files change. The FlatBuffers job uses flatc --conform against the main branch baseline; the Protobuf job uses buf breaking with a git reference against main. A minimal buf.yaml is added to define the proto module boundary.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
