### PR TITLE
fix: Allow running CDA with test data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,13 +63,28 @@ jobs:
             exit 1
           fi
           echo "Generated files are up to date."
-      - name: Verify reference config is up to date
+      - name: Verify reference config matches generated config
         run: |
           cargo run --locked --all-features -- generate-config --output /tmp/opensovd-cda.toml
           if ! diff -u opensovd-cda.toml /tmp/opensovd-cda.toml; then
             echo ""
-            echo "::error::opensovd-cda.toml is out of date."
-            echo "Regenerate with: cargo run --all-features -- generate-config --output opensovd-cda.toml"
+            echo "::error::opensovd-cda.toml does not match configuration generated from code."
+
+            cat <<EOF
+          The opensovd-cda.toml file is a reference generated from the source code.
+          You should not edit it directly and it needs to be regenerated when you
+          edit the configuration fields in the source code.
+
+          You can regenerate it with:
+          cargo run --all-features -- generate-config --output opensovd-cda.toml
+
+          You will need DLT installed as a library on your system.
+          You can install it like so:
+            * On Debian-based systems: apt install libdlt-dev
+            * On macOS with Homebrew:
+              brew tap COVESA/dlt-daemon https://github.com/COVESA/dlt-daemon
+              brew install COVESA/dlt-daemon/dlt-daemon
+          EOF
             exit 1
           fi
           echo "opensovd-cda.toml is up to date."

--- a/cda-database/src/lib.rs
+++ b/cda-database/src/lib.rs
@@ -58,10 +58,9 @@ pub struct DatabaseConfig {
     /// This helps catch typos in ECU names early. When `false` (default),
     /// unmatched per-ECU config entries only produce a warning.
     pub strict_ecu_config: bool,
-    /// When `true`, MDD files that fail to load are skipped and the remaining
-    /// databases continue loading. When `false` (the default), any MDD load
+    /// When `true` (the default), MDD files that fail to load are skipped and
+    /// the remaining databases continue loading. When `false`, any MDD load
     /// failure aborts the entire load/reload operation.
-    #[serde(default)]
     pub ignore_invalid_mdd: bool,
 }
 
@@ -75,7 +74,7 @@ impl Default for DatabaseConfig {
             ignore_protocol: false,
             strict_parameter_validation: false,
             strict_ecu_config: false,
-            ignore_invalid_mdd: false,
+            ignore_invalid_mdd: true,
         }
     }
 }

--- a/cda-database/src/lib.rs
+++ b/cda-database/src/lib.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 
 // Allowed because it makes sense for a configuration to have more than 3 bools
 #[allow(clippy::struct_excessive_bools)]
-#[derive(Deserialize, Serialize, Clone, Debug, Default, schemars::JsonSchema)]
+#[derive(Deserialize, Serialize, Clone, Debug, schemars::JsonSchema)]
 pub struct DatabaseConfig {
     /// Path to load the databases from, this must be a directory.
     pub path: String,
@@ -63,4 +63,19 @@ pub struct DatabaseConfig {
     /// failure aborts the entire load/reload operation.
     #[serde(default)]
     pub ignore_invalid_mdd: bool,
+}
+
+impl Default for DatabaseConfig {
+    fn default() -> Self {
+        Self {
+            path: ".".to_owned(),
+            naming_convention: DatabaseNamingConvention::default(),
+            exit_no_database_loaded: false,
+            fallback_to_base_variant: true,
+            ignore_protocol: false,
+            strict_parameter_validation: false,
+            strict_ecu_config: false,
+            ignore_invalid_mdd: false,
+        }
+    }
 }

--- a/cda-interfaces/src/lib.rs
+++ b/cda-interfaces/src/lib.rs
@@ -295,6 +295,15 @@ pub struct FunctionalDescriptionConfig {
     /// Position of the protocol identifier in service names.
     pub protocol_position: datatypes::DiagnosticServiceAffixPosition,
 }
+impl Default for FunctionalDescriptionConfig {
+    fn default() -> Self {
+        Self {
+            description_database: "functional_groups".to_owned(),
+            enabled_functional_groups: None,
+            protocol_position: datatypes::DiagnosticServiceAffixPosition::Suffix,
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum DiagServiceError {

--- a/cda-main/src/config/configfile.rs
+++ b/cda-main/src/config/configfile.rs
@@ -190,6 +190,14 @@ pub struct ServerConfig {
     /// TCP port the server listens on.
     pub port: u16,
 }
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            address: "0.0.0.0".to_owned(),
+            port: 20002,
+        }
+    }
+}
 
 pub trait ConfigSanity {
     /// Checks the configuration for common mistakes and returns an error message if found.
@@ -201,21 +209,9 @@ pub trait ConfigSanity {
 impl Default for Configuration {
     fn default() -> Self {
         Configuration {
-            database: DatabaseConfig {
-                path: ".".to_owned(),
-                naming_convention: DatabaseNamingConvention::default(),
-                exit_no_database_loaded: false,
-                fallback_to_base_variant: true,
-                ignore_protocol: false,
-                strict_parameter_validation: false,
-                strict_ecu_config: false,
-                ignore_invalid_mdd: false,
-            },
+            database: DatabaseConfig::default(),
             flash_files_path: ".".to_owned(),
-            server: ServerConfig {
-                address: "0.0.0.0".to_owned(),
-                port: 20002,
-            },
+            server: ServerConfig::default(),
             #[cfg(feature = "health")]
             health: cda_health::config::HealthConfig::default(),
             doip: DoipConfig {
@@ -225,12 +221,7 @@ impl Default for Configuration {
             logging: cda_tracing::LoggingConfig::default(),
             com_params: ComParams::default(),
             flat_buf: FlatbBufConfig::default(),
-            functional_description: FunctionalDescriptionConfig {
-                description_database: "functional_groups".to_owned(),
-                enabled_functional_groups: None,
-                protocol_position:
-                    cda_interfaces::datatypes::DiagnosticServiceAffixPosition::Suffix,
-            },
+            functional_description: FunctionalDescriptionConfig::default(),
             components: ComponentsConfig {
                 additional_fields: HashMap::from_iter([
                     (

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -382,10 +382,10 @@
 # If true, when variant detection fails to find a matching variant,
 # the ECU will fall back to the base variant instead of reporting an error.
 # fallback_to_base_variant = true
-# When `true`, MDD files that fail to load are skipped and the remaining
-# databases continue loading. When `false` (the default), any MDD load
+# When `true` (the default), MDD files that fail to load are skipped and
+# the remaining databases continue loading. When `false`, any MDD load
 # failure aborts the entire load/reload operation.
-# ignore_invalid_mdd = false
+# ignore_invalid_mdd = true
 # When `true`, com-param and protocol lookups ignore the protocol filter
 # and match by parameter name alone.
 #


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
The test data contains an invalid ECU for testing purposes. This causes the CDA to fail during startup, when using the test data.

This changes the included configuration to be more suitable for development use.
For production use, it should be configured differently, like many other configuration values.

---
While implementing this, I also ran into an error message, because I had manually edited the reference configuration. I've made this error message more general and more helpful.  
Here's what the error message looks like in practice now: https://github.com/eclipse-opensovd/classic-diagnostic-adapter/actions/runs/27951065426/job/82707812599?pr=391

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
As discussed with @alexmohr and @theswiftfox.

---

Frank Märkle [frank.maerkle@mercedes-benz.com](mailto:frank.maerkle@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
