### PR TITLE
fix: improve diagnostic communication reliability and logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,7 @@ dependencies = [
  "openssl",
  "schemars",
  "serde",
+ "serde_json",
  "socket2",
  "thiserror 2.0.17",
  "tokio",

--- a/cda-comm-doip/Cargo.toml
+++ b/cda-comm-doip/Cargo.toml
@@ -40,7 +40,7 @@ schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 socket2 = { workspace = true, features = ["all"] }
 #tokio
-tokio = { workspace = true, features = ["time", "fs", "sync"] }
+tokio = { workspace = true, features = ["time", "fs", "sync", "rt", "macros"] }
 tokio-util = { workspace = true, features = ["codec", "net"] }
 # futures
 futures = { workspace = true }
@@ -61,3 +61,7 @@ mbedtls = ["dep:mbedtls-rs"]
 openssl = ["dep:openssl", "dep:tokio-openssl"]
 openssl-vendored = ["openssl", "openssl/vendored"]
 dlt-tracing = ["cda-interfaces/dlt-tracing"]
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "time", "sync", "test-util"] }
+serde_json = { workspace = true }

--- a/cda-comm-doip/src/config.rs
+++ b/cda-comm-doip/src/config.rs
@@ -31,6 +31,10 @@ pub struct DoipConfig {
     pub send_timeout_ms: u64,
     /// Whether to request a diagnostic message positive acknowledgement.
     pub send_diagnostic_message_ack: bool,
+    /// Interval in seconds between `DoIP` alive check requests sent on idle connections.
+    /// The alive check is only sent when no diagnostic communication has occurred
+    /// for this duration. Set to 0 to disable the alive check.
+    pub alive_check_interval_secs: u64,
     /// The name of the protocol to use.
     /// Matched case-insensitive against the database.
     pub protocol_name: String,
@@ -46,6 +50,7 @@ impl Default for DoipConfig {
             tls_port: 3496,
             send_timeout_ms: 1000,
             send_diagnostic_message_ack: true,
+            alive_check_interval_secs: 1800, // 30 minutes
             protocol_name: Protocol::default().to_string(),
         }
     }

--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -753,6 +753,9 @@ fn spawn_gateway_receiver_task<T>(
             }
 
             // wait for a message to be received or a send request
+            // Tokio is randomizing which branch takes precedence when both are ready.
+            // this is good here because it prevents send / receive starvation by
+            // not prioritizing one of the branches.
             tokio::select! {
                 send_pending_result = send_pending_rx.changed() => {
                     if let Err(()) = handle_send_pending(

--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -22,11 +22,14 @@ use doip_definitions::payload::{
     RoutingActivationRequest,
 };
 use thiserror::Error;
-use tokio::sync::{Mutex, RwLock, broadcast, mpsc, watch};
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    sync::{Mutex, RwLock, broadcast, mpsc, watch},
+};
 
 use crate::{
     ConnectionError, DiagnosticResponse, DoipConnection, DoipEcu, DoipTarget,
-    NRC_BUSY_REPEAT_REQUEST, NRC_RESPONSE_PENDING, NRC_TEMPORARILY_NOT_AVAILABLE, SLEEP_INTERVAL,
+    NRC_BUSY_REPEAT_REQUEST, NRC_RESPONSE_PENDING, NRC_TEMPORARILY_NOT_AVAILABLE,
     connections::EcuError::EcuConnectionError,
     ecu_connection::{
         self, ConnectionConfig, ECUConnectionRead, ECUConnectionSend as _, EcuConnectionTarget,
@@ -36,6 +39,21 @@ use crate::{
 
 type ConnectionResetReason = String;
 
+/// Configuration for establishing a gateway connection.
+pub(crate) struct GatewayConfig {
+    pub connection: ConnectionConfig,
+    pub doip: DoIPConfig,
+    pub send_timeout: Duration,
+    pub alive_check_interval: Duration,
+}
+
+/// Runtime state for managing active gateway connections and ECU mappings.
+pub(crate) struct GatewayState<T> {
+    pub doip_connections: Arc<RwLock<Vec<Arc<DoipConnection>>>>,
+    pub ecus: Arc<HashMap<String, RwLock<T>>>,
+    pub gateway_ecu_map: HashMap<u16, Vec<u16>>,
+}
+
 #[derive(Clone, Copy)]
 struct ConnectionSettings {
     routing_activation: Duration,
@@ -43,6 +61,7 @@ struct ConnectionSettings {
     connect_timeout: Duration,
     max_retry_attempts: u32,
     send_timeout: Duration,
+    alive_check_interval: Duration,
 }
 
 #[derive(Error, Debug, Clone)]
@@ -89,11 +108,11 @@ impl From<EcuError> for DiagServiceError {
 }
 
 #[tracing::instrument(
-    skip(doip_connections, ecus, gateway_ecu_map, connection_config),
+    skip(config, state),
     fields(
-        tester_ip = connection_config.source_ip.clone(),
-        port = connection_config.port,
-        tls_port = connection_config.tls_port,
+        tester_ip = config.connection.source_ip.clone(),
+        port = config.connection.port,
+        tls_port = config.connection.tls_port,
         gateway_ecu = %gateway.ecu,
         gateway_ip = %gateway.ip,
         logical_address = %format!("{:#06x}", gateway.logical_address),
@@ -101,18 +120,15 @@ impl From<EcuError> for DiagServiceError {
     )
 )]
 pub(crate) async fn handle_gateway_connection<T>(
-    connection_config: &ConnectionConfig,
     gateway: DoipTarget,
-    doip_connection_config: DoIPConfig,
-    doip_connections: &Arc<RwLock<Vec<Arc<DoipConnection>>>>,
-    ecus: &Arc<HashMap<String, RwLock<T>>>,
-    gateway_ecu_map: &HashMap<u16, Vec<u16>>,
-    send_timeout: Duration,
+    config: &GatewayConfig,
+    state: &GatewayState<T>,
 ) -> Result<u16, EcuError>
 where
     T: EcuAddresses + DoipComParams,
 {
-    let tester_address = ecus
+    let tester_address = state
+        .ecus
         .get(&gateway.ecu)
         .map(|ecu| async { ecu.read().await.tester_address() })
         .ok_or_else(|| EcuError::ResourceNotFound("ECU not found".to_owned()))?
@@ -124,16 +140,17 @@ where
         buffer: [0, 0, 0, 0],
     };
 
-    let ecu_ids: Vec<u16> = if let Some(ecu_ids) = gateway_ecu_map.get(&gateway.logical_address) {
-        ecu_ids.clone()
-    } else {
-        return Err(EcuError::ResourceNotFound(format!(
-            "No ECUs found for gateway address {}. Skipping, as the gateway cannot be used.",
-            gateway.logical_address
-        )));
-    };
+    let ecu_ids: Vec<u16> =
+        if let Some(ecu_ids) = state.gateway_ecu_map.get(&gateway.logical_address) {
+            ecu_ids.clone()
+        } else {
+            return Err(EcuError::ResourceNotFound(format!(
+                "No ECUs found for gateway address {}. Skipping, as the gateway cannot be used.",
+                gateway.logical_address
+            )));
+        };
 
-    let gateway_ecu = match ecus.get(&gateway.ecu) {
+    let gateway_ecu = match state.ecus.get(&gateway.ecu) {
         Some(ecu) => ecu.read().await,
         None => {
             return Err(EcuError::ResourceNotFound(
@@ -147,10 +164,10 @@ where
     let connection_retry_attempts = gateway_ecu.connection_retry_attempts();
 
     let (sender, receiver) = match connection_handler(
-        connection_config.clone(),
+        config.connection.clone(),
         gateway.ip.clone(),
         gateway.ecu.clone(),
-        doip_connection_config,
+        config.doip,
         routing_activation_request,
         ecu_ids.clone(),
         ConnectionSettings {
@@ -158,7 +175,8 @@ where
             retry_delay: connection_retry_delay,
             connect_timeout: connection_timeout,
             max_retry_attempts: connection_retry_attempts,
-            send_timeout,
+            send_timeout: config.send_timeout,
+            alive_check_interval: config.alive_check_interval,
         },
     )
     .await
@@ -177,7 +195,8 @@ where
     let doip_ecus = create_ecu_receiver_map(ecu_ids, &sender, &receiver);
 
     tracing::info!("Connected to gateway");
-    doip_connections
+    state
+        .doip_connections
         .write()
         .await
         .push(Arc::new(DoipConnection {
@@ -309,6 +328,7 @@ async fn connection_handler(
         connection_settings.send_timeout,
         conn_reset_tx.clone(),
         send_pending_tx.clone(),
+        connection_settings.alive_check_interval,
     );
     spawn_gateway_receiver_task(
         gateway_ip.clone(),
@@ -414,14 +434,18 @@ fn spawn_connection_reset_task(
         dlt_context = dlt_ctx!("DOIP")
     )
 )]
-fn spawn_gateway_sender_task(
+fn spawn_gateway_sender_task<T>(
     gateway_ip: &str,
     mut inrx: mpsc::Receiver<DoipPayload>,
-    gateway_conn: Arc<EcuConnectionTarget>,
+    gateway_conn: Arc<EcuConnectionTarget<T>>,
     send_timeout: Duration,
     reset_tx: mpsc::Sender<ConnectionResetReason>,
     send_pending_tx: watch::Sender<bool>,
-) {
+    alive_check_interval: Duration,
+) -> tokio::task::JoinHandle<()>
+where
+    T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
     cda_interfaces::spawn_named!(&format!("doip-gateway-sender-{gateway_ip}"), async move {
         fn send_pending_status(
             send_pending_tx: &watch::Sender<bool>,
@@ -432,18 +456,30 @@ fn spawn_gateway_sender_task(
             })
         }
 
-        let send_mtx = Arc::new(Mutex::new(()));
+        let alive_check_enabled = alive_check_interval > Duration::ZERO;
+        let effective_interval = if alive_check_enabled {
+            alive_check_interval
+        } else {
+            // Use a very large duration when disabled so the interval never fires.
+            // tokio::time::Instant is limited so we use ~136 years which is well
+            // within the representable range.
+            Duration::from_secs(u64::from(u32::MAX))
+        };
         let mut alive_interval = tokio::time::interval_at(
             tokio::time::Instant::now()
-                .checked_add(SLEEP_INTERVAL)
+                .checked_add(effective_interval)
                 .expect("interval start overflow"),
-            SLEEP_INTERVAL,
+            effective_interval,
         );
         alive_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         loop {
             tokio::select! {
+                // Per default tokio, randomized which branch is checked first to ensure fairness.
+                // We always want to priotize sending messages over the alive check.
+                // Adding 'biased' means the selects are checked in order from top to bottom.
+                // https://docs.rs/tokio/latest/tokio/macro.select.html#fairness
+                biased;
                 Some(msg) = inrx.recv() => {
-                    let lock = send_mtx.lock().await;
                     // let rx task know that we want to send something.
                     if send_pending_status(&send_pending_tx, true).is_err() {
                         break;
@@ -455,11 +491,7 @@ fn spawn_gateway_sender_task(
                             let conn = guard.get_sender();
                             let lock_after = start.elapsed();
 
-                            match tokio::time::timeout(send_timeout, conn
-                                .send(msg)
-                            )
-                                .await
-                            {
+                            match tokio::time::timeout(send_timeout, conn.send(msg)).await {
                                 Ok(Ok(())) => {},
                                 Ok(Err(e)) => {
                                     tracing::error!(error = ?e, "Failed to send message");
@@ -486,10 +518,12 @@ fn spawn_gateway_sender_task(
                     if send_pending_status(&send_pending_tx, false).is_err() {
                         break;
                     }
-                    drop(lock);
+                    // Reset the alive check timer so it only fires after a full
+                    // interval of silence - never during active communication.
+                    alive_interval.reset();
                 },
-                _ = alive_interval.tick() => {
-                    let lock = send_mtx.lock().await;
+
+                _ = alive_interval.tick(), if alive_check_enabled => {
                     if send_pending_status(&send_pending_tx, true).is_err() {
                         break;
                     }
@@ -528,11 +562,10 @@ fn spawn_gateway_sender_task(
                     if send_pending_status(&send_pending_tx, false).is_err() {
                         break;
                     }
-                    drop(lock);
                 }
             }
         }
-    });
+    })
 }
 
 /// allowed because there are two inline functions in here,
@@ -547,15 +580,17 @@ fn spawn_gateway_sender_task(
         dlt_context = dlt_ctx!("DOIP"),
     )
 )]
-fn spawn_gateway_receiver_task(
+fn spawn_gateway_receiver_task<T>(
     gateway_ip: String,
     gateway_name: String,
     outtx: HashMap<u16, broadcast::Sender<Result<DiagnosticResponse, EcuError>>>,
-    gateway_conn: Arc<EcuConnectionTarget>,
+    gateway_conn: Arc<EcuConnectionTarget<T>>,
     mut send_pending_rx: watch::Receiver<bool>,
     reset_tx: mpsc::Sender<ConnectionResetReason>,
     send_tx: mpsc::Sender<DoipPayload>,
-) {
+) where
+    T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
     // note: the handlers are defined here, as rustfmt cannot format the correctly inside the
     // tokio::select! macro block
     async fn handle_send_pending(
@@ -757,8 +792,14 @@ fn spawn_gateway_receiver_task(
     });
 }
 
-async fn send_alive_request(conn: &EcuConnectionTarget) -> Result<(), ()> {
-    async fn handle_alive_request_response(conn: &EcuConnectionTarget) {
+async fn send_alive_request<T>(conn: &EcuConnectionTarget<T>) -> Result<(), ()>
+where
+    T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    async fn handle_alive_request_response<T>(conn: &EcuConnectionTarget<T>)
+    where
+        T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
         if tokio::time::timeout(Duration::from_secs(1), async {
             let Ok(mut reader_mtx) = conn.lock_read().await else {
                 return;
@@ -881,4 +922,232 @@ async fn try_read(
     tokio::time::timeout(timeout, read_response(reader))
         .await
         .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use doip_definitions::{
+        header::ProtocolVersion,
+        payload::{DoipPayload, EntityStatusRequest},
+    };
+    use tokio::sync::{Mutex, mpsc, watch};
+
+    use crate::{
+        connections::{ConnectionResetReason, spawn_gateway_sender_task},
+        ecu_connection::{EcuConnectionReadVariant, EcuConnectionSendVariant, EcuConnectionTarget},
+        socket::{DoIPConfig, DoIPConnection},
+    };
+
+    /// Builds a duplex-backed `EcuConnectionTarget` together with the server-side
+    /// `DoIPConnection` used to respond to alive checks and dummy messages.
+    /// `lock_send()` succeeds and `alive_interval.reset()` is called on each
+    /// message processed by the sender task.
+    fn duplex_ecu_connection_target() -> (
+        EcuConnectionTarget<tokio::io::DuplexStream>,
+        DoIPConnection<tokio::io::DuplexStream>,
+    ) {
+        let (client, server) = tokio::io::duplex(1024);
+        let config = DoIPConfig {
+            protocol_version: ProtocolVersion::Iso13400_2012,
+            send_diagnostic_message_ack: false,
+        };
+        let server_conn = DoIPConnection::new(server, config);
+        let (read_half, write_half) = DoIPConnection::new(client, config).into_split();
+        let target = EcuConnectionTarget {
+            ecu_connection_rx: Mutex::new(Some(EcuConnectionReadVariant::Plain(read_half))),
+            ecu_connection_tx: Mutex::new(Some(EcuConnectionSendVariant::Plain(write_half))),
+            gateway_name: String::new(),
+            gateway_ip: String::new(),
+        };
+        (target, server_conn)
+    }
+
+    /// Shared test harness for gateway sender task tests.
+    /// Creates all channels, the duplex connection, pauses time, spawns the task,
+    /// and starts a background responder that simulates a real gateway on the
+    /// server side of the duplex.
+    ///
+    /// The responder handles two types of incoming messages:
+    /// - `AliveCheckRequest`: replies with `AliveCheckResponse` so the sender's
+    ///   alive check completes immediately instead of timing out.
+    /// - `EntityStatusRequest` (dummy diagnostic messages sent by the test):
+    ///   replies with `DiagnosticMessageAck` to simulate a real gateway that
+    ///   acknowledges incoming diagnostic messages. Without this, the ack would
+    ///   be missing from the read buffer, which would make the test less realistic.
+    ///
+    /// The test then uses the returned handles to drive the scenario.
+    struct GatewaySenderTestHarness {
+        msg_tx: mpsc::Sender<DoipPayload>,
+        reset_rx: mpsc::Receiver<ConnectionResetReason>,
+        _gateway_conn: Arc<EcuConnectionTarget<tokio::io::DuplexStream>>,
+        _send_pending_rx: watch::Receiver<bool>,
+        task: tokio::task::JoinHandle<()>,
+    }
+
+    impl GatewaySenderTestHarness {
+        fn new(alive_check_interval: Duration) -> Self {
+            tokio::time::pause();
+
+            let (msg_tx, msg_rx) = mpsc::channel::<DoipPayload>(10);
+            let (reset_tx, reset_rx) = mpsc::channel::<ConnectionResetReason>(10);
+            let (send_pending_tx, send_pending_rx) = watch::channel(false);
+            let (gateway_target, _) = duplex_ecu_connection_target();
+
+            let gateway_conn = Arc::new(gateway_target);
+
+            let task = spawn_gateway_sender_task(
+                "127.0.0.1",
+                msg_rx,
+                Arc::clone(&gateway_conn),
+                Duration::from_secs(1),
+                reset_tx,
+                send_pending_tx,
+                alive_check_interval,
+            );
+
+            Self {
+                msg_tx,
+                reset_rx,
+                _gateway_conn: gateway_conn,
+                _send_pending_rx: send_pending_rx,
+                task,
+            }
+        }
+
+        /// Sends a dummy diagnostic message through the message channel.
+        ///
+        /// The payload (`EntityStatusRequest`) is just a placeholder - the only
+        /// thing that matters is that sending any message through `msg_tx` triggers
+        /// `alive_interval.reset()` inside the sender task.  The exact variant is
+        /// irrelevant for the timer behavior we are testing here.
+        ///
+        /// After sending, we yield once so the sender task is polled and actually
+        /// processes the message.
+        async fn send_dummy_message(&self) {
+            self.msg_tx
+                .send(DoipPayload::EntityStatusRequest(EntityStatusRequest {}))
+                .await
+                .unwrap();
+            tokio::task::yield_now().await;
+        }
+    }
+
+    /// This test validates that the alive check timer resets after each message send,
+    /// ensuring the alive check only fires after a full interval of idle time.
+    #[tokio::test]
+    async fn alive_check_only_fires_when_idle() {
+        let harness = GatewaySenderTestHarness::new(Duration::from_secs(10));
+
+        // Sending messages before the interval elapses prevents alive check.
+        // Send a message at t=4s (before 10s interval).
+        tokio::time::advance(Duration::from_secs(4)).await;
+        harness.send_dummy_message().await;
+
+        // Advance another 4s (total 8s from last send, still within 10s interval).
+        tokio::time::advance(Duration::from_secs(4)).await;
+        harness.send_dummy_message().await;
+
+        // Advance 9s (total 9s from last send, still within 10s interval).
+        tokio::time::advance(Duration::from_secs(9)).await;
+        tokio::task::yield_now().await;
+
+        // The alive check interval has not elapsed since the last message send -
+        // the sender task should still be running and no reset should have been requested.
+        assert!(
+            !harness.task.is_finished(),
+            "Alive check should not have fired during active communication"
+        );
+
+        // Advance 2 more seconds (total 11s from last send, exceeds 10s interval).
+        // The alive check fires: the responder task automatically replies with
+        // AliveCheckResponse, so the request/response cycle completes without
+        // waiting for any timeout.
+        tokio::time::advance(Duration::from_secs(2)).await;
+        // Yield twice so the sender task sends the request, the responder replies,
+        // and the sender reads the response.
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        // Task should still be alive after the alive check fired.
+        assert!(
+            !harness.task.is_finished(),
+            "Task should still be running after alive check fired"
+        );
+
+        // After alive check fires, sending a message resets the timer.
+        harness.send_dummy_message().await;
+
+        // Advance 9s (within 10s interval from last send).
+        tokio::time::advance(Duration::from_secs(9)).await;
+        tokio::task::yield_now().await;
+
+        assert!(
+            !harness.task.is_finished(),
+            "Alive check should not fire after timer reset by message send"
+        );
+
+        // Advance 2 more seconds (total 11s from last send) - alive check fires again.
+        tokio::time::advance(Duration::from_secs(2)).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        assert!(
+            !harness.task.is_finished(),
+            "Task should still be running after second alive check fired"
+        );
+
+        // Clean up: abort the task.
+        harness.task.abort();
+        let _ = harness.task.await;
+    }
+
+    /// Validates that the alive check does not fire when the interval is set to zero
+    /// (disabled).
+    #[tokio::test]
+    async fn alive_check_disabled_when_interval_zero() {
+        let mut harness = GatewaySenderTestHarness::new(Duration::ZERO);
+
+        // Advance a very long time - alive check should never fire.
+        #[allow(unknown_lints, clippy::duration_suboptimal_units)]
+        tokio::time::advance(Duration::from_secs(4200)).await;
+        tokio::task::yield_now().await;
+
+        assert!(
+            harness.reset_rx.try_recv().is_err(),
+            "Alive check should never fire when interval is zero (disabled)"
+        );
+        assert!(!harness.task.is_finished(), "Task should still be running");
+
+        // Clean up: abort the task.
+        harness.task.abort();
+        let _ = harness.task.await;
+    }
+
+    /// Validates that when both a message and the alive check are ready simultaneously,
+    /// the biased select ensures the message branch wins.
+    #[tokio::test]
+    async fn biased_select_prioritizes_messages_over_alive_check() {
+        let mut harness = GatewaySenderTestHarness::new(Duration::from_secs(5));
+
+        // Advance time past the alive check interval so both tick and message are ready.
+        tokio::time::advance(Duration::from_secs(6)).await;
+        // Send a message - both the tick and the message channel are now ready.
+        harness.send_dummy_message().await;
+
+        // Due to biased select the message branch is evaluated before the alive check
+        // branch. The message is processed first, which resets the timer - so the
+        // alive check does not fire this iteration and no reset is triggered.
+        assert!(
+            harness.reset_rx.try_recv().is_err(),
+            "Biased select should process the message before the alive check,              \
+             preventing an immediate reset"
+        );
+        assert!(!harness.task.is_finished(), "Task should still be running");
+
+        // Clean up: abort the task.
+        harness.task.abort();
+        let _ = harness.task.await;
+    }
 }

--- a/cda-comm-doip/src/ecu_connection.rs
+++ b/cda-comm-doip/src/ecu_connection.rs
@@ -26,6 +26,7 @@ use mbedtls_rs::{
 #[cfg(feature = "openssl")]
 use openssl::ssl::{Ssl, SslContextBuilder, SslMethod, SslOptions, SslVerifyMode, SslVersion};
 use tokio::{
+    io::{AsyncRead, AsyncWrite},
     net::{TcpSocket, TcpStream},
     sync::Mutex,
 };
@@ -126,13 +127,13 @@ pub(crate) trait ECUConnectionSend {
         Self: std::borrow::Borrow<Self>;
 }
 
-enum EcuConnectionVariant {
+enum EcuConnectionVariant<T: AsyncRead + AsyncWrite + Unpin = TcpStream> {
     #[cfg(any(feature = "openssl", feature = "mbedtls"))]
     Tls(DoIPConnection<TlsStream<TcpStream>>),
-    Plain(DoIPConnection<TcpStream>),
+    Plain(DoIPConnection<T>),
 }
 
-impl EcuConnectionVariant {
+impl<T: AsyncRead + AsyncWrite + Unpin> EcuConnectionVariant<T> {
     async fn send(&mut self, msg: DoipPayload) -> Result<(), ConnectionError> {
         match self {
             #[cfg(any(feature = "openssl", feature = "mbedtls"))]
@@ -148,7 +149,7 @@ impl EcuConnectionVariant {
             EcuConnectionVariant::Plain(conn) => conn.read().await,
         }
     }
-    fn into_split(self) -> (EcuConnectionReadVariant, EcuConnectionSendVariant) {
+    fn into_split(self) -> (EcuConnectionReadVariant<T>, EcuConnectionSendVariant<T>) {
         match self {
             #[cfg(any(feature = "openssl", feature = "mbedtls"))]
             EcuConnectionVariant::Tls(conn) => {
@@ -169,51 +170,53 @@ impl EcuConnectionVariant {
     }
 }
 
-pub(crate) enum EcuConnectionReadVariant {
+pub(crate) enum EcuConnectionReadVariant<T: AsyncRead + Unpin = TcpStream> {
     #[cfg(any(feature = "openssl", feature = "mbedtls"))]
     Tls(DoIPConnectionReadHalf<TlsStream<TcpStream>>),
-    Plain(DoIPConnectionReadHalf<TcpStream>),
+    Plain(DoIPConnectionReadHalf<T>),
 }
-pub(crate) enum EcuConnectionSendVariant {
+pub(crate) enum EcuConnectionSendVariant<T: AsyncWrite + Unpin = TcpStream> {
     #[cfg(any(feature = "openssl", feature = "mbedtls"))]
     Tls(DoIPConnectionWriteHalf<TlsStream<TcpStream>>),
-    Plain(DoIPConnectionWriteHalf<TcpStream>),
+    Plain(DoIPConnectionWriteHalf<T>),
 }
 
-pub(crate) struct EcuConnectionTarget {
-    pub(crate) ecu_connection_rx: Mutex<Option<EcuConnectionReadVariant>>,
-    pub(crate) ecu_connection_tx: Mutex<Option<EcuConnectionSendVariant>>,
+pub(crate) struct EcuConnectionTarget<
+    T: AsyncRead + AsyncWrite + Unpin + Send + 'static = TcpStream,
+> {
+    pub(crate) ecu_connection_rx: Mutex<Option<EcuConnectionReadVariant<T>>>,
+    pub(crate) ecu_connection_tx: Mutex<Option<EcuConnectionSendVariant<T>>>,
     pub(crate) gateway_name: String,
     pub(crate) gateway_ip: String,
 }
 
-pub struct EcuConnectionSendGuard<'a> {
-    guard: tokio::sync::MutexGuard<'a, Option<EcuConnectionSendVariant>>,
+pub struct EcuConnectionSendGuard<'a, T: AsyncWrite + Unpin = TcpStream> {
+    guard: tokio::sync::MutexGuard<'a, Option<EcuConnectionSendVariant<T>>>,
 }
 
-impl EcuConnectionSendGuard<'_> {
-    pub(crate) fn get_sender(&mut self) -> &mut EcuConnectionSendVariant {
+impl<T: AsyncWrite + Unpin> EcuConnectionSendGuard<'_, T> {
+    pub(crate) fn get_sender(&mut self) -> &mut EcuConnectionSendVariant<T> {
         self.guard.as_mut().expect("Sender should be Some")
     }
 }
 
-pub struct EcuConnectionReadGuard<'a> {
-    guard: tokio::sync::MutexGuard<'a, Option<EcuConnectionReadVariant>>,
+pub struct EcuConnectionReadGuard<'a, T: AsyncRead + Unpin = TcpStream> {
+    guard: tokio::sync::MutexGuard<'a, Option<EcuConnectionReadVariant<T>>>,
 }
 
-impl EcuConnectionReadGuard<'_> {
-    pub(crate) fn get_reader(&mut self) -> &mut EcuConnectionReadVariant {
+impl<T: AsyncRead + Unpin> EcuConnectionReadGuard<'_, T> {
+    pub(crate) fn get_reader(&mut self) -> &mut EcuConnectionReadVariant<T> {
         self.guard.as_mut().expect("Reader should be Some")
     }
 }
 
-pub struct EcuConnectionGuard<'a> {
-    read_guard: EcuConnectionReadGuard<'a>,
-    send_guard: EcuConnectionSendGuard<'a>,
+pub struct EcuConnectionGuard<'a, T: AsyncRead + AsyncWrite + Unpin + Send + 'static = TcpStream> {
+    read_guard: EcuConnectionReadGuard<'a, T>,
+    send_guard: EcuConnectionSendGuard<'a, T>,
 }
 
-impl EcuConnectionTarget {
-    pub(crate) async fn lock_send(&self) -> Result<EcuConnectionSendGuard<'_>, ConnectionError> {
+impl<T: AsyncRead + AsyncWrite + Unpin + Send + 'static> EcuConnectionTarget<T> {
+    pub(crate) async fn lock_send(&self) -> Result<EcuConnectionSendGuard<'_, T>, ConnectionError> {
         let guard = self.ecu_connection_tx.lock().await;
         match *guard {
             Some(_) => Ok(EcuConnectionSendGuard { guard }),
@@ -221,7 +224,7 @@ impl EcuConnectionTarget {
         }
     }
 
-    pub(crate) async fn lock_read(&self) -> Result<EcuConnectionReadGuard<'_>, ConnectionError> {
+    pub(crate) async fn lock_read(&self) -> Result<EcuConnectionReadGuard<'_, T>, ConnectionError> {
         let guard = self.ecu_connection_rx.lock().await;
         match *guard {
             Some(_) => Ok(EcuConnectionReadGuard { guard }),
@@ -229,7 +232,7 @@ impl EcuConnectionTarget {
         }
     }
 
-    pub(crate) async fn lock_connection(&self) -> EcuConnectionGuard<'_> {
+    pub(crate) async fn lock_connection(&self) -> EcuConnectionGuard<'_, T> {
         let ecu_connection_rx = self.ecu_connection_rx.lock().await;
         let ecu_connection_tx = self.ecu_connection_tx.lock().await;
         EcuConnectionGuard {
@@ -242,13 +245,16 @@ impl EcuConnectionTarget {
         }
     }
 
-    pub(crate) fn reconnect(guard: &mut EcuConnectionGuard<'_>, new_target: EcuConnectionTarget) {
+    pub(crate) fn reconnect(
+        guard: &mut EcuConnectionGuard<'_, T>,
+        new_target: EcuConnectionTarget<T>,
+    ) {
         *guard.read_guard.guard = new_target.ecu_connection_rx.into_inner();
         *guard.send_guard.guard = new_target.ecu_connection_tx.into_inner();
     }
 }
 
-impl ECUConnectionSend for EcuConnectionSendVariant {
+impl<T: AsyncWrite + Unpin> ECUConnectionSend for EcuConnectionSendVariant<T> {
     async fn send(&mut self, msg: DoipPayload) -> Result<(), ConnectionError> {
         match self {
             #[cfg(any(feature = "openssl", feature = "mbedtls"))]
@@ -259,7 +265,7 @@ impl ECUConnectionSend for EcuConnectionSendVariant {
     }
 }
 
-impl ECUConnectionRead for EcuConnectionReadVariant {
+impl<T: AsyncRead + Unpin> ECUConnectionRead for EcuConnectionReadVariant<T> {
     async fn read(&mut self) -> Option<Result<DoipMessage, ConnectionError>> {
         match self {
             #[cfg(any(feature = "openssl", feature = "mbedtls"))]
@@ -599,9 +605,9 @@ async fn create_tls_stream(
         dlt_context  = dlt_ctx!("DOIP"),
     )
 )]
-async fn try_read_routing_activation_response(
+async fn try_read_routing_activation_response<T: AsyncRead + AsyncWrite + Unpin>(
     timeout: std::time::Duration,
-    reader: &mut EcuConnectionVariant,
+    reader: &mut EcuConnectionVariant<T>,
     _gateway_name: &str,
     _gateway_ip: &str,
 ) -> Result<RoutingActivationResponse, DiagServiceError> {

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -556,6 +556,11 @@ impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
                     // i.e. when the ecu is busy and sends NRC 0x78
                     loop {
                         tokio::select! {
+                            // Using biased saves a bit of CPU time, because tokio does not
+                            // have to generate a random number to select the branch.
+                            // Prioritizing the ecu.reciver over the closed handler is fine
+                            // because it is unlikely that both signal at the exact same time.
+                            biased;
                             res = ecu.receiver.recv() => {
                                 if let Ok(res) = res { match res {
                                     Ok(response) => {

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -33,7 +33,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     config::DoipConfig,
-    connections::EcuError,
+    connections::{EcuError, GatewayConfig, GatewayState},
     ecu_connection::ConnectionConfig,
     socket::{DoIPConfig, DoIPUdpSocket},
 };
@@ -43,8 +43,6 @@ mod connections;
 mod ecu_connection;
 mod socket;
 mod vir_vam;
-
-const SLEEP_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Timeout when suppressPosRspMsgIndicationBit is set.
 /// ECUs that reject a request usually respond quickly with an NRC and
@@ -176,6 +174,7 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
             tls_port,
             send_timeout_ms,
             send_diagnostic_message_ack,
+            alive_check_interval_secs,
             ..
         } = doip_config;
         let gateway_port = *gateway_port;
@@ -193,6 +192,7 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
             send_diagnostic_message_ack: *send_diagnostic_message_ack,
         };
         let send_timeout = Duration::from_millis(*send_timeout_ms);
+        let alive_check_interval = Duration::from_secs(*alive_check_interval_secs);
 
         tracing::info!("Initializing DoipDiagGateway");
 
@@ -245,13 +245,18 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
 
             for gateway in gateways {
                 if let Ok(logical_address) = connections::handle_gateway_connection::<T>(
-                    &connection_config,
                     gateway,
-                    doip_connection_config,
-                    &doip_connections,
-                    &ecus,
-                    &gateway_ecu_map,
-                    send_timeout,
+                    &GatewayConfig {
+                        connection: connection_config.clone(),
+                        doip: doip_connection_config,
+                        send_timeout,
+                        alive_check_interval,
+                    },
+                    &GatewayState {
+                        doip_connections: Arc::clone(&doip_connections),
+                        ecus: Arc::clone(&ecus),
+                        gateway_ecu_map: gateway_ecu_map.clone(),
+                    },
                 )
                 .await
                 {
@@ -279,6 +284,7 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
             gateway.clone(),
             variant_detection,
             send_timeout,
+            alive_check_interval,
             shared_shutdown_signal,
             gateway.cancel_token.child_token(),
         )

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -420,7 +420,10 @@ impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
                                 if let Ok(result) = ecu.receiver.recv().await {
                                     match result {
                                         Ok(DiagnosticResponse::Ack((_, prev))) => {
-                                            tracing::debug!("Received ACK");
+                                            tracing::debug!(
+                                                ecu_name = %transmission_params.ecu_name,
+                                                "Received ACK"
+                                            );
                                             if !prev.is_empty()
                                                 && !doip_message.message.starts_with(&prev)
                                             {
@@ -440,6 +443,11 @@ impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
                                         }
                                         Ok(DiagnosticResponse::GenericNack(nack)) => {
                                             // todo #22: handle generic NACK
+                                            tracing::warn!(
+                                                ecu_name = %transmission_params.ecu_name,
+                                                nack_code = ?nack.nack_code,
+                                                "Received generic NACK"
+                                            );
                                             try_send_uds_response(
                                                 &response_sender,
                                                 Err(DiagServiceError::Nack(u8::from(
@@ -449,6 +457,11 @@ impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
                                             .await;
                                         }
                                         Ok(DiagnosticResponse::Nack(nack)) => {
+                                            tracing::warn!(
+                                                ecu_name = %transmission_params.ecu_name,
+                                                nack_code = ?nack.nack_code,
+                                                "Received NACK"
+                                            );
                                             try_send_uds_response(
                                                 &response_sender,
                                                 Err(DiagServiceError::Nack(u8::from(
@@ -459,8 +472,8 @@ impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
                                         }
                                         Ok(msg) => {
                                             tracing::warn!(
-                                                "Expected ACK/NACK but received unexpected \
-                                                 message: {:?}",
+                                                ecu_name = %transmission_params.ecu_name,
+                                                "Expected ACK/NACK but received unexpected message: {:?}",
                                                 msg
                                             );
                                             // any response but ACK/NACK is unexpected because
@@ -472,6 +485,11 @@ impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
                                             continue 'ack_waiting;
                                         }
                                         Err(e) => {
+                                            tracing::error!(
+                                                ecu_name = %transmission_params.ecu_name,
+                                                error = %e,
+                                                "Error while waiting for ACK/NACK"
+                                            );
                                             try_send_uds_response(
                                                 &response_sender,
                                                 Err(DiagServiceError::NoResponse(format!(
@@ -485,6 +503,10 @@ impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
                                     break 'ack_waiting false;
                                 }
                                 // did not get anything from ecu receiver, meaning it is closed.
+                                tracing::error!(
+                                    ecu_name = %transmission_params.ecu_name,
+                                    "ECU receiver unexpectedly closed while waiting for ACK/NACK"
+                                );
                                 try_send_uds_response(
                                     &response_sender,
                                     Err(DiagServiceError::NoResponse(
@@ -504,8 +526,9 @@ impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
                         }
                     } else {
                         tracing::warn!(
-                            "Timeout waiting for ACK/NACK from ECU after {:?}",
-                            transmission_params.timeout_ack
+                            ecu_name = %transmission_params.ecu_name,
+                            timeout = ?transmission_params.timeout_ack,
+                            "Timeout waiting for ACK/NACK from ECU"
                         );
                         // timeout branch of tokio::select, no response received,
                         // informing receiver about timeout and giving up.
@@ -536,6 +559,11 @@ impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
                                         }
                                     }
                                     Err(e) => {
+                                        tracing::error!(
+                                            ecu_name = %transmission_params.ecu_name,
+                                            error = %e,
+                                            "Error while waiting for response message"
+                                        );
                                         if !try_send_uds_response(
                                                 &response_sender,
                                                 Err(DiagServiceError::NoResponse(
@@ -546,6 +574,10 @@ impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
                                         }
                                     }
                                 } } else {
+                                    tracing::error!(
+                                        ecu_name = %transmission_params.ecu_name,
+                                        "ECU receiver unexpectedly closed while waiting for response"
+                                    );
                                     try_send_uds_response(&response_sender,
                                         Err(DiagServiceError::NoResponse(
                                             "ECU receiver unexpectedly closed".to_owned(),
@@ -554,7 +586,10 @@ impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
                                 }
                             }
                             () = response_sender.closed() => {
-                                tracing::debug!("Response sender closed, aborting loop");
+                                tracing::debug!(
+                                    ecu_name = %transmission_params.ecu_name,
+                                    "Response sender closed, aborting loop"
+                                );
                                 break;
                             }
                         }
@@ -566,6 +601,7 @@ impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
                         .saturating_sub(send_and_ackd_after)
                         .saturating_sub(receiver_flushed);
                     tracing::debug!(
+                        ecu_name = %transmission_params.ecu_name,
                         total_duration = ?start.elapsed(),
                         lock_duration = ?lock_acquired,
                         flush_duration = ?receiver_flushed,

--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -25,7 +25,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     DoipDiagGateway, DoipTarget,
-    connections::handle_gateway_connection,
+    connections::{GatewayConfig, GatewayState, handle_gateway_connection},
     ecu_connection::ConnectionConfig,
     socket::{DoIPConfig, DoIPUdpSocket},
 };
@@ -108,6 +108,7 @@ pub(crate) async fn listen_for_vams<T, F>(
     gateway: DoipDiagGateway<T>,
     variant_detection: mpsc::Sender<Vec<String>>,
     send_timeout: Duration,
+    alive_check_interval: Duration,
     mut shutdown_signal: futures::future::Shared<F>,
     cancel_token: CancellationToken,
 ) where
@@ -138,6 +139,7 @@ pub(crate) async fn listen_for_vams<T, F>(
         connection_config: &ConnectionConfig,
         gateway: &DoipDiagGateway<T>,
         send_timeout: Duration,
+        alive_check_interval: Duration,
         doip_msg_ctx: DoipMessageContext,
         gateway_ecu_map: &HashMap<u16, Vec<u16>>,
         gateway_ecu_name_map: &HashMap<u16, Vec<String>>,
@@ -175,13 +177,18 @@ pub(crate) async fn listen_for_vams<T, F>(
                     tracing::info!(ecu_name = %doip_target.ecu, "New Gateway ECU detected");
 
                     match handle_gateway_connection::<T>(
-                        connection_config,
                         doip_target,
-                        doip_connection_config,
-                        &gateway.doip_connections,
-                        &gateway.ecus,
-                        gateway_ecu_map,
-                        send_timeout,
+                        &GatewayConfig {
+                            connection: connection_config.clone(),
+                            doip: doip_connection_config,
+                            send_timeout,
+                            alive_check_interval,
+                        },
+                        &GatewayState {
+                            doip_connections: Arc::clone(&gateway.doip_connections),
+                            ecus: Arc::clone(&gateway.ecus),
+                            gateway_ecu_map: gateway_ecu_map.clone(),
+                        },
                     )
                     .await
                     {
@@ -299,6 +306,7 @@ pub(crate) async fn listen_for_vams<T, F>(
                                 &connection_config,
                                 &gateway,
                                 send_timeout,
+                                alive_check_interval,
                                 DoipMessageContext {
                                     doip_msg,
                                     source_addr,

--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -58,6 +58,10 @@ where
     let vam_timeout = Duration::from_secs(1); // not the actual timeout from the spec ...
 
     tokio::select! {
+        // Use `biased` to prioritize shutdown signal over the VIR receive loop.
+        // This ensures that if shutdown is already signaled when entering the
+        // select, we exit immediately without starting unnecessary work.
+        biased;
         () = &mut shutdown_signal => {
             tracing::info!("Shutdown signal received");
         },
@@ -294,6 +298,9 @@ pub(crate) async fn listen_for_vams<T, F>(
             loop {
                 let mut socket = broadcast_socket.lock().await;
                 tokio::select! {
+                    // Use `biased` to prioritize shutdown signal and cancel handling
+                    // over processing the VAM
+                    biased;
                     () = &mut shutdown_signal => {
                         break
                     },

--- a/cda-core/src/diag_kernel/payload.rs
+++ b/cda-core/src/diag_kernel/payload.rs
@@ -152,19 +152,25 @@ pub(in crate::diag_kernel) fn str_to_json_value(
     let json_value = match data_type {
         datatypes::DataType::Int32 => {
             let i32val = value.parse::<i32>().map_err(|e| {
-                DiagServiceError::InvalidDatabase(format!("CodedConst value conversion error: {e}"))
+                DiagServiceError::InvalidDatabase(format!(
+                    "CodedConst value ({value}) conversion error: {e}"
+                ))
             })?;
             serde_json::Number::from(i32val).into()
         }
         datatypes::DataType::UInt32 => {
             let u32val = value.parse::<u32>().map_err(|e| {
-                DiagServiceError::InvalidDatabase(format!("CodedConst value conversion error: {e}"))
+                DiagServiceError::InvalidDatabase(format!(
+                    "CodedConst value ({value}) conversion error: {e}"
+                ))
             })?;
             serde_json::Number::from(u32val).into()
         }
         datatypes::DataType::Float32 | datatypes::DataType::Float64 => {
             let f64val = value.parse::<f64>().map_err(|e| {
-                DiagServiceError::InvalidDatabase(format!("CodedConst value conversion error: {e}"))
+                DiagServiceError::InvalidDatabase(format!(
+                    "CodedConst value ({value}) conversion error: {e}"
+                ))
             })?;
             serde_json::Number::from_f64(f64val).into()
         }

--- a/cda-core/src/diag_kernel/payload.rs
+++ b/cda-core/src/diag_kernel/payload.rs
@@ -184,6 +184,11 @@ pub(in crate::diag_kernel) fn str_to_json_value(
 
 #[cfg(test)]
 mod tests {
+    use cda_database::datatypes::DataType;
+    use serde_json::json;
+
+    use super::*;
+
     #[test]
     fn test_payload_type() {
         let raw_payload = vec![
@@ -206,5 +211,66 @@ mod tests {
         payload.set_last_read_byte_pos(20);
         payload.consume();
         assert!(payload.exhausted()); // should be exhausted now
+    }
+
+    #[test]
+    fn test_str_to_json_value_int32_success() {
+        assert_eq!(str_to_json_value("42", DataType::Int32), Ok(json!(42)));
+        assert_eq!(str_to_json_value("-1", DataType::Int32), Ok(json!(-1)));
+    }
+
+    #[test]
+    fn test_str_to_json_value_int32_invalid() {
+        assert!(str_to_json_value("abc", DataType::Int32).is_err());
+        assert!(str_to_json_value("12.5", DataType::Int32).is_err());
+    }
+
+    #[test]
+    fn test_str_to_json_value_uint32_success() {
+        assert_eq!(str_to_json_value("42", DataType::UInt32), Ok(json!(42)));
+    }
+
+    #[test]
+    fn test_str_to_json_value_uint32_invalid() {
+        assert!(str_to_json_value("-1", DataType::UInt32).is_err());
+        assert!(str_to_json_value("abc", DataType::UInt32).is_err());
+    }
+
+    #[test]
+    fn test_str_to_json_value_float32() {
+        assert_eq!(
+            str_to_json_value("3.42", DataType::Float32),
+            Ok(json!(3.42))
+        );
+        assert_eq!(str_to_json_value("42", DataType::Float32), Ok(json!(42.0)));
+        assert!(str_to_json_value("abc", DataType::Float32).is_err());
+    }
+
+    #[test]
+    fn test_str_to_json_value_float64() {
+        assert_eq!(
+            str_to_json_value("3.42", DataType::Float64),
+            Ok(json!(3.42))
+        );
+    }
+
+    #[test]
+    fn test_str_to_json_value_string_types() {
+        assert_eq!(
+            str_to_json_value("hello", DataType::AsciiString),
+            Ok(json!("hello"))
+        );
+        assert_eq!(
+            str_to_json_value("hello", DataType::Utf8String),
+            Ok(json!("hello"))
+        );
+        assert_eq!(
+            str_to_json_value("hello", DataType::Unicode2String),
+            Ok(json!("hello"))
+        );
+        assert_eq!(
+            str_to_json_value("hello", DataType::ByteField),
+            Ok(json!("hello"))
+        );
     }
 }

--- a/cda-core/src/diag_kernel/security.rs
+++ b/cda-core/src/diag_kernel/security.rs
@@ -41,6 +41,10 @@ impl<S: SecurityPlugin> EcuSecurity for EcuManager<S> {
             // whose short name contains the level name (underscores stripped, case-insensitive).
             // 2 request parameters (SID + subfunction, no key payload) distinguishes RequestSeed
             // from SendKey services whose subfunctions overlap in the ISO range.
+            let level_sub_func: Option<u32> = level
+                .split('_')
+                .next_back()
+                .and_then(|l| u32::from_str_radix(l, 16).ok().or_else(|| l.parse().ok()));
             let level_stripped = level.replace('_', "");
             let request_seed_service = self
                 .lookup_services_by_sid(service_ids::SECURITY_ACCESS)?
@@ -60,11 +64,13 @@ impl<S: SecurityPlugin> EcuSecurity for EcuManager<S> {
                         && service
                             .request()
                             .is_some_and(|r| r.params().is_some_and(|p| p.len() >= 2))
-                        && service.diag_comm().is_some_and(|dc| {
+                        // Try matching by name first, if that did not yield a result,
+                        // check if the subfunction ID matches the level.
+                        && (service.diag_comm().is_some_and(|dc| {
                             dc.short_name().is_some_and(|n| {
                                 contains_ignore_ascii_case(&n.replace('_', ""), &level_stripped)
                             })
-                        })
+                        })  || Some(sub_func) == level_sub_func)
                 })
                 .ok_or_else(|| {
                     DiagServiceError::NotFound(format!(
@@ -74,6 +80,10 @@ impl<S: SecurityPlugin> EcuSecurity for EcuManager<S> {
                 })?;
 
             let request_seed_service = request_seed_service.try_into()?;
+            tracing::debug!(
+                "Found request_seed_service: {request_seed_service:?}, sub function id \
+                 {level_sub_func:?}"
+            );
 
             Ok(SecurityAccess::RequestSeed(request_seed_service))
         }
@@ -302,4 +312,114 @@ pub(in crate::diag_kernel) fn check_security_plugin<S: SecurityPlugin>(
         .map(SecurityPlugin::as_security_plugin)?;
 
     security_plugin.validate_service(service)
+}
+
+#[cfg(test)]
+mod tests {
+    use cda_interfaces::{DiagServiceError, EcuSecurity, EcuStateManager, SecurityAccess, service_ids};
+
+    use crate::diag_kernel::test_utils::ecu_manager_builder::create_ecu_manager_with_security_access_services;
+
+    /// Name-based lookup: level name is contained in the service's `short_name`
+    /// (underscores stripped, case-insensitive). The matching service is returned
+    /// as `SecurityAccess::RequestSeed`.
+    #[tokio::test]
+    async fn test_lookup_security_access_request_seed_by_name() {
+        let (ecu_manager, _, request_seed_12_name, _) =
+            create_ecu_manager_with_security_access_services();
+        {
+            let mut states = ecu_manager.ecu_service_states.write().await;
+            states.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_owned());
+            states.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
+        }
+
+        let result = ecu_manager
+            .lookup_security_access_change("level_12", false)
+            .await;
+        assert!(
+            result.is_ok(),
+            "name-based lookup for level_12 failed: {:?}",
+            result.err()
+        );
+        let SecurityAccess::RequestSeed(dc) = result.unwrap() else {
+            panic!("expected SecurityAccess::RequestSeed");
+        };
+        assert_eq!(dc.name, request_seed_12_name);
+    }
+
+    /// Per-id lookup with a bare hex-encoded trailing suffix (no "0x" prefix).
+    /// `"access_12"` -> trailing segment "12" -> `from_str_radix("12", 16)` = 18 = 0x12
+    /// -> sub-func 0x12 -> matches `RequestSeed_level_12`.
+    #[tokio::test]
+    async fn test_lookup_security_access_request_seed_by_subfunction_id_hex() {
+        let (ecu_manager, _, request_seed_12_name, _) =
+            create_ecu_manager_with_security_access_services();
+        {
+            let mut states = ecu_manager.ecu_service_states.write().await;
+            states.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_owned());
+            states.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
+        }
+
+        // "access_12" -> trailing "12" -> from_str_radix("12", 16) = 18 -> sub-func 0x12
+        let result = ecu_manager
+            .lookup_security_access_change("access_12", false)
+            .await;
+        assert!(
+            result.is_ok(),
+            "subfunction-id bare-hex fallback lookup failed: {:?}",
+            result.err()
+        );
+        let SecurityAccess::RequestSeed(dc) = result.unwrap() else {
+            panic!("expected SecurityAccess::RequestSeed");
+        };
+        assert_eq!(dc.name, request_seed_12_name);
+    }
+
+    /// A level that cannot be resolved either by name or by subfunction ID must
+    /// return `Err(DiagServiceError::NotFound)`.
+    #[tokio::test]
+    async fn test_lookup_security_access_request_seed_not_found() {
+        let (ecu_manager, ..) = create_ecu_manager_with_security_access_services();
+        {
+            let mut states = ecu_manager.ecu_service_states.write().await;
+            states.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_owned());
+            states.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
+        }
+
+        // "unknown_99" - name not in any service, sub-func 99 (0x63) is outside
+        // the RequestSeed range (1 | 3..=5 | 7..=41) so no service matches.
+        let result = ecu_manager
+            .lookup_security_access_change("unknown_99", false)
+            .await;
+        assert!(
+            matches!(result, Err(DiagServiceError::NotFound(_))),
+            "expected NotFound for unresolvable level, got {:?}",
+            result.err()
+        );
+    }
+
+    /// `has_key = true` path: `lookup_security_access_change` must delegate to
+    /// `lookup_state_transition_for_active` on the SECURITY state chart and
+    /// return `SecurityAccess::SendKey` pointing at the service that carries the
+    /// `LockedSecurity -> ExtendedSecurity` transition ref.
+    #[tokio::test]
+    async fn test_lookup_security_access_send_key_via_state_transition() {
+        let (ecu_manager, _, _, send_key_01_name) =
+            create_ecu_manager_with_security_access_services();
+        {
+            let mut states = ecu_manager.ecu_service_states.write().await;
+            states.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_owned());
+            states.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
+        }
+
+        // Transition LockedSecurity -> ExtendedSecurity; SendKey_level_01 carries that ref.
+        let result = ecu_manager
+            .lookup_security_access_change("ExtendedSecurity", true)
+            .await;
+        assert!(result.is_ok(), "SendKey lookup failed: {:?}", result.err());
+        let SecurityAccess::SendKey(dc) = result.unwrap() else {
+            panic!("expected SecurityAccess::SendKey");
+        };
+        assert_eq!(dc.name, send_key_01_name);
+    }
 }

--- a/cda-core/src/diag_kernel/security.rs
+++ b/cda-core/src/diag_kernel/security.rs
@@ -316,7 +316,7 @@ pub(in crate::diag_kernel) fn check_security_plugin<S: SecurityPlugin>(
 
 #[cfg(test)]
 mod tests {
-    use cda_interfaces::{DiagServiceError, EcuSecurity, EcuStateManager, SecurityAccess, service_ids};
+    use cda_interfaces::{DiagServiceError, EcuSecurity, SecurityAccess, service_ids};
 
     use crate::diag_kernel::test_utils::ecu_manager_builder::create_ecu_manager_with_security_access_services;
 

--- a/cda-core/src/diag_kernel/state.rs
+++ b/cda-core/src/diag_kernel/state.rs
@@ -123,11 +123,18 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 let transition_source = state_transition.source_short_name_ref()?;
                 let transition_target = state_transition.target_short_name_ref()?;
 
-                // Check if this transition exists in the state chart and starts from current state
+                // Check if this transition exists in the state chart and starts from current state.
+                // All comparisons are case-insensitive because state names may be stored
+                // with different casing (e.g. "extended" vs "Extended") depending on the
+                // source (SOVD mode value vs ODX state chart definition).
                 if state_chart.state_transitions()?.iter().any(|chart_st| {
-                    chart_st.source_short_name_ref() == Some(transition_source)
-                        && chart_st.target_short_name_ref() == Some(transition_target)
-                        && transition_source == current_state
+                    chart_st
+                        .source_short_name_ref()
+                        .is_some_and(|s| s.eq_ignore_ascii_case(transition_source))
+                        && chart_st
+                            .target_short_name_ref()
+                            .is_some_and(|t| t.eq_ignore_ascii_case(transition_target))
+                        && transition_source.eq_ignore_ascii_case(current_state)
                 }) {
                     Some(transition_target.to_owned())
                 } else {
@@ -159,22 +166,53 @@ impl<S: SecurityPlugin> EcuManager<S> {
             })
         });
 
+        if state_chart_session.is_none() {
+            tracing::debug!(
+                diag_comm_name = ?diag_comm.short_name(),
+                "No SESSION state chart found in diag layers"
+            );
+        }
+        if state_chart_security.is_none() {
+            tracing::debug!(
+                diag_comm_name = ?diag_comm.short_name(),
+                "No SECURITY state chart found in diag layers"
+            );
+        }
+
         let states = self.ecu_service_states.write().await;
-        let new_session = states
-            .get(&service_ids::SESSION_CONTROL)
-            .as_ref()
-            .and_then(|session| {
-                state_chart_session
-                    .and_then(|sc| Self::lookup_state_transition(diag_comm, &(sc.into()), session))
-            });
-        let new_security = states
-            .get(&service_ids::SECURITY_ACCESS)
-            .as_ref()
-            .and_then(|session| {
-                state_chart_security
-                    .and_then(|sc| Self::lookup_state_transition(diag_comm, &(sc.into()), session))
-            });
+
+        let current_session = states.get(&service_ids::SESSION_CONTROL);
+        let current_security = states.get(&service_ids::SECURITY_ACCESS);
+
+        if current_session.is_none() {
+            tracing::warn!(
+                diag_comm_name = ?diag_comm.short_name(),
+                "ecu_service_states has no SESSION_CONTROL entry - states not initialized"
+            );
+        }
+        if current_security.is_none() {
+            tracing::warn!(
+                diag_comm_name = ?diag_comm.short_name(),
+                "ecu_service_states has no SECURITY_ACCESS entry - states not initialized"
+            );
+        }
+
+        let new_session = current_session.and_then(|session| {
+            state_chart_session
+                .and_then(|sc| Self::lookup_state_transition(diag_comm, &(sc.into()), session))
+        });
+        let new_security = current_security.and_then(|security| {
+            state_chart_security
+                .and_then(|sc| Self::lookup_state_transition(diag_comm, &(sc.into()), security))
+        });
         drop(states);
+
+        tracing::debug!(
+            diag_comm_name = ?diag_comm.short_name(),
+            new_session = ?new_session,
+            new_security = ?new_security,
+            "Lookup state transition for active service"
+        );
 
         (new_session, new_security)
     }
@@ -427,6 +465,44 @@ mod tests {
             fg_result.is_ok(),
             "Functional group service should skip precondition check. Error: {:?}",
             fg_result.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_lookup_state_transition_ignore_case() {
+        let (ecu_manager, _dc) =
+            create_ecu_manager_with_state_transitions(ServiceSecurityTransition::LockedToExtended);
+        {
+            let mut states = ecu_manager.ecu_service_states.write().await;
+            states.insert(service_ids::SESSION_CONTROL, "defaultSession".to_owned());
+            states.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
+        }
+        let result = ecu_manager.lookup_session_change("extendedSessioN").await;
+        assert!(
+            result.is_ok(),
+            "Current_state must resolve against PascalCase chart: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_lookup_state_transition_wrong_current_state_returns_none() {
+        let (ecu_manager, _dc) =
+            create_ecu_manager_with_state_transitions(ServiceSecurityTransition::LockedToExtended);
+        {
+            let mut states = ecu_manager.ecu_service_states.write().await;
+            // ECU is already in ExtendedSession - the service's session transition is
+            // DefaultSession -> ExtendedSession, which does not start from Extended.
+            states.insert(service_ids::SESSION_CONTROL, "ExtendedSession".to_owned());
+            states.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
+        }
+        // There is no service whose session transition starts from ExtendedSession, so
+        // lookup_session_change to ProgrammingSession must fail.
+        let result = ecu_manager
+            .lookup_session_change("ProgrammingSession")
+            .await;
+        assert!(
+            result.is_err(),
+            "transition from wrong source state must not match: {result:?}"
         );
     }
 }

--- a/cda-core/src/diag_kernel/state.rs
+++ b/cda-core/src/diag_kernel/state.rs
@@ -505,4 +505,62 @@ mod tests {
             "transition from wrong source state must not match: {result:?}"
         );
     }
+
+    #[tokio::test]
+    async fn test_lookup_state_transition_no_match_returns_none() {
+        let (ecu_manager, dc) =
+            create_ecu_manager_with_state_transitions(ServiceSecurityTransition::LockedToExtended);
+        {
+            let mut states = ecu_manager.ecu_service_states.write().await;
+            states.insert(
+                service_ids::SESSION_CONTROL,
+                "Programmingsession".to_owned(),
+            );
+            states.insert(
+                service_ids::SECURITY_ACCESS,
+                "programmingsecurity".to_owned(),
+            );
+        }
+        let payload_data = UdsPayloadData::Raw(vec![service_ids::WRITE_DATA_BY_IDENTIFIER]);
+        let result = ecu_manager
+            .create_uds_payload(&dc, &skip_sec_plugin!(), Some(payload_data), None)
+            .await;
+        assert!(
+            result.is_ok(),
+            "UDS payload creation should succeed: {:?}",
+            result.err()
+        );
+        let payload = result.unwrap();
+        assert!(
+            payload.new_session.is_none(),
+            "expected no session transition when current state does not match"
+        );
+        assert!(
+            payload.new_security.is_none(),
+            "expected no security transition when current state does not match"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_lookup_state_transition_match_returns_target() {
+        let (ecu_manager, dc) =
+            create_ecu_manager_with_state_transitions(ServiceSecurityTransition::LockedToExtended);
+        {
+            let mut states = ecu_manager.ecu_service_states.write().await;
+            states.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_owned());
+            states.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
+        }
+        let payload_data = UdsPayloadData::Raw(vec![service_ids::WRITE_DATA_BY_IDENTIFIER]);
+        let result = ecu_manager
+            .create_uds_payload(&dc, &skip_sec_plugin!(), Some(payload_data), None)
+            .await;
+        assert!(
+            result.is_ok(),
+            "UDS payload creation should succeed: {:?}",
+            result.err()
+        );
+        let payload = result.unwrap();
+        assert_eq!(payload.new_session, Some("ExtendedSession".to_owned()));
+        assert_eq!(payload.new_security, Some("ExtendedSecurity".to_owned()));
+    }
 }

--- a/cda-core/src/diag_kernel/test_utils/ecu_manager_builder.rs
+++ b/cda-core/src/diag_kernel/test_utils/ecu_manager_builder.rs
@@ -2022,3 +2022,168 @@ pub(crate) fn create_ecu_manager_with_routine_control_service()
     let db = finish_db!(db_builder, protocol, vec![diag_service]);
     new_ecu_manager(db)
 }
+
+/// Build an ECU manager with two SID 0x27 (`SecurityAccess`) `RequestSeed` services,
+/// one `SendKey` service, and a SECURITY state chart.
+///
+/// Services:
+/// - `RequestSeed_level_01`: sub-function 0x01, 2 params (SID + `sub_func`)
+/// - `RequestSeed_level_12`: sub-function 0x12 (18 dec), 2 params
+/// - `SendKey_level_01`: sub-function 0x02, 3 params, carries LockedSecurity->ExtendedSecurity ref
+///
+/// Returns `(ecu_manager, request_seed_name_01, request_seed_name_12, send_key_name)`.
+#[allow(clippy::too_many_lines)] // Splitting the 'create' function up, makes it worse to read.
+pub(crate) fn create_ecu_manager_with_security_access_services() -> (
+    crate::diag_kernel::ecumanager::EcuManager<DefaultSecurityPluginData>,
+    String,
+    String,
+    String,
+) {
+    let mut db_builder = EcuDataBuilder::new();
+    let protocol_name = Protocol::default().to_string();
+    let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
+    let cp_ref = db_builder.create_com_param_ref(None, None, None, Some(protocol), None);
+
+    let sid = service_ids::SECURITY_ACCESS;
+
+    let request_seed_01_name = "RequestSeed_level_01";
+    let request_seed_01_sid = db_builder.create_coded_const_param(
+        SID_PARM_NAME,
+        &sid.to_string(),
+        0,
+        0,
+        8,
+        DataType::UInt32,
+    );
+    let request_seed_01_sub_func =
+        db_builder.create_coded_const_param("sub_func", "1", 1, 0, 8, DataType::UInt32);
+    let request_seed_01_request = db_builder.create_request(
+        Some(vec![request_seed_01_sid, request_seed_01_sub_func]),
+        None,
+    );
+    let request_seed_01_diag_comm = db_builder.create_diag_comm(DiagCommParams {
+        short_name: request_seed_01_name,
+        protocols: Some(vec![protocol]),
+        ..Default::default()
+    });
+    let request_seed_01_service = new_diag_service!(
+        db_builder,
+        request_seed_01_diag_comm,
+        request_seed_01_request,
+        vec![],
+        vec![]
+    );
+
+    // Sub-function 0x12 (18 dec) - used to test the hex-string id fallback path.
+    let request_seed_12_name = "RequestSeed_level_12";
+    let request_seed_12_sid = db_builder.create_coded_const_param(
+        SID_PARM_NAME,
+        &sid.to_string(),
+        0,
+        0,
+        8,
+        DataType::UInt32,
+    );
+    let request_seed_12_sub_func =
+        db_builder.create_coded_const_param("sub_func", "18", 1, 0, 8, DataType::UInt32);
+    let request_seed_12_request = db_builder.create_request(
+        Some(vec![request_seed_12_sid, request_seed_12_sub_func]),
+        None,
+    );
+    let request_seed_12_diag_comm = db_builder.create_diag_comm(DiagCommParams {
+        short_name: request_seed_12_name,
+        protocols: Some(vec![protocol]),
+        ..Default::default()
+    });
+    let request_seed_12_service = new_diag_service!(
+        db_builder,
+        request_seed_12_diag_comm,
+        request_seed_12_request,
+        vec![],
+        vec![]
+    );
+
+    let locked_state = db_builder.create_state("LockedSecurity", None);
+    let extended_state = db_builder.create_state("ExtendedSecurity", None);
+
+    let locked_to_extended = db_builder.create_state_transition(
+        "LockedToExtended",
+        Some("LockedSecurity"),
+        Some("ExtendedSecurity"),
+    );
+
+    let security_state_chart = db_builder.create_state_chart(
+        "SecurityAccess",
+        Some(semantics::SECURITY),
+        Some(vec![locked_to_extended]),
+        Some("LockedSecurity"),
+        Some(vec![locked_state, extended_state]),
+    );
+
+    let default_session_state = db_builder.create_state("DefaultSession", None);
+    let session_state_chart = db_builder.create_state_chart(
+        "Session",
+        Some(semantics::SESSION),
+        None,
+        Some("DefaultSession"),
+        Some(vec![default_session_state]),
+    );
+
+    let send_key_01_name = "SendKey_level_01";
+    let send_key_01_sid = db_builder.create_coded_const_param(
+        SID_PARM_NAME,
+        &sid.to_string(),
+        0,
+        0,
+        8,
+        DataType::UInt32,
+    );
+    let send_key_01_sub_func =
+        db_builder.create_coded_const_param("sub_func", "2", 1, 0, 8, DataType::UInt32);
+    let send_key_01_key =
+        db_builder.create_coded_const_param("key", "0", 2, 0, 8, DataType::UInt32);
+    let send_key_01_request = db_builder.create_request(
+        Some(vec![send_key_01_sid, send_key_01_sub_func, send_key_01_key]),
+        None,
+    );
+    let locked_to_extended_ref = db_builder.create_state_transition_ref(locked_to_extended);
+    let send_key_01_diag_comm = db_builder.create_diag_comm(DiagCommParams {
+        short_name: send_key_01_name,
+        state_transition_refs: Some(vec![locked_to_extended_ref]),
+        protocols: Some(vec![protocol]),
+        ..Default::default()
+    });
+    let send_key_01_service = new_diag_service!(
+        db_builder,
+        send_key_01_diag_comm,
+        send_key_01_request,
+        vec![],
+        vec![]
+    );
+
+    let diag_layer = db_builder.create_diag_layer(DiagLayerParams {
+        short_name: TEST_DIAG_LAYER,
+        com_param_refs: Some(vec![cp_ref]),
+        diag_services: Some(vec![
+            request_seed_01_service,
+            request_seed_12_service,
+            send_key_01_service,
+        ]),
+        state_charts: Some(vec![session_state_chart, security_state_chart]),
+        ..Default::default()
+    });
+    let variant = db_builder.create_variant(diag_layer, true, None, None);
+    let db = db_builder.finish(EcuDataParams {
+        revision: "1",
+        version: "1.0.0",
+        variants: Some(vec![variant]),
+        ..Default::default()
+    });
+
+    (
+        new_ecu_manager(db),
+        request_seed_01_name.to_owned(),
+        request_seed_12_name.to_owned(),
+        send_key_01_name.to_owned(),
+    )
+}

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -505,6 +505,10 @@
 
 # `DoIP` (Diagnostics over IP) transport layer settings.
 [doip]
+# Interval in seconds between `DoIP` alive check requests sent on idle connections.
+# The alive check is only sent when no diagnostic communication has occurred
+# for this duration. Set to 0 to disable the alive check.
+# alive_check_interval_secs = 1800
 # UDP/TCP port for `DoIP` gateway discovery and communication.
 # gateway_port = 13400
 # The name of the protocol to use.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

1. fix(doip): add ecu name to 'send' logs
Includes the ECU name in send-related log statements so each log line identifies which ECU it refers to.
2. fix(ecumanager): lookup case insensitive and by id lookup
- lookup_state_transition: changed string comparisons to eq_ignore_ascii_case so state names from SOVD (lowercase) match ODX state charts (PascalCase).
- lookup_security_access_change: added fallback that parses the subfunction ID from the level string (hex/decimal) when name-based matching fails.
3. fix(doip): prevent alive check from interrupting active communication
- New alive_check_interval_secs config option (default 30 min).
- Alive check timer resets after each message so it only fires while idle.
- Biased select! to prioritize message sending over alive checks.
- Refactored handle_gateway_connection into GatewayConfig/GatewayState structs.
- Unit tests for alive check timer behavior.
4. fix: optimize tokio::select! with biased modifier and clarify fairness
Added biased; to select! in vir_vam.rs (shutdown over VIR/VAM), lib.rs (ECU receiver over closed handler), and added a comment in connections.rs explaining random selection prevents starvation.


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
