### PR TITLE
fix: remove extra generic parameter from docs_endpoint handlers

### DIFF
--- a/cda-sovd/src/sovd/components/ecu/configurations.rs
+++ b/cda-sovd/src/sovd/components/ecu/configurations.rs
@@ -190,10 +190,7 @@ pub(crate) mod diag_service {
             extract::{Path, State},
             response::{IntoResponse as _, Response},
         };
-        use cda_interfaces::{
-            DynamicPlugin, SchemaProvider, UdsEcu, diagservices::DiagServiceResponse,
-            file_manager::FileManager,
-        };
+        use cda_interfaces::{DynamicPlugin, SchemaProvider, UdsEcu, file_manager::FileManager};
         use cda_plugin_security::Secured;
 
         use crate::{
@@ -203,14 +200,10 @@ pub(crate) mod diag_service {
 
         openapi::aide_helper::gen_path_param!(ConfigDocsPathParam service String);
 
-        pub(crate) async fn get<
-            R: DiagServiceResponse,
-            T: UdsEcu + SchemaProvider + Clone,
-            U: FileManager,
-        >(
+        pub(crate) async fn get<T: UdsEcu + SchemaProvider + Clone, U: FileManager>(
             UseApi(Secured(security_plugin), _): UseApi<Secured, ()>,
             Path(ConfigDocsPathParam { service }): Path<ConfigDocsPathParam>,
-            State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<R, T, U>>,
+            State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<T, U>>,
         ) -> Response {
             let security_plugin: DynamicPlugin = security_plugin;
 
@@ -257,8 +250,7 @@ pub(crate) mod diag_service {
             use axum::{extract::State, http::StatusCode};
             use cda_interfaces::{
                 DiagServiceError, datatypes::ComponentConfigurationsInfo,
-                diagservices::mock::MockDiagServiceResponse, file_manager::mock::MockFileManager,
-                mock::MockUdsEcu,
+                file_manager::mock::MockFileManager, mock::MockUdsEcu,
             };
             use cda_plugin_security::{Secured, mock::TestSecurityPlugin};
 
@@ -281,14 +273,13 @@ pub(crate) mod diag_service {
                         }])
                     });
 
-                let state =
-                    create_test_webserver_state::<
-                        MockDiagServiceResponse,
-                        MockUdsEcu,
-                        MockFileManager,
-                    >("TestECU".to_owned(), mock_uds, MockFileManager::new());
+                let state = create_test_webserver_state::<MockUdsEcu, MockFileManager>(
+                    "TestECU".to_owned(),
+                    mock_uds,
+                    MockFileManager::new(),
+                );
 
-                let response = get::<MockDiagServiceResponse, MockUdsEcu, MockFileManager>(
+                let response = get::<MockUdsEcu, MockFileManager>(
                     UseApi(
                         Secured(Box::new(TestSecurityPlugin)),
                         std::marker::PhantomData,
@@ -326,14 +317,13 @@ pub(crate) mod diag_service {
                         }])
                     });
 
-                let state =
-                    create_test_webserver_state::<
-                        MockDiagServiceResponse,
-                        MockUdsEcu,
-                        MockFileManager,
-                    >("TestECU".to_owned(), mock_uds, MockFileManager::new());
+                let state = create_test_webserver_state::<MockUdsEcu, MockFileManager>(
+                    "TestECU".to_owned(),
+                    mock_uds,
+                    MockFileManager::new(),
+                );
 
-                let response = get::<MockDiagServiceResponse, MockUdsEcu, MockFileManager>(
+                let response = get::<MockUdsEcu, MockFileManager>(
                     UseApi(
                         Secured(Box::new(TestSecurityPlugin)),
                         std::marker::PhantomData,
@@ -359,14 +349,13 @@ pub(crate) mod diag_service {
                         ))
                     });
 
-                let state =
-                    create_test_webserver_state::<
-                        MockDiagServiceResponse,
-                        MockUdsEcu,
-                        MockFileManager,
-                    >("TestECU".to_owned(), mock_uds, MockFileManager::new());
+                let state = create_test_webserver_state::<MockUdsEcu, MockFileManager>(
+                    "TestECU".to_owned(),
+                    mock_uds,
+                    MockFileManager::new(),
+                );
 
-                let response = get::<MockDiagServiceResponse, MockUdsEcu, MockFileManager>(
+                let response = get::<MockUdsEcu, MockFileManager>(
                     UseApi(
                         Secured(Box::new(TestSecurityPlugin)),
                         std::marker::PhantomData,

--- a/cda-sovd/src/sovd/components/ecu/data.rs
+++ b/cda-sovd/src/sovd/components/ecu/data.rs
@@ -292,10 +292,7 @@ pub(crate) mod diag_service {
             extract::{Path, State},
             response::{IntoResponse as _, Response},
         };
-        use cda_interfaces::{
-            DynamicPlugin, SchemaProvider, UdsEcu, diagservices::DiagServiceResponse,
-            file_manager::FileManager,
-        };
+        use cda_interfaces::{DynamicPlugin, SchemaProvider, UdsEcu, file_manager::FileManager};
         use cda_plugin_security::Secured;
 
         use crate::{
@@ -305,14 +302,10 @@ pub(crate) mod diag_service {
 
         openapi::aide_helper::gen_path_param!(DataDocsPathParam service String);
 
-        pub(crate) async fn get<
-            R: DiagServiceResponse,
-            T: UdsEcu + SchemaProvider + Clone,
-            U: FileManager,
-        >(
+        pub(crate) async fn get<T: UdsEcu + SchemaProvider + Clone, U: FileManager>(
             UseApi(Secured(security_plugin), _): UseApi<Secured, ()>,
             Path(DataDocsPathParam { service }): Path<DataDocsPathParam>,
-            State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<R, T, U>>,
+            State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<T, U>>,
         ) -> Response {
             let security_plugin: DynamicPlugin = security_plugin;
 
@@ -354,8 +347,7 @@ pub(crate) mod diag_service {
             use axum::{extract::State, http::StatusCode};
             use cda_interfaces::{
                 DiagServiceError, datatypes::ComponentDataInfo,
-                diagservices::mock::MockDiagServiceResponse, file_manager::mock::MockFileManager,
-                mock::MockUdsEcu,
+                file_manager::mock::MockFileManager, mock::MockUdsEcu,
             };
             use cda_plugin_security::{Secured, mock::TestSecurityPlugin};
 
@@ -377,14 +369,13 @@ pub(crate) mod diag_service {
                         }])
                     });
 
-                let state =
-                    create_test_webserver_state::<
-                        MockDiagServiceResponse,
-                        MockUdsEcu,
-                        MockFileManager,
-                    >("TestECU".to_owned(), mock_uds, MockFileManager::new());
+                let state = create_test_webserver_state::<MockUdsEcu, MockFileManager>(
+                    "TestECU".to_owned(),
+                    mock_uds,
+                    MockFileManager::new(),
+                );
 
-                let response = get::<MockDiagServiceResponse, MockUdsEcu, MockFileManager>(
+                let response = get::<MockUdsEcu, MockFileManager>(
                     UseApi(
                         Secured(Box::new(TestSecurityPlugin)),
                         std::marker::PhantomData,
@@ -421,14 +412,13 @@ pub(crate) mod diag_service {
                         }])
                     });
 
-                let state =
-                    create_test_webserver_state::<
-                        MockDiagServiceResponse,
-                        MockUdsEcu,
-                        MockFileManager,
-                    >("TestECU".to_owned(), mock_uds, MockFileManager::new());
+                let state = create_test_webserver_state::<MockUdsEcu, MockFileManager>(
+                    "TestECU".to_owned(),
+                    mock_uds,
+                    MockFileManager::new(),
+                );
 
-                let response = get::<MockDiagServiceResponse, MockUdsEcu, MockFileManager>(
+                let response = get::<MockUdsEcu, MockFileManager>(
                     UseApi(
                         Secured(Box::new(TestSecurityPlugin)),
                         std::marker::PhantomData,
@@ -450,14 +440,13 @@ pub(crate) mod diag_service {
                     .expect_get_components_data_info()
                     .returning(|_, _| Err(DiagServiceError::NotFound("ECU not found".to_owned())));
 
-                let state =
-                    create_test_webserver_state::<
-                        MockDiagServiceResponse,
-                        MockUdsEcu,
-                        MockFileManager,
-                    >("TestECU".to_owned(), mock_uds, MockFileManager::new());
+                let state = create_test_webserver_state::<MockUdsEcu, MockFileManager>(
+                    "TestECU".to_owned(),
+                    mock_uds,
+                    MockFileManager::new(),
+                );
 
-                let response = get::<MockDiagServiceResponse, MockUdsEcu, MockFileManager>(
+                let response = get::<MockUdsEcu, MockFileManager>(
                     UseApi(
                         Secured(Box::new(TestSecurityPlugin)),
                         std::marker::PhantomData,

--- a/cda-sovd/src/sovd/docs/data.rs
+++ b/cda-sovd/src/sovd/docs/data.rs
@@ -1,6 +1,5 @@
 /*
- * SPDX-License-Identifier: Apache-2.0
- * SPDX-FileCopyrightText: 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -8,6 +7,8 @@
  * This program and the accompanying materials are made available under the
  * terms of the Apache License Version 2.0 which is available at
  * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 //! Builders for the online capability description of SOVD data and configuration


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
The docs_endpoint::get functions in configurations.rs and data.rs incorrectly declared 3 generic type parameters (R, T, U) and used WebserverEcuState<R, T, U>, but the struct only takes 2 (T, U).

Remove the unnecessary R: DiagServiceResponse parameter and fix all corresponding test call sites that passed MockDiagServiceResponse as the first turbofish argument.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
