### PR TITLE
feat(config): consolidate strict flags into dedicated [strict] section

### DIFF
--- a/cda-database/src/lib.rs
+++ b/cda-database/src/lib.rs
@@ -47,17 +47,6 @@ pub struct DatabaseConfig {
     /// attempting a lookup with this flag set against a multi-protocol database
     /// returns `DiagServiceError::InvalidDatabase`.
     pub ignore_protocol: bool,
-    /// When `true`, requests that contain parameters not defined in the service
-    /// are rejected with a `BadPayload` error (400 Bad Request).
-    /// When `false` (default), unexpected parameters trigger a warning log but
-    /// are otherwise ignored.
-    pub strict_parameter_validation: bool,
-    /// When `true`, the application will exit with an error if any key under
-    /// `[ecu.<name>]` in the configuration does not match a loaded MDD database.
-    ///
-    /// This helps catch typos in ECU names early. When `false` (default),
-    /// unmatched per-ECU config entries only produce a warning.
-    pub strict_ecu_config: bool,
     /// When `true` (the default), MDD files that fail to load are skipped and
     /// the remaining databases continue loading. When `false`, any MDD load
     /// failure aborts the entire load/reload operation.
@@ -72,8 +61,6 @@ impl Default for DatabaseConfig {
             exit_no_database_loaded: false,
             fallback_to_base_variant: true,
             ignore_protocol: false,
-            strict_parameter_validation: false,
-            strict_ecu_config: false,
             ignore_invalid_mdd: true,
         }
     }

--- a/cda-main/src/config/configfile.rs
+++ b/cda-main/src/config/configfile.rs
@@ -131,6 +131,35 @@ impl schemars::JsonSchema for EcuComParams {
     }
 }
 
+/// Strict-mode flags that opt in to stricter runtime validation.
+///
+/// When `enabled` is `true`, every individual check is activated regardless
+/// of its own value.  Individual flags can also be turned on independently
+/// for more granular control.
+#[derive(Deserialize, Serialize, Clone, Debug, Default, schemars::JsonSchema)]
+pub struct StrictConfig {
+    /// Master switch - when `true`, all individual strict checks are enabled.
+    pub enabled: bool,
+    /// Reject requests containing parameters not defined in the diagnostic
+    /// service with a `BadPayload` error (HTTP 400).
+    pub parameter_validation: bool,
+    /// Exit with an error if any key under `[ecu.<name>]` does not match a
+    /// loaded MDD database.
+    pub ecu_config: bool,
+}
+
+impl StrictConfig {
+    #[must_use]
+    pub fn parameter_validation(&self) -> bool {
+        self.enabled || self.parameter_validation
+    }
+
+    #[must_use]
+    pub fn ecu_config(&self) -> bool {
+        self.enabled || self.ecu_config
+    }
+}
+
 /// Top-level application configuration.
 #[derive(Deserialize, Serialize, Clone, Debug, schemars::JsonSchema)]
 pub struct Configuration {
@@ -159,10 +188,11 @@ pub struct Configuration {
     pub faults: FaultConfig,
     /// Per-ECU configuration blocks keyed by ECU short name (case-insensitive
     /// match against the MDD short name returned by `load_proto_data`).
-    #[serde(default)]
     pub ecu: HashMap<String, EcuConfig>,
     /// Configuration for update plugin, i.e. storage paths
     pub runtime_update_config: RuntimeUpdateConfig,
+    /// Strict-mode validation flags.
+    pub strict: StrictConfig,
 }
 
 /// Per-ECU configuration block.
@@ -249,6 +279,7 @@ impl Default for Configuration {
             faults: FaultConfig::default(),
             ecu: HashMap::default(),
             runtime_update_config: RuntimeUpdateConfig::default(),
+            strict: StrictConfig::default(),
         }
     }
 }
@@ -701,5 +732,48 @@ logical_gateway_address = 9999
             "figment extraction must fail when the TOML contains an incompatible type; confirms \
              the resolve_com_params Err branch is reachable"
         );
+    }
+
+    #[test]
+    fn strict_config_master_switch_enables_all() {
+        let cfg = StrictConfig {
+            enabled: true,
+            parameter_validation: false,
+            ecu_config: false,
+        };
+        assert!(cfg.parameter_validation());
+        assert!(cfg.ecu_config());
+    }
+
+    #[test]
+    fn strict_config_individual_flags_work_independently() {
+        let cfg = StrictConfig {
+            enabled: false,
+            parameter_validation: true,
+            ecu_config: false,
+        };
+        assert!(cfg.parameter_validation());
+        assert!(!cfg.ecu_config());
+    }
+
+    #[test]
+    fn strict_config_defaults_to_all_disabled() {
+        let cfg = StrictConfig::default();
+        assert!(!cfg.parameter_validation());
+        assert!(!cfg.ecu_config());
+    }
+
+    #[tokio::test]
+    async fn strict_config_parsed_from_toml() {
+        let config_str = r"
+[strict]
+enabled = false
+parameter_validation = true
+";
+        let figment = Figment::from(Serialized::defaults(Configuration::default()))
+            .merge(Toml::string(config_str));
+        let config: Configuration = figment.extract().unwrap();
+        assert!(config.strict.parameter_validation());
+        assert!(!config.strict.ecu_config());
     }
 }

--- a/cda-main/src/mdd.rs
+++ b/cda-main/src/mdd.rs
@@ -194,11 +194,7 @@ pub async fn load_databases<S: SecurityPlugin>(
         .map(|(k, v): (String, FileManager)| (k.to_lowercase(), v))
         .collect();
 
-    handle_ecu_config_keys(
-        &ecu_config_map,
-        &databases,
-        config.database.strict_ecu_config,
-    )?;
+    handle_ecu_config_keys(&ecu_config_map, &databases, config.strict.ecu_config())?;
 
     let end = std::time::Instant::now();
     tracing::info!(
@@ -371,7 +367,7 @@ pub(crate) fn handle_ecu_config_keys<S: SecurityPlugin>(
     }
     if strict && !unmatched.is_empty() {
         return Err(AppError::ConfigurationError(format!(
-            "strict_ecu_config is enabled and the following per-ECU config entries do not match \
+            "[strict] ecu_config is enabled and the following per-ECU config entries do not match \
              any loaded database: {}",
             unmatched.join(", ")
         )));
@@ -599,7 +595,7 @@ fn load_single_mdd<S: SecurityPlugin>(
         protocol,
         com_params: &com_params,
         fallback_to_base_variant: config.database.fallback_to_base_variant,
-        strict_parameter_validation: config.database.strict_parameter_validation,
+        strict_parameter_validation: config.strict.parameter_validation(),
     };
 
     let per_ecu_cfg = ecu_config_map.get(&ecu_name.to_lowercase());

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -31,7 +31,7 @@ use opensovd_cda_lib::{
     cda_version,
     config::configfile::{
         ConfigSanity, Configuration, DatabaseConfig, EcuComParams, EcuConfig, RuntimeUpdateConfig,
-        ServerConfig,
+        ServerConfig, StrictConfig,
     },
 };
 use tokio::sync::{Mutex, MutexGuard, OnceCell};
@@ -172,8 +172,6 @@ fn cda_test_config(
             exit_no_database_loaded: true,
             fallback_to_base_variant: true,
             ignore_protocol: false,
-            strict_parameter_validation: false,
-            strict_ecu_config: false,
             ignore_invalid_mdd: false,
         },
         logging: LoggingConfig::default(),
@@ -273,6 +271,7 @@ fn cda_test_config(
             init_storage_from_database_path: true,
             ..RuntimeUpdateConfig::default()
         },
+        strict: StrictConfig::default(),
     };
     Ok(config)
 }

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -400,17 +400,6 @@
 # ignore_protocol = false
 # Path to load the databases from, this must be a directory.
 # path = "."
-# When `true`, the application will exit with an error if any key under
-# `[ecu.<name>]` in the configuration does not match a loaded MDD database.
-#
-# This helps catch typos in ECU names early. When `false` (default),
-# unmatched per-ECU config entries only produce a warning.
-# strict_ecu_config = false
-# When `true`, requests that contain parameters not defined in the service
-# are rejected with a `BadPayload` error (400 Bad Request).
-# When `false` (default), unexpected parameters trigger a warning log but
-# are otherwise ignored.
-# strict_parameter_validation = false
 
 # Holds configuration for diagnostic service naming conventions.
 #
@@ -663,3 +652,14 @@
 # address = "0.0.0.0"
 # TCP port the server listens on.
 # port = 20002
+
+# Strict-mode validation flags.
+[strict]
+# Exit with an error if any key under `[ecu.<name>]` does not match a
+# loaded MDD database.
+# ecu_config = false
+# Master switch - when `true`, all individual strict checks are enabled.
+# enabled = false
+# Reject requests containing parameters not defined in the diagnostic
+# service with a `BadPayload` error (HTTP 400).
+# parameter_validation = false


### PR DESCRIPTION
Move strict_parameter_validation and strict_ecu_config out of [database] into a new top-level [strict] config section with a master enabled switch that activates all checks at once. Individual flags remain available for granular control.

Closes #377

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Consolidates scattered strict-mode flags (`strict_parameter_validation`, `strict_ecu_config`) from the `[database]` config section into a new top-level `[strict]` section. Adds a master `enabled` switch that activates all strict checks at once, while individual flags (`parameter_validation`, `ecu_config`) remain available for granular control. This improves discoverability and provides a consistent pattern for future strict checks.

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related

Follow-up to #342 (strict_parameter_validation feature)

## Notes for Reviewers

- `StrictConfig` resolution: `config.strict.parameter_validation()` returns `self.enabled || self.parameter_validation`, so the master switch OR individual flags activate each check.
- All fields use `#[serde(default)]`, so existing configs without a `[strict]` section continue to work (all checks default to disabled).
- The reference config (`opensovd-cda.toml`) was regenerated via `cargo run --all-features -- generate-config`.
- 4 new unit tests cover: master switch, individual flags, defaults, and TOML parsing.
- Error message in `handle_ecu_config_keys` updated to reference the new `[strict] ecu_config` path.