### PR TITLE
fix(ecumanager): initialize default ECU service states for variant detection

### DIFF
--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -1988,6 +1988,16 @@ impl<S: EcuGateway, R: DiagServiceResponse, T: EcuManager<Response = R>> UdsEcu
             })?;
         }
 
+        // Seed the session/security map before sending detection requests so
+        // that check_service_preconditions can validate them. This only
+        // works for ECUS whose state charts are defined on the base variant level
+        if let Err(e) = ecu.read().await.init_default_states().await {
+            tracing::debug!(
+                error = %e,
+                "Could not pre-initialize ECU default states"
+            );
+        }
+
         let mut service_responses = HashMap::new();
         'variant_detection_calls: {
             for (name, service) in requests {

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -345,6 +345,10 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
         &self.variant_detection.diag_service_requests
     }
 
+    fn init_default_states(&self) -> impl Future<Output = Result<(), DiagServiceError>> + Send {
+        self.set_default_states()
+    }
+
     #[tracing::instrument(skip(self),
         fields(
             ecu_name = self.ecu_name,
@@ -2914,7 +2918,11 @@ impl<S: SecurityPlugin> EcuManager<S> {
     /// Collects all `DiagLayers` from the current variant and its parent references.
     /// The variants own `DiagLayer` is placed first to give it higher priority in
     /// subsequent operations, followed by layers resolved recursively from parent references.
-    /// Returns an empty vector if no variant is set.
+    ///
+    /// When no specific variant has been detected yet, falls back to the base variant so
+    /// that state-chart and service lookups work correctly during variant detection.
+    /// Returns an empty vector only if neither a detected variant nor a base variant
+    /// is available.
     ///
     /// # Example
     ///
@@ -2927,7 +2935,14 @@ impl<S: SecurityPlugin> EcuManager<S> {
     /// }
     /// ```
     fn get_diag_layers_from_variant_and_parent_refs(&self) -> Vec<datatypes::DiagLayer<'_>> {
-        let Some(variant) = self.variant() else {
+        // Fall back to the base variant when no specific variant has been detected yet.
+        // This is necessary to allow state-chart and service lookups during variant detection,
+        // consistent with the approach used in `get_variant_parent_ref_services` and
+        // the service lookup functions.
+        let Some(variant) = self
+            .variant()
+            .or_else(|| self.diag_database.base_variant().ok())
+        else {
             return Vec::new();
         };
 

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -362,6 +362,16 @@ pub trait EcuManager:
         &mut self,
         service_responses: HashMap<String, T>,
     ) -> impl Future<Output = Result<(), DiagServiceError>> + Send;
+    /// Initialize default ECU service states (session, security level, etc.) if not
+    /// already set. Must be called after [`Self::load`] and before sending any service
+    /// requests that have `pre_condition_state_refs`.
+    ///
+    /// Uses `entry().or_insert()` semantics - safe to call multiple times; will never
+    /// overwrite a live state set by a previous successful variant detection.
+    ///
+    /// # Errors
+    /// Returns `Err` if the database state charts cannot be found.
+    fn init_default_states(&self) -> impl Future<Output = Result<(), DiagServiceError>> + Send;
     fn get_variant_detection_requests(&self) -> &HashMap<String, DiagComm>;
     /// Communication parameters for the ECU.
     /// # Errors


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

Fixes an issue where when pre-condition states are set on the services used for ecu detection, the ecu detection failed.
Now the state defaults are set earlier, and retrieval of state charts/services will fall back to base variant.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
