### PR TITLE
Add license check script with Eclipse Dash

### DIFF
--- a/.github/scripts/check-3rd-party-licenses.sh
+++ b/.github/scripts/check-3rd-party-licenses.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2025 Copyright (c) Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 deps_file=${DEPS_FILE:-"DEPS.txt"}

--- a/.github/scripts/check-3rd-party-licenses.sh
+++ b/.github/scripts/check-3rd-party-licenses.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+deps_file=${DEPS_FILE:-"DEPS.txt"}
+dash_jar=${DASH_JAR:-"/tmp/dash.jar"}
+dash_summary=${DASH_SUMMARY:-"DASH_SUMMARY.txt"}
+project=${PROJECT:-"automotive.opensovd"}
+manifest_path=${MANIFEST_PATH:-"Cargo.toml"}
+token=${1:-}
+
+echo "creating 3rd party dependency list..."
+cargo tree --manifest-path "$manifest_path" --workspace -e no-build,no-dev --prefix none --no-dedupe --locked \
+  | sed -n '2~1p' \
+  | sort -u \
+  | grep -v '^[[:space:]]*$' \
+  | grep -v '^cda-' \
+  | grep -v '^opensovd-' \
+  | grep -v '^mbedtls-' \
+  | grep -v '^sovd-interfaces' \
+  | grep -v '^integration-tests' \
+  | sed -E 's|([^ ]+) v([^ ]+).*|crate/cratesio/-/\1/\2|' \
+  > "$deps_file"
+
+if [[ ! -r "$dash_jar" ]]; then
+  echo "Eclipse Dash JAR file [${dash_jar}] not found, downloading latest version from GitHub..."
+  wget_bin=$(which wget)
+  if [[ -z "$wget_bin" ]]; then
+    echo "wget command not available on path"
+    exit 127
+  else
+    wget --quiet -O "$dash_jar" "https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST"
+  echo "successfully downloaded Eclipse Dash JAR to ${dash_jar}"
+  fi
+fi
+
+args=(-jar "$dash_jar" -timeout 60 -batch 90 -summary "$dash_summary")
+if [[ -n "$token" ]]; then
+  args=("${args[@]}" -review -token "$token" -project "$project")
+fi
+args=("${args[@]}" "$deps_file")
+
+echo "checking 3rd party licenses..."
+java "${args[@]}"

--- a/.github/scripts/check-3rd-party-licenses.sh
+++ b/.github/scripts/check-3rd-party-licenses.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 deps_file=${DEPS_FILE:-"DEPS.txt"}
-dash_jar=${DASH_JAR:-"/tmp/dash.jar"}
+tmp_root=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
+dash_jar=${DASH_JAR:-"${tmp_root}/dash.jar"}
 dash_summary=${DASH_SUMMARY:-"DASH_SUMMARY.txt"}
 project=${PROJECT:-"automotive.opensovd"}
 manifest_path=${MANIFEST_PATH:-"Cargo.toml"}
@@ -25,15 +26,19 @@ cargo tree --manifest-path "$manifest_path" --workspace -e no-build,no-dev --pre
   > "$deps_file"
 
 if [[ ! -r "$dash_jar" ]]; then
-  echo "Eclipse Dash JAR file [${dash_jar}] not found, downloading latest version from GitHub..."
-  wget_bin=$(which wget)
-  if [[ -z "$wget_bin" ]]; then
-    echo "wget command not available on path"
-    exit 127
+  echo "Eclipse Dash JAR file [${dash_jar}] not found, downloading latest version from Eclipse repository..."
+  dash_url="https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST"
+
+  if command -v wget >/dev/null 2>&1; then
+    wget --quiet -O "$dash_jar" "$dash_url"
+  elif command -v curl >/dev/null 2>&1; then
+    curl --fail --silent --show-error --location --output "$dash_jar" "$dash_url"
   else
-    wget --quiet -O "$dash_jar" "https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST"
-  echo "successfully downloaded Eclipse Dash JAR to ${dash_jar}"
+    echo "Neither wget nor curl is available on PATH"
+    exit 127
   fi
+
+  echo "successfully downloaded Eclipse Dash JAR to ${dash_jar}"
 fi
 
 args=(-jar "$dash_jar" -timeout 60 -batch 90 -summary "$dash_summary")

--- a/.github/scripts/check-3rd-party-licenses.sh
+++ b/.github/scripts/check-3rd-party-licenses.sh
@@ -8,6 +8,9 @@ project=${PROJECT:-"automotive.opensovd"}
 manifest_path=${MANIFEST_PATH:-"Cargo.toml"}
 token=${1:-}
 
+# Ensure the summary file exists even when checks fail early so CI can upload it as artifact.
+: > "$dash_summary"
+
 echo "creating 3rd party dependency list..."
 cargo tree --manifest-path "$manifest_path" --workspace -e no-build,no-dev --prefix none --no-dedupe --locked \
   | sed -n '2~1p' \

--- a/.github/scripts/check-3rd-party-licenses.sh
+++ b/.github/scripts/check-3rd-party-licenses.sh
@@ -27,15 +27,20 @@ cargo tree --manifest-path "$manifest_path" --workspace -e no-build,no-dev --pre
 
 if [[ ! -r "$dash_jar" ]]; then
   echo "Eclipse Dash JAR file [${dash_jar}] not found, downloading latest version from Eclipse repository..."
-  dash_url="https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST"
+  dash_url=${DASH_URL:-"https://repo.eclipse.org/service/rest/v1/search/assets/download?sort=version&repository=dash-maven2-releases&maven.groupId=org.eclipse.dash&maven.artifactId=org.eclipse.dash.licenses&maven.extension=jar"}
 
   if command -v wget >/dev/null 2>&1; then
-    wget --quiet -O "$dash_jar" "$dash_url"
+    wget --tries=3 --retry-connrefused --waitretry=2 -O "$dash_jar" "$dash_url"
   elif command -v curl >/dev/null 2>&1; then
-    curl --fail --silent --show-error --location --output "$dash_jar" "$dash_url"
+    curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --output "$dash_jar" "$dash_url"
   else
     echo "Neither wget nor curl is available on PATH"
     exit 127
+  fi
+
+  if [[ ! -s "$dash_jar" ]]; then
+    echo "Failed to download Eclipse Dash JAR from ${dash_url}"
+    exit 1
   fi
 
   echo "successfully downloaded Eclipse Dash JAR to ${dash_jar}"

--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -1,15 +1,13 @@
-# ********************************************************************************
-#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+# SPDX-FileCopyrightText: 2025 Copyright (c) Contributors to the Eclipse Foundation
 #
-#  See the NOTICE file(s) distributed with this work for additional
-#  information regarding copyright ownership.
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
 #
-#  This program and the accompanying materials are made available under the
-#  terms of the Apache License Version 2.0 which is available at
-#  https://www.apache.org/licenses/LICENSE-2.0
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
 #
-#  SPDX-License-Identifier: Apache-2.0
-# *******************************************************************************/
+# SPDX-License-Identifier: Apache-2.0
 
 name: Check 3rd party dependencies
 

--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -13,10 +13,10 @@ name: Check 3rd party dependencies
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-#    paths:
-#    - "Cargo.lock"
+  #    paths:
+  #    - "Cargo.lock"
   workflow_call:
   workflow_dispatch:
 
@@ -31,27 +31,27 @@ jobs:
     env:
       DASH_SUMMARY: "DEPENDENCIES.txt"
     steps:
-    - uses: actions/checkout@v4
-    - name: "Check 3rd party license compatibility"
-      id: "run-checks"
-      run: |
-        if bash .github/scripts/check-3rd-party-licenses.sh
-        then
-          echo "checks-failed=0" >> $GITHUB_OUTPUT
-          echo "License information of 3rd party dependencies has been vetted successfully." >> $GITHUB_STEP_SUMMARY
-        else
-          echo "checks-failed=1" >> $GITHUB_OUTPUT
-          echo "License information of some 3rd party dependencies could not be vetted successfully." >> $GITHUB_STEP_SUMMARY
-          echo "A DEPENDENCIES file containing the vetted information has been attached to this workflow run." >> $GITHUB_STEP_SUMMARY
-        fi
-    - name: Upload DEPENDENCIES file
-      if: ${{ steps.run-checks.outputs.checks-failed == '1' }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: 3rd-party-dependencies
-        path: ${{ env.DASH_SUMMARY }}
-    - name: "Determine exit code"
-      env:
-        EXIT_CODE: ${{ steps.run-checks.outputs.checks-failed }}
-      run: |
-        exit $EXIT_CODE
+      - uses: actions/checkout@v4
+      - name: "Check 3rd party license compatibility"
+        id: "run-checks"
+        run: |
+          if bash .github/scripts/check-3rd-party-licenses.sh
+          then
+            echo "checks-failed=0" >> $GITHUB_OUTPUT
+            echo "License information of 3rd party dependencies has been vetted successfully." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "checks-failed=1" >> $GITHUB_OUTPUT
+            echo "License information of some 3rd party dependencies could not be vetted successfully." >> $GITHUB_STEP_SUMMARY
+            echo "A DEPENDENCIES file containing the vetted information has been attached to this workflow run." >> $GITHUB_STEP_SUMMARY
+          fi
+      - name: Upload DEPENDENCIES file
+        if: ${{ steps.run-checks.outputs.checks-failed == '1' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: 3rd-party-dependencies
+          path: ${{ env.DASH_SUMMARY }}
+      - name: "Determine exit code"
+        env:
+          EXIT_CODE: ${{ steps.run-checks.outputs.checks-failed }}
+        run: |
+          exit $EXIT_CODE

--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -1,0 +1,59 @@
+# ********************************************************************************
+#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************/
+
+name: Check 3rd party dependencies
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+#    paths:
+#    - "Cargo.lock"
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  deps:
+    name: "Check 3rd party Rust dependencies' licenses"
+    runs-on: ubuntu-latest
+    env:
+      DASH_SUMMARY: "DEPENDENCIES.txt"
+    steps:
+    - uses: actions/checkout@v4
+    - name: "Check 3rd party license compatibility"
+      id: "run-checks"
+      run: |
+        if bash .github/scripts/check-3rd-party-licenses.sh
+        then
+          echo "checks-failed=0" >> $GITHUB_OUTPUT
+          echo "License information of 3rd party dependencies has been vetted successfully." >> $GITHUB_STEP_SUMMARY
+        else
+          echo "checks-failed=1" >> $GITHUB_OUTPUT
+          echo "License information of some 3rd party dependencies could not be vetted successfully." >> $GITHUB_STEP_SUMMARY
+          echo "A DEPENDENCIES file containing the vetted information has been attached to this workflow run." >> $GITHUB_STEP_SUMMARY
+        fi
+    - name: Upload DEPENDENCIES file
+      if: ${{ steps.run-checks.outputs.checks-failed == '1' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: 3rd-party-dependencies
+        path: ${{ env.DASH_SUMMARY }}
+    - name: "Determine exit code"
+      env:
+        EXIT_CODE: ${{ steps.run-checks.outputs.checks-failed }}
+      run: |
+        exit $EXIT_CODE


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
This pull request introduces automated checking of third-party Rust dependencies' licenses using Eclipse Dash, integrating it into the CI workflow. The main changes include adding a new GitHub Actions workflow and a supporting shell script to generate and verify license information for all Rust dependencies.

**CI/CD Integration for License Checking:**

* Added a new GitHub Actions workflow (`.github/workflows/check-dependencies.yaml`) to automatically check the licenses of third-party Rust dependencies on every push, pull request, and manual trigger. The workflow runs a custom script, summarizes results, and uploads the vetted dependencies file if issues are found.

**License Checking Script:**

* Introduced a shell script (`.github/scripts/check-3rd-party-licenses.sh`) that:
  * Generates a list of all third-party Rust dependencies.
  * Downloads the Eclipse Dash license checker JAR if not present.
  * Runs the license compatibility check and outputs a summary for CI consumption.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ x ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->
no relation

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
There are uncleared dependencies.
Either IPLab issues must be opened manually or follow the Eclipse Dash process to automatically open the IPReviews:
https://github.com/eclipse-dash/dash-licenses/blob/master/README.md#automatic-ip-team-review-requests
A solution for this can be found in the branch here: 
https://github.com/chheis/classic-diagnostic-adapter/tree/feat-dash-automatic-review

Listed here:
[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:705)successfully downloaded Eclipse Dash JAR to /home/runner/work/_temp/dash.jar

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:706)checking 3rd party licenses...

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:709)[main] INFO Querying Eclipse Foundation for license data for 90 items.

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:710)[main] INFO Found 41 items.

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:711)[main] INFO Querying Eclipse Foundation for license data for 90 items.

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:714)[main] INFO Found 43 items.

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:715)[main] INFO Querying Eclipse Foundation for license data for 37 items.

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:716)[main] INFO Found 18 items.

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:717)[main] INFO Querying ClearlyDefined for license data for 90 items.

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:718)[main] INFO Found 90 items.

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:719)[main] INFO Querying ClearlyDefined for license data for 79 items.

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:720)[main] INFO Found 79 items.

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:721)[main] INFO License information could not be automatically verified for the following content:

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:722)[main] INFO 

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:723)[main] INFO crate/cratesio/-/aide-macros/0.16.0-alpha.1

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:724)[main] INFO crate/cratesio/-/aide/0.16.0-alpha.1

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:725)[main] INFO crate/cratesio/-/axum-extra/0.12.2

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:726)[main] INFO crate/cratesio/-/bytecheck/0.8.2

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:727)[main] INFO crate/cratesio/-/bytecheck_derive/0.8.2

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:728)[main] INFO crate/cratesio/-/doip-codec/2.0.8

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:729)[main] INFO crate/cratesio/-/doip-definitions/3.0.13

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:730)[main] INFO crate/cratesio/-/hyper-tls/0.6.0

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:731)[main] INFO crate/cratesio/-/ipnet/2.11.0

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:732)[main] INFO crate/cratesio/-/lzma-sys/0.1.20

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:733)[main] INFO crate/cratesio/-/mimalloc/3.0.1

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:734)[main] INFO crate/cratesio/-/openssl-macros/0.1.1

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:735)[main] INFO crate/cratesio/-/openssl/0.10.80

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:736)[main] INFO crate/cratesio/-/rand/0.9.3

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:737)[main] INFO crate/cratesio/-/reqwest/0.12.28

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:738)[main] INFO crate/cratesio/-/rkyv/0.8.16

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:739)[main] INFO crate/cratesio/-/rkyv_derive/0.8.16

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:740)[main] INFO crate/cratesio/-/serde_qs/1.0.0-rc.3

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:741)[main] INFO crate/cratesio/-/tokio-openssl/0.6.5

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:742)[main] INFO crate/cratesio/-/uncased/0.9.10

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:743)[main] INFO crate/cratesio/-/unicase/2.8.1

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:744)[main] INFO 

[](https://github.com/chheis/classic-diagnostic-adapter/actions/runs/28169907094/job/83431115863#step:3:745)[main] INFO This content is either not correctly mapped by the system, or requires review.


