### PR TITLE
feat(docs): add online capability description endpoints for data and configurations services

### DIFF
--- a/cda-sovd/src/sovd/components/ecu/configurations.rs
+++ b/cda-sovd/src/sovd/components/ecu/configurations.rs
@@ -185,4 +185,206 @@ pub(crate) mod diag_service {
             .with(openapi::error_bad_request)
             .with(openapi::error_bad_gateway)
     }
+
+    /// `GET /configurations/{service}/docs` - online capability description for a
+    /// configuration service.
+    pub(crate) mod docs_endpoint {
+        use aide::{UseApi, openapi::OpenApi, transform::TransformOperation};
+        use axum::{
+            Json,
+            extract::{Path, State},
+            response::{IntoResponse as _, Response},
+        };
+        use cda_interfaces::{
+            DynamicPlugin, SchemaProvider, UdsEcu, diagservices::DiagServiceResponse,
+            file_manager::FileManager,
+        };
+        use cda_plugin_security::Secured;
+
+        use crate::{
+            openapi,
+            sovd::{WebserverEcuState, docs, error::ApiError},
+        };
+
+        openapi::aide_helper::gen_path_param!(ConfigDocsPathParam service String);
+
+        pub(crate) async fn get<
+            R: DiagServiceResponse,
+            T: UdsEcu + SchemaProvider + Clone,
+            U: FileManager,
+        >(
+            UseApi(Secured(security_plugin), _): UseApi<Secured, ()>,
+            Path(ConfigDocsPathParam { service }): Path<ConfigDocsPathParam>,
+            State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<R, T, U>>,
+        ) -> Response {
+            let security_plugin: DynamicPlugin = security_plugin;
+
+            // Verify the configuration service exists
+            let config_info = match uds
+                .get_components_configuration_info(&ecu_name, &security_plugin)
+                .await
+            {
+                Ok(info) => info,
+                Err(e) => return ApiError::from(e).into_response(),
+            };
+
+            if !config_info
+                .iter()
+                .any(|c| c.id.eq_ignore_ascii_case(&service))
+            {
+                return ApiError::NotFound(Some(format!(
+                    "Configuration service '{service}' not found"
+                )))
+                .into_response();
+            }
+
+            docs::data::build_docs_response(&uds, &ecu_name, &service, "configurations").await
+        }
+
+        pub(crate) fn docs_transform(op: TransformOperation) -> TransformOperation {
+            op.description(
+                "Online capability description for a specific configuration service on this ECU \
+                 component (ISO 17978-3 Section 7.5). Returns a self-contained OpenAPI \
+                 specification describing the available methods (GET and PUT) with their data \
+                 types.",
+            )
+            .response_with::<200, Json<OpenApi>, _>(|res| {
+                res.description(
+                    "Self-contained OpenAPI 3.1 specification for this configuration service.",
+                )
+            })
+            .with(openapi::error_not_found)
+        }
+
+        #[cfg(test)]
+        mod tests {
+            use aide::UseApi;
+            use axum::{extract::State, http::StatusCode};
+            use cda_interfaces::{
+                DiagServiceError, datatypes::ComponentConfigurationsInfo,
+                diagservices::mock::MockDiagServiceResponse, file_manager::mock::MockFileManager,
+                mock::MockUdsEcu,
+            };
+            use cda_plugin_security::{Secured, mock::TestSecurityPlugin};
+
+            use super::*;
+            use crate::sovd::tests::create_test_webserver_state;
+
+            #[tokio::test]
+            async fn returns_200_with_openapi_doc_when_config_exists() {
+                let mut mock_uds = MockUdsEcu::new();
+                mock_uds
+                    .expect_get_components_configuration_info()
+                    .withf(|ecu, _| ecu == "TestECU")
+                    .times(1)
+                    .returning(|_, _| {
+                        Ok(vec![ComponentConfigurationsInfo {
+                            id: "VarCoding1".to_owned(),
+                            name: "Variant Coding 1".to_owned(),
+                            configurations_type: "varcoding".to_owned(),
+                            service_abstract: vec![vec![0x22, 0x01, 0x00]],
+                        }])
+                    });
+
+                let state =
+                    create_test_webserver_state::<
+                        MockDiagServiceResponse,
+                        MockUdsEcu,
+                        MockFileManager,
+                    >("TestECU".to_owned(), mock_uds, MockFileManager::new());
+
+                let response = get::<MockDiagServiceResponse, MockUdsEcu, MockFileManager>(
+                    UseApi(
+                        Secured(Box::new(TestSecurityPlugin)),
+                        std::marker::PhantomData,
+                    ),
+                    Path(ConfigDocsPathParam {
+                        service: "VarCoding1".to_owned(),
+                    }),
+                    State(state),
+                )
+                .await;
+
+                assert_eq!(response.status(), StatusCode::OK);
+                let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let doc: serde_json::Value = serde_json::from_slice(&body).unwrap();
+                assert!(
+                    doc.get("info").is_some(),
+                    "Response should be a valid OpenAPI doc"
+                );
+                assert!(doc.get("paths").is_some(), "Response should contain paths");
+            }
+
+            #[tokio::test]
+            async fn returns_404_when_config_not_found() {
+                let mut mock_uds = MockUdsEcu::new();
+                mock_uds
+                    .expect_get_components_configuration_info()
+                    .returning(|_, _| {
+                        Ok(vec![ComponentConfigurationsInfo {
+                            id: "VarCoding1".to_owned(),
+                            name: "Variant Coding 1".to_owned(),
+                            configurations_type: "varcoding".to_owned(),
+                            service_abstract: vec![],
+                        }])
+                    });
+
+                let state =
+                    create_test_webserver_state::<
+                        MockDiagServiceResponse,
+                        MockUdsEcu,
+                        MockFileManager,
+                    >("TestECU".to_owned(), mock_uds, MockFileManager::new());
+
+                let response = get::<MockDiagServiceResponse, MockUdsEcu, MockFileManager>(
+                    UseApi(
+                        Secured(Box::new(TestSecurityPlugin)),
+                        std::marker::PhantomData,
+                    ),
+                    Path(ConfigDocsPathParam {
+                        service: "NonExistent".to_owned(),
+                    }),
+                    State(state),
+                )
+                .await;
+
+                assert_eq!(response.status(), StatusCode::NOT_FOUND);
+            }
+
+            #[tokio::test]
+            async fn returns_error_when_config_info_lookup_fails() {
+                let mut mock_uds = MockUdsEcu::new();
+                mock_uds
+                    .expect_get_components_configuration_info()
+                    .returning(|_, _| {
+                        Err(DiagServiceError::NotFound(
+                            "Functional class not found".to_owned(),
+                        ))
+                    });
+
+                let state =
+                    create_test_webserver_state::<
+                        MockDiagServiceResponse,
+                        MockUdsEcu,
+                        MockFileManager,
+                    >("TestECU".to_owned(), mock_uds, MockFileManager::new());
+
+                let response = get::<MockDiagServiceResponse, MockUdsEcu, MockFileManager>(
+                    UseApi(
+                        Secured(Box::new(TestSecurityPlugin)),
+                        std::marker::PhantomData,
+                    ),
+                    Path(ConfigDocsPathParam {
+                        service: "Anything".to_owned(),
+                    }),
+                    State(state),
+                )
+                .await;
+
+                assert_eq!(response.status(), StatusCode::NOT_FOUND);
+            }
+        }
+    }
 }

--- a/cda-sovd/src/sovd/components/ecu/data.rs
+++ b/cda-sovd/src/sovd/components/ecu/data.rs
@@ -291,4 +291,194 @@ pub(crate) mod diag_service {
             .with(openapi::error_bad_request)
             .with(openapi::error_bad_gateway)
     }
+
+    /// `GET /data/{service}/docs` - online capability description for a data service.
+    pub(crate) mod docs_endpoint {
+        use aide::{UseApi, openapi::OpenApi, transform::TransformOperation};
+        use axum::{
+            Json,
+            extract::{Path, State},
+            response::{IntoResponse as _, Response},
+        };
+        use cda_interfaces::{
+            DynamicPlugin, SchemaProvider, UdsEcu, diagservices::DiagServiceResponse,
+            file_manager::FileManager,
+        };
+        use cda_plugin_security::Secured;
+
+        use crate::{
+            openapi,
+            sovd::{WebserverEcuState, docs, error::ApiError},
+        };
+
+        openapi::aide_helper::gen_path_param!(DataDocsPathParam service String);
+
+        pub(crate) async fn get<
+            R: DiagServiceResponse,
+            T: UdsEcu + SchemaProvider + Clone,
+            U: FileManager,
+        >(
+            UseApi(Secured(security_plugin), _): UseApi<Secured, ()>,
+            Path(DataDocsPathParam { service }): Path<DataDocsPathParam>,
+            State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<R, T, U>>,
+        ) -> Response {
+            let security_plugin: DynamicPlugin = security_plugin;
+
+            // Verify the data service exists
+            let data_info = match uds
+                .get_components_data_info(&ecu_name, &security_plugin)
+                .await
+            {
+                Ok(info) => info,
+                Err(e) => return ApiError::from(e).into_response(),
+            };
+
+            if !data_info
+                .iter()
+                .any(|d| d.id.eq_ignore_ascii_case(&service))
+            {
+                return ApiError::NotFound(Some(format!("Data service '{service}' not found")))
+                    .into_response();
+            }
+
+            docs::data::build_docs_response(&uds, &ecu_name, &service, "data").await
+        }
+
+        pub(crate) fn docs_transform(op: TransformOperation) -> TransformOperation {
+            op.description(
+                "Online capability description for a specific data service on this ECU component \
+                 (ISO 17978-3 Section 7.5). Returns a self-contained OpenAPI specification \
+                 describing the available methods (GET and optionally PUT) with their data types.",
+            )
+            .response_with::<200, Json<OpenApi>, _>(|res| {
+                res.description("Self-contained OpenAPI 3.1 specification for this data service.")
+            })
+            .with(openapi::error_not_found)
+        }
+
+        #[cfg(test)]
+        mod tests {
+            use aide::UseApi;
+            use axum::{extract::State, http::StatusCode};
+            use cda_interfaces::{
+                DiagServiceError, datatypes::ComponentDataInfo,
+                diagservices::mock::MockDiagServiceResponse, file_manager::mock::MockFileManager,
+                mock::MockUdsEcu,
+            };
+            use cda_plugin_security::{Secured, mock::TestSecurityPlugin};
+
+            use super::*;
+            use crate::sovd::tests::create_test_webserver_state;
+
+            #[tokio::test]
+            async fn returns_200_with_openapi_doc_when_service_exists() {
+                let mut mock_uds = MockUdsEcu::new();
+                mock_uds
+                    .expect_get_components_data_info()
+                    .withf(|ecu, _| ecu == "TestECU")
+                    .times(1)
+                    .returning(|_, _| {
+                        Ok(vec![ComponentDataInfo {
+                            category: "sensor".to_owned(),
+                            id: "EngineTemp".to_owned(),
+                            name: "Engine Temperature".to_owned(),
+                        }])
+                    });
+
+                let state =
+                    create_test_webserver_state::<
+                        MockDiagServiceResponse,
+                        MockUdsEcu,
+                        MockFileManager,
+                    >("TestECU".to_owned(), mock_uds, MockFileManager::new());
+
+                let response = get::<MockDiagServiceResponse, MockUdsEcu, MockFileManager>(
+                    UseApi(
+                        Secured(Box::new(TestSecurityPlugin)),
+                        std::marker::PhantomData,
+                    ),
+                    Path(DataDocsPathParam {
+                        service: "EngineTemp".to_owned(),
+                    }),
+                    State(state),
+                )
+                .await;
+
+                assert_eq!(response.status(), StatusCode::OK);
+                let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+                let doc: serde_json::Value = serde_json::from_slice(&body).unwrap();
+                assert!(
+                    doc.get("info").is_some(),
+                    "Response should be a valid OpenAPI doc"
+                );
+                assert!(doc.get("paths").is_some(), "Response should contain paths");
+            }
+
+            #[tokio::test]
+            async fn returns_404_when_service_not_found() {
+                let mut mock_uds = MockUdsEcu::new();
+                mock_uds
+                    .expect_get_components_data_info()
+                    .returning(|_, _| {
+                        Ok(vec![ComponentDataInfo {
+                            category: "sensor".to_owned(),
+                            id: "EngineTemp".to_owned(),
+                            name: "Engine Temperature".to_owned(),
+                        }])
+                    });
+
+                let state =
+                    create_test_webserver_state::<
+                        MockDiagServiceResponse,
+                        MockUdsEcu,
+                        MockFileManager,
+                    >("TestECU".to_owned(), mock_uds, MockFileManager::new());
+
+                let response = get::<MockDiagServiceResponse, MockUdsEcu, MockFileManager>(
+                    UseApi(
+                        Secured(Box::new(TestSecurityPlugin)),
+                        std::marker::PhantomData,
+                    ),
+                    Path(DataDocsPathParam {
+                        service: "NonExistent".to_owned(),
+                    }),
+                    State(state),
+                )
+                .await;
+
+                assert_eq!(response.status(), StatusCode::NOT_FOUND);
+            }
+
+            #[tokio::test]
+            async fn returns_error_when_data_info_lookup_fails() {
+                let mut mock_uds = MockUdsEcu::new();
+                mock_uds
+                    .expect_get_components_data_info()
+                    .returning(|_, _| Err(DiagServiceError::NotFound("ECU not found".to_owned())));
+
+                let state =
+                    create_test_webserver_state::<
+                        MockDiagServiceResponse,
+                        MockUdsEcu,
+                        MockFileManager,
+                    >("TestECU".to_owned(), mock_uds, MockFileManager::new());
+
+                let response = get::<MockDiagServiceResponse, MockUdsEcu, MockFileManager>(
+                    UseApi(
+                        Secured(Box::new(TestSecurityPlugin)),
+                        std::marker::PhantomData,
+                    ),
+                    Path(DataDocsPathParam {
+                        service: "Anything".to_owned(),
+                    }),
+                    State(state),
+                )
+                .await;
+
+                assert_eq!(response.status(), StatusCode::NOT_FOUND);
+            }
+        }
+    }
 }

--- a/cda-sovd/src/sovd/docs/data.rs
+++ b/cda-sovd/src/sovd/docs/data.rs
@@ -1,0 +1,354 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+//! Builders for the online capability description of SOVD data and configuration
+//! resources.
+//!
+//! Produces the [`PathItem`]s that describe a data/configuration service's API
+//! surface (GET for reading, optionally PUT for writing) and embeds
+//! request/response parameter schemas obtained from the diagnostic layer.
+//!
+//! The [`build_docs_response`] helper is shared by both the `/data/{service}/docs`
+//! and `/configurations/{service}/docs` endpoint handlers.
+
+use aide::openapi::{Operation, PathItem};
+use axum::{Json, http::StatusCode, response::IntoResponse as _};
+use cda_interfaces::{DiagComm, DiagCommType, SchemaProvider, UdsEcu};
+use indexmap::IndexMap;
+use schemars::Schema;
+use sovd_interfaces::docs;
+
+use super::{error_schema, json_request_body, json_response, responses};
+
+/// Metadata needed to construct the online capability description for a single
+/// SOVD data resource.
+pub struct DataDocsMeta {
+    /// Human-readable name of the data service.
+    pub name: String,
+    /// JSON Schema describing the data returned by GET (the `data` property in
+    /// the response). `None` if the schema could not be determined.
+    pub read_response_schema: Option<Schema>,
+    /// If `Some`, the data service supports PUT (a corresponding
+    /// `WriteDataByIdentifier` / 0x2E service exists in the diagnostic
+    /// description). The schema describes the request parameters for writing.
+    /// If `None`, only GET is available.
+    pub write_request_schema: Option<Schema>,
+}
+
+/// Shared helper that retrieves schemas from the diagnostic layer and builds
+/// the self-contained `OpenAPI` 3.1 response for both `/data/{service}/docs` and
+/// `/configurations/{service}/docs`.
+///
+/// The caller is responsible for verifying that the service exists before
+/// calling this function.
+///
+/// # Arguments
+/// * `uds` - UDS gateway providing schema lookups
+/// * `ecu_name` - Name of the ECU component
+/// * `service` - Short name of the data/configuration service
+/// * `resource_type` - Path segment identifying the resource kind (e.g. `"data"`
+///   or `"configurations"`)
+pub async fn build_docs_response<T: UdsEcu + SchemaProvider + Clone>(
+    uds: &T,
+    ecu_name: &str,
+    service: &str,
+    resource_type: &str,
+) -> axum::response::Response {
+    // Get the read (GET) response schema (ReadDataByIdentifier / 0x22)
+    let read_service = DiagComm {
+        name: service.to_owned(),
+        type_: DiagCommType::Data,
+        lookup_name: None,
+        subfunction_id: None,
+    };
+
+    let read_response_schema = uds
+        .schema_for_responses(ecu_name, &read_service)
+        .await
+        .ok()
+        .and_then(cda_interfaces::SchemaDescription::into_schema);
+
+    // Check if a corresponding WriteDataByIdentifier (0x2E) service exists
+    // by attempting to resolve its request schema
+    let write_service = DiagComm {
+        name: service.to_owned(),
+        type_: DiagCommType::Configurations,
+        lookup_name: None,
+        subfunction_id: None,
+    };
+
+    let write_request_schema = uds
+        .schema_for_request(ecu_name, &write_service)
+        .await
+        .ok()
+        .and_then(cda_interfaces::SchemaDescription::into_schema);
+
+    let meta = DataDocsMeta {
+        name: service.to_owned(),
+        read_response_schema,
+        write_request_schema,
+    };
+
+    let title_prefix = match resource_type {
+        "configurations" => "Configuration",
+        _ => "Data",
+    };
+
+    let base_path = format!("/components/{ecu_name}/{resource_type}/{service}");
+    let path_items = build_path_items(&base_path, &meta);
+    let doc = super::build_openapi_doc(&format!("{title_prefix}: {service}"), path_items);
+
+    (StatusCode::OK, Json(doc)).into_response()
+}
+
+/// Build the `PathItem` entries for a single data service.
+///
+/// Returns an ordered map with a single entry:
+/// - `{base_path}` - GET (read) and optionally PUT (write)
+///
+/// PUT is only included when `meta.write_request_schema` is `Some`, indicating
+/// that a `WriteDataByIdentifier` (0x2E) service exists for this data identifier.
+pub fn build_path_items(base_path: &str, meta: &DataDocsMeta) -> IndexMap<String, PathItem> {
+    let mut paths = IndexMap::new();
+
+    let path_item = PathItem {
+        get: Some(build_get_operation(meta)),
+        put: meta
+            .write_request_schema
+            .as_ref()
+            .map(|_| build_put_operation(meta)),
+        extensions: path_item_extensions(),
+        ..Default::default()
+    };
+    paths.insert(base_path.to_owned(), path_item);
+
+    paths
+}
+
+/// GET operation for reading a data service value.
+fn build_get_operation(meta: &DataDocsMeta) -> Operation {
+    let response_schema = build_get_response_schema(meta);
+
+    let mut get_op = Operation {
+        summary: Some(format!("Read data: {}", meta.name)),
+        ..Default::default()
+    };
+    get_op.responses = Some(responses(vec![
+        (
+            200,
+            json_response("Data read successfully.", response_schema),
+        ),
+        (
+            404,
+            json_response("Data service not found.", error_schema()),
+        ),
+    ]));
+    get_op
+}
+
+/// PUT operation for writing a data service value.
+fn build_put_operation(meta: &DataDocsMeta) -> Operation {
+    let request_schema = build_put_request_schema(meta);
+
+    let mut put_op = Operation {
+        summary: Some(format!("Write data: {}", meta.name)),
+        ..Default::default()
+    };
+    put_op.request_body = Some(json_request_body(request_schema));
+    put_op.responses = Some(responses(vec![
+        (
+            200,
+            json_response(
+                "Data written successfully.",
+                build_put_response_schema(meta),
+            ),
+        ),
+        (
+            400,
+            json_response("Invalid request payload.", error_schema()),
+        ),
+        (
+            404,
+            json_response("Data service not found.", error_schema()),
+        ),
+    ]));
+    put_op
+}
+
+/// Build the JSON Schema for the GET response body.
+///
+/// Matches the `ObjectDataItem` structure: `{ id, data: { ... }, errors: [] }`.
+fn build_get_response_schema(meta: &DataDocsMeta) -> Schema {
+    let data_schema = meta
+        .read_response_schema
+        .as_ref()
+        .map_or(serde_json::json!({ "type": "object" }), |s| {
+            serde_json::Value::from(s.clone())
+        });
+
+    schemars::json_schema!({
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string",
+                "description": "Identifier of the data service."
+            },
+            "data": data_schema,
+            "errors": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "message": { "type": "string" },
+                        "error_code": { "type": "string" }
+                    }
+                },
+                "description": "Errors that occurred while reading individual parameters."
+            }
+        },
+        "required": ["id", "data"]
+    })
+}
+
+/// Build the JSON Schema for the PUT request body.
+///
+/// Matches the `DataRequestPayload` structure: `{ data: { ... } }`.
+fn build_put_request_schema(meta: &DataDocsMeta) -> Schema {
+    let data_schema = meta
+        .write_request_schema
+        .as_ref()
+        .map_or(serde_json::json!({ "type": "object" }), |s| {
+            serde_json::Value::from(s.clone())
+        });
+
+    schemars::json_schema!({
+        "type": "object",
+        "properties": {
+            "data": data_schema
+        },
+        "required": ["data"]
+    })
+}
+
+/// Build the JSON Schema for the PUT response body.
+///
+/// After a successful write the server echoes back the written data in the same
+/// `ObjectDataItem` format as GET.
+fn build_put_response_schema(meta: &DataDocsMeta) -> Schema {
+    // Re-use the GET response schema structure; the written values are echoed back.
+    build_get_response_schema(meta)
+}
+
+/// Collect the SOVD extension properties for the `PathItem` object
+/// (ISO 17978-3 Table 169).
+///
+/// Emits `x-sovd-proximity-proof-required` which is always `false` for classic
+/// UDS data services.
+fn path_item_extensions() -> IndexMap<String, serde_json::Value> {
+    let mut ext = IndexMap::new();
+    ext.insert(
+        docs::X_SOVD_PROXIMITY_PROOF_REQUIRED.to_owned(),
+        serde_json::Value::Bool(false),
+    );
+    ext
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_schema() -> Schema {
+        schemars::json_schema!({
+            "type": "object",
+            "properties": {
+                "temperature": { "type": "integer", "description": "Sensor temperature" }
+            }
+        })
+    }
+
+    #[test]
+    fn build_path_items_read_only_has_get_but_no_put() {
+        let meta = DataDocsMeta {
+            name: "Sensor".to_owned(),
+            read_response_schema: Some(sample_schema()),
+            write_request_schema: None,
+        };
+        let paths = build_path_items("/components/ecu1/data/Sensor", &meta);
+
+        assert_eq!(paths.len(), 1);
+        let item = paths.get("/components/ecu1/data/Sensor").unwrap();
+        assert!(item.get.is_some(), "GET operation should be present");
+        assert!(
+            item.put.is_none(),
+            "PUT operation should not be present for read-only data"
+        );
+    }
+
+    #[test]
+    fn build_path_items_read_write_has_both_get_and_put() {
+        let meta = DataDocsMeta {
+            name: "Config".to_owned(),
+            read_response_schema: Some(sample_schema()),
+            write_request_schema: Some(sample_schema()),
+        };
+        let paths = build_path_items("/components/ecu1/configurations/Config", &meta);
+
+        assert_eq!(paths.len(), 1);
+        let item = paths.get("/components/ecu1/configurations/Config").unwrap();
+        assert!(item.get.is_some(), "GET operation should be present");
+        assert!(
+            item.put.is_some(),
+            "PUT operation should be present for writable data"
+        );
+    }
+
+    #[test]
+    fn build_path_items_no_schemas_produces_valid_get_only() {
+        let meta = DataDocsMeta {
+            name: "Empty".to_owned(),
+            read_response_schema: None,
+            write_request_schema: None,
+        };
+        let paths = build_path_items("/components/ecu1/data/Empty", &meta);
+
+        let item = paths.get("/components/ecu1/data/Empty").unwrap();
+        assert!(
+            item.get.is_some(),
+            "GET should still be generated with fallback schema"
+        );
+        assert!(
+            item.put.is_none(),
+            "PUT should not be present without write schema"
+        );
+
+        // Verify GET has a valid response
+        let get_op = item.get.as_ref().unwrap();
+        assert!(get_op.responses.is_some());
+    }
+
+    #[test]
+    fn path_item_has_proximity_proof_extension() {
+        let meta = DataDocsMeta {
+            name: "X".to_owned(),
+            read_response_schema: None,
+            write_request_schema: None,
+        };
+        let paths = build_path_items("/components/ecu1/data/X", &meta);
+        let item = paths.get("/components/ecu1/data/X").unwrap();
+
+        assert_eq!(
+            item.extensions.get(docs::X_SOVD_PROXIMITY_PROOF_REQUIRED),
+            Some(&serde_json::Value::Bool(false)),
+            "PathItem should have x-sovd-proximity-proof-required: false"
+        );
+    }
+}

--- a/cda-sovd/src/sovd/docs/mod.rs
+++ b/cda-sovd/src/sovd/docs/mod.rs
@@ -17,6 +17,7 @@
 //! [`PathItem`]s and passes them to [`build_openapi_doc`] to produce a valid,
 //! self-contained `OpenAPI` specification returned by `GET .../docs`.
 
+pub mod data;
 pub mod operations;
 
 use aide::openapi::{

--- a/cda-sovd/src/sovd/mod.rs
+++ b/cda-sovd/src/sovd/mod.rs
@@ -684,11 +684,25 @@ async fn ecu_route<
             )
             .get_with(data::diag_service::get, data::diag_service::docs_get),
         )
+        .api_route(
+            "/configurations/{service}/docs",
+            routing::get_with(
+                configurations::diag_service::docs_endpoint::get,
+                configurations::diag_service::docs_endpoint::docs_transform,
+            ),
+        )
         .api_route("/data", routing::get_with(data::get, data::docs_get))
         .api_route(
             "/data/{service}",
             routing::get_with(data::diag_service::get, data::diag_service::docs_get)
                 .put_with(data::diag_service::put, data::diag_service::docs_put),
+        )
+        .api_route(
+            "/data/{service}/docs",
+            routing::get_with(
+                data::diag_service::docs_endpoint::get,
+                data::diag_service::docs_endpoint::docs_transform,
+            ),
         )
         .api_route(
             "/genericservice",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
Adds /docs for data and configurations services

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
