### PR TITLE
refactor: move trim_routine_name into DatabaseNamingConvention

### DIFF
--- a/cda-core/src/diag_kernel/component_info.rs
+++ b/cda-core/src/diag_kernel/component_info.rs
@@ -228,7 +228,8 @@ impl<S: SecurityPlugin> ComponentInfos for EcuManager<S> {
                 && is_service_visible::<S>(security_plugin, service)
                 && service.diag_comm().is_some_and(|dc| {
                     dc.short_name().is_some_and(|name| {
-                        self.trim_routine_name(name)
+                        self.database_naming_convention
+                            .trim_routine_name(name)
                             .eq_ignore_ascii_case(service_name)
                     })
                 })
@@ -288,7 +289,8 @@ impl<S: SecurityPlugin> ComponentInfos for EcuManager<S> {
                     && is_service_visible::<S>(security_plugin, service)
                     && service.diag_comm().is_some_and(|dc| {
                         dc.short_name().is_some_and(|name| {
-                            self.trim_routine_name(name)
+                            self.database_naming_convention
+                                .trim_routine_name(name)
                                 .eq_ignore_ascii_case(service_name)
                         })
                     })
@@ -567,15 +569,6 @@ impl<S: SecurityPlugin> EcuManager<S> {
         }
     }
 
-    /// Trims affixes from a routine control service name to derive the base routine name.
-    fn trim_routine_name(&self, name: &str) -> String {
-        let name_trimmed = self
-            .database_naming_convention
-            .trim_service_name_affixes(service_ids::ROUTINE_CONTROL, name.to_owned());
-        self.database_naming_convention
-            .trim_short_name_affixes(&name_trimmed)
-    }
-
     /// Filter and transform services into `ComponentOperationsInfo`
     /// This is used for operation lookup and metadata.
     fn filter_and_transform_operations(
@@ -589,7 +582,9 @@ impl<S: SecurityPlugin> EcuManager<S> {
             // without any affixes
             .filter_map(|service| {
                 let diag_comm = service.diag_comm()?;
-                let id = self.trim_routine_name(diag_comm.short_name()?);
+                let id = self
+                    .database_naming_convention
+                    .trim_routine_name(diag_comm.short_name()?);
                 Some((id, service))
             })
             // fold over the id of the previous steps creating a map of

--- a/cda-interfaces/src/datatypes/database_naming_convention.rs
+++ b/cda-interfaces/src/datatypes/database_naming_convention.rs
@@ -153,6 +153,14 @@ impl DatabaseNamingConvention {
         }
         short_name
     }
+
+    /// Trims affixes from a routine control service name to derive the base routine name.
+    #[must_use]
+    pub fn trim_routine_name(&self, name: &str) -> String {
+        let name_trimmed =
+            self.trim_service_name_affixes(service_ids::ROUTINE_CONTROL, name.to_owned());
+        self.trim_short_name_affixes(&name_trimmed)
+    }
 }
 
 impl Default for DatabaseNamingConvention {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Moves `trim_routine_name` from `EcuManager` (in `component_info.rs`) into `DatabaseNamingConvention` (in `database_naming_convention.rs`). The method only used `self.database_naming_convention`, no other `EcuManager` state. So it belongs alongside the other `trim_*_affixes` methods it wraps. Originally suggested by @theswiftfox in PR #378.

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

Closes #396
Follow-up from PR #378 (review comment by @theswiftfox)

## Notes for Reviewers

Pure refactor, no behavior change. The method body is identical, just calling `self.trim_service_name_affixes()` and `self.trim_short_name_affixes()` directly instead of going through `self.database_naming_convention`. All 3 call sites in `component_info.rs` updated to `self.database_naming_convention.trim_routine_name(...)`.
