### PR TITLE
fix(mbedtls-sys): apply patches relative to mbedtls source parent dir

### DIFF
--- a/comm-mbedtls/mbedtls-sys/build.rs
+++ b/comm-mbedtls/mbedtls-sys/build.rs
@@ -298,13 +298,19 @@ fn ensure_mbedtls_source(workspace_dir: &Path) {
         return;
     }
 
+    // Patches are applied relative to the parent of the mbedtls source tree so
+    // that paths like `mbedtls-4.0.0/library/ssl_client.c` resolve correctly
+    // regardless of whether the source lives inside workspace_dir or was
+    // supplied via MBEDTLS_DIR pointing at an external location.
+    let patch_work_dir = mbedtls_dir.parent().unwrap_or(workspace_dir);
+
     // Apply record-size-limit patch adding the extension for TLS1.2 aswell
     let patch_file = workspace_dir
         .join("patches")
         .join("record-size-limit-tls12.patch");
     if patch_file.exists() {
         eprintln!("Applying record-size-limit patch ...");
-        apply_patch(&patch_file, workspace_dir);
+        apply_patch(&patch_file, patch_work_dir);
     } else {
         eprintln!(
             "warning: patch file {} not found - skipping",
@@ -318,7 +324,7 @@ fn ensure_mbedtls_source(workspace_dir: &Path) {
         .join("ed25519-psa-driver.patch");
     if patch_file.exists() {
         eprintln!("Applying Ed25519 patch ...");
-        apply_patch(&patch_file, workspace_dir);
+        apply_patch(&patch_file, patch_work_dir);
     } else {
         eprintln!(
             "warning: patch file {} not found - skipping",


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

When MBEDTLS_DIR points to an external location, apply_patch was called with workspace_dir as the work directory, causing it to look for patch targets (e.g. mbedtls-4.0.0/library/ssl_client.c) in the wrong place.

Compute patch_work_dir as mbedtls_dir.parent() so patch paths resolve correctly regardless of whether the source is inside the workspace or supplied via MBEDTLS_DIR.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->



Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)