### PR TITLE
feat(tests): add Tester Present integration tests

### DIFF
--- a/cda-comm-doip/src/config.rs
+++ b/cda-comm-doip/src/config.rs
@@ -11,7 +11,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use cda_interfaces::Protocol;
+use cda_interfaces::{
+    Protocol,
+    config::{ConfigSanity, ConfigSanityError},
+};
 use serde::{Deserialize, Serialize};
 
 /// `DoIP` (Diagnostics over IP) transport layer configuration.
@@ -53,6 +56,53 @@ impl Default for DoipConfig {
             alive_check_interval_secs: 1800, // 30 minutes
             protocol_name: Protocol::default().to_string(),
         }
+    }
+}
+
+impl ConfigSanity for DoipConfig {
+    fn validate_sanity(&self) -> Result<(), ConfigSanityError> {
+        fn validate_ip(ip: &str, field: &str) -> Result<(), ConfigSanityError> {
+            ip.parse::<std::net::IpAddr>().map(|_| ()).map_err(|_| {
+                ConfigSanityError::InvalidValue {
+                    field: field.to_owned(),
+                    reason: format!("{ip} is neither a valid IPv4 nor IPv6 address"),
+                }
+            })
+        }
+
+        fn validate_port(port: u16, field: &str) -> Result<(), ConfigSanityError> {
+            if port == 0 {
+                return Err(ConfigSanityError::InvalidValue {
+                    field: field.to_owned(),
+                    reason: "Port must be greater than 0".to_string(),
+                });
+            }
+            Ok(())
+        }
+
+        fn validate_timeout(timeout: u64, field: &str) -> Result<(), ConfigSanityError> {
+            if timeout == 0 {
+                return Err(ConfigSanityError::InvalidValue {
+                    field: field.to_owned(),
+                    reason: "Timeout must be greater than 0".to_string(),
+                });
+            }
+            Ok(())
+        }
+
+        validate_ip(&self.tester_address, "tester_address")?;
+        validate_ip(&self.tester_subnet, "tester_address")?;
+        validate_port(self.gateway_port, "gateway_port")?;
+        validate_port(self.tls_port, "tls_port")?;
+        validate_timeout(self.send_timeout_ms, "send_timeout_ms")?;
+        if self.alive_check_interval_secs > u64::from(u32::MAX) {
+            return Err(ConfigSanityError::InvalidValue {
+                field: "alive_check_interval_secs".to_owned(),
+                reason: "Interval is too large, use 0 to disable it".to_string(),
+            });
+        }
+
+        Ok(())
     }
 }
 

--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -64,6 +64,28 @@ struct ConnectionSettings {
     alive_check_interval: Duration,
 }
 
+#[derive(Clone)]
+struct GatewayTarget {
+    ip: String,
+    name: String,
+    ecus: Vec<u16>,
+}
+
+#[derive(Clone)]
+struct GatewayHandlerConfig {
+    connection_config: ConnectionConfig,
+    doip_connection_config: DoIPConfig,
+    routing_activation_request: RoutingActivationRequest,
+    connection_settings: ConnectionSettings,
+    variant_detection: Option<(mpsc::Sender<Vec<String>>, Vec<String>)>,
+}
+
+struct GatewayConnectionHandles {
+    sender: mpsc::Sender<DoipPayload>,
+    receivers: HashMap<u16, broadcast::Receiver<Result<DiagnosticResponse, EcuError>>>,
+    task_handles: Vec<tokio::task::JoinHandle<()>>,
+}
+
 #[derive(Error, Debug, Clone)]
 pub enum EcuError {
     #[error("Resource not found: `{0}`")]
@@ -164,14 +186,16 @@ where
     let connection_timeout = gateway_ecu.connection_timeout();
     let connection_retry_attempts = gateway_ecu.connection_retry_attempts();
 
-    let (sender, receiver, task_handles) = match connection_handler(
-        config.connection.clone(),
-        gateway.ip.clone(),
-        gateway.ecu.clone(),
-        config.doip,
+    let target = GatewayTarget {
+        ip: gateway.ip.clone(),
+        name: gateway.ecu.clone(),
+        ecus: ecu_ids.clone(),
+    };
+    let config = GatewayHandlerConfig {
+        connection_config: connection_config.clone(),
+        doip_connection_config,
         routing_activation_request,
-        ecu_ids.clone(),
-        ConnectionSettings {
+        connection_settings: ConnectionSettings {
             routing_activation: routing_activation_timeout,
             retry_delay: connection_retry_delay,
             connect_timeout: connection_timeout,
@@ -180,10 +204,13 @@ where
             alive_check_interval: config.alive_check_interval,
         },
         variant_detection,
-    )
-    .await
-    {
-        Ok((sender, receiver, task_handles)) => (sender, receiver, task_handles),
+    };
+    let GatewayConnectionHandles {
+        sender,
+        receivers,
+        task_handles,
+    } = match connection_handler(target, config).await {
+        Ok(handles) => handles,
         Err(e) => {
             return Err(EcuError::EcuConnectionError(
                 ConnectionError::ConnectionFailed(format!(
@@ -194,7 +221,7 @@ where
         }
     };
 
-    let doip_ecus = create_ecu_receiver_map(ecu_ids, &sender, &receiver);
+    let doip_ecus = create_ecu_receiver_map(ecu_ids, &sender, &receivers);
 
     tracing::info!("Connected to gateway");
     state
@@ -243,36 +270,22 @@ fn create_ecu_receiver_map(
     doip_ecus
 }
 
-#[allow(clippy::type_complexity)]
 #[tracing::instrument(
-    skip(routing_activation_request, connection_settings, connection_config),
+    skip(target, config),
     fields(
-        tester_ip = connection_config.source_ip.clone(),
-        port = connection_config.port,
-        tls_port = connection_config.tls_port,
-        gateway_ip = %gateway_ip,
-        gateway_name = %gateway_name,
-        ecu_count = ecus.len(),
+        tester_ip = config.connection_config.source_ip.clone(),
+        port = config.connection_config.port,
+        tls_port = config.connection_config.tls_port,
+        gateway_ip = %target.ip,
+        gateway_name = %target.name,
+        ecu_count = target.ecus.len(),
         dlt_context = dlt_ctx!("DOIP"),
     )
 )]
 async fn connection_handler(
-    connection_config: ConnectionConfig,
-    gateway_ip: String,
-    gateway_name: String,
-    doip_connection_config: DoIPConfig,
-    routing_activation_request: RoutingActivationRequest,
-    ecus: Vec<u16>,
-    connection_settings: ConnectionSettings,
-    variant_detection: Option<(mpsc::Sender<Vec<String>>, Vec<String>)>,
-) -> Result<
-    (
-        mpsc::Sender<DoipPayload>,
-        HashMap<u16, broadcast::Receiver<Result<DiagnosticResponse, EcuError>>>,
-        Vec<tokio::task::JoinHandle<()>>,
-    ),
-    EcuError,
-> {
+    target: GatewayTarget,
+    config: GatewayHandlerConfig,
+) -> Result<GatewayConnectionHandles, EcuError> {
     // channel to send messages to the gateway / ecus
     let (intx, inrx) = mpsc::channel::<DoipPayload>(50);
 
@@ -285,7 +298,7 @@ async fn connection_handler(
         HashMap::new();
 
     // create ecu response channels
-    for ecu in ecus {
+    for &ecu in &target.ecus {
         let (tx, rx) = broadcast::channel::<Result<DiagnosticResponse, EcuError>>(10);
 
         outtx.insert(ecu, tx);
@@ -295,17 +308,17 @@ async fn connection_handler(
     // setting up initial gateway connection
     let gateway_conn = Arc::new(
         ecu_connection::establish_ecu_connection(
-            &connection_config,
-            &gateway_ip,
-            &gateway_name,
-            doip_connection_config,
-            routing_activation_request,
-            connection_settings.connect_timeout,
-            connection_settings.routing_activation,
+            &config.connection_config,
+            &target.ip,
+            &target.name,
+            config.doip_connection_config,
+            config.routing_activation_request,
+            config.connection_settings.connect_timeout,
+            config.connection_settings.routing_activation,
         )
         .await
         .inspect_err(|e| {
-            tracing::error!("Failed to connect to gateway at {gateway_ip}: {e:?}");
+            tracing::error!("Failed to connect to gateway at {}: {e:?}", target.ip);
         })?,
     );
 
@@ -313,32 +326,25 @@ async fn connection_handler(
     let (conn_reset_tx, conn_reset_rx) = mpsc::channel::<ConnectionResetReason>(1);
     // task to handle connection resets and reconnects
     let conn_reset = Arc::<EcuConnectionTarget>::clone(&gateway_conn);
-    let connection_reset_task = spawn_connection_reset_task(
-        connection_config.clone(),
-        gateway_ip.clone(),
-        doip_connection_config,
-        routing_activation_request,
-        conn_reset_rx,
-        conn_reset,
-        connection_settings,
-        variant_detection,
-    );
+    let send_timeout = config.connection_settings.send_timeout;
+    let connection_reset_task =
+        spawn_connection_reset_task(target.clone(), config, conn_reset_rx, conn_reset);
 
     // communication between send / receiver task to unlock the connection in the receiver task
     // when sender task wants to send something
     let (send_pending_tx, send_pending_rx) = watch::channel::<bool>(false);
     let gateway_sender_task = spawn_gateway_sender_task(
-        &gateway_ip,
+        &target.ip,
         inrx,
         Arc::<EcuConnectionTarget>::clone(&gateway_conn),
-        connection_settings.send_timeout,
+        send_timeout,
         conn_reset_tx.clone(),
         send_pending_tx.clone(),
         connection_settings.alive_check_interval,
     );
     let gateway_receiver_task = spawn_gateway_receiver_task(
-        gateway_ip.clone(),
-        gateway_name.clone(),
+        target.ip.clone(),
+        target.name.clone(),
         outtx,
         Arc::<EcuConnectionTarget>::clone(&gateway_conn),
         send_pending_rx,
@@ -347,33 +353,37 @@ async fn connection_handler(
     );
 
     // no need to wait until the connection is alive, we will reconnect automatically anyway
-    Ok((
-        intx,
-        outrx,
-        vec![
+    Ok(GatewayConnectionHandles {
+        sender: intx,
+        receivers: outrx,
+        task_handles: vec![
             connection_reset_task,
             gateway_sender_task,
             gateway_receiver_task,
         ],
-    ))
+    })
 }
 
 #[tracing::instrument(
-    skip_all
+    skip_all,
     fields(
         dlt_context = dlt_ctx!("DOIP")
     )
 )]
 fn spawn_connection_reset_task(
-    connection_config: ConnectionConfig,
-    gateway_ip: String,
-    doip_connection_config: DoIPConfig,
-    routing_activation_request: RoutingActivationRequest,
+    target: GatewayTarget,
+    config: GatewayHandlerConfig,
     mut conn_reset_rx: mpsc::Receiver<ConnectionResetReason>,
     conn_reset: Arc<EcuConnectionTarget>,
-    connection_timeouts: ConnectionSettings,
-    variant_detection: Option<(mpsc::Sender<Vec<String>>, Vec<String>)>,
 ) -> tokio::task::JoinHandle<()> {
+    let GatewayTarget { ip: gateway_ip, .. } = target;
+    let GatewayHandlerConfig {
+        connection_config,
+        doip_connection_config,
+        routing_activation_request,
+        connection_settings: connection_timeouts,
+        variant_detection,
+    } = config;
     cda_interfaces::spawn_named!(
         &format!("doip-connection-reset-{gateway_ip}"),
         Box::pin(async move {

--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -204,6 +204,7 @@ where
         .push(Arc::new(DoipConnection {
             ecus: doip_ecus,
             ip: gateway.ip,
+            task_handles,
         }));
 
     Ok(gateway.logical_address)
@@ -346,7 +347,15 @@ async fn connection_handler(
     );
 
     // no need to wait until the connection is alive, we will reconnect automatically anyway
-    Ok((intx, outrx, vec![connection_reset_task, gateway_sender_task, gateway_receiver_task]))
+    Ok((
+        intx,
+        outrx,
+        vec![
+            connection_reset_task,
+            gateway_sender_task,
+            gateway_receiver_task,
+        ],
+    ))
 }
 
 #[tracing::instrument(
@@ -500,7 +509,12 @@ where
                 // Adding 'biased' means the selects are checked in order from top to bottom.
                 // https://docs.rs/tokio/latest/tokio/macro.select.html#fairness
                 biased;
-                Some(msg) = inrx.recv() => {
+                msg = inrx.recv() => {
+                    let Some(msg) = msg else {
+                        // Channel closed - all senders dropped (gateway shut down).
+                        tracing::debug!("Send channel closed, shutting down sender task");
+                        break;
+                    };
                     // let rx task know that we want to send something.
                     if send_pending_status(&send_pending_tx, true).is_err() {
                         break;
@@ -609,7 +623,8 @@ fn spawn_gateway_receiver_task<T>(
     mut send_pending_rx: watch::Receiver<bool>,
     reset_tx: mpsc::Sender<ConnectionResetReason>,
     send_tx: mpsc::Sender<DoipPayload>,
-) -> tokio::task::JoinHandle<()> where
+) -> tokio::task::JoinHandle<()>
+where
     T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     // note: the handlers are defined here, as rustfmt cannot format the correctly inside the
@@ -981,6 +996,8 @@ mod tests {
         let config = DoIPConfig {
             protocol_version: ProtocolVersion::Iso13400_2012,
             send_diagnostic_message_ack: false,
+            send_timeout: Duration::from_secs(10),
+            alive_check_interval: Duration::from_secs(10),
         };
         let server_conn = DoIPConnection::new(server, config);
         let (read_half, write_half) = DoIPConnection::new(client, config).into_split();

--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -25,6 +25,7 @@ use thiserror::Error;
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     sync::{Mutex, RwLock, broadcast, mpsc, watch},
+    task::{JoinError, JoinSet},
 };
 
 use crate::{
@@ -42,12 +43,12 @@ pub(crate) struct GatewayState<T> {
     pub doip_connections: Arc<RwLock<Vec<Arc<DoipConnection>>>>,
     pub ecus: Arc<HashMap<String, RwLock<T>>>,
     pub gateway_ecu_map: HashMap<u16, Vec<u16>>,
+    pub connection_tasks: Arc<Mutex<JoinSet<Result<(), JoinError>>>>,
 }
 
 struct GatewayConnectionHandles {
     sender: mpsc::Sender<DoipPayload>,
     receivers: HashMap<u16, broadcast::Receiver<Result<DiagnosticResponse, EcuError>>>,
-    task_handles: Vec<tokio::task::JoinHandle<()>>,
 }
 
 #[derive(Error, Debug, Clone)]
@@ -171,21 +172,18 @@ where
         ecus: ecu_ids.clone(),
         variant_detection,
     };
-    let GatewayConnectionHandles {
-        sender,
-        receivers,
-        task_handles,
-    } = match connection_handler(gateway).await {
-        Ok(handles) => handles,
-        Err(e) => {
-            return Err(EcuError::EcuConnectionError(
-                ConnectionError::ConnectionFailed(format!(
-                    "Failed to connect to {}: {}",
-                    discovered_gateway.ecu_name, e
-                )),
-            ));
-        }
-    };
+    let GatewayConnectionHandles { sender, receivers } =
+        match connection_handler(gateway, Arc::clone(&state.connection_tasks)).await {
+            Ok(handles) => handles,
+            Err(e) => {
+                return Err(EcuError::EcuConnectionError(
+                    ConnectionError::ConnectionFailed(format!(
+                        "Failed to connect to {}: {}",
+                        discovered_gateway.ecu_name, e
+                    )),
+                ));
+            }
+        };
 
     let doip_ecus = create_ecu_receiver_map(ecu_ids, &sender, &receivers);
 
@@ -197,7 +195,6 @@ where
         .push(Arc::new(DoipConnection {
             ecus: doip_ecus,
             ip: discovered_gateway.ip,
-            task_handles,
         }));
 
     Ok(discovered_gateway.logical_address)
@@ -245,7 +242,10 @@ fn create_ecu_receiver_map(
         dlt_context = dlt_ctx!("DOIP"),
     )
 )]
-async fn connection_handler(gateway: GatewaySetup) -> Result<GatewayConnectionHandles, EcuError> {
+async fn connection_handler(
+    gateway: GatewaySetup,
+    connection_tasks: Arc<Mutex<JoinSet<Result<(), JoinError>>>>,
+) -> Result<GatewayConnectionHandles, EcuError> {
     // channel to send messages to the gateway / ecus
     let (intx, inrx) = mpsc::channel::<DoipPayload>(50);
 
@@ -281,35 +281,36 @@ async fn connection_handler(gateway: GatewaySetup) -> Result<GatewayConnectionHa
     let (conn_reset_tx, conn_reset_rx) = mpsc::channel::<ConnectionResetReason>(1);
     // task to handle connection resets and reconnects
     let conn_reset = Arc::<EcuConnectionTarget>::clone(&gateway_conn);
-    let connection_reset_task =
-        spawn_connection_reset_task(gateway.clone(), conn_reset_rx, conn_reset);
+
+    let mut tasks = connection_tasks.lock().await;
+    tasks.spawn(spawn_connection_reset_task(
+        gateway.clone(),
+        conn_reset_rx,
+        conn_reset,
+    ));
 
     // communication between send / receiver task to unlock the connection in the receiver task
     // when sender task wants to send something
     let (send_pending_tx, send_pending_rx) = watch::channel::<bool>(false);
-    let gateway_sender_task = spawn_gateway_sender_task(
+    tasks.spawn(spawn_gateway_sender_task(
         Arc::<EcuConnectionTarget>::clone(&gateway_conn),
         inrx,
         conn_reset_tx.clone(),
         send_pending_tx.clone(),
-    );
-    let gateway_receiver_task = spawn_gateway_receiver_task(
+    ));
+    tasks.spawn(spawn_gateway_receiver_task(
         outtx,
         Arc::<EcuConnectionTarget>::clone(&gateway_conn),
         send_pending_rx,
         conn_reset_tx,
         intx.clone(),
-    );
+    ));
+    drop(tasks);
 
     // no need to wait until the connection is alive, we will reconnect automatically anyway
     Ok(GatewayConnectionHandles {
         sender: intx,
         receivers: outrx,
-        task_handles: vec![
-            connection_reset_task,
-            gateway_sender_task,
-            gateway_receiver_task,
-        ],
     })
 }
 

--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -28,56 +28,20 @@ use tokio::{
 };
 
 use crate::{
-    ConnectionError, DiagnosticResponse, DoipConnection, DoipEcu, DoipTarget,
+    ConnectionError, DiagnosticResponse, DiscoveredGateway, DoipConnection, DoipEcu,
+    DoipTransportConfig, EcuTimeouts, GatewayConnectionConfig, GatewayDoipConfig, GatewaySetup,
     NRC_BUSY_REPEAT_REQUEST, NRC_RESPONSE_PENDING, NRC_TEMPORARILY_NOT_AVAILABLE,
     connections::EcuError::EcuConnectionError,
-    ecu_connection::{
-        self, ConnectionConfig, ECUConnectionRead, ECUConnectionSend as _, EcuConnectionTarget,
-    },
-    socket::DoIPConfig,
+    ecu_connection::{self, ECUConnectionRead, ECUConnectionSend as _, EcuConnectionTarget},
 };
 
 type ConnectionResetReason = String;
-
-/// Configuration for establishing a gateway connection.
-pub(crate) struct GatewayConfig {
-    pub connection: ConnectionConfig,
-    pub doip: DoIPConfig,
-    pub send_timeout: Duration,
-    pub alive_check_interval: Duration,
-}
 
 /// Runtime state for managing active gateway connections and ECU mappings.
 pub(crate) struct GatewayState<T> {
     pub doip_connections: Arc<RwLock<Vec<Arc<DoipConnection>>>>,
     pub ecus: Arc<HashMap<String, RwLock<T>>>,
     pub gateway_ecu_map: HashMap<u16, Vec<u16>>,
-}
-
-#[derive(Clone, Copy)]
-struct ConnectionSettings {
-    routing_activation: Duration,
-    retry_delay: Duration,
-    connect_timeout: Duration,
-    max_retry_attempts: u32,
-    send_timeout: Duration,
-    alive_check_interval: Duration,
-}
-
-#[derive(Clone)]
-struct GatewayTarget {
-    ip: String,
-    name: String,
-    ecus: Vec<u16>,
-}
-
-#[derive(Clone)]
-struct GatewayHandlerConfig {
-    connection_config: ConnectionConfig,
-    doip_connection_config: DoIPConfig,
-    routing_activation_request: RoutingActivationRequest,
-    connection_settings: ConnectionSettings,
-    variant_detection: Option<(mpsc::Sender<Vec<String>>, Vec<String>)>,
 }
 
 struct GatewayConnectionHandles {
@@ -130,20 +94,20 @@ impl From<EcuError> for DiagServiceError {
 }
 
 #[tracing::instrument(
-    skip(config, state),
+    skip(transport, state),
     fields(
-        tester_ip = config.connection.source_ip.clone(),
-        port = config.connection.port,
-        tls_port = config.connection.tls_port,
-        gateway_ecu = %gateway.ecu,
-        gateway_ip = %gateway.ip,
-        logical_address = %format!("{:#06x}", gateway.logical_address),
+        tester_ip = transport.tester_ip.clone(),
+        port = transport.port,
+        tls_port = transport.tls_port,
+        gateway_ecu = %discovered_gateway.ecu_name,
+        gateway_ip = %discovered_gateway.ip,
+        logical_address = %format!("{:#06x}", discovered_gateway.logical_address),
         dlt_context = dlt_ctx!("DOIP")
     )
 )]
 pub(crate) async fn handle_gateway_connection<T>(
-    gateway: DoipTarget,
-    config: &GatewayConfig,
+    discovered_gateway: DiscoveredGateway,
+    transport: &DoipTransportConfig,
     state: &GatewayState<T>,
     variant_detection: Option<(mpsc::Sender<Vec<String>>, Vec<String>)>,
 ) -> Result<u16, EcuError>
@@ -152,7 +116,7 @@ where
 {
     let tester_address = state
         .ecus
-        .get(&gateway.ecu)
+        .get(&discovered_gateway.ecu_name)
         .map(|ecu| async { ecu.read().await.tester_address() })
         .ok_or_else(|| EcuError::ResourceNotFound("ECU not found".to_owned()))?
         .await;
@@ -163,17 +127,19 @@ where
         buffer: [0, 0, 0, 0],
     };
 
-    let ecu_ids: Vec<u16> =
-        if let Some(ecu_ids) = state.gateway_ecu_map.get(&gateway.logical_address) {
-            ecu_ids.clone()
-        } else {
-            return Err(EcuError::ResourceNotFound(format!(
-                "No ECUs found for gateway address {}. Skipping, as the gateway cannot be used.",
-                gateway.logical_address
-            )));
-        };
+    let ecu_ids: Vec<u16> = if let Some(ecu_ids) = state
+        .gateway_ecu_map
+        .get(&discovered_gateway.logical_address)
+    {
+        ecu_ids.clone()
+    } else {
+        return Err(EcuError::ResourceNotFound(format!(
+            "No ECUs found for gateway address {}. Skipping, as the gateway cannot be used.",
+            discovered_gateway.logical_address
+        )));
+    };
 
-    let gateway_ecu = match state.ecus.get(&gateway.ecu) {
+    let gateway_ecu = match state.ecus.get(&discovered_gateway.ecu_name) {
         Some(ecu) => ecu.read().await,
         None => {
             return Err(EcuError::ResourceNotFound(
@@ -186,36 +152,36 @@ where
     let connection_timeout = gateway_ecu.connection_timeout();
     let connection_retry_attempts = gateway_ecu.connection_retry_attempts();
 
-    let target = GatewayTarget {
-        ip: gateway.ip.clone(),
-        name: gateway.ecu.clone(),
-        ecus: ecu_ids.clone(),
-    };
-    let config = GatewayHandlerConfig {
-        connection_config: connection_config.clone(),
-        doip_connection_config,
-        routing_activation_request,
-        connection_settings: ConnectionSettings {
-            routing_activation: routing_activation_timeout,
-            retry_delay: connection_retry_delay,
-            connect_timeout: connection_timeout,
-            max_retry_attempts: connection_retry_attempts,
-            send_timeout: config.send_timeout,
-            alive_check_interval: config.alive_check_interval,
+    let gateway = GatewaySetup {
+        connection: GatewayConnectionConfig {
+            doip: GatewayDoipConfig {
+                gateway_ip: discovered_gateway.ip.clone(),
+                name: discovered_gateway.ecu_name.clone(),
+                tester_address: gateway_ecu.tester_address().to_be_bytes(),
+                transport: transport.clone(),
+            },
+            routing_activation_request,
+            ecu_timeouts: EcuTimeouts {
+                routing_activation: routing_activation_timeout,
+                retry_delay: connection_retry_delay,
+                connection: connection_timeout,
+                max_retry_attempts: connection_retry_attempts,
+            },
         },
+        ecus: ecu_ids.clone(),
         variant_detection,
     };
     let GatewayConnectionHandles {
         sender,
         receivers,
         task_handles,
-    } = match connection_handler(target, config).await {
+    } = match connection_handler(gateway).await {
         Ok(handles) => handles,
         Err(e) => {
             return Err(EcuError::EcuConnectionError(
                 ConnectionError::ConnectionFailed(format!(
                     "Failed to connect to {}: {}",
-                    gateway.ecu, e
+                    discovered_gateway.ecu_name, e
                 )),
             ));
         }
@@ -230,11 +196,11 @@ where
         .await
         .push(Arc::new(DoipConnection {
             ecus: doip_ecus,
-            ip: gateway.ip,
+            ip: discovered_gateway.ip,
             task_handles,
         }));
 
-    Ok(gateway.logical_address)
+    Ok(discovered_gateway.logical_address)
 }
 
 #[tracing::instrument(skip(sender, receiver),
@@ -271,21 +237,15 @@ fn create_ecu_receiver_map(
 }
 
 #[tracing::instrument(
-    skip(target, config),
+    skip_all,
     fields(
-        tester_ip = config.connection_config.source_ip.clone(),
-        port = config.connection_config.port,
-        tls_port = config.connection_config.tls_port,
-        gateway_ip = %target.ip,
-        gateway_name = %target.name,
-        ecu_count = target.ecus.len(),
+        gateway_ip = %gateway.connection.doip.gateway_ip,
+        gateway_name = %gateway.connection.doip.name,
+        ecu_count = gateway.ecus.len(),
         dlt_context = dlt_ctx!("DOIP"),
     )
 )]
-async fn connection_handler(
-    target: GatewayTarget,
-    config: GatewayHandlerConfig,
-) -> Result<GatewayConnectionHandles, EcuError> {
+async fn connection_handler(gateway: GatewaySetup) -> Result<GatewayConnectionHandles, EcuError> {
     // channel to send messages to the gateway / ecus
     let (intx, inrx) = mpsc::channel::<DoipPayload>(50);
 
@@ -298,7 +258,7 @@ async fn connection_handler(
         HashMap::new();
 
     // create ecu response channels
-    for &ecu in &target.ecus {
+    for &ecu in &gateway.ecus {
         let (tx, rx) = broadcast::channel::<Result<DiagnosticResponse, EcuError>>(10);
 
         outtx.insert(ecu, tx);
@@ -307,44 +267,33 @@ async fn connection_handler(
 
     // setting up initial gateway connection
     let gateway_conn = Arc::new(
-        ecu_connection::establish_ecu_connection(
-            &config.connection_config,
-            &target.ip,
-            &target.name,
-            config.doip_connection_config,
-            config.routing_activation_request,
-            config.connection_settings.connect_timeout,
-            config.connection_settings.routing_activation,
-        )
-        .await
-        .inspect_err(|e| {
-            tracing::error!("Failed to connect to gateway at {}: {e:?}", target.ip);
-        })?,
+        ecu_connection::establish_ecu_connection(&gateway.connection)
+            .await
+            .inspect_err(|e| {
+                tracing::error!(
+                    "Failed to connect to gateway at {}: {e:?}",
+                    gateway.connection.doip.gateway_ip
+                );
+            })?,
     );
 
     // used by receiver / sender task to reset the connection
     let (conn_reset_tx, conn_reset_rx) = mpsc::channel::<ConnectionResetReason>(1);
     // task to handle connection resets and reconnects
     let conn_reset = Arc::<EcuConnectionTarget>::clone(&gateway_conn);
-    let send_timeout = config.connection_settings.send_timeout;
     let connection_reset_task =
-        spawn_connection_reset_task(target.clone(), config, conn_reset_rx, conn_reset);
+        spawn_connection_reset_task(gateway.clone(), conn_reset_rx, conn_reset);
 
     // communication between send / receiver task to unlock the connection in the receiver task
     // when sender task wants to send something
     let (send_pending_tx, send_pending_rx) = watch::channel::<bool>(false);
     let gateway_sender_task = spawn_gateway_sender_task(
-        &target.ip,
-        inrx,
         Arc::<EcuConnectionTarget>::clone(&gateway_conn),
-        send_timeout,
+        inrx,
         conn_reset_tx.clone(),
         send_pending_tx.clone(),
-        connection_settings.alive_check_interval,
     );
     let gateway_receiver_task = spawn_gateway_receiver_task(
-        target.ip.clone(),
-        target.name.clone(),
         outtx,
         Arc::<EcuConnectionTarget>::clone(&gateway_conn),
         send_pending_rx,
@@ -371,19 +320,11 @@ async fn connection_handler(
     )
 )]
 fn spawn_connection_reset_task(
-    target: GatewayTarget,
-    config: GatewayHandlerConfig,
+    gateway: GatewaySetup,
     mut conn_reset_rx: mpsc::Receiver<ConnectionResetReason>,
     conn_reset: Arc<EcuConnectionTarget>,
 ) -> tokio::task::JoinHandle<()> {
-    let GatewayTarget { ip: gateway_ip, .. } = target;
-    let GatewayHandlerConfig {
-        connection_config,
-        doip_connection_config,
-        routing_activation_request,
-        connection_settings: connection_timeouts,
-        variant_detection,
-    } = config;
+    let gateway_ip = gateway.connection.doip.gateway_ip.clone();
     cda_interfaces::spawn_named!(
         &format!("doip-connection-reset-{gateway_ip}"),
         Box::pin(async move {
@@ -394,16 +335,8 @@ fn spawn_connection_reset_task(
                     let mut conn_guard = conn_reset.lock_connection().await;
 
                     'reconnect: loop {
-                        let new_connection = ecu_connection::establish_ecu_connection(
-                            &connection_config,
-                            &gateway_ip,
-                            &conn_reset.gateway_name,
-                            doip_connection_config,
-                            routing_activation_request,
-                            connection_timeouts.connect_timeout,
-                            connection_timeouts.routing_activation,
-                        )
-                        .await;
+                        let new_connection =
+                            ecu_connection::establish_ecu_connection(&gateway.connection).await;
 
                         match new_connection {
                             Ok(conn) => {
@@ -422,7 +355,8 @@ fn spawn_connection_reset_task(
                                 }
                                 // Trigger variant detection after successful reconnection
                                 // so that ECUs transition back to Online.
-                                if let Some((ref vd_tx, ref ecu_names)) = variant_detection {
+                                if let Some((ref vd_tx, ref ecu_names)) = gateway.variant_detection
+                                {
                                     if let Err(e) = vd_tx.send(ecu_names.clone()).await {
                                         tracing::error!(
                                             error = ?e,
@@ -440,18 +374,21 @@ fn spawn_connection_reset_task(
                             Err(e) => {
                                 tracing::error!(
                                     error = ?e,
-                                    retry_delay = ?connection_timeouts.retry_delay,
+                                    retry_delay = ?gateway.connection.ecu_timeouts.retry_delay,
                                     "Failed to reset connection, retrying"
                                 );
                                 cda_interfaces::util::tokio_ext::sleep_for(
-                                    connection_timeouts.retry_delay,
+                                    gateway.connection.ecu_timeouts.retry_delay,
                                 )
                                 .await;
                                 reconnect_attempts = reconnect_attempts.saturating_add(1);
-                                if reconnect_attempts >= connection_timeouts.max_retry_attempts {
+                                if reconnect_attempts
+                                    >= gateway.connection.ecu_timeouts.max_retry_attempts
+                                {
                                     tracing::error!(
                                         attempts = reconnect_attempts,
-                                        max_attempts = connection_timeouts.max_retry_attempts,
+                                        max_attempts =
+                                            gateway.connection.ecu_timeouts.max_retry_attempts,
                                         "Max reconnect attempts reached, giving up"
                                     );
                                     return;
@@ -469,148 +406,159 @@ fn spawn_connection_reset_task(
 }
 
 #[tracing::instrument(
-    skip_all
+    skip_all,
     fields(
         dlt_context = dlt_ctx!("DOIP")
     )
 )]
 fn spawn_gateway_sender_task<T>(
-    gateway_ip: &str,
+    gateway_connection: Arc<EcuConnectionTarget<T>>,
     mut inrx: mpsc::Receiver<DoipPayload>,
-    gateway_conn: Arc<EcuConnectionTarget<T>>,
-    send_timeout: Duration,
     reset_tx: mpsc::Sender<ConnectionResetReason>,
     send_pending_tx: watch::Sender<bool>,
-    alive_check_interval: Duration,
 ) -> tokio::task::JoinHandle<()>
 where
     T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
-    cda_interfaces::spawn_named!(&format!("doip-gateway-sender-{gateway_ip}"), async move {
-        fn send_pending_status(
-            send_pending_tx: &watch::Sender<bool>,
-            value: bool,
-        ) -> Result<(), ()> {
-            send_pending_tx.send(value).map_err(|_| {
-                tracing::warn!("Send pending receiver closed");
-            })
-        }
+    cda_interfaces::spawn_named!(
+        &format!(
+            "doip-gateway-sender-{}",
+            gateway_connection.gateway_doip_config.gateway_ip
+        ),
+        async move {
+            fn send_pending_status(
+                send_pending_tx: &watch::Sender<bool>,
+                value: bool,
+            ) -> Result<(), ()> {
+                send_pending_tx.send(value).map_err(|_| {
+                    tracing::warn!("Send pending receiver closed");
+                })
+            }
 
-        let alive_check_enabled = alive_check_interval > Duration::ZERO;
-        let effective_interval = if alive_check_enabled {
-            alive_check_interval
-        } else {
-            // Use a very large duration when disabled so the interval never fires.
-            // tokio::time::Instant is limited so we use ~136 years which is well
-            // within the representable range.
-            Duration::from_secs(u64::from(u32::MAX))
-        };
-        let mut alive_interval = tokio::time::interval_at(
-            tokio::time::Instant::now()
-                .checked_add(effective_interval)
-                .expect("interval start overflow"),
-            effective_interval,
-        );
-        alive_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        loop {
-            tokio::select! {
-                // Per default tokio, randomized which branch is checked first to ensure fairness.
-                // We always want to priotize sending messages over the alive check.
-                // Adding 'biased' means the selects are checked in order from top to bottom.
-                // https://docs.rs/tokio/latest/tokio/macro.select.html#fairness
-                biased;
-                msg = inrx.recv() => {
-                    let Some(msg) = msg else {
-                        // Channel closed - all senders dropped (gateway shut down).
-                        tracing::debug!("Send channel closed, shutting down sender task");
-                        break;
-                    };
-                    // let rx task know that we want to send something.
-                    if send_pending_status(&send_pending_tx, true).is_err() {
-                        break;
-                    }
-
-                    let start = std::time::Instant::now();
-                    let lock_after = match gateway_conn.lock_send().await {
-                        Ok(mut guard) => {
-                            let conn = guard.get_sender();
-                            let lock_after = start.elapsed();
-
-                            match tokio::time::timeout(send_timeout, conn.send(msg)).await {
-                                Ok(Ok(())) => {},
-                                Ok(Err(e)) => {
-                                    tracing::error!(error = ?e, "Failed to send message");
-                                }
-                                Err(e) => {
-                                    tracing::error!(error = ?e, "Timeout sending message");
-                                }
-                            }
-                            lock_after
-                        },
-                        Err(_) => {
-                            continue; // connection was closed
-                        }
-                    };
-
-                    let send_after = start.elapsed().saturating_sub(lock_after);
-                    tracing::debug!(
-                        total_duration = ?start.elapsed(),
-                        lock_duration = ?lock_after,
-                        send_duration = ?send_after,
-                        "DoIP send request timing"
-                    );
-                    // inform the rx task that we are done sending
-                    if send_pending_status(&send_pending_tx, false).is_err() {
-                        break;
-                    }
-                    // Reset the alive check timer so it only fires after a full
-                    // interval of silence - never during active communication.
-                    alive_interval.reset();
-                },
-
-                _ = alive_interval.tick(), if alive_check_enabled => {
-                    if send_pending_status(&send_pending_tx, true).is_err() {
-                        break;
-                    }
-
-                    let (alive_response, conn_gateway_name, conn_gateway_ip) = {
-                        (
-                            send_alive_response(&gateway_conn, gateway_conn.tester_address).await,
-                            gateway_conn.gateway_name.clone(),
-                            gateway_conn.gateway_ip.clone(),
-                        )
-                    };
-
-                    if let Err(e) = alive_response {
-                        tracing::error!(
-                            error = ?e,
-                            gateway_name = %conn_gateway_name,
-                            gateway_ip = %conn_gateway_ip,
-                            "Failed to send alive check request, resetting connection"
-                        );
-                        // no need for any 'sleep' here, the reset task holds the connection
-                        // lock until the connection is ready again.
-                        if let Err(e) = reset_tx
-                            .send("Unable to send alive check request".to_owned())
-                            .await
-                        {
-                            tracing::error!(
-                                error = ?e,
-                                "Failed to send connection reset request"
-                            );
-                            // if the reset channel is closed, we cannot reset the connection
-                            // and there is no point in continuing
+            let alive_check_interval = gateway_connection
+                .gateway_doip_config
+                .transport
+                .alive_check_interval;
+            let send_timeout = gateway_connection
+                .gateway_doip_config
+                .transport
+                .send_timeout;
+            let alive_check_enabled = alive_check_interval > Duration::ZERO;
+            let effective_interval = if alive_check_enabled {
+                alive_check_interval
+            } else {
+                // Use a very large duration when disabled so the interval never fires.
+                // tokio::time::Instant is limited so we use ~136 years which is well
+                // within the representable range.
+                Duration::from_secs(u64::from(u32::MAX))
+            };
+            let mut alive_interval = tokio::time::interval_at(
+                tokio::time::Instant::now()
+                    .checked_add(effective_interval)
+                    .expect("interval start overflow"),
+                effective_interval,
+            );
+            alive_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                tokio::select! {
+                    // Per default tokio, randomized which branch is checked first to ensure fairness.
+                    // We always want to priotize sending messages over the alive check.
+                    // Adding 'biased' means the selects are checked in order from top to bottom.
+                    // https://docs.rs/tokio/latest/tokio/macro.select.html#fairness
+                    biased;
+                    msg = inrx.recv() => {
+                        let Some(msg) = msg else {
+                            // Channel closed - all senders dropped (gateway shut down).
+                            tracing::debug!("Send channel closed, shutting down sender task");
+                            break;
+                        };
+                        // let rx task know that we want to send something.
+                        if send_pending_status(&send_pending_tx, true).is_err() {
                             break;
                         }
-                    }
 
-                    if send_pending_status(&send_pending_tx, false).is_err() {
-                        break;
+                        let start = std::time::Instant::now();
+                        let lock_after = match gateway_connection.lock_send().await {
+                            Ok(mut guard) => {
+                                let conn = guard.get_sender();
+                                let lock_after = start.elapsed();
+
+                                match tokio::time::timeout(send_timeout, conn.send(msg)).await {
+                                    Ok(Ok(())) => {},
+                                    Ok(Err(e)) => {
+                                        tracing::error!(error = ?e, "Failed to send message");
+                                    }
+                                    Err(e) => {
+                                        tracing::error!(error = ?e, "Timeout sending message");
+                                    }
+                                }
+                                lock_after
+                            },
+                            Err(_) => {
+                                continue; // connection was closed
+                            }
+                        };
+
+                        let send_after = start.elapsed().saturating_sub(lock_after);
+                        tracing::debug!(
+                            total_duration = ?start.elapsed(),
+                            lock_duration = ?lock_after,
+                            send_duration = ?send_after,
+                            "DoIP send request timing"
+                        );
+                        // inform the rx task that we are done sending
+                        if send_pending_status(&send_pending_tx, false).is_err() {
+                            break;
+                        }
+                        // Reset the alive check timer so it only fires after a full
+                        // interval of silence - never during active communication.
+                        alive_interval.reset();
+                    },
+
+                    _ = alive_interval.tick(), if alive_check_enabled => {
+                        if send_pending_status(&send_pending_tx, true).is_err() {
+                            break;
+                        }
+
+                        let (alive_response, conn_gateway_name, conn_gateway_ip) = {
+                            (
+                                send_alive_response(&gateway_connection).await,
+                                gateway_connection.gateway_doip_config.name.clone(),
+                                gateway_connection.gateway_doip_config.gateway_ip.clone(),
+                            )
+                        };
+
+                        if let Err(e) = alive_response {
+                            tracing::error!(
+                                error = ?e,
+                                gateway_name = %conn_gateway_name,
+                                gateway_ip = %conn_gateway_ip,
+                                "Failed to send alive check request, resetting connection"
+                            );
+                            // no need for any 'sleep' here, the reset task holds the connection
+                            // lock until the connection is ready again.
+                            if let Err(e) = reset_tx
+                                .send("Unable to send alive check request".to_owned())
+                                .await
+                            {
+                                tracing::error!(
+                                    error = ?e,
+                                    "Failed to send connection reset request"
+                                );
+                                // if the reset channel is closed, we cannot reset the connection
+                                // and there is no point in continuing
+                                break;
+                            }
+                        }
+
+                        if send_pending_status(&send_pending_tx, false).is_err() {
+                            break;
+                        }
                     }
                 }
             }
         }
-    })
+    )
 }
 
 /// allowed because there are two inline functions in here,
@@ -619,15 +567,13 @@ where
 #[tracing::instrument(
     skip(outtx, gateway_conn, send_pending_rx, reset_tx),
     fields(
-        gateway_ip = %gateway_ip,
-        gateway_name = %gateway_name,
+        gateway_ip = %gateway_conn.gateway_doip_config.gateway_ip,
+        gateway_name = %gateway_conn.gateway_doip_config.name,
         active_ecus = outtx.len(),
         dlt_context = dlt_ctx!("DOIP"),
     )
 )]
 fn spawn_gateway_receiver_task<T>(
-    gateway_ip: String,
-    gateway_name: String,
     outtx: HashMap<u16, broadcast::Sender<Result<DiagnosticResponse, EcuError>>>,
     gateway_conn: Arc<EcuConnectionTarget<T>>,
     mut send_pending_rx: watch::Receiver<bool>,
@@ -637,6 +583,8 @@ fn spawn_gateway_receiver_task<T>(
 where
     T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
+    let gateway_ip = gateway_conn.gateway_doip_config.gateway_ip.clone();
+    let gateway_name = gateway_conn.gateway_doip_config.name.clone();
     // note: the handlers are defined here, as rustfmt cannot format the correctly inside the
     // tokio::select! macro block
     async fn handle_send_pending(
@@ -841,10 +789,7 @@ where
     })
 }
 
-async fn send_alive_response<T>(
-    conn: &EcuConnectionTarget<T>,
-    tester_address: [u8; 2],
-) -> Result<(), ()>
+async fn send_alive_response<T>(conn: &EcuConnectionTarget<T>) -> Result<(), ()>
 where
     T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
@@ -893,7 +838,7 @@ where
     match sender
         .get_sender()
         .send(DoipPayload::AliveCheckResponse(AliveCheckResponse {
-            source_address: tester_address,
+            source_address: conn.gateway_doip_config.tester_address,
         }))
         .await
     {
@@ -989,34 +934,45 @@ mod tests {
     use tokio::sync::{Mutex, mpsc, watch};
 
     use crate::{
+        DoipTransportConfig, GatewayDoipConfig,
         connections::{ConnectionResetReason, spawn_gateway_sender_task},
         ecu_connection::{EcuConnectionReadVariant, EcuConnectionSendVariant, EcuConnectionTarget},
-        socket::{DoIPConfig, DoIPConnection},
+        socket::{DoIPConnection, DoipSocketConfig},
     };
 
     /// Builds a duplex-backed `EcuConnectionTarget` together with the server-side
     /// `DoIPConnection` used to respond to alive checks and dummy messages.
     /// `lock_send()` succeeds and `alive_interval.reset()` is called on each
     /// message processed by the sender task.
-    fn duplex_ecu_connection_target() -> (
+    fn duplex_ecu_connection_target(
+        alive_check_interval: Duration,
+    ) -> (
         EcuConnectionTarget<tokio::io::DuplexStream>,
         DoIPConnection<tokio::io::DuplexStream>,
     ) {
         let (client, server) = tokio::io::duplex(1024);
-        let config = DoIPConfig {
+        let config = DoipSocketConfig {
             protocol_version: ProtocolVersion::Iso13400_2012,
             send_diagnostic_message_ack: false,
-            send_timeout: Duration::from_secs(10),
-            alive_check_interval: Duration::from_secs(10),
         };
         let server_conn = DoIPConnection::new(server, config);
         let (read_half, write_half) = DoIPConnection::new(client, config).into_split();
         let target = EcuConnectionTarget {
             ecu_connection_rx: Mutex::new(Some(EcuConnectionReadVariant::Plain(read_half))),
             ecu_connection_tx: Mutex::new(Some(EcuConnectionSendVariant::Plain(write_half))),
-            gateway_name: String::new(),
-            gateway_ip: String::new(),
-            tester_address: [0, 0],
+            gateway_doip_config: GatewayDoipConfig {
+                gateway_ip: "127.0.0.1".to_owned(),
+                name: String::new(),
+                tester_address: [0, 0],
+                transport: DoipTransportConfig {
+                    tester_ip: "127.0.0.1".to_owned(),
+                    port: 13400,
+                    tls_port: 0,
+                    socket: config,
+                    send_timeout: Duration::from_secs(5),
+                    alive_check_interval,
+                },
+            },
         };
         (target, server_conn)
     }
@@ -1050,18 +1006,15 @@ mod tests {
             let (msg_tx, msg_rx) = mpsc::channel::<DoipPayload>(10);
             let (reset_tx, reset_rx) = mpsc::channel::<ConnectionResetReason>(10);
             let (send_pending_tx, send_pending_rx) = watch::channel(false);
-            let (gateway_target, _) = duplex_ecu_connection_target();
+            let (gateway_target, _) = duplex_ecu_connection_target(alive_check_interval);
 
             let gateway_conn = Arc::new(gateway_target);
 
             let task = spawn_gateway_sender_task(
-                "127.0.0.1",
-                msg_rx,
                 Arc::clone(&gateway_conn),
-                Duration::from_secs(1),
+                msg_rx,
                 reset_tx,
                 send_pending_tx,
-                alive_check_interval,
             );
 
             Self {

--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -26,6 +26,7 @@ use tokio::{
     io::{AsyncRead, AsyncWrite},
     sync::{Mutex, RwLock, broadcast, mpsc, watch},
     task::{JoinError, JoinSet},
+    time::Interval,
 };
 
 use crate::{
@@ -445,21 +446,18 @@ where
                 .transport
                 .send_timeout;
             let alive_check_enabled = alive_check_interval > Duration::ZERO;
-            let effective_interval = if alive_check_enabled {
-                alive_check_interval
-            } else {
-                // Use a very large duration when disabled so the interval never fires.
-                // tokio::time::Instant is limited so we use ~136 years which is well
-                // within the representable range.
-                Duration::from_secs(u64::from(u32::MAX))
-            };
-            let mut alive_interval = tokio::time::interval_at(
-                tokio::time::Instant::now()
-                    .checked_add(effective_interval)
-                    .expect("interval start overflow"),
-                effective_interval,
-            );
-            alive_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            let mut alive_interval = alive_check_enabled.then(|| {
+                let mut interval = tokio::time::interval_at(
+                    // If setting a huge value for the alive check this is okay to fail,
+                    // as it is guarded by a config sanity check.
+                    tokio::time::Instant::now()
+                        .checked_add(alive_check_interval)
+                        .expect("Failed to set interval, alive check value is too big"),
+                    alive_check_interval,
+                );
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                interval
+            });
             loop {
                 tokio::select! {
                     // Per default tokio, randomized which branch is checked first to ensure fairness.
@@ -513,10 +511,15 @@ where
                         }
                         // Reset the alive check timer so it only fires after a full
                         // interval of silence - never during active communication.
-                        alive_interval.reset();
+                       alive_interval.as_mut().map(Interval::reset);
                     },
 
-                    _ = alive_interval.tick(), if alive_check_enabled => {
+                   _ = async {
+                        match alive_interval.as_mut() {
+                                Some(interval) => interval.tick().await,
+                                None => std::future::pending().await,
+                            }
+                        }, if alive_check_enabled => {
                         if send_pending_status(&send_pending_tx, true).is_err() {
                             break;
                         }

--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -123,6 +123,7 @@ pub(crate) async fn handle_gateway_connection<T>(
     gateway: DoipTarget,
     config: &GatewayConfig,
     state: &GatewayState<T>,
+    variant_detection: Option<(mpsc::Sender<Vec<String>>, Vec<String>)>,
 ) -> Result<u16, EcuError>
 where
     T: EcuAddresses + DoipComParams,
@@ -163,7 +164,7 @@ where
     let connection_timeout = gateway_ecu.connection_timeout();
     let connection_retry_attempts = gateway_ecu.connection_retry_attempts();
 
-    let (sender, receiver) = match connection_handler(
+    let (sender, receiver, task_handles) = match connection_handler(
         config.connection.clone(),
         gateway.ip.clone(),
         gateway.ecu.clone(),
@@ -178,10 +179,11 @@ where
             send_timeout: config.send_timeout,
             alive_check_interval: config.alive_check_interval,
         },
+        variant_detection,
     )
     .await
     {
-        Ok((sender, receiver)) => (sender, receiver),
+        Ok((sender, receiver, task_handles)) => (sender, receiver, task_handles),
         Err(e) => {
             return Err(EcuError::EcuConnectionError(
                 ConnectionError::ConnectionFailed(format!(
@@ -261,10 +263,12 @@ async fn connection_handler(
     routing_activation_request: RoutingActivationRequest,
     ecus: Vec<u16>,
     connection_settings: ConnectionSettings,
+    variant_detection: Option<(mpsc::Sender<Vec<String>>, Vec<String>)>,
 ) -> Result<
     (
         mpsc::Sender<DoipPayload>,
         HashMap<u16, broadcast::Receiver<Result<DiagnosticResponse, EcuError>>>,
+        Vec<tokio::task::JoinHandle<()>>,
     ),
     EcuError,
 > {
@@ -308,7 +312,7 @@ async fn connection_handler(
     let (conn_reset_tx, conn_reset_rx) = mpsc::channel::<ConnectionResetReason>(1);
     // task to handle connection resets and reconnects
     let conn_reset = Arc::<EcuConnectionTarget>::clone(&gateway_conn);
-    spawn_connection_reset_task(
+    let connection_reset_task = spawn_connection_reset_task(
         connection_config.clone(),
         gateway_ip.clone(),
         doip_connection_config,
@@ -316,12 +320,13 @@ async fn connection_handler(
         conn_reset_rx,
         conn_reset,
         connection_settings,
+        variant_detection,
     );
 
     // communication between send / receiver task to unlock the connection in the receiver task
     // when sender task wants to send something
     let (send_pending_tx, send_pending_rx) = watch::channel::<bool>(false);
-    spawn_gateway_sender_task(
+    let gateway_sender_task = spawn_gateway_sender_task(
         &gateway_ip,
         inrx,
         Arc::<EcuConnectionTarget>::clone(&gateway_conn),
@@ -330,7 +335,7 @@ async fn connection_handler(
         send_pending_tx.clone(),
         connection_settings.alive_check_interval,
     );
-    spawn_gateway_receiver_task(
+    let gateway_receiver_task = spawn_gateway_receiver_task(
         gateway_ip.clone(),
         gateway_name.clone(),
         outtx,
@@ -341,7 +346,7 @@ async fn connection_handler(
     );
 
     // no need to wait until the connection is alive, we will reconnect automatically anyway
-    Ok((intx, outrx))
+    Ok((intx, outrx, vec![connection_reset_task, gateway_sender_task, gateway_receiver_task]))
 }
 
 #[tracing::instrument(
@@ -358,7 +363,8 @@ fn spawn_connection_reset_task(
     mut conn_reset_rx: mpsc::Receiver<ConnectionResetReason>,
     conn_reset: Arc<EcuConnectionTarget>,
     connection_timeouts: ConnectionSettings,
-) {
+    variant_detection: Option<(mpsc::Sender<Vec<String>>, Vec<String>)>,
+) -> tokio::task::JoinHandle<()> {
     cda_interfaces::spawn_named!(
         &format!("doip-connection-reset-{gateway_ip}"),
         Box::pin(async move {
@@ -395,6 +401,21 @@ fn spawn_connection_reset_task(
                                         return;
                                     }
                                 }
+                                // Trigger variant detection after successful reconnection
+                                // so that ECUs transition back to Online.
+                                if let Some((ref vd_tx, ref ecu_names)) = variant_detection {
+                                    if let Err(e) = vd_tx.send(ecu_names.clone()).await {
+                                        tracing::error!(
+                                            error = ?e,
+                                            "Failed to trigger variant detection after reconnect"
+                                        );
+                                    } else {
+                                        tracing::info!(
+                                            ecus = ?ecu_names,
+                                            "Triggered variant detection after reconnect"
+                                        );
+                                    }
+                                }
                                 break 'reconnect;
                             }
                             Err(e) => {
@@ -425,7 +446,7 @@ fn spawn_connection_reset_task(
                 }
             }
         })
-    );
+    )
 }
 
 #[tracing::instrument(
@@ -588,7 +609,7 @@ fn spawn_gateway_receiver_task<T>(
     mut send_pending_rx: watch::Receiver<bool>,
     reset_tx: mpsc::Sender<ConnectionResetReason>,
     send_tx: mpsc::Sender<DoipPayload>,
-) where
+) -> tokio::task::JoinHandle<()> where
     T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     // note: the handlers are defined here, as rustfmt cannot format the correctly inside the
@@ -792,7 +813,7 @@ fn spawn_gateway_receiver_task<T>(
                 }
             }
         }
-    });
+    })
 }
 
 async fn send_alive_response<T>(

--- a/cda-comm-doip/src/ecu_connection.rs
+++ b/cda-comm-doip/src/ecu_connection.rs
@@ -11,12 +11,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::time::Duration;
-
 use cda_interfaces::{DiagServiceError, dlt_ctx};
 use doip_definitions::{
     message::DoipMessage,
-    payload::{ActivationCode, DoipPayload, RoutingActivationRequest, RoutingActivationResponse},
+    payload::{ActivationCode, DoipPayload, RoutingActivationResponse},
 };
 #[cfg(all(feature = "mbedtls", not(feature = "openssl")))]
 use mbedtls_rs::{
@@ -34,8 +32,8 @@ use tokio::{
 use tokio_openssl::SslStream as TlsStream;
 
 use crate::{
-    ConnectionError,
-    socket::{DoIPConfig, DoIPConnection, DoIPConnectionReadHalf, DoIPConnectionWriteHalf},
+    ConnectionError, GatewayConnectionConfig, GatewayDoipConfig,
+    socket::{DoIPConnection, DoIPConnectionReadHalf, DoIPConnectionWriteHalf, DoipSocketConfig},
 };
 
 /// This module contains the (currently) static TLS configuration for the CDA
@@ -106,13 +104,6 @@ mod tlsconfig {
         MBEDTLS_TLS1_3_SIG_RSA_PKCS1_SHA1 as u16,
         MBEDTLS_TLS1_3_SIG_ED25519 as u16,
     ];
-}
-
-#[derive(Clone)]
-pub(crate) struct ConnectionConfig {
-    pub source_ip: String,
-    pub port: u16,
-    pub tls_port: u16,
 }
 
 pub(crate) trait ECUConnectionRead {
@@ -186,9 +177,7 @@ pub(crate) struct EcuConnectionTarget<
 > {
     pub(crate) ecu_connection_rx: Mutex<Option<EcuConnectionReadVariant<T>>>,
     pub(crate) ecu_connection_tx: Mutex<Option<EcuConnectionSendVariant<T>>>,
-    pub(crate) gateway_name: String,
-    pub(crate) gateway_ip: String,
-    pub(crate) tester_address: [u8; 2],
+    pub(crate) gateway_doip_config: GatewayDoipConfig,
 }
 
 pub struct EcuConnectionSendGuard<'a, T: AsyncWrite + Unpin = TcpStream> {
@@ -305,38 +294,32 @@ async fn connect_to_gateway(
 }
 
 #[tracing::instrument(
-    skip(routing_activation_request, connection_config),
+    skip_all,
     fields(
-        source_ip = connection_config.source_ip.clone(),
-        port = connection_config.port,
-        gateway_ip,
-        gateway_name,
-        connect_timeout_ms = connect_timeout.as_millis(),
-        routing_timeout_ms = routing_activation_timeout.as_millis(),
+        tester_ip = config.doip.transport.tester_ip.clone(),
+        port = config.doip.transport.port,
+        gateway_ip = config.doip.gateway_ip.clone(),
+        gateway_name = config.doip.name.clone(),
+        connect_timeout_ms = config.ecu_timeouts.connection.as_millis(),
+        routing_timeout_ms = config.ecu_timeouts.routing_activation.as_millis(),
         dlt_context = dlt_ctx!("DOIP"),
     )
 )]
 pub(crate) async fn establish_ecu_connection(
-    connection_config: &ConnectionConfig,
-    gateway_ip: &str,
-    gateway_name: &str,
-    doip_connection_config: DoIPConfig,
-    routing_activation_request: RoutingActivationRequest,
-    connect_timeout: Duration,
-    routing_activation_timeout: Duration,
+    config: &GatewayConnectionConfig,
 ) -> Result<EcuConnectionTarget, ConnectionError> {
     let mut gateway_conn = match tokio::time::timeout(
-        connect_timeout,
+        config.ecu_timeouts.connection,
         connect_to_gateway(
-            &connection_config.source_ip,
-            gateway_ip,
-            connection_config.port,
+            &config.doip.transport.tester_ip,
+            &config.doip.gateway_ip,
+            config.doip.transport.port,
         ),
     )
     .await
     {
         Ok(Ok(stream)) => {
-            EcuConnectionVariant::Plain(DoIPConnection::new(stream, doip_connection_config))
+            EcuConnectionVariant::Plain(DoIPConnection::new(stream, config.doip.transport.socket))
         }
         Ok(Err(e)) => return Err(e),
         Err(_) => {
@@ -348,7 +331,7 @@ pub(crate) async fn establish_ecu_connection(
 
     if let Err(e) = gateway_conn
         .send(DoipPayload::RoutingActivationRequest(
-            routing_activation_request,
+            config.routing_activation_request,
         ))
         .await
     {
@@ -358,10 +341,10 @@ pub(crate) async fn establish_ecu_connection(
     }
 
     match try_read_routing_activation_response(
-        routing_activation_timeout,
+        config.ecu_timeouts.routing_activation,
         &mut gateway_conn,
-        gateway_name,
-        gateway_ip,
+        &config.doip.name,
+        &config.doip.gateway_ip,
     )
     .await
     {
@@ -374,29 +357,20 @@ pub(crate) async fn establish_ecu_connection(
                     Ok(EcuConnectionTarget {
                         ecu_connection_tx: Mutex::new(Some(write)),
                         ecu_connection_rx: Mutex::new(Some(read)),
-                        gateway_name: gateway_name.to_owned(),
-                        gateway_ip: gateway_ip.to_owned(),
-                        tester_address: routing_activation_request.source_address,
+                        gateway_doip_config: config.doip.clone(),
                     })
                 }
                 ActivationCode::DeniedRequestEncryptedTLSConnection => {
                     tracing::info!("TLS connection requested");
-                    let tls_gateway_name = if gateway_name.ends_with("[TLS]") {
-                        gateway_name.to_owned()
+                    let tls_gateway_name = if config.doip.name.ends_with("[TLS]") {
+                        config.doip.name.clone()
                     } else {
-                        format!("{gateway_name} [TLS]")
+                        format!("{} [TLS]", config.doip.name)
                     };
 
-                    establish_tls_ecu_connection(
-                        connection_config,
-                        gateway_ip,
-                        &tls_gateway_name,
-                        doip_connection_config,
-                        routing_activation_request,
-                        connect_timeout,
-                        routing_activation_timeout,
-                    )
-                    .await
+                    let mut tls_config = config.clone();
+                    tls_config.doip.name = tls_gateway_name;
+                    establish_tls_ecu_connection(&tls_config).await
                 }
                 _ => Err(ConnectionError::RoutingError(format!(
                     "Failed to activate routing: {:?}",
@@ -411,37 +385,31 @@ pub(crate) async fn establish_ecu_connection(
 }
 
 #[tracing::instrument(
-    skip(routing_activation_request, connection_config),
+    skip_all,
     fields(
-        source_ip = connection_config.source_ip.clone(),
-        port = connection_config.tls_port,
-        gateway_ip,
-        gateway_name,
-        connect_timeout_ms = connnect_timeout.as_millis(),
-        routing_timeout_ms = routing_activation_timeout.as_millis(),
+        tester_ip = config.doip.transport.tester_ip.clone(),
+        port = config.doip.transport.tls_port,
+        gateway_ip = config.doip.gateway_ip.clone(),
+        gateway_name = config.doip.name.clone(),
+        connect_timeout_ms = config.ecu_timeouts.connection.as_millis(),
+        routing_timeout_ms = config.ecu_timeouts.routing_activation.as_millis(),
         dlt_context = dlt_ctx!("DOIP"),
     )
 )]
 pub(crate) async fn establish_tls_ecu_connection(
-    connection_config: &ConnectionConfig,
-    gateway_ip: &str,
-    gateway_name: &str,
-    doip_connection_config: DoIPConfig,
-    routing_activation_request: RoutingActivationRequest,
-    connnect_timeout: Duration,
-    routing_activation_timeout: Duration,
+    config: &GatewayConnectionConfig,
 ) -> Result<EcuConnectionTarget, ConnectionError> {
     let mut gateway_conn = match tokio::time::timeout(
-        connnect_timeout,
+        config.ecu_timeouts.connection,
         connect_to_gateway(
-            &connection_config.source_ip,
-            gateway_ip,
-            connection_config.tls_port,
+            &config.doip.transport.tester_ip,
+            &config.doip.gateway_ip,
+            config.doip.transport.tls_port,
         ),
     )
     .await
     {
-        Ok(Ok(stream)) => create_tls_stream(stream, doip_connection_config).await?,
+        Ok(Ok(stream)) => create_tls_stream(stream, config.doip.transport.socket).await?,
         Ok(Err(e)) => {
             return Err(ConnectionError::ConnectionFailed(format!(
                 "Connect failed: {e:?}"
@@ -456,7 +424,7 @@ pub(crate) async fn establish_tls_ecu_connection(
 
     if let Err(e) = gateway_conn
         .send(DoipPayload::RoutingActivationRequest(
-            routing_activation_request,
+            config.routing_activation_request,
         ))
         .await
     {
@@ -466,10 +434,10 @@ pub(crate) async fn establish_tls_ecu_connection(
     }
 
     match try_read_routing_activation_response(
-        routing_activation_timeout,
+        config.ecu_timeouts.routing_activation,
         &mut gateway_conn,
-        gateway_name,
-        gateway_ip,
+        &config.doip.name,
+        &config.doip.gateway_ip,
     )
     .await
     {
@@ -485,9 +453,7 @@ pub(crate) async fn establish_tls_ecu_connection(
             Ok(EcuConnectionTarget {
                 ecu_connection_tx: Mutex::new(Some(write)),
                 ecu_connection_rx: Mutex::new(Some(read)),
-                gateway_name: gateway_name.to_owned(),
-                gateway_ip: gateway_ip.to_owned(),
-                tester_address: routing_activation_request.source_address,
+                gateway_doip_config: config.doip.clone(),
             }) // Routing activated
         }
         Err(e) => Err(ConnectionError::RoutingError(format!(
@@ -499,7 +465,7 @@ pub(crate) async fn establish_tls_ecu_connection(
 #[cfg(all(feature = "mbedtls", not(feature = "openssl")))]
 async fn create_tls_stream(
     stream: tokio::net::TcpStream,
-    doip_connection_config: DoIPConfig,
+    socket_config: DoipSocketConfig,
 ) -> Result<EcuConnectionVariant, ConnectionError> {
     let config = SslConfigBuilder::new_client()
         .map_err(|e| {
@@ -520,14 +486,14 @@ async fn create_tls_stream(
         })?;
     Ok(EcuConnectionVariant::Tls(DoIPConnection::new(
         ssl,
-        doip_connection_config,
+        socket_config,
     )))
 }
 
 #[cfg(feature = "openssl")]
 async fn create_tls_stream(
     stream: tokio::net::TcpStream,
-    doip_connection_config: DoIPConfig,
+    socket_config: DoipSocketConfig,
 ) -> Result<EcuConnectionVariant, ConnectionError> {
     // allow unsafe ciphers
     let mut builder = SslContextBuilder::new(SslMethod::tls_client()).map_err(|e| {
@@ -581,7 +547,7 @@ async fn create_tls_stream(
 
     Ok(EcuConnectionVariant::Tls(DoIPConnection::new(
         stream,
-        doip_connection_config,
+        socket_config,
     )))
 }
 
@@ -589,7 +555,7 @@ async fn create_tls_stream(
 #[cfg(all(not(feature = "openssl"), not(feature = "mbedtls")))]
 async fn create_tls_stream(
     _stream: tokio::net::TcpStream,
-    _doip_connection_config: DoIPConfig,
+    _socket_config: DoipSocketConfig,
 ) -> Result<EcuConnectionVariant, ConnectionError> {
     Err(ConnectionError::ConnectionFailed(
         "CDA built without TLS support.".to_owned(),

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -31,7 +31,10 @@ use doip_definitions::{
 };
 use futures::FutureExt;
 use thiserror::Error;
-use tokio::sync::{Mutex, RwLock, broadcast, mpsc};
+use tokio::{
+    sync::{Mutex, RwLock, broadcast, mpsc},
+    task::{JoinError, JoinSet},
+};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -78,6 +81,7 @@ pub(crate) struct DoipGatewayState<T: EcuAddresses + DoipComParams> {
     pub(crate) logical_address_to_connection: Arc<RwLock<HashMap<u16, usize>>>,
     pub(crate) ecus: Arc<HashMap<String, RwLock<T>>>,
     pub(crate) socket: Arc<Mutex<DoIPUdpSocket>>,
+    pub(crate) connection_tasks: Arc<Mutex<JoinSet<Result<(), JoinError>>>>,
 }
 
 impl<T: EcuAddresses + DoipComParams> Clone for DoipGatewayState<T> {
@@ -87,6 +91,7 @@ impl<T: EcuAddresses + DoipComParams> Clone for DoipGatewayState<T> {
             logical_address_to_connection: Arc::clone(&self.logical_address_to_connection),
             ecus: Arc::clone(&self.ecus),
             socket: Arc::clone(&self.socket),
+            connection_tasks: Arc::clone(&self.connection_tasks),
         }
     }
 }
@@ -94,7 +99,7 @@ impl<T: EcuAddresses + DoipComParams> Clone for DoipGatewayState<T> {
 pub struct DoipDiagGateway<T: EcuAddresses + DoipComParams> {
     state: DoipGatewayState<T>,
     cancel_token: CancellationToken,
-    vam_listener_handle: Arc<tokio::task::JoinHandle<()>>,
+    vam_listener_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
 }
 
 /// A gateway discovered on the network during `DoIP` vehicle discovery.
@@ -179,7 +184,6 @@ struct DoipEcu {
 struct DoipConnection {
     ecus: HashMap<u16, Arc<Mutex<DoipEcu>>>,
     ip: String,
-    task_handles: Vec<tokio::task::JoinHandle<()>>,
 }
 
 #[derive(Error, Debug, Clone)]
@@ -302,12 +306,15 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
 
         let cancel_token = CancellationToken::new();
 
+        let connection_tasks = Arc::new(Mutex::new(JoinSet::new()));
+
         let state = if gateways.is_empty() {
             DoipGatewayState {
                 doip_connections: Arc::new(RwLock::new(Vec::new())),
                 logical_address_to_connection: Arc::new(RwLock::new(HashMap::new())),
                 ecus,
                 socket: Arc::clone(&doip_socket),
+                connection_tasks,
             }
         } else {
             tracing::info!(gateway_count = gateways.len(), "Gateways found");
@@ -343,6 +350,7 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
                         doip_connections: Arc::clone(&doip_connections),
                         ecus: Arc::clone(&ecus),
                         gateway_ecu_map: gateway_ecu_map.clone(),
+                        connection_tasks: Arc::clone(&connection_tasks),
                     },
                     Some((variant_detection.clone(), ecu_names_for_gateway)),
                 )
@@ -360,6 +368,7 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
                 logical_address_to_connection: Arc::new(RwLock::new(logical_address_to_connection)),
                 ecus,
                 socket: Arc::clone(&doip_socket),
+                connection_tasks,
             }
         };
 
@@ -376,23 +385,27 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
         Ok(DoipDiagGateway {
             state,
             cancel_token,
-            vam_listener_handle: Arc::new(vam_listener_handle),
+            vam_listener_handle: Arc::new(Mutex::new(Some(vam_listener_handle))),
         })
     }
 
     pub async fn shutdown(&mut self) {
         self.cancel_token.cancel();
-        // Abort and await the VAM listener task so it stops reading from the
-        // shared UDP socket before a new gateway reuses it.
-        self.vam_listener_handle.abort();
+
+        if let Some(vam_listener_handle) = self.vam_listener_handle.lock().await.take() {
+            // Abort and await the VAM listener task so it stops reading from the
+            // shared UDP socket before a new gateway reuses it.
+            vam_listener_handle.abort();
+            let _ = vam_listener_handle.await;
+        }
+
         // Abort all background tasks (sender, receiver, connection-reset) for each
         // gateway connection. This immediately drops their TCP socket halves.
         let connections = self.state.doip_connections.write().await;
-        for conn in connections.iter() {
-            for handle in &conn.task_handles {
-                handle.abort();
-            }
-        }
+        let mut tasks = self.state.connection_tasks.lock().await;
+        tasks.abort_all();
+        while tasks.join_next().await.is_some() {}
+        drop(tasks);
         drop(connections);
         self.state.doip_connections.write().await.clear();
     }

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -232,11 +232,13 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
 
             // create mapping gateway_logical_address -> Vec<ecu_logical_address>
             let mut gateway_ecu_map: HashMap<u16, Vec<u16>> = HashMap::new();
+            let mut gateway_ecu_name_map: HashMap<u16, Vec<String>> = HashMap::new();
             for ecu_lock in ecus.values() {
                 let ecu = ecu_lock.read().await;
                 let addr = ecu.logical_address();
                 let gateway = ecu.logical_gateway_address();
                 gateway_ecu_map.entry(gateway).or_default().push(addr);
+                gateway_ecu_name_map.entry(gateway).or_default().push(ecu.ecu_name());
             }
 
             let doip_connections: Arc<RwLock<Vec<Arc<DoipConnection>>>> =
@@ -244,6 +246,10 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
             let mut logical_address_to_connection = HashMap::new();
 
             for gateway in gateways {
+                let ecu_names_for_gateway = gateway_ecu_name_map
+                    .get(&gateway.logical_address)
+                    .cloned()
+                    .unwrap_or_default();
                 if let Ok(logical_address) = connections::handle_gateway_connection::<T>(
                     gateway,
                     &GatewayConfig {
@@ -257,6 +263,7 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
                         ecus: Arc::clone(&ecus),
                         gateway_ecu_map: gateway_ecu_map.clone(),
                     },
+                    Some((variant_detection.clone(), ecu_names_for_gateway)),
                 )
                 .await
                 {

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -24,7 +24,10 @@ use cda_interfaces::{
 };
 use doip_definitions::{
     header::ProtocolVersion,
-    payload::{DiagnosticMessage, DiagnosticMessageNack, DoipPayload, GenericNack},
+    payload::{
+        DiagnosticMessage, DiagnosticMessageNack, DoipPayload, GenericNack,
+        RoutingActivationRequest,
+    },
 };
 use futures::FutureExt;
 use thiserror::Error;
@@ -33,9 +36,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     config::DoipConfig,
-    connections::{EcuError, GatewayConfig, GatewayState},
-    ecu_connection::ConnectionConfig,
-    socket::{DoIPConfig, DoIPUdpSocket},
+    connections::{EcuError, GatewayState},
+    socket::{DoIPUdpSocket, DoipSocketConfig},
 };
 
 pub mod config;
@@ -78,17 +80,95 @@ pub(crate) struct DoipGatewayState<T: EcuAddresses + DoipComParams> {
     pub(crate) socket: Arc<Mutex<DoIPUdpSocket>>,
 }
 
+impl<T: EcuAddresses + DoipComParams> Clone for DoipGatewayState<T> {
+    fn clone(&self) -> Self {
+        Self {
+            doip_connections: Arc::clone(&self.doip_connections),
+            logical_address_to_connection: Arc::clone(&self.logical_address_to_connection),
+            ecus: Arc::clone(&self.ecus),
+            socket: Arc::clone(&self.socket),
+        }
+    }
+}
+
 pub struct DoipDiagGateway<T: EcuAddresses + DoipComParams> {
-    state: Arc<DoipGatewayState<T>>,
+    state: DoipGatewayState<T>,
     cancel_token: CancellationToken,
     vam_listener_handle: Arc<tokio::task::JoinHandle<()>>,
 }
 
+/// A gateway discovered on the network during `DoIP` vehicle discovery.
+///
+/// Contains the IP address, ECU name, and logical address obtained from a
+/// `VehicleIdentificationResponse` or `EntityStatusResponse` message.
 #[derive(Debug)]
-struct DoipTarget {
-    ip: String,
-    ecu: String,
-    logical_address: u16,
+pub(crate) struct DiscoveredGateway {
+    pub(crate) ip: String,
+    pub(crate) ecu_name: String,
+    pub(crate) logical_address: u16,
+}
+
+/// Transport-level settings shared across all `DoIP` gateway connections.
+/// Built once from `DoipConfig` in `DoipDiagGateway::new`; cloned into each
+/// `GatewayDoipConfig` when a specific gateway is discovered.
+#[derive(Clone)]
+pub(crate) struct DoipTransportConfig {
+    /// IP address of the diagnostic tester interface.
+    pub(crate) tester_ip: String,
+    /// TCP port for `DoIP` communication.
+    pub(crate) port: u16,
+    /// TCP port for `DoIP` over TLS communication.
+    pub(crate) tls_port: u16,
+    /// `DoIP` socket-level settings (protocol version, ack behavior).
+    pub(crate) socket: DoipSocketConfig,
+    /// Timeout for sending a single `DoIP` message.
+    pub(crate) send_timeout: Duration,
+    /// Interval between alive-check requests on idle connections (0 = disabled).
+    pub(crate) alive_check_interval: Duration,
+}
+
+/// Per-gateway configuration combining the discovered gateway identity with the
+/// shared transport settings.  Only constructed inside `handle_gateway_connection`
+/// once a real `ip` and `name` are known - never holds placeholder values.
+#[derive(Clone)]
+pub(crate) struct GatewayDoipConfig {
+    /// IP address of the gateway ECU.
+    pub(crate) gateway_ip: String,
+    /// Name of the gateway ECU.
+    pub(crate) name: String,
+    /// UDS address of the tester.
+    pub(crate) tester_address: [u8; 2],
+    /// Shared transport-level settings (tester IP, ports, socket config, timeouts).
+    pub(crate) transport: DoipTransportConfig,
+}
+
+/// ECU-lifecycle timeouts sourced from `EcuAddresses` / `DoipComParams` during gateway setup.
+#[derive(Clone, Copy)]
+pub(crate) struct EcuTimeouts {
+    pub(crate) routing_activation: Duration,
+    pub(crate) retry_delay: Duration,
+    pub(crate) connection: Duration,
+    pub(crate) max_retry_attempts: u32,
+}
+
+/// Parameters needed to (re-)establish a TCP connection to one `DoIP` gateway.
+/// Cloned into the reconnect task and passed to `ecu_connection` functions;
+/// does **not** carry one-time setup data such as the ECU list or variant-detection channel.
+#[derive(Clone)]
+pub(crate) struct GatewayConnectionConfig {
+    pub(crate) doip: GatewayDoipConfig,
+    pub(crate) routing_activation_request: RoutingActivationRequest,
+    pub(crate) ecu_timeouts: EcuTimeouts,
+}
+
+/// One-shot setup bundle consumed by `connection_handler` when bringing up a new gateway.
+/// Carries `GatewayConnectionConfig` plus the data that is only needed during initial
+/// channel creation (`ecus`) and reconnection signlling (`variant_detection`).
+#[derive(Clone)]
+pub(crate) struct GatewaySetup {
+    pub(crate) connection: GatewayConnectionConfig,
+    pub(crate) ecus: Vec<u16>,
+    pub(crate) variant_detection: Option<(mpsc::Sender<Vec<String>>, Vec<String>)>,
 }
 
 struct DoipEcu {
@@ -185,23 +265,21 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
             ..
         } = doip_config;
         let gateway_port = *gateway_port;
-        let connection_config = ConnectionConfig {
-            source_ip: tester_ip.to_owned(),
+        let transport_config = DoipTransportConfig {
+            tester_ip: tester_ip.to_owned(),
             port: gateway_port,
             tls_port: *tls_port,
-        };
-        let doip_connection_config = DoIPConfig {
-            protocol_version: ProtocolVersion::try_from(protocol_version).map_err(|err| {
-                DoipGatewaySetupError::InvalidConfiguration(format!(
-                    "Invalid DoIP protocol version: {err}"
-                ))
-            })?,
-            send_diagnostic_message_ack: *send_diagnostic_message_ack,
+            socket: DoipSocketConfig {
+                protocol_version: ProtocolVersion::try_from(protocol_version).map_err(|err| {
+                    DoipGatewaySetupError::InvalidConfiguration(format!(
+                        "Invalid DoIP protocol version: {err}"
+                    ))
+                })?,
+                send_diagnostic_message_ack: *send_diagnostic_message_ack,
+            },
             send_timeout: Duration::from_millis(*send_timeout_ms),
             alive_check_interval: Duration::from_secs(*alive_check_interval_secs),
         };
-        let send_timeout = Duration::from_millis(*send_timeout_ms);
-        let alive_check_interval = Duration::from_secs(*alive_check_interval_secs);
 
         tracing::info!("Initializing DoipDiagGateway");
 
@@ -225,12 +303,12 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
         let cancel_token = CancellationToken::new();
 
         let state = if gateways.is_empty() {
-            Arc::new(DoipGatewayState {
+            DoipGatewayState {
                 doip_connections: Arc::new(RwLock::new(Vec::new())),
                 logical_address_to_connection: Arc::new(RwLock::new(HashMap::new())),
                 ecus,
                 socket: Arc::clone(&doip_socket),
-            })
+            }
         } else {
             tracing::info!(gateway_count = gateways.len(), "Gateways found");
 
@@ -257,14 +335,10 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
                     .get(&gateway.logical_address)
                     .cloned()
                     .unwrap_or_default();
+
                 if let Ok(logical_address) = connections::handle_gateway_connection::<T>(
                     gateway,
-                    &GatewayConfig {
-                        connection: connection_config.clone(),
-                        doip: doip_connection_config,
-                        send_timeout,
-                        alive_check_interval,
-                    },
+                    &transport_config,
                     &GatewayState {
                         doip_connections: Arc::clone(&doip_connections),
                         ecus: Arc::clone(&ecus),
@@ -281,20 +355,18 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
                 }
             }
 
-            Arc::new(DoipGatewayState {
+            DoipGatewayState {
                 doip_connections,
                 logical_address_to_connection: Arc::new(RwLock::new(logical_address_to_connection)),
                 ecus,
                 socket: Arc::clone(&doip_socket),
-            })
+            }
         };
 
         let vam_listener_handle = vir_vam::listen_for_vams(
-            connection_config,
-            gateway_port,
-            doip_connection_config,
+            transport_config,
             mask,
-            Arc::clone(&state),
+            state.clone(),
             variant_detection,
             shared_shutdown_signal,
             cancel_token.child_token(),
@@ -955,7 +1027,7 @@ fn create_socket_with_protocol(
 impl<T: EcuAddresses + DoipComParams> Clone for DoipDiagGateway<T> {
     fn clone(&self) -> Self {
         Self {
-            state: Arc::clone(&self.state),
+            state: self.state.clone(),
             cancel_token: self.cancel_token.clone(),
             vam_listener_handle: Arc::clone(&self.vam_listener_handle),
         }

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -41,7 +41,7 @@ use crate::{
 pub mod config;
 mod connections;
 mod ecu_connection;
-mod socket;
+pub mod socket;
 mod vir_vam;
 
 /// Timeout when suppressPosRspMsgIndicationBit is set.
@@ -71,12 +71,17 @@ enum DiagnosticResponse {
     TemporarilyNotAvailable(u16),
 }
 
+pub(crate) struct DoipGatewayState<T: EcuAddresses + DoipComParams> {
+    pub(crate) doip_connections: Arc<RwLock<Vec<Arc<DoipConnection>>>>,
+    pub(crate) logical_address_to_connection: Arc<RwLock<HashMap<u16, usize>>>,
+    pub(crate) ecus: Arc<HashMap<String, RwLock<T>>>,
+    pub(crate) socket: Arc<Mutex<DoIPUdpSocket>>,
+}
+
 pub struct DoipDiagGateway<T: EcuAddresses + DoipComParams> {
-    doip_connections: Arc<RwLock<Vec<Arc<DoipConnection>>>>,
-    logical_address_to_connection: Arc<RwLock<HashMap<u16, usize>>>,
-    ecus: Arc<HashMap<String, RwLock<T>>>,
-    socket: Arc<Mutex<DoIPUdpSocket>>,
+    state: Arc<DoipGatewayState<T>>,
     cancel_token: CancellationToken,
+    vam_listener_handle: Arc<tokio::task::JoinHandle<()>>,
 }
 
 #[derive(Debug)]
@@ -94,6 +99,7 @@ struct DoipEcu {
 struct DoipConnection {
     ecus: HashMap<u16, Arc<Mutex<DoipEcu>>>,
     ip: String,
+    task_handles: Vec<tokio::task::JoinHandle<()>>,
 }
 
 #[derive(Error, Debug, Clone)]
@@ -149,7 +155,7 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
     /// # Errors
     /// Returns `String` if initialization fails, e.g. when socket creation fails.
     #[tracing::instrument(
-        skip(doip_config, ecus, variant_detection, shutdown_signal),
+        skip(doip_config, ecus, variant_detection, shutdown_signal, doip_socket),
         fields(
             tester_ip = doip_config.tester_address,
             gateway_port = doip_config.gateway_port,
@@ -162,6 +168,7 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
         ecus: Arc<HashMap<String, RwLock<T>>>,
         variant_detection: mpsc::Sender<Vec<String>>,
         shutdown_signal: F,
+        doip_socket: Arc<Mutex<DoIPUdpSocket>>,
     ) -> Result<Self, DoipGatewaySetupError>
     where
         F: Future<Output = ()> + Send + 'static,
@@ -190,23 +197,19 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
                 ))
             })?,
             send_diagnostic_message_ack: *send_diagnostic_message_ack,
+            send_timeout: Duration::from_millis(*send_timeout_ms),
+            alive_check_interval: Duration::from_secs(*alive_check_interval_secs),
         };
         let send_timeout = Duration::from_millis(*send_timeout_ms);
         let alive_check_interval = Duration::from_secs(*alive_check_interval_secs);
 
         tracing::info!("Initializing DoipDiagGateway");
 
-        let mut socket = create_socket(
-            tester_ip,
-            gateway_port,
-            doip_connection_config.protocol_version,
-        )?;
         let mask = create_netmask(tester_ip, tester_subnet)?;
 
         let shared_shutdown_signal = shutdown_signal.shared();
-
         let gateways = vir_vam::get_vehicle_identification::<T, F>(
-            &mut socket,
+            &mut *doip_socket.lock().await,
             mask,
             gateway_port,
             &ecus,
@@ -219,14 +222,15 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
             ))
         })?;
 
-        let gateway = if gateways.is_empty() {
-            DoipDiagGateway {
+        let cancel_token = CancellationToken::new();
+
+        let state = if gateways.is_empty() {
+            Arc::new(DoipGatewayState {
                 doip_connections: Arc::new(RwLock::new(Vec::new())),
                 logical_address_to_connection: Arc::new(RwLock::new(HashMap::new())),
                 ecus,
-                socket: Arc::new(Mutex::new(socket)),
-                cancel_token: CancellationToken::new(),
-            }
+                socket: Arc::clone(&doip_socket),
+            })
         } else {
             tracing::info!(gateway_count = gateways.len(), "Gateways found");
 
@@ -238,7 +242,10 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
                 let addr = ecu.logical_address();
                 let gateway = ecu.logical_gateway_address();
                 gateway_ecu_map.entry(gateway).or_default().push(addr);
-                gateway_ecu_name_map.entry(gateway).or_default().push(ecu.ecu_name());
+                gateway_ecu_name_map
+                    .entry(gateway)
+                    .or_default()
+                    .push(ecu.ecu_name().to_lowercase());
             }
 
             let doip_connections: Arc<RwLock<Vec<Arc<DoipConnection>>>> =
@@ -274,34 +281,55 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
                 }
             }
 
-            DoipDiagGateway {
+            Arc::new(DoipGatewayState {
                 doip_connections,
                 logical_address_to_connection: Arc::new(RwLock::new(logical_address_to_connection)),
                 ecus,
-                socket: Arc::new(Mutex::new(socket)),
-                cancel_token: CancellationToken::new(),
-            }
+                socket: Arc::clone(&doip_socket),
+            })
         };
 
-        vir_vam::listen_for_vams(
+        let vam_listener_handle = vir_vam::listen_for_vams(
             connection_config,
             gateway_port,
             doip_connection_config,
             mask,
-            gateway.clone(),
+            Arc::clone(&state),
             variant_detection,
-            send_timeout,
-            alive_check_interval,
             shared_shutdown_signal,
-            gateway.cancel_token.child_token(),
+            cancel_token.child_token(),
         )
         .await;
 
-        Ok(gateway)
+        Ok(DoipDiagGateway {
+            state,
+            cancel_token,
+            vam_listener_handle: Arc::new(vam_listener_handle),
+        })
     }
 
-    pub fn shutdown(&self) {
+    pub async fn shutdown(&mut self) {
         self.cancel_token.cancel();
+        // Abort and await the VAM listener task so it stops reading from the
+        // shared UDP socket before a new gateway reuses it.
+        self.vam_listener_handle.abort();
+        // Abort all background tasks (sender, receiver, connection-reset) for each
+        // gateway connection. This immediately drops their TCP socket halves.
+        let connections = self.state.doip_connections.write().await;
+        for conn in connections.iter() {
+            for handle in &conn.task_handles {
+                handle.abort();
+            }
+        }
+        drop(connections);
+        self.state.doip_connections.write().await.clear();
+    }
+
+    /// Returns a clone of the UDP socket Arc for reuse in a new gateway instance.
+    /// This avoids binding a second socket on the same port during reloads.
+    #[must_use]
+    pub fn udp_socket(&self) -> Arc<Mutex<DoIPUdpSocket>> {
+        Arc::clone(&self.state.socket)
     }
 
     async fn get_doip_connection(
@@ -309,13 +337,14 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
         logical_address: u16,
     ) -> Result<Arc<DoipConnection>, DiagServiceError> {
         let conn_idx = *self
+            .state
             .logical_address_to_connection
             .read()
             .await
             .get(&logical_address)
             .ok_or_else(|| DiagServiceError::EcuOffline(format!("[{logical_address}]")))?;
 
-        let lock = self.doip_connections.read().await;
+        let lock = self.state.doip_connections.read().await;
         let conn = lock
             .get(conn_idx)
             .ok_or(DiagServiceError::ConnectionClosed(format!(
@@ -341,7 +370,10 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
         // in that case, lookup the ecu name and check if the functional address
         // matches the given address.
         // this will be the case for tester present.
-        if let Some(ecu) = self.ecus.get(&transmission_params.ecu_name.to_lowercase())
+        if let Some(ecu) = self
+            .state
+            .ecus
+            .get(&transmission_params.ecu_name.to_lowercase())
             && ecu.read().await.logical_functional_address() == message.target_address
             && let Some(gateway_ecu) = doip_conn.ecus.get(&transmission_params.gateway_address)
         {
@@ -356,7 +388,8 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
 
 impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
     async fn get_gateway_network_address(&self, logical_address: u16) -> Option<String> {
-        self.doip_connections
+        self.state
+            .doip_connections
             .read()
             .await
             .iter()
@@ -839,7 +872,24 @@ fn create_netmask(tester_ip: &str, tester_subnet: &str) -> Result<u32, DoipGatew
     Ok(ip.to_bits() & subnet.to_bits())
 }
 
-fn create_socket(
+/// Creates a UDP socket for `DoIP` communication.
+///
+/// # Errors
+///
+/// Returns [`DoipGatewaySetupError::InvalidConfiguration`] if `protocol_version` does not map
+/// to a valid [`ProtocolVersion`], or any error propagated from the underlying socket setup.
+pub fn create_socket(
+    tester_ip: &str,
+    gateway_port: u16,
+    protocol_version: u8,
+) -> Result<DoIPUdpSocket, DoipGatewaySetupError> {
+    let protocol_version = ProtocolVersion::try_from(&protocol_version).map_err(|err| {
+        DoipGatewaySetupError::InvalidConfiguration(format!("Invalid DoIP protocol version: {err}"))
+    })?;
+    create_socket_with_protocol(tester_ip, gateway_port, protocol_version)
+}
+
+fn create_socket_with_protocol(
     tester_ip: &str,
     gateway_port: u16,
     protocol_version: ProtocolVersion,
@@ -905,11 +955,9 @@ fn create_socket(
 impl<T: EcuAddresses + DoipComParams> Clone for DoipDiagGateway<T> {
     fn clone(&self) -> Self {
         Self {
-            doip_connections: Arc::clone(&self.doip_connections),
-            logical_address_to_connection: Arc::clone(&self.logical_address_to_connection),
-            ecus: Arc::clone(&self.ecus),
-            socket: Arc::clone(&self.socket),
+            state: Arc::clone(&self.state),
             cancel_token: self.cancel_token.clone(),
+            vam_listener_handle: Arc::clone(&self.vam_listener_handle),
         }
     }
 }

--- a/cda-comm-doip/src/socket.rs
+++ b/cda-comm-doip/src/socket.rs
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::net::SocketAddr;
+use std::{net::SocketAddr, time::Duration};
 
 use doip_codec::DoipCodec;
 use doip_definitions::{
@@ -34,6 +34,7 @@ use crate::ConnectionError;
 pub(crate) struct DoIPConfig {
     pub protocol_version: ProtocolVersion,
     pub send_diagnostic_message_ack: bool,
+    pub send_timeout: Duration,
 }
 
 pub(crate) struct DoIPConnection<T: AsyncRead + AsyncWrite + Unpin> {
@@ -113,13 +114,13 @@ impl<T: AsyncRead + Unpin> DoIPConnectionReadHalf<T> {
     }
 }
 
-pub(crate) struct DoIPUdpSocket {
+pub struct DoIPUdpSocket {
     io: UdpFramed<DoipCodec, tokio::net::UdpSocket>,
     protocol_version: ProtocolVersion,
 }
 
 impl DoIPUdpSocket {
-    pub fn new(
+    pub(crate) fn new(
         socket: std::net::UdpSocket,
         protocol_version: ProtocolVersion,
     ) -> Result<Self, std::io::Error> {
@@ -130,7 +131,7 @@ impl DoIPUdpSocket {
         })
     }
 
-    pub async fn send(
+    pub(crate) async fn send(
         &mut self,
         payload: DoipPayload,
         addr: SocketAddr,
@@ -145,7 +146,9 @@ impl DoIPUdpSocket {
             .map_err(|e| ConnectionError::SendFailed(format!("Failed to send message: {e:?}")))
     }
 
-    pub async fn recv(&mut self) -> Option<Result<(DoipMessage, SocketAddr), ConnectionError>> {
+    pub(crate) async fn recv(
+        &mut self,
+    ) -> Option<Result<(DoipMessage, SocketAddr), ConnectionError>> {
         self.io.next().await.map(|opt| {
             opt.map_err(|e| {
                 // In case of error (remaining bytes, corrupted DoIP message, etc...),

--- a/cda-comm-doip/src/socket.rs
+++ b/cda-comm-doip/src/socket.rs
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::{net::SocketAddr, time::Duration};
+use std::net::SocketAddr;
 
 use doip_codec::DoipCodec;
 use doip_definitions::{
@@ -31,19 +31,18 @@ use tokio_util::{
 use crate::ConnectionError;
 
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct DoIPConfig {
+pub(crate) struct DoipSocketConfig {
     pub protocol_version: ProtocolVersion,
     pub send_diagnostic_message_ack: bool,
-    pub send_timeout: Duration,
 }
 
 pub(crate) struct DoIPConnection<T: AsyncRead + AsyncWrite + Unpin> {
     io: Framed<T, DoipCodec>,
-    config: DoIPConfig,
+    config: DoipSocketConfig,
 }
 
 impl<T: AsyncRead + AsyncWrite + Unpin> DoIPConnection<T> {
-    pub fn new(io: T, config: DoIPConfig) -> Self {
+    pub fn new(io: T, config: DoipSocketConfig) -> Self {
         Self {
             io: Framed::new(io, DoipCodec {}),
             config,

--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -181,6 +181,7 @@ where
                             doip_connections: Arc::clone(&state.doip_connections),
                             ecus: Arc::clone(&state.ecus),
                             gateway_ecu_map: gateway_ecu_map.clone(),
+                            connection_tasks: Arc::clone(&state.connection_tasks),
                         },
                         Some((variant_detection.clone(), ecu_names_for_gateway)),
                     )

--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -24,10 +24,9 @@ use tokio::sync::{Mutex, RwLock, mpsc};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    DoipGatewayState, DoipTarget,
-    connections::{GatewayConfig, GatewayState, handle_gateway_connection},
-    ecu_connection::ConnectionConfig,
-    socket::{DoIPConfig, DoIPUdpSocket},
+    DiscoveredGateway, DoipGatewayState, DoipTransportConfig,
+    connections::{GatewayState, handle_gateway_connection},
+    socket::DoIPUdpSocket,
 };
 pub(crate) async fn get_vehicle_identification<T, F>(
     socket: &mut DoIPUdpSocket,
@@ -35,7 +34,7 @@ pub(crate) async fn get_vehicle_identification<T, F>(
     gateway_port: u16,
     ecus: &Arc<HashMap<String, RwLock<T>>>,
     mut shutdown_signal: futures::future::Shared<F>,
-) -> Result<Vec<DoipTarget>, DiagServiceError>
+) -> Result<Vec<DiscoveredGateway>, DiagServiceError>
 where
     T: EcuAddresses,
     F: Future<Output = ()> + Send + 'static,
@@ -102,14 +101,10 @@ where
 
 // allowed due to nested functions
 #[allow(clippy::too_many_lines)]
-// allowed as it does not improve readability here to put args in a struct
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn listen_for_vams<T, F>(
-    connection_config: ConnectionConfig,
-    gateway_port: u16,
-    doip_connection_config: DoIPConfig,
+    transport_config: DoipTransportConfig,
     netmask: u32,
-    state: Arc<DoipGatewayState<T>>,
+    state: DoipGatewayState<T>,
     variant_detection: mpsc::Sender<Vec<String>>,
     mut shutdown_signal: futures::future::Shared<F>,
     cancel_token: CancellationToken,
@@ -123,7 +118,6 @@ where
         doip_msg: doip_definitions::message::DoipMessage,
         source_addr: std::net::SocketAddr,
         netmask: u32,
-        doip_connection_config: DoIPConfig,
     }
 
     #[tracing::instrument(
@@ -132,17 +126,15 @@ where
             gateway_ecu_map,
             gateway_ecu_name_map,
             variant_detection,
-            connection_config
+            transport_config
         ),
         fields(
             dlt_context = dlt_ctx!("DOIP")
         )
     )]
     async fn handle_doip_response<T: EcuAddresses + DoipComParams>(
-        connection_config: &ConnectionConfig,
+        transport_config: &DoipTransportConfig,
         state: &DoipGatewayState<T>,
-        send_timeout: Duration,
-        alive_check_interval: Duration,
         doip_msg_ctx: DoipMessageContext,
         gateway_ecu_map: &HashMap<u16, Vec<u16>>,
         gateway_ecu_name_map: &HashMap<u16, Vec<String>>,
@@ -152,12 +144,11 @@ where
             doip_msg,
             source_addr,
             netmask,
-            doip_connection_config,
         } = doip_msg_ctx;
         match handle_vam::<T>(&state.ecus, doip_msg, source_addr, netmask).await {
             Ok(Some(doip_target)) => {
                 tracing::debug!(
-                    ecu_name = %doip_target.ecu,
+                    ecu_name = %doip_target.ecu_name,
                     logical_address = %format!("{:#06x}", doip_target.logical_address),
                     "VAM received"
                 );
@@ -177,7 +168,7 @@ where
                     )
                     .await;
                 } else {
-                    tracing::info!(ecu_name = %doip_target.ecu, "New Gateway ECU detected");
+                    tracing::info!(ecu_name = %doip_target.ecu_name, "New Gateway ECU detected");
 
                     let ecu_names_for_gateway = gateway_ecu_name_map
                         .get(&doip_target.logical_address)
@@ -185,12 +176,7 @@ where
                         .unwrap_or_default();
                     match handle_gateway_connection::<T>(
                         doip_target,
-                        &GatewayConfig {
-                            connection: connection_config.clone(),
-                            doip: doip_connection_config,
-                            send_timeout,
-                            alive_check_interval,
-                        },
+                        transport_config,
                         &GatewayState {
                             doip_connections: Arc::clone(&state.doip_connections),
                             ecus: Arc::clone(&state.ecus),
@@ -271,20 +257,20 @@ where
         "vam-listen",
         Box::pin(async move {
             let broadcast_ip = "0.0.0.0";
-            let broadcast_socket = if connection_config.source_ip == broadcast_ip {
+            let broadcast_socket = if transport_config.tester_ip == broadcast_ip {
                 Arc::clone(&state.socket)
             } else {
                 match crate::create_socket_with_protocol(
                     broadcast_ip,
-                    gateway_port,
-                    doip_connection_config.protocol_version,
+                    transport_config.port,
+                    transport_config.socket.protocol_version,
                 ) {
                     Ok(sock) => Arc::new(Mutex::new(sock)),
                     Err(e) => {
                         tracing::warn!(
                             broadcast_ip = %broadcast_ip,
-                            tester_ip = %connection_config.source_ip,
-                            gateway_port = %gateway_port,
+                            tester_ip = %transport_config.tester_ip,
+                            gateway_port = %transport_config.port,
                             error = ?e,
                             "Failed to bind broadcast socket, falling back to tester IP,\
                              this can lead to missed VAMs"
@@ -309,15 +295,12 @@ where
                     Some(Ok((doip_msg, source_addr))) = socket.recv() => {
                         if let DoipPayload::VehicleAnnouncementMessage(_) = &doip_msg.payload {
                             handle_doip_response(
-                                &connection_config,
+                                &transport_config,
                                 &state,
-                                doip_connection_config.send_timeout,
-                                doip_connection_config.alive_check_interval,
                                 DoipMessageContext {
                                     doip_msg,
                                     source_addr,
                                     netmask,
-                                    doip_connection_config
                                 },
                                 &gateway_ecu_map,
                                 &gateway_ecu_name_map,
@@ -339,7 +322,7 @@ async fn handle_vam<T>(
     doip_msg: doip_definitions::message::DoipMessage,
     source_addr: std::net::SocketAddr,
     netmask: u32,
-) -> Result<Option<DoipTarget>, String>
+) -> Result<Option<DiscoveredGateway>, String>
 where
     T: EcuAddresses,
 {
@@ -377,9 +360,9 @@ where
                     logical_address = %format!("{:#06x}", logical_address),
                     "Matching ECU found"
                 );
-                Ok(Some(DoipTarget {
+                Ok(Some(DiscoveredGateway {
                     ip: source_addr.ip().to_string(),
-                    ecu: ecu.clone(),
+                    ecu_name: ecu.clone(),
                     logical_address,
                 }))
             } else {

--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -180,6 +180,10 @@ pub(crate) async fn listen_for_vams<T, F>(
                 } else {
                     tracing::info!(ecu_name = %doip_target.ecu, "New Gateway ECU detected");
 
+                    let ecu_names_for_gateway = gateway_ecu_name_map
+                        .get(&doip_target.logical_address)
+                        .cloned()
+                        .unwrap_or_default();
                     match handle_gateway_connection::<T>(
                         doip_target,
                         &GatewayConfig {
@@ -193,6 +197,7 @@ pub(crate) async fn listen_for_vams<T, F>(
                             ecus: Arc::clone(&gateway.ecus),
                             gateway_ecu_map: gateway_ecu_map.clone(),
                         },
+                        Some((variant_detection.clone(), ecu_names_for_gateway)),
                     )
                     .await
                     {

--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -24,7 +24,7 @@ use tokio::sync::{Mutex, RwLock, mpsc};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    DoipDiagGateway, DoipTarget,
+    DoipGatewayState, DoipTarget,
     connections::{GatewayConfig, GatewayState, handle_gateway_connection},
     ecu_connection::ConnectionConfig,
     socket::{DoIPConfig, DoIPUdpSocket},
@@ -109,13 +109,12 @@ pub(crate) async fn listen_for_vams<T, F>(
     gateway_port: u16,
     doip_connection_config: DoIPConfig,
     netmask: u32,
-    gateway: DoipDiagGateway<T>,
+    state: Arc<DoipGatewayState<T>>,
     variant_detection: mpsc::Sender<Vec<String>>,
-    send_timeout: Duration,
-    alive_check_interval: Duration,
     mut shutdown_signal: futures::future::Shared<F>,
     cancel_token: CancellationToken,
-) where
+) -> tokio::task::JoinHandle<()>
+where
     T: EcuAddresses + DoipComParams,
     F: Future<Output = ()> + Send + 'static,
 {
@@ -129,7 +128,7 @@ pub(crate) async fn listen_for_vams<T, F>(
 
     #[tracing::instrument(
         skip(
-            gateway,
+            state,
             gateway_ecu_map,
             gateway_ecu_name_map,
             variant_detection,
@@ -141,7 +140,7 @@ pub(crate) async fn listen_for_vams<T, F>(
     )]
     async fn handle_doip_response<T: EcuAddresses + DoipComParams>(
         connection_config: &ConnectionConfig,
-        gateway: &DoipDiagGateway<T>,
+        state: &DoipGatewayState<T>,
         send_timeout: Duration,
         alive_check_interval: Duration,
         doip_msg_ctx: DoipMessageContext,
@@ -155,14 +154,14 @@ pub(crate) async fn listen_for_vams<T, F>(
             netmask,
             doip_connection_config,
         } = doip_msg_ctx;
-        match handle_vam::<T>(&gateway.ecus, doip_msg, source_addr, netmask).await {
+        match handle_vam::<T>(&state.ecus, doip_msg, source_addr, netmask).await {
             Ok(Some(doip_target)) => {
                 tracing::debug!(
                     ecu_name = %doip_target.ecu,
                     logical_address = %format!("{:#06x}", doip_target.logical_address),
                     "VAM received"
                 );
-                if gateway
+                if state
                     .logical_address_to_connection
                     .read()
                     .await
@@ -193,8 +192,8 @@ pub(crate) async fn listen_for_vams<T, F>(
                             alive_check_interval,
                         },
                         &GatewayState {
-                            doip_connections: Arc::clone(&gateway.doip_connections),
-                            ecus: Arc::clone(&gateway.ecus),
+                            doip_connections: Arc::clone(&state.doip_connections),
+                            ecus: Arc::clone(&state.ecus),
                             gateway_ecu_map: gateway_ecu_map.clone(),
                         },
                         Some((variant_detection.clone(), ecu_names_for_gateway)),
@@ -202,14 +201,9 @@ pub(crate) async fn listen_for_vams<T, F>(
                     .await
                     {
                         Ok(logical_address) => {
-                            gateway.logical_address_to_connection.write().await.insert(
+                            state.logical_address_to_connection.write().await.insert(
                                 logical_address,
-                                gateway
-                                    .doip_connections
-                                    .read()
-                                    .await
-                                    .len()
-                                    .saturating_sub(1),
+                                state.doip_connections.read().await.len().saturating_sub(1),
                             );
                             send_variant_detection(
                                 gateway_ecu_name_map,
@@ -242,7 +236,7 @@ pub(crate) async fn listen_for_vams<T, F>(
     ) {
         if let Some(ecus) = gateway_ecu_name_map.get(&logical_address) {
             if let Err(e) = variant_detection.send(ecus.clone()).await {
-                tracing::error!(
+                tracing::warn!(
                     error = ?e,
                     "Failed to send variant detection request"
                 );
@@ -258,15 +252,15 @@ pub(crate) async fn listen_for_vams<T, F>(
     // create mapping gateway_logical_address -> Vec<ecu_logical_address>
     let mut gateway_ecu_map: HashMap<u16, Vec<u16>> = HashMap::new();
     let mut gateway_ecu_name_map: HashMap<u16, Vec<String>> = HashMap::new();
-    for ecu_lock in gateway.ecus.values() {
+    for ecu_lock in state.ecus.values() {
         let ecu = ecu_lock.read().await;
         let ecu_name = ecu.ecu_name();
 
         let addr = ecu.logical_address();
-        let gateway = ecu.logical_gateway_address();
-        gateway_ecu_map.entry(gateway).or_default().push(addr);
+        let gateway_addr = ecu.logical_gateway_address();
+        gateway_ecu_map.entry(gateway_addr).or_default().push(addr);
         gateway_ecu_name_map
-            .entry(gateway)
+            .entry(gateway_addr)
             .or_default()
             .push(ecu_name.to_lowercase());
     }
@@ -278,9 +272,9 @@ pub(crate) async fn listen_for_vams<T, F>(
         Box::pin(async move {
             let broadcast_ip = "0.0.0.0";
             let broadcast_socket = if connection_config.source_ip == broadcast_ip {
-                Arc::clone(&gateway.socket)
+                Arc::clone(&state.socket)
             } else {
-                match crate::create_socket(
+                match crate::create_socket_with_protocol(
                     broadcast_ip,
                     gateway_port,
                     doip_connection_config.protocol_version,
@@ -295,7 +289,7 @@ pub(crate) async fn listen_for_vams<T, F>(
                             "Failed to bind broadcast socket, falling back to tester IP,\
                              this can lead to missed VAMs"
                         );
-                        Arc::clone(&gateway.socket)
+                        Arc::clone(&state.socket)
                     }
                 }
             };
@@ -316,9 +310,9 @@ pub(crate) async fn listen_for_vams<T, F>(
                         if let DoipPayload::VehicleAnnouncementMessage(_) = &doip_msg.payload {
                             handle_doip_response(
                                 &connection_config,
-                                &gateway,
-                                send_timeout,
-                                alive_check_interval,
+                                &state,
+                                doip_connection_config.send_timeout,
+                                doip_connection_config.alive_check_interval,
                                 DoipMessageContext {
                                     doip_msg,
                                     source_addr,
@@ -334,7 +328,7 @@ pub(crate) async fn listen_for_vams<T, F>(
                 }
             }
         })
-    );
+    )
 }
 
 #[tracing::instrument(skip_all,

--- a/cda-interfaces/src/config.rs
+++ b/cda-interfaces/src/config.rs
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ConfigSanityError {
+    #[error("Failed to parse value: {0}")]
+    ParsingError(String),
+
+    #[error("Missing required field: {0}")]
+    MissingField(String),
+
+    #[error("Invalid value for '{field}': {reason}")]
+    InvalidValue { field: String, reason: String },
+}
+
+pub trait ConfigSanity {
+    /// Checks the configuration for common mistakes and returns an error message if found.
+    /// # Errors
+    /// Returns `Err(String)` if a sanity check fails, with a descriptive error message.
+    fn validate_sanity(&self) -> Result<(), ConfigSanityError>;
+}

--- a/cda-interfaces/src/datatypes/database_naming_convention.rs
+++ b/cda-interfaces/src/datatypes/database_naming_convention.rs
@@ -12,7 +12,12 @@
  */
 use serde::{Deserialize, Serialize};
 
-use crate::{HashMap, service_ids, util::serde_ext};
+use crate::{
+    HashMap,
+    config::{ConfigSanity, ConfigSanityError},
+    service_ids,
+    util::serde_ext,
+};
 
 /// Holds configuration for diagnostic service naming conventions.
 ///
@@ -67,6 +72,59 @@ pub struct DatabaseNamingConvention {
     // it will be validated in the validate sanity function
     #[serde(deserialize_with = "serde_ext::normalized_u8_key_map::deserialize")]
     pub service_affixes: HashMap<String, (DiagnosticServiceAffixPosition, Vec<String>)>,
+}
+
+impl ConfigSanity for DatabaseNamingConvention {
+    fn validate_sanity(&self) -> Result<(), ConfigSanityError> {
+        const SHORT_NAME_AFFIX_KEY: &str = "database_naming_convention.short_name_affixes";
+        const LONG_NAME_AFFIX_KEY: &str = "database_naming_convention.long_name_affixes";
+        const SERVICE_NAME_AFFIX_KEY: &str = "database_naming_convention.service_name_affixes";
+
+        fn validate_affix(
+            affix: &str,
+            pos: &DiagnosticServiceAffixPosition,
+            key: &str,
+        ) -> Result<(), ConfigSanityError> {
+            match pos {
+                DiagnosticServiceAffixPosition::Prefix => {
+                    if affix.starts_with(' ') {
+                        return Err(ConfigSanityError::InvalidValue {
+                            field: key.to_owned(),
+                            reason: format!("'{affix}' has leading whitespace"),
+                        });
+                    }
+                }
+                DiagnosticServiceAffixPosition::Suffix => {
+                    if affix.ends_with(' ') {
+                        return Err(ConfigSanityError::InvalidValue {
+                            field: key.to_owned(),
+                            reason: format!("'{affix}' has trailing whitespace"),
+                        });
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        // Check short name affixes
+        for affix in &self.short_name_affixes {
+            validate_affix(affix, &self.short_name_affix_position, SHORT_NAME_AFFIX_KEY)?;
+        }
+
+        // Check long name affixes
+        for affix in &self.long_name_affixes {
+            validate_affix(affix, &self.long_name_affix_position, LONG_NAME_AFFIX_KEY)?;
+        }
+
+        // Validate services affixes
+        for (pos, affixes) in self.service_affixes.values() {
+            for affix in affixes {
+                validate_affix(affix, pos, SERVICE_NAME_AFFIX_KEY)?;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl DatabaseNamingConvention {

--- a/cda-interfaces/src/lib.rs
+++ b/cda-interfaces/src/lib.rs
@@ -32,6 +32,7 @@ pub use ecuuds::*;
 pub mod file_manager;
 mod schema;
 pub use schema::*;
+pub mod config;
 pub mod runtime_update_api;
 pub mod storage_api;
 

--- a/cda-main/src/config/configfile.rs
+++ b/cda-main/src/config/configfile.rs
@@ -15,15 +15,14 @@ pub use cda_comm_doip::config::DoipConfig;
 pub use cda_database::DatabaseConfig;
 use cda_interfaces::{
     FunctionalDescriptionConfig, HashMap,
+    config::{ConfigSanity, ConfigSanityError},
     datatypes::{
-        ComParams, ComponentsConfig, DatabaseNamingConvention, DiagnosticServiceAffixPosition,
-        FaultConfig, FlatbBufConfig, SdBoolMappings, SdMappingsTruthyValue,
+        ComParams, ComponentsConfig, FaultConfig, FlatbBufConfig, SdBoolMappings,
+        SdMappingsTruthyValue,
     },
 };
 pub use cda_plugin_runtime_update::config::RuntimeUpdateConfig;
 use serde::{Deserialize, Serialize};
-
-use crate::AppError;
 
 /// Type-safe per-ECU communication parameter overrides.
 ///
@@ -229,13 +228,6 @@ impl Default for ServerConfig {
     }
 }
 
-pub trait ConfigSanity {
-    /// Checks the configuration for common mistakes and returns an error message if found.
-    /// # Errors
-    /// Returns `Err(String)` if a sanity check fails, with a descriptive error message.
-    fn validate_sanity(&self) -> Result<(), AppError>;
-}
-
 impl Default for Configuration {
     fn default() -> Self {
         Configuration {
@@ -285,60 +277,10 @@ impl Default for Configuration {
 }
 
 impl ConfigSanity for Configuration {
-    fn validate_sanity(&self) -> Result<(), AppError> {
+    fn validate_sanity(&self) -> Result<(), ConfigSanityError> {
         self.database.naming_convention.validate_sanity()?;
+        self.doip.validate_sanity()?;
         // Add more checks for Configuration fields here if needed
-        Ok(())
-    }
-}
-
-impl ConfigSanity for DatabaseNamingConvention {
-    fn validate_sanity(&self) -> Result<(), AppError> {
-        const SHORT_NAME_AFFIX_KEY: &str = "database_naming_convention.short_name_affixes";
-        const LONG_NAME_AFFIX_KEY: &str = "database_naming_convention.long_name_affixes";
-        const SERVICE_NAME_AFFIX_KEY: &str = "database_naming_convention.service_name_affixes";
-
-        fn validate_affix(
-            affix: &str,
-            pos: &DiagnosticServiceAffixPosition,
-            key: &str,
-        ) -> Result<(), AppError> {
-            match pos {
-                DiagnosticServiceAffixPosition::Prefix => {
-                    if affix.starts_with(' ') {
-                        return Err(AppError::ConfigurationError(format!(
-                            "{key}: '{affix}' has leading whitespace"
-                        )));
-                    }
-                }
-                DiagnosticServiceAffixPosition::Suffix => {
-                    if affix.ends_with(' ') {
-                        return Err(AppError::ConfigurationError(format!(
-                            "{key}: '{affix}' has trailing whitespace"
-                        )));
-                    }
-                }
-            }
-            Ok(())
-        }
-
-        // Check short name affixes
-        for affix in &self.short_name_affixes {
-            validate_affix(affix, &self.short_name_affix_position, SHORT_NAME_AFFIX_KEY)?;
-        }
-
-        // Check long name affixes
-        for affix in &self.long_name_affixes {
-            validate_affix(affix, &self.long_name_affix_position, LONG_NAME_AFFIX_KEY)?;
-        }
-
-        // Validate services affixes
-        for (pos, affixes) in self.service_affixes.values() {
-            for affix in affixes {
-                validate_affix(affix, pos, SERVICE_NAME_AFFIX_KEY)?;
-            }
-        }
-
         Ok(())
     }
 }

--- a/cda-main/src/config/generate.rs
+++ b/cda-main/src/config/generate.rs
@@ -302,7 +302,7 @@ fn format_toml_line(
 mod tests {
     use std::time::Duration;
 
-    use cda_interfaces::datatypes::ComParamPrecedence;
+    use cda_interfaces::{config::ConfigSanity, datatypes::ComParamPrecedence};
 
     use super::*;
 
@@ -376,8 +376,6 @@ mod tests {
             Figment,
             providers::{Format, Serialized, Toml},
         };
-
-        use crate::config::configfile::ConfigSanity;
 
         let reference = generate_reference_config().unwrap();
         let config: crate::config::configfile::Configuration =

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -590,7 +590,7 @@ pub async fn setup_vehicle_and_routes<SP: SecurityPlugin, SL: SecurityPluginLoad
             uds_manager: vehicle_data.uds_manager,
             doip_gateway: vehicle_data.diagnostic_gateway,
             health: vehicle_data.health_providers,
-            variant_detection_handle: vehicle_data.variant_detection_handle,
+            variant_detection_handle: Some(vehicle_data.variant_detection_handle),
             security_handler: Arc::new(UpdateSecurityHandler::new(
                 Arc::clone(&lock_provider),
                 vec![

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -20,6 +20,7 @@ use cda_database::FileManager;
 use cda_interfaces::{
     DiagServiceError, DoipGatewaySetupError, FunctionalDescriptionConfig, HashMap, UdsQuery,
     UdsVariant,
+    config::{ConfigSanity, ConfigSanityError},
     datatypes::{ComParams, FaultConfig},
     dlt_ctx,
 };
@@ -235,6 +236,12 @@ impl From<TracingSetupError> for AppError {
     }
 }
 
+impl From<ConfigSanityError> for AppError {
+    fn from(value: ConfigSanityError) -> Self {
+        AppError::ConfigurationError(value.to_string())
+    }
+}
+
 impl AppArgs {
     #[tracing::instrument(skip(self, config),
         fields(
@@ -372,8 +379,7 @@ where
     // Command line arguments always take precedence over stored configuration
     args.update_config(&mut config);
 
-    use crate::config::configfile::ConfigSanity;
-    config.validate_sanity()?;
+    config.validate_sanity().map_err(AppError::from)?;
 
     run_with_config_ext::<SP, SL, _, _>(config, extra_health_providers, pre_load_hook).await
 }

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -34,7 +34,7 @@ use figment::{
     providers::{Format, Serialized, Toml},
 };
 use futures::future::FutureExt;
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::{Mutex, RwLock, mpsc};
 use tracing_subscriber::layer::SubscriberExt;
 
 use crate::{
@@ -698,12 +698,19 @@ pub async fn load_vehicle_data<
     };
 
     let update_guard = cda_sovd::UpdateGuardState::new();
+    let doip_socket = cda_comm_doip::create_socket(
+        &config.doip.tester_address,
+        config.doip.gateway_port,
+        config.doip.protocol_version,
+    )
+    .map_err(|e| AppError::InitializationFailed(format!("Failed to create DoIP socket: {e}")))?;
     let components = create_vehicle_components::<F, S>(
         config,
         &mdd_paths,
         clonable_shutdown_signal,
         health_providers.as_ref(),
         update_guard.busy_handle(),
+        Arc::new(Mutex::new(doip_socket)),
     )
     .await?;
 
@@ -767,6 +774,7 @@ pub async fn create_vehicle_components<
     shutdown_signal: F,
     health_providers: Option<&HealthProviders>,
     update_in_progress: Arc<std::sync::atomic::AtomicBool>,
+    doip_socket: Arc<tokio::sync::Mutex<cda_comm_doip::socket::DoIPUdpSocket>>,
 ) -> Result<VehicleComponents<S>, AppError> {
     let db_provider = health_providers.map(|h| &h.database);
     let doip_provider = health_providers.map(|h| &h.doip);
@@ -781,6 +789,7 @@ pub async fn create_vehicle_components<
         variant_detection_tx,
         shutdown_signal,
         doip_provider,
+        doip_socket,
     )
     .await?;
 
@@ -808,7 +817,7 @@ pub async fn create_vehicle_components<
 }
 
 #[tracing::instrument(
-    skip(databases, variant_detection, shutdown_signal, doip_health_provider),
+    skip(databases, variant_detection, shutdown_signal, doip_health_provider, doip_socket),
     fields(
         database_count = databases.len(),
         dlt_context = dlt_ctx!("MAIN"),
@@ -822,13 +831,20 @@ pub async fn create_diagnostic_gateway<S: SecurityPlugin>(
     variant_detection: mpsc::Sender<Vec<String>>,
     shutdown_signal: impl Future<Output = ()> + Send + 'static,
     doip_health_provider: Option<&Arc<cda_health::StatusHealthProvider>>,
+    doip_socket: Arc<Mutex<cda_comm_doip::socket::DoIPUdpSocket>>,
 ) -> Result<DoipDiagGateway<EcuManager<S>>, DoipGatewaySetupError> {
     if let Some(provider) = doip_health_provider {
         provider.update_status(cda_health::Status::Starting).await;
     }
 
-    let result =
-        DoipDiagGateway::new(doip_config, databases, variant_detection, shutdown_signal).await;
+    let result = DoipDiagGateway::new(
+        doip_config,
+        databases,
+        variant_detection,
+        shutdown_signal,
+        doip_socket,
+    )
+    .await;
     let status = if result.is_ok() {
         cda_health::Status::Up
     } else {

--- a/cda-main/src/update/mod.rs
+++ b/cda-main/src/update/mod.rs
@@ -22,7 +22,7 @@ use cda_interfaces::{
     runtime_update_api::{ReloadError, RuntimeFilesUpdateSecurityHandler},
 };
 use cda_plugin_security::{SecurityPlugin, SecurityPluginLoader};
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 use crate::{AppError, UdsManagerType};
 
@@ -45,7 +45,7 @@ where
     pub ecu_execution_registry: cda_sovd::EcuExecutionRegistry,
     pub update_guard: cda_sovd::UpdateGuardState,
     pub health: Option<crate::HealthProviders>,
-    pub variant_detection_handle: tokio::sync::Mutex<tokio::task::JoinHandle<()>>,
+    pub variant_detection_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 pub struct DefaultRuntimeFileReloadHandler<S, F, P>
@@ -66,7 +66,7 @@ where
     update_guard: cda_sovd::UpdateGuardState,
     ecu_execution_registry: cda_sovd::EcuExecutionRegistry,
     health: Option<crate::HealthProviders>,
-    variant_detection_handle: tokio::sync::Mutex<tokio::task::JoinHandle<()>>,
+    variant_detection_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     _phantom: std::marker::PhantomData<P>,
 }
 
@@ -112,7 +112,11 @@ where
         // conflicts. Reuse the existing UDP socket so that there is never a second
         // socket bound to the same DoIP port (which would cause non-deterministic
         // VAM delivery between old and new listeners).
-        self.variant_detection_handle.lock().await.abort();
+        if let Some(variant_detection_handle) = self.variant_detection_handle.lock().await.take() {
+            variant_detection_handle.abort();
+            let _ = variant_detection_handle.await;
+        }
+
         self.uds_manager.write().await.shutdown().await;
         let doip_socket = {
             let mut gw = self.doip_gateway.write().await;
@@ -133,7 +137,7 @@ where
         .map_err(|e| ReloadError(format!("Failed to create vehicle components: {e}")))?;
 
         // Replace with new components
-        *self.variant_detection_handle.lock().await = new_components.variant_detection_handle;
+        *self.variant_detection_handle.lock().await = Some(new_components.variant_detection_handle);
         *self.uds_manager.write().await = new_components.uds_manager.clone();
         *self.doip_gateway.write().await = new_components.diagnostic_gateway;
 
@@ -213,7 +217,7 @@ pub struct RuntimeUpdateContext<
     pub uds_manager: UdsManagerType<S>,
     pub doip_gateway: DoipDiagGateway<EcuManager<S>>,
     pub health: Option<crate::HealthProviders>,
-    pub variant_detection_handle: tokio::task::JoinHandle<()>,
+    pub variant_detection_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
 /// Registers the runtime update routes on the dynamic router using the provided plugin.
@@ -302,7 +306,7 @@ where
             update_guard: ctx.update_guard.clone(),
             ecu_execution_registry: ctx.ecu_execution_registry,
             health: ctx.health,
-            variant_detection_handle: tokio::sync::Mutex::new(ctx.variant_detection_handle),
+            variant_detection_handle: Mutex::new(ctx.variant_detection_handle),
         },
     ));
     let storage = Arc::new(

--- a/cda-main/src/update/mod.rs
+++ b/cda-main/src/update/mod.rs
@@ -108,31 +108,34 @@ where
     async fn reload_databases(&self, mdd_paths: Vec<PathBuf>) -> Result<(), ReloadError> {
         let cfg = self.config.read().await.clone();
 
+        // Shut down old components BEFORE creating new ones to avoid port/socket
+        // conflicts. Reuse the existing UDP socket so that there is never a second
+        // socket bound to the same DoIP port (which would cause non-deterministic
+        // VAM delivery between old and new listeners).
+        self.variant_detection_handle.lock().await.abort();
+        self.uds_manager.write().await.shutdown().await;
+        let doip_socket = {
+            let mut gw = self.doip_gateway.write().await;
+            let socket = gw.udp_socket();
+            gw.shutdown().await;
+            socket
+        };
+
         let new_components = crate::create_vehicle_components::<F, S>(
             &cfg,
             &mdd_paths,
             self.shutdown_signal.clone(),
             self.health.as_ref(),
             self.update_guard.busy_handle(),
+            doip_socket,
         )
         .await
         .map_err(|e| ReloadError(format!("Failed to create vehicle components: {e}")))?;
 
-        let mut variant_detection_handle = self.variant_detection_handle.lock().await;
-        variant_detection_handle.abort();
-        *variant_detection_handle = new_components.variant_detection_handle;
-        drop(variant_detection_handle);
-
-        // Shutdown old components and replace with new ones
-        let mut uds_manager_rw = self.uds_manager.write().await;
-        uds_manager_rw.shutdown().await;
-        *uds_manager_rw = new_components.uds_manager.clone();
-        drop(uds_manager_rw);
-
-        let mut doip_gateway_rw = self.doip_gateway.write().await;
-        doip_gateway_rw.shutdown();
-        *doip_gateway_rw = new_components.diagnostic_gateway;
-        drop(doip_gateway_rw);
+        // Replace with new components
+        *self.variant_detection_handle.lock().await = new_components.variant_detection_handle;
+        *self.uds_manager.write().await = new_components.uds_manager.clone();
+        *self.doip_gateway.write().await = new_components.diagnostic_gateway;
 
         // Update lock entries, to make sure new ECUs or removed ECUs are updated.
         let ecu_names = new_components.uds_manager.get_physical_ecus().await;

--- a/cda-sovd-interfaces/src/apps.rs
+++ b/cda-sovd-interfaces/src/apps.rs
@@ -101,9 +101,9 @@ pub mod sovd2uds {
 
     pub mod data {
         pub mod network_structure {
-            use serde::Serialize;
+            use serde::{Deserialize, Serialize};
 
-            #[derive(Serialize)]
+            #[derive(Serialize, Deserialize)]
             #[serde(rename_all = "PascalCase")]
             #[derive(schemars::JsonSchema)]
             pub struct Ecu {
@@ -120,7 +120,7 @@ pub mod sovd2uds {
                 pub logical_link: String,
             }
 
-            #[derive(Serialize)]
+            #[derive(Serialize, Deserialize)]
             #[serde(rename_all = "PascalCase")]
             #[derive(schemars::JsonSchema)]
             pub struct Gateway {
@@ -134,7 +134,7 @@ pub mod sovd2uds {
                 pub ecus: Vec<Ecu>,
             }
 
-            #[derive(Serialize)]
+            #[derive(Serialize, Deserialize)]
             #[serde(rename_all = "PascalCase")]
             #[derive(schemars::JsonSchema)]
             pub struct FunctionalGroup {
@@ -142,7 +142,7 @@ pub mod sovd2uds {
                 pub ecus: Vec<Ecu>,
             }
 
-            #[derive(Serialize)]
+            #[derive(Serialize, Deserialize)]
             #[serde(rename_all = "PascalCase")]
             #[derive(schemars::JsonSchema)]
             pub struct NetworkStructure {
@@ -151,9 +151,9 @@ pub mod sovd2uds {
             }
 
             pub mod get {
-                use serde::Serialize;
+                use serde::{Deserialize, Serialize};
 
-                #[derive(Serialize, schemars::JsonSchema)]
+                #[derive(Serialize, Deserialize, schemars::JsonSchema)]
                 #[schemars(rename = "NetworkStructureResponse")]
                 pub struct Response {
                     pub id: String,

--- a/integration-tests/tests/sovd/custom_routes.rs
+++ b/integration-tests/tests/sovd/custom_routes.rs
@@ -83,6 +83,7 @@ async fn add_custom_routes(dynamic_router: &DynamicRouter) {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)] // makes sense to keep the test together
 async fn test_custom_demo_endpoint() {
     // Use loopback since we don't need actual ECU connections for this test
     let host = host();
@@ -133,13 +134,19 @@ async fn test_custom_demo_endpoint() {
         provider
     };
 
+    let doip_socket = cda_comm_doip::create_socket(
+        &doip_config.tester_address,
+        doip_config.gateway_port,
+        doip_config.protocol_version,
+    )
+    .expect("Failed to create DoIP socket");
     let gateway = opensovd_cda_lib::create_diagnostic_gateway(
         Arc::clone(&databases),
         &doip_config,
         variant_tx,
         shutdown_signal.clone(),
         None,
-        None,
+        Arc::new(tokio::sync::Mutex::new(doip_socket)),
     )
     .await
     .expect("Failed to create gateway");

--- a/integration-tests/tests/sovd/custom_routes.rs
+++ b/integration-tests/tests/sovd/custom_routes.rs
@@ -139,6 +139,7 @@ async fn test_custom_demo_endpoint() {
         variant_tx,
         shutdown_signal.clone(),
         None,
+        None,
     )
     .await
     .expect("Failed to create gateway");

--- a/integration-tests/tests/sovd/mod.rs
+++ b/integration-tests/tests/sovd/mod.rs
@@ -39,6 +39,7 @@ mod flash_download;
 mod locks;
 mod operations;
 mod runtimefiles;
+mod tester_present;
 mod version_endpoint;
 
 pub(crate) const ECU_FLXC1000_ENDPOINT: &str = "components/flxc1000";

--- a/integration-tests/tests/sovd/runtimefiles.rs
+++ b/integration-tests/tests/sovd/runtimefiles.rs
@@ -34,7 +34,7 @@ use crate::{
     util::{
         TestingError,
         http::{QueryParams, auth_header, response_to_t, send_cda_request},
-        runtime::{setup_integration_test, test_container_dir},
+        runtime::{setup_integration_test, test_container_dir, wait_for_ecus_online},
     },
 };
 
@@ -1648,6 +1648,12 @@ async fn runtimefiles_apply_removes_ecu_routes() -> Result<(), TestingError> {
     // Apply created a backup of the original database; Rollback restores it.
     execute_mode(&runtime.config, &auth, ExecutionMode::Rollback).await?;
     cda_interfaces::util::tokio_ext::sleep_for(Duration::from_secs(5)).await;
+
+    // Wait for all ECUs to come back online after the reload triggered by rollback.
+    // The reload creates a fresh DoIP gateway that must re-discover ECUs via VIR/VAM
+    // and run variant detection. Without this wait, subsequent tests may find ECUs
+    // still in Offline state.
+    wait_for_ecus_online(&runtime.config).await?;
 
     // Rollback restores the original database -> FLXC1000 is back.
     send_cda_request(

--- a/integration-tests/tests/sovd/tester_present.rs
+++ b/integration-tests/tests/sovd/tester_present.rs
@@ -359,7 +359,7 @@ async fn tester_present_resumes_after_network_disconnect() -> Result<(), Testing
 
     // Force-close all active DoIP TCP connections - simulates a transient network fault.
     // The ECU is still running and will re-announce itself via VAMs immediately.
-    ecusim::disconnect(&runtime.ecu_sim, ECU_SIM_NAME)
+    ecusim::disconnect(&runtime.ecu_sim)
         .await
         .expect("failed to disconnect ECU sim");
 

--- a/integration-tests/tests/sovd/tester_present.rs
+++ b/integration-tests/tests/sovd/tester_present.rs
@@ -1,0 +1,404 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::time::Duration;
+
+use http::{Method, StatusCode};
+
+use crate::{
+    sovd::{
+        self,
+        ecu::switch_session,
+        locks::{ECU_ENDPOINT as ECU_LOCK_ENDPOINT, create_lock, lock_operation},
+    },
+    util::{
+        TestingError, ecusim,
+        http::{auth_header, extract_field_from_json, response_to_json, send_cda_request},
+        runtime::{setup_integration_test, wait_for_ecus_online},
+    },
+};
+
+const ECU_SIM_NAME: &str = "flxc1000";
+
+/// Tester Present frame: SID 0x3E with suppressPositiveResponse bit set (0x80)
+const TESTER_PRESENT_FRAME: &str = "3e80";
+
+/// Verifies that Tester Present frames (0x3E 0x80) are sent to the ECU while
+/// an ECU lock is held.
+///
+/// The SOVD specification requires that acquiring a lock on an ECU starts
+/// periodic Tester Present messages to keep the diagnostic session alive.
+/// This test reproduces a scenario where Tester Present frames were observed
+/// to be missing despite an active lock.
+#[tokio::test]
+async fn tester_present_sent_while_ecu_lock_held() -> Result<(), TestingError> {
+    let (runtime, _exclusive) = setup_integration_test(true).await?;
+    wait_for_ecus_online(&runtime.config).await?;
+    let auth = auth_header(&runtime.config, None).await?;
+
+    // Start recording UDS frames on the ECU simulator before creating the lock
+    // so we capture even the very first Tester Present frame.
+    ecusim::start_recording(&runtime.ecu_sim, ECU_SIM_NAME)
+        .await
+        .expect("failed to start ECU sim recording");
+
+    // Create an ECU lock - this should trigger Tester Present to start
+    let lock_response = create_lock(
+        Duration::from_secs(100),
+        ECU_LOCK_ENDPOINT,
+        StatusCode::CREATED,
+        &runtime.config,
+        &auth,
+    )
+    .await;
+    let lock_id = extract_field_from_json::<String>(&response_to_json(&lock_response)?, "id")?;
+
+    // Wait long enough for multiple Tester Present intervals.
+    // Default TP interval is 2 seconds; waiting 5 seconds should yield at least 2 frames.
+    cda_interfaces::util::tokio_ext::sleep_for(Duration::from_secs(5)).await;
+
+    // Stop recording and collect all UDS frames received by the ECU simulator
+    let recorded_frames = ecusim::stop_and_clear_recording(&runtime.ecu_sim, ECU_SIM_NAME)
+        .await
+        .expect("failed to stop ECU sim recording");
+
+    // Cleanup: delete the lock regardless of the assertion outcome
+    let _ = lock_operation(
+        ECU_LOCK_ENDPOINT,
+        Some(&lock_id),
+        &runtime.config,
+        &auth,
+        StatusCode::NO_CONTENT,
+        Method::DELETE,
+    )
+    .await;
+
+    // Assert that at least one Tester Present frame was received
+    let tp_count = recorded_frames
+        .iter()
+        .filter(|frame| frame.eq_ignore_ascii_case(TESTER_PRESENT_FRAME))
+        .count();
+
+    assert!(
+        tp_count > 0,
+        "Expected at least one Tester Present frame ({TESTER_PRESENT_FRAME}) to be sent while ECU \
+         lock is held, but none were found in 5s of recording.\nRecorded frames: \
+         {recorded_frames:?}",
+    );
+
+    Ok(())
+}
+
+/// Verifies that Tester Present frames continue to be sent after switching to
+/// a programming session while the ECU lock is held.
+///
+/// The expectation is that Tester Present continues regardless of session changes
+/// as long as the lock is held.
+#[tokio::test]
+async fn tester_present_sent_after_programming_session_switch() -> Result<(), TestingError> {
+    let (runtime, _exclusive) = setup_integration_test(true).await?;
+    wait_for_ecus_online(&runtime.config).await?;
+    let auth = auth_header(&runtime.config, None).await?;
+    let ecu_endpoint = sovd::ECU_FLXC1000_ENDPOINT;
+
+    // Create an ECU lock - this should trigger Tester Present to start
+    let lock_response = create_lock(
+        Duration::from_secs(100),
+        ECU_LOCK_ENDPOINT,
+        StatusCode::CREATED,
+        &runtime.config,
+        &auth,
+    )
+    .await;
+    let lock_id = extract_field_from_json::<String>(&response_to_json(&lock_response)?, "id")?;
+
+    // Switch the ECU sim to BOOT variant (simulates ECU going into bootloader)
+    ecusim::switch_variant(&runtime.ecu_sim, "FLXC1000", "BOOT")
+        .await
+        .expect("failed to switch ECU sim to BOOT variant");
+
+    // Force variant detection so the CDA picks up the boot variant
+    send_cda_request(
+        &runtime.config,
+        ecu_endpoint,
+        StatusCode::CREATED,
+        Method::PUT,
+        None,
+        Some(&auth),
+        None,
+    )
+    .await
+    .expect("failed to trigger variant detection");
+
+    // Switch to programming session
+    switch_session(
+        "programming",
+        &runtime.config,
+        &auth,
+        ecu_endpoint,
+        StatusCode::OK,
+    )
+    .await
+    .expect("failed to switch to programming session");
+
+    // Now start recording after the session switch to isolate the issue:
+    // We want to verify that TP continues to be sent in the new session state.
+    ecusim::start_recording(&runtime.ecu_sim, ECU_SIM_NAME)
+        .await
+        .expect("failed to start ECU sim recording");
+
+    // Wait long enough for multiple Tester Present intervals.
+    cda_interfaces::util::tokio_ext::sleep_for(Duration::from_secs(5)).await;
+
+    // Stop recording and collect all UDS frames received by the ECU simulator
+    let recorded_frames = ecusim::stop_and_clear_recording(&runtime.ecu_sim, ECU_SIM_NAME)
+        .await
+        .expect("failed to stop ECU sim recording");
+
+    // Cleanup: switch back to application variant and delete the lock
+    ecusim::switch_variant(&runtime.ecu_sim, "FLXC1000", "APPLICATION")
+        .await
+        .expect("failed to switch ECU sim back to APPLICATION variant");
+
+    // Force variant re-detection
+    let _ = send_cda_request(
+        &runtime.config,
+        ecu_endpoint,
+        StatusCode::CREATED,
+        Method::PUT,
+        None,
+        Some(&auth),
+        None,
+    )
+    .await;
+
+    let _ = lock_operation(
+        ECU_LOCK_ENDPOINT,
+        Some(&lock_id),
+        &runtime.config,
+        &auth,
+        StatusCode::NO_CONTENT,
+        Method::DELETE,
+    )
+    .await;
+
+    // Assert that at least one Tester Present frame was received after session switch
+    let tp_count = recorded_frames
+        .iter()
+        .filter(|frame| frame.eq_ignore_ascii_case(TESTER_PRESENT_FRAME))
+        .count();
+
+    assert!(
+        tp_count > 0,
+        "Expected at least one Tester Present frame ({TESTER_PRESENT_FRAME}) to be sent after \
+         switching to programming session while ECU lock is held, but none were found in 5s of \
+         recording.\nRecorded frames: {recorded_frames:?}",
+    );
+
+    Ok(())
+}
+
+/// Verifies that Tester Present frames are sent after the ECU reconnects following
+/// a `DoIP` TCP connection drop while the lock is held.
+///
+/// This reproduces a reconnection scenario where Tester Present could stop:
+/// 1. An ECU lock is acquired (starts Tester Present)
+/// 2. The `DoIP` TCP connection is forcefully closed (simulates ECU reboot / network glitch)
+/// 3. The ECU re-announces itself and the CDA reconnects
+/// 4. Tester Present should resume after reconnection
+///
+/// In this scenario, Tester Present frames may be missing after the
+/// connection is re-established, which is the bug this test aims to reproduce.
+#[tokio::test]
+async fn tester_present_sent_after_doip_reconnection() -> Result<(), TestingError> {
+    let (runtime, _exclusive) = setup_integration_test(true).await?;
+    wait_for_ecus_online(&runtime.config).await?;
+    let auth = auth_header(&runtime.config, None).await?;
+
+    // Create an ECU lock - this should trigger Tester Present to start
+    let lock_response = create_lock(
+        Duration::from_secs(100),
+        ECU_LOCK_ENDPOINT,
+        StatusCode::CREATED,
+        &runtime.config,
+        &auth,
+    )
+    .await;
+    let lock_id = extract_field_from_json::<String>(&response_to_json(&lock_response)?, "id")?;
+
+    // Wait briefly to confirm TP is running before we disconnect
+    cda_interfaces::util::tokio_ext::sleep_for(Duration::from_secs(3)).await;
+
+    // Simulate a DoIP TCP connection drop by configuring the ECU sim to perform
+    // a hard reset (which closes the TCP connection) for 5 seconds, then triggering
+    // the reset via UDS ECU Reset (0x11 0x01) through the CDA's genericservice.
+    ecusim::set_hard_reset_duration(&runtime.ecu_sim, "FLXC1000", 5)
+        .await
+        .expect("failed to set hard reset duration");
+
+    // Send UDS ECU Reset (0x11 0x01) via genericservice - this triggers the ECU sim
+    // to close the TCP connection for 5 seconds (simulating a real ECU reboot)
+    let _ = send_cda_request(
+        &runtime.config,
+        &format!("{}/genericservice", sovd::ECU_FLXC1000_ENDPOINT),
+        StatusCode::OK,
+        Method::PUT,
+        Some(&serde_json::json!({"request": "0x11 0x01"}).to_string()),
+        Some(&auth),
+        None,
+    )
+    .await;
+
+    // Wait for the ECU to come back online after the hard reset (5s reset + reconnection time)
+    cda_interfaces::util::tokio_ext::sleep_for(Duration::from_secs(10)).await;
+
+    // Start recording AFTER reconnection to verify TP resumes
+    ecusim::start_recording(&runtime.ecu_sim, ECU_SIM_NAME)
+        .await
+        .expect("failed to start ECU sim recording");
+
+    // Wait for multiple TP intervals
+    cda_interfaces::util::tokio_ext::sleep_for(Duration::from_secs(5)).await;
+
+    // Stop recording and collect all UDS frames received by the ECU simulator
+    let recorded_frames = ecusim::stop_and_clear_recording(&runtime.ecu_sim, ECU_SIM_NAME)
+        .await
+        .expect("failed to stop ECU sim recording");
+
+    // Cleanup: reset hard reset duration to 0 to avoid leaking armed state into subsequent tests,
+    // then delete the lock.
+    let _ = ecusim::set_hard_reset_duration(&runtime.ecu_sim, "FLXC1000", 0).await;
+
+    let _ = lock_operation(
+        ECU_LOCK_ENDPOINT,
+        Some(&lock_id),
+        &runtime.config,
+        &auth,
+        StatusCode::NO_CONTENT,
+        Method::DELETE,
+    )
+    .await;
+
+    // Assert that at least one Tester Present frame was received after reconnection
+    let tp_count = recorded_frames
+        .iter()
+        .filter(|frame| frame.eq_ignore_ascii_case(TESTER_PRESENT_FRAME))
+        .count();
+
+    assert!(
+        tp_count > 0,
+        "Expected at least one Tester Present frame ({TESTER_PRESENT_FRAME}) to be sent after \
+         DoIP reconnection while ECU lock is held, but none were found in 5s of recording after \
+         reconnection.\nRecorded frames: {recorded_frames:?}",
+    );
+
+    Ok(())
+}
+
+/// Verifies that Tester Present frames resume after a pure network-level `DoIP` TCP disconnect
+/// (not triggered by a UDS ECU Reset) while the ECU lock is held.
+///
+/// Unlike `tester_present_sent_after_doip_reconnection`, which uses the UDS ECU Reset path
+/// to trigger a disconnect, this test calls `ecusim::disconnect` directly to simulate a
+/// transient network fault (e.g., cable pull, switch reset) where the ECU itself is still
+/// running. The ECU re-announces via VAMs immediately and the CDA should re-establish the
+/// `DoIP` connection without any lock disruption.
+///
+/// Two-phase assertion:
+/// 1. TP is confirmed running before the disconnect.
+/// 2. TP resumes after the reconnect.
+#[tokio::test]
+async fn tester_present_resumes_after_network_disconnect() -> Result<(), TestingError> {
+    let (runtime, _exclusive) = setup_integration_test(true).await?;
+    wait_for_ecus_online(&runtime.config).await?;
+    let auth = auth_header(&runtime.config, None).await?;
+
+    // Start recording before acquiring the lock to capture the very first TP frame.
+    ecusim::start_recording(&runtime.ecu_sim, ECU_SIM_NAME)
+        .await
+        .expect("failed to start ECU sim recording");
+
+    // Acquire an ECU lock - this should trigger Tester Present to start.
+    let lock_response = create_lock(
+        Duration::from_secs(100),
+        ECU_LOCK_ENDPOINT,
+        StatusCode::CREATED,
+        &runtime.config,
+        &auth,
+    )
+    .await;
+    let lock_id = extract_field_from_json::<String>(&response_to_json(&lock_response)?, "id")?;
+
+    // Wait for multiple TP intervals to confirm TP is running before we disconnect.
+    cda_interfaces::util::tokio_ext::sleep_for(Duration::from_secs(3)).await;
+
+    let pre_disconnect_frames = ecusim::stop_and_clear_recording(&runtime.ecu_sim, ECU_SIM_NAME)
+        .await
+        .expect("failed to stop pre-disconnect recording");
+
+    let pre_tp_count = pre_disconnect_frames
+        .iter()
+        .filter(|frame| frame.eq_ignore_ascii_case(TESTER_PRESENT_FRAME))
+        .count();
+
+    assert!(
+        pre_tp_count > 0,
+        "Precondition failed: expected Tester Present frames before disconnect but found none in \
+         3s of recording.\nRecorded frames: {pre_disconnect_frames:?}"
+    );
+
+    // Force-close all active DoIP TCP connections - simulates a transient network fault.
+    // The ECU is still running and will re-announce itself via VAMs immediately.
+    ecusim::disconnect(&runtime.ecu_sim, ECU_SIM_NAME)
+        .await
+        .expect("failed to disconnect ECU sim");
+
+    // Wait for the ECU to re-announce via VAM and the CDA to re-establish the DoIP connection.
+    wait_for_ecus_online(&runtime.config).await?;
+
+    // Record after reconnection to verify TP resumed.
+    ecusim::start_recording(&runtime.ecu_sim, ECU_SIM_NAME)
+        .await
+        .expect("failed to start post-reconnect recording");
+
+    cda_interfaces::util::tokio_ext::sleep_for(Duration::from_secs(10)).await;
+
+    let post_reconnect_frames = ecusim::stop_and_clear_recording(&runtime.ecu_sim, ECU_SIM_NAME)
+        .await
+        .expect("failed to stop post-reconnect recording");
+
+    // Cleanup: delete the lock.
+    let _ = lock_operation(
+        ECU_LOCK_ENDPOINT,
+        Some(&lock_id),
+        &runtime.config,
+        &auth,
+        StatusCode::NO_CONTENT,
+        Method::DELETE,
+    )
+    .await;
+
+    let post_tp_count = post_reconnect_frames
+        .iter()
+        .filter(|frame| frame.eq_ignore_ascii_case(TESTER_PRESENT_FRAME))
+        .count();
+
+    assert!(
+        post_tp_count > 0,
+        "Expected at least one Tester Present frame ({TESTER_PRESENT_FRAME}) to be sent after \
+         network-level DoIP disconnect while ECU lock is held, but none were found in 5s of \
+         recording after reconnection.\nRecorded frames: {post_reconnect_frames:?}",
+    );
+
+    Ok(())
+}

--- a/integration-tests/tests/util/ecusim.rs
+++ b/integration-tests/tests/util/ecusim.rs
@@ -380,3 +380,42 @@ pub(crate) async fn clear_interceptor(
     .await?;
     Ok(())
 }
+
+/// Force-close all active `DoIP` TCP connections for the specified ECU.
+///
+/// This simulates a network disconnect or ECU reboot where the TCP link is lost.
+/// After the disconnect, the ECU will re-announce itself via VAMs and the CDA
+/// should re-establish the connection automatically.
+pub(crate) async fn disconnect(sim: &EcuSim, ecu: &str) -> Result<(), TestingError> {
+    let mut url = sim_endpoint(sim)?;
+    url.path_segments_mut()
+        .map_err(|()| TestingError::InvalidUrl("cannot modify URL path".to_owned()))?
+        .push(ecu)
+        .push("disconnect");
+
+    crate::util::http::send_request(StatusCode::OK, http::Method::POST, None, None, url).await?;
+    Ok(())
+}
+
+/// Configure the ECU simulator's hard reset duration.
+///
+/// When set to a value > 0, subsequent UDS ECU Reset (0x11 0x01) requests will cause
+/// the ECU to close its TCP connection for the specified number of seconds, simulating
+/// a real ECU reboot with `DoIP` disconnection.
+pub(crate) async fn set_hard_reset_duration(
+    sim: &EcuSim,
+    ecu: &str,
+    seconds: i32,
+) -> Result<(), TestingError> {
+    let mut url = sim_endpoint(sim)?;
+    url.path_segments_mut()
+        .map_err(|()| TestingError::InvalidUrl("cannot modify URL path".to_owned()))?
+        .push(ecu)
+        .push("state");
+
+    let body = serde_json::json!({"hardResetForSeconds": seconds}).to_string();
+
+    crate::util::http::send_request(StatusCode::OK, http::Method::PUT, Some(&body), None, url)
+        .await?;
+    Ok(())
+}

--- a/integration-tests/tests/util/ecusim.rs
+++ b/integration-tests/tests/util/ecusim.rs
@@ -381,16 +381,15 @@ pub(crate) async fn clear_interceptor(
     Ok(())
 }
 
-/// Force-close all active `DoIP` TCP connections for the specified ECU.
+/// Force-close all active `DoIP` TCP connections for all ECUs.
 ///
 /// This simulates a network disconnect or ECU reboot where the TCP link is lost.
-/// After the disconnect, the ECU will re-announce itself via VAMs and the CDA
-/// should re-establish the connection automatically.
-pub(crate) async fn disconnect(sim: &EcuSim, ecu: &str) -> Result<(), TestingError> {
+/// After the disconnect, the ECUs will re-announce themselves via VAMs and the CDA
+/// should re-establish the connections automatically.
+pub(crate) async fn disconnect(sim: &EcuSim) -> Result<(), TestingError> {
     let mut url = sim_endpoint(sim)?;
     url.path_segments_mut()
         .map_err(|()| TestingError::InvalidUrl("cannot modify URL path".to_owned()))?
-        .push(ecu)
         .push("disconnect");
 
     crate::util::http::send_request(StatusCode::OK, http::Method::POST, None, None, url).await?;

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -19,6 +19,7 @@ use std::{
 use cda_health::config::HealthConfig;
 use cda_interfaces::{
     FunctionalDescriptionConfig, HashMap, HashMapExtensions,
+    config::ConfigSanity,
     datatypes::{
         ComParamConfig, ComParamPrecedence, ComParams, ComponentsConfig, DatabaseNamingConvention,
         DoipComParams, FaultConfig, FlatbBufConfig,
@@ -31,8 +32,8 @@ use http::{Method, StatusCode};
 use opensovd_cda_lib::{
     cda_version,
     config::configfile::{
-        ConfigSanity, Configuration, DatabaseConfig, EcuComParams, EcuConfig, RuntimeUpdateConfig,
-        ServerConfig, StrictConfig,
+        Configuration, DatabaseConfig, EcuComParams, EcuConfig, RuntimeUpdateConfig, ServerConfig,
+        StrictConfig,
     },
 };
 use sovd_interfaces::apps::sovd2uds::data::network_structure::get::Response as NetworkStructureResponse;

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -739,17 +739,14 @@ async fn wait_for_http_ready_with_timeout(
     let start_time = Instant::now();
 
     while start_time.elapsed() < timeout {
-        match client.get(&url).send().await {
-            Ok(response) => {
-                if let Some(expected_status) = result {
-                    if response.status() == expected_status {
-                        return Ok(());
-                    }
-                } else {
+        if let Ok(response) = client.get(&url).send().await {
+            if let Some(expected_status) = result {
+                if response.status() == expected_status {
                     return Ok(());
                 }
+            } else {
+                return Ok(());
             }
-            _ => {}
         }
         cda_interfaces::util::tokio_ext::sleep_for(Duration::from_millis(250)).await;
     }
@@ -780,14 +777,16 @@ pub(crate) async fn wait_for_cda_online(cfg: &ServerConfig) -> Result<(), Testin
 /// Poll the networkstructure endpoint until every ECU in every gateway reports
 /// `"Online"`, or until the timeout elapses.
 ///
-/// This is needed after `reset_sim` because the DoIP reconnection and variant
+/// This is needed after `reset_sim` because the `DoIP` reconnection and variant
 /// detection run asynchronously: returning immediately after reset would allow
 /// tests to start before the ECU is reachable, causing `ecu_state=Offline` at
 /// lock creation time and making tester-present tasks skip every tick.
 pub(crate) async fn wait_for_ecus_online(config: &Configuration) -> Result<(), TestingError> {
     const POLL_INTERVAL: Duration = Duration::from_secs(1);
     const TIMEOUT: Duration = Duration::from_secs(30);
-    let deadline = Instant::now() + TIMEOUT;
+    let deadline = Instant::now().checked_add(TIMEOUT).ok_or_else(|| {
+        TestingError::SetupError("timeout duration overflowed Instant".to_owned())
+    })?;
     let mut last_offline_ecus: Option<String> = None;
 
     loop {
@@ -799,7 +798,7 @@ pub(crate) async fn wait_for_ecus_online(config: &Configuration) -> Result<(), T
         }
 
         let response = send_cda_request(
-            &config,
+            config,
             "apps/sovd2uds/data/networkstructure",
             StatusCode::OK,
             Method::GET,
@@ -808,8 +807,10 @@ pub(crate) async fn wait_for_ecus_online(config: &Configuration) -> Result<(), T
             None,
         )
         .await?;
-        let network_structure_response: NetworkStructureResponse =
-            response_to_t(&response).unwrap();
+        let network_structure_response: NetworkStructureResponse = response_to_t(&response)
+            .map_err(|e| {
+                TestingError::InvalidData(format!("Failed to parse networkstructure response: {e}"))
+            })?;
 
         let offline_ecus: Vec<String> = network_structure_response
             .data

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -27,6 +27,7 @@ use cda_interfaces::{
 use cda_plugin_security::{DefaultSecurityPlugin, DefaultSecurityPluginData};
 use cda_tracing::LoggingConfig;
 use futures::FutureExt as _;
+use http::{Method, StatusCode};
 use opensovd_cda_lib::{
     cda_version,
     config::configfile::{
@@ -34,10 +35,14 @@ use opensovd_cda_lib::{
         ServerConfig, StrictConfig,
     },
 };
+use sovd_interfaces::apps::sovd2uds::data::network_structure::get::Response as NetworkStructureResponse;
 use tokio::sync::{Mutex, MutexGuard, OnceCell};
 use tracing_subscriber::layer::SubscriberExt;
 
-use crate::util::{TestingError, ecusim};
+use crate::util::{
+    TestingError, ecusim,
+    http::{response_to_t, send_cda_request},
+};
 
 static TEST_RUNTIME: OnceCell<TestRuntime> = OnceCell::const_new();
 
@@ -89,7 +94,6 @@ pub(crate) async fn setup_integration_test<'a>(
 
     // Make sure we have a clean state at the beginning of the test
     ecusim::reset_sim(&runtime.ecu_sim).await?;
-
     if exclusive {
         // If exclusive access is requested, lock the dedicated mutex
         // and return the guard. The test must hold onto this guard.
@@ -714,8 +718,9 @@ async fn wait_for_http_ready_with_timeout(
                     return Ok(());
                 }
             }
-            _ => cda_interfaces::util::tokio_ext::sleep_for(Duration::from_millis(250)).await,
+            _ => {}
         }
+        cda_interfaces::util::tokio_ext::sleep_for(Duration::from_millis(250)).await;
     }
 
     Err(TestingError::ProcessFailed(format!(
@@ -739,6 +744,59 @@ async fn wait_for_ecu_sim_ready(host: &str, sim_control_port: u16) -> Result<(),
 pub(crate) async fn wait_for_cda_online(cfg: &ServerConfig) -> Result<(), TestingError> {
     let url = format!("http://{}:{}/health/ready", cfg.address, cfg.port);
     wait_for_http_ready(url, "CDA", Some(http::StatusCode::NO_CONTENT)).await
+}
+
+/// Poll the networkstructure endpoint until every ECU in every gateway reports
+/// `"Online"`, or until the timeout elapses.
+///
+/// This is needed after `reset_sim` because the DoIP reconnection and variant
+/// detection run asynchronously: returning immediately after reset would allow
+/// tests to start before the ECU is reachable, causing `ecu_state=Offline` at
+/// lock creation time and making tester-present tasks skip every tick.
+pub(crate) async fn wait_for_ecus_online(config: &Configuration) -> Result<(), TestingError> {
+    const POLL_INTERVAL: Duration = Duration::from_secs(1);
+    const TIMEOUT: Duration = Duration::from_secs(30);
+    let deadline = Instant::now() + TIMEOUT;
+    let mut last_offline_ecus: Option<String> = None;
+
+    loop {
+        if Instant::now() >= deadline {
+            return Err(TestingError::ProcessFailed(format!(
+                "ECUs did not reach Online state within 30s after reset: {}",
+                last_offline_ecus.unwrap_or_else(|| "unknown".to_owned())
+            )));
+        }
+
+        let response = send_cda_request(
+            &config,
+            "apps/sovd2uds/data/networkstructure",
+            StatusCode::OK,
+            Method::GET,
+            None,
+            None,
+            None,
+        )
+        .await?;
+        let network_structure_response: NetworkStructureResponse =
+            response_to_t(&response).unwrap();
+
+        let offline_ecus: Vec<String> = network_structure_response
+            .data
+            .iter()
+            .flat_map(|ns| ns.gateways.iter())
+            .flat_map(|gw| gw.ecus.iter())
+            .filter(|ecu| !matches!(ecu.state.as_str(), "Online" | "Duplicate"))
+            .map(|ecu| format!("{}={}", ecu.qualifier, ecu.state))
+            .collect();
+
+        if offline_ecus.is_empty() {
+            return Ok(());
+        }
+
+        last_offline_ecus = Some(offline_ecus.join(", "));
+
+        cda_interfaces::util::tokio_ext::sleep_for(POLL_INTERVAL).await;
+    }
 }
 
 fn ecu_sim_dir() -> Result<std::path::PathBuf, TestingError> {

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -597,6 +597,37 @@ fn write_config_toml(
             config_path.display()
         ))
     })?;
+
+    // Sync the file itself to ensure content is flushed to disk before Docker
+    // mounts the volume. This prevents a race condition where Docker reads a
+    // partially written or cached config file.
+    let file = std::fs::File::open(&config_path).map_err(|e| {
+        TestingError::ProcessFailed(format!(
+            "Failed to open config file for sync '{}': {e}",
+            config_path.display()
+        ))
+    })?;
+    file.sync_all().map_err(|e| {
+        TestingError::ProcessFailed(format!(
+            "Failed to fsync config file '{}': {e}",
+            config_path.display()
+        ))
+    })?;
+
+    // Also sync the directory to ensure metadata is flushed.
+    let dir = std::fs::File::open(test_container_dir).map_err(|e| {
+        TestingError::ProcessFailed(format!(
+            "Failed to open config directory '{}': {e}",
+            test_container_dir.display()
+        ))
+    })?;
+    dir.sync_all().map_err(|e| {
+        TestingError::ProcessFailed(format!(
+            "Failed to fsync config directory '{}': {e}",
+            test_container_dir.display()
+        ))
+    })?;
+
     tracing::debug!("Wrote CDA test config to {:?}", config_path);
     Ok(())
 }

--- a/testcontainer/ecu-sim/src/main/kotlin/webserver/DataObjects.kt
+++ b/testcontainer/ecu-sim/src/main/kotlin/webserver/DataObjects.kt
@@ -58,6 +58,7 @@ fun EcuState.updateWith(dto: EcuStateDto) {
     this.vin = dto.vin ?: this.vin
     this.maxNumberOfBlockLength = dto.maxNumberOfBlockLength ?: this.maxNumberOfBlockLength
     this.dtcSettingType = dto.dtcSettingType ?: this.dtcSettingType
+    this.hardResetForSeconds = dto.hardResetForSeconds ?: this.hardResetForSeconds
 }
 
 fun EcuState.toDto() =

--- a/testcontainer/ecu-sim/src/main/kotlin/webserver/EmbeddedWebserver.kt
+++ b/testcontainer/ecu-sim/src/main/kotlin/webserver/EmbeddedWebserver.kt
@@ -82,6 +82,7 @@ fun Application.appModule() {
         addFlashTransferRoutes()
         addRecordingRoutes()
         addDtcFaultsRoutes()
+        addDisconnectRoutes()
         addInterceptorRoutes()
         addJwtAuthServerMockRoutes()
 

--- a/testcontainer/ecu-sim/src/main/kotlin/webserver/WebserverRoutes.kt
+++ b/testcontainer/ecu-sim/src/main/kotlin/webserver/WebserverRoutes.kt
@@ -198,27 +198,16 @@ data class SimpleInterceptorDto(
 /**
  * Routes to simulate DoIP TCP connection disruptions.
  *
- * - POST /{ecu}/disconnect: Closes all active TCP connections to the specified ECU's DoIP entity.
+ * - POST /disconnect: Closes all active TCP connections on all DoIP entities.
  *   This simulates a network disconnect or ECU reboot where the TCP link is lost.
- *   After the disconnect, the ECU will re-announce itself via VAMs and the tester
+ *   After the disconnect, ECUs will re-announce themselves via VAMs and the tester
  *   should re-establish the connection.
  */
 fun Route.addDisconnectRoutes() {
-    post("/{ecu}/disconnect") {
+    post("/disconnect") {
         MDC.clear()
-        val ecuName = call.parameters["ecu"].orEmpty()
         var closedConnections = 0
 
-        // Verify the ECU exists
-        findByEcuName(ecuName)
-            ?: return@post call.respond(
-                HttpStatusCode.NotFound,
-                mapOf("message" to "ECU $ecuName not found"),
-            )
-
-        // Close all TCP connections on all DoIP entities in all network instances.
-        // Since a single TCP connection may serve multiple ECUs through the same gateway,
-        // we close all connections to ensure the target ECU's connection is dropped.
         networkInstances().forEach { network ->
             network.doipEntities.forEach { entity ->
                 entity.connectionHandlers.toList().forEach { handler ->
@@ -230,7 +219,7 @@ fun Route.addDisconnectRoutes() {
 
         call.respond(
             HttpStatusCode.OK,
-            mapOf("message" to "Closed $closedConnections TCP connection(s) for ECU $ecuName"),
+            mapOf("message" to "Closed $closedConnections TCP connection(s)"),
         )
     }
 }

--- a/testcontainer/ecu-sim/src/main/kotlin/webserver/WebserverRoutes.kt
+++ b/testcontainer/ecu-sim/src/main/kotlin/webserver/WebserverRoutes.kt
@@ -196,6 +196,46 @@ data class SimpleInterceptorDto(
 )
 
 /**
+ * Routes to simulate DoIP TCP connection disruptions.
+ *
+ * - POST /{ecu}/disconnect: Closes all active TCP connections to the specified ECU's DoIP entity.
+ *   This simulates a network disconnect or ECU reboot where the TCP link is lost.
+ *   After the disconnect, the ECU will re-announce itself via VAMs and the tester
+ *   should re-establish the connection.
+ */
+fun Route.addDisconnectRoutes() {
+    post("/{ecu}/disconnect") {
+        MDC.clear()
+        val ecuName = call.parameters["ecu"].orEmpty()
+        var closedConnections = 0
+
+        // Verify the ECU exists
+        findByEcuName(ecuName)
+            ?: return@post call.respond(
+                HttpStatusCode.NotFound,
+                mapOf("message" to "ECU $ecuName not found"),
+            )
+
+        // Close all TCP connections on all DoIP entities in all network instances.
+        // Since a single TCP connection may serve multiple ECUs through the same gateway,
+        // we close all connections to ensure the target ECU's connection is dropped.
+        networkInstances().forEach { network ->
+            network.doipEntities.forEach { entity ->
+                entity.connectionHandlers.toList().forEach { handler ->
+                    handler.closeSocket()
+                    closedConnections++
+                }
+            }
+        }
+
+        call.respond(
+            HttpStatusCode.OK,
+            mapOf("message" to "Closed $closedConnections TCP connection(s) for ECU $ecuName"),
+        )
+    }
+}
+
+/**
  * Routes to install/remove named inbound interceptors on ECUs.
  * This is used in integration tests to simulate custom ECU responses
  * (e.g., malformed responses, suppressed responses, or temporary overrides).


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

### feat(tests): add Tester Present integration tests
Add ECU simulator disconnect/hard reset capabilities to simulate TCP connection drops and ECU reboots. Add comprehensive tests verifying Tester Present frames are maintained during active locks across session switches and network disrupts.

### fix(integration-tests): fsync testcontainer CDA configuraiton
When running the integration tests in a loop, to test for flaky tests, the tests break from time to time because they are unable to parse the CDA configuration. The parser points out the file is only partially written. This commit syncs the disk state for the test container directory (making sure meta data is up to date) and the configuration file itself to make sure this is fully flushed before usage too.

### fix(variant-detection): trigger variant detection after reconnection
To make sure an ECU is correctly detected as online after a network disconnect, this commit triggers a variant detection as soon as the connection is re-established. Aside from setting the correct ECU state, this makes also sure that the tester present task does not skip the ECU anymore, marking it as offline.

### fix(update-reload): fix an issue that ECUs do not come back online
The shutdown was not canceling several tasks which left them running with outdated references. This commit collects all tasks that must be shut down and does so cleanly during application shutdown or when applying an update. Update is now destroying all old instances first, then setting up new instances instead doing this one at a time. Fix an issue where the DOIP socket was not closed properly, leaving messages being sent to the wrong instance by re-using the existing socket instead of re-creating it.

### refactor(connection): add two structs containing connection setup
Solves clippy warning of too many parameters and makes usage a bit more ergonomic.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Deeming the crap regression as acceptable because create_socket(_with_protocol) is actually tested through the integration tests and just not measured yet. 


Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)