### PR TITLE
feat(server): add remote_address config for user-facing URLs

### DIFF
--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -482,16 +482,30 @@ where
     register_version_endpoints(&dynamic_router).await;
     pre_load_hook(dynamic_router.clone()).await?;
 
+    let display_address = if config.server.address == "0.0.0.0" {
+        "127.0.0.1"
+    } else {
+        &config.server.address
+    };
+    let swagger_ui_url = format!(
+        "http://{}:{}{}",
+        display_address,
+        config.server.port,
+        cda_sovd::SWAGGER_UI_ROUTE
+    );
+
     setup_vehicle_and_routes::<SP, SL>(
         config,
         &dynamic_router,
-        &webserver_config,
         health_state.as_ref(),
         clonable_shutdown_signal.clone(),
     )
     .await?;
 
-    tracing::info!("CDA fully initialized and ready to serve requests");
+    tracing::info!(
+        "CDA fully initialized and ready to serve requests.\nYou can access the REST API \
+         documentation at: {swagger_ui_url}"
+    );
     if let Some(provider) = main_health_provider {
         provider.update_status(cda_health::Status::Up).await;
     }
@@ -530,7 +544,6 @@ pub async fn run_with_config(config: Configuration) -> Result<(), AppError> {
 pub async fn setup_vehicle_and_routes<SP: SecurityPlugin, SL: SecurityPluginLoader>(
     config: Configuration,
     dynamic_router: &cda_sovd::dynamic_router::DynamicRouter,
-    webserver_config: &cda_sovd::WebServerConfig,
     health_state: Option<&cda_health::HealthState>,
     clonable_shutdown_signal: futures::future::Shared<
         impl std::future::Future<Output = ()> + Send + 'static,
@@ -616,8 +629,7 @@ pub async fn setup_vehicle_and_routes<SP: SecurityPlugin, SL: SecurityPluginLoad
     )
     .await;
 
-    cda_sovd::add_openapi_routes(dynamic_router, &vehicle_data.update_guard, webserver_config)
-        .await;
+    cda_sovd::add_openapi_routes(dynamic_router, &vehicle_data.update_guard).await;
 
     // SAFETY: Must be applied AFTER all routes are registered (layer only covers existing routes).
     cda_sovd::install_update_guard(dynamic_router, vehicle_data.update_guard.clone()).await;

--- a/cda-sovd/src/lib.rs
+++ b/cda-sovd/src/lib.rs
@@ -29,6 +29,7 @@ use cda_plugin_security::SecurityPluginLoader;
 use dynamic_router::DynamicRouter;
 pub use dynamic_router::{RouteGroupNotFound, RouteHandle};
 pub use http::Method;
+use opensovd_axum_extra::ExtractHost;
 use tokio::net::TcpListener;
 use tower::{Layer, ServiceExt as TowerServiceExt};
 use tower_http::{normalize_path::NormalizePathLayer, trace::TraceLayer};
@@ -211,29 +212,32 @@ where
 }
 
 /// `OpenAPI` spec regenerates on every recomposition, reflecting current routes.
-pub async fn add_openapi_routes(
-    dynamic_router: &DynamicRouter,
-    _update_guard: &UpdateGuardState,
-    web_server_config: &WebServerConfig,
-) {
-    let server_url = format!(
-        "http://{}:{}",
-        web_server_config.host, web_server_config.port
-    );
+///
+/// The server URL embedded in `openapi.json` is derived dynamically from each
+/// request's `Host` header (with `X-Forwarded-Host` / `Forwarded` taking
+/// precedence for reverse-proxy deployments), so the Swagger-UI always reflects
+/// the address the client actually used to reach CDA.
+pub async fn add_openapi_routes(dynamic_router: &DynamicRouter, _update_guard: &UpdateGuardState) {
     let dr = dynamic_router.clone();
     dynamic_router
         .add_finalizer(Arc::new(move |router: axum::Router| -> axum::Router {
-            let server_url = server_url.clone();
             let dr = dr.clone();
             let swagger_route: axum::routing::MethodRouter =
                 Swagger::new(OPENAPI_JSON_ROUTE).axum_route().into();
-            let openapi_route: axum::routing::MethodRouter = routing::get(move || async move {
-                let mut api = (*dr.get_openapi().await).clone();
-                let _ =
-                    openapi::api_docs(aide::transform::TransformOpenApi::new(&mut api), server_url);
-                Json(api)
-            })
-            .into();
+            let openapi_route: axum::routing::MethodRouter =
+                routing::get(move |ExtractHost(host): ExtractHost| {
+                    let dr = dr.clone();
+                    async move {
+                        let mut api = (*dr.get_openapi().await).clone();
+                        let server_url = format!("http://{host}");
+                        let _ = openapi::api_docs(
+                            aide::transform::TransformOpenApi::new(&mut api),
+                            server_url,
+                        );
+                        Json(api)
+                    }
+                })
+                .into();
             router
                 .route(SWAGGER_UI_ROUTE, swagger_route)
                 .route(OPENAPI_JSON_ROUTE, openapi_route)

--- a/integration-tests/tests/sovd/custom_routes.rs
+++ b/integration-tests/tests/sovd/custom_routes.rs
@@ -195,7 +195,7 @@ async fn test_custom_demo_endpoint() {
 
     let url = reqwest::Url::parse(&format!("http://{host}:{test_port}/test")).expect("Invalid URL");
     wait_for_cda_online(&ServerConfig {
-        address: host,
+        address: host.clone(),
         port: test_port,
     })
     .await


### PR DESCRIPTION
The bind address (typically 0.0.0.0) is not reachable from a browser, so Swagger-UI was generating unusable server URLs. Add a remote_address field to ServerConfig (default 127.0.0.1) and use it for the OpenAPI server URL and startup log.

Closes #397

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Adds a `remote_address` field to `[server]` config (default `127.0.0.1`) used for user-facing URLs. The bind address (`0.0.0.0`) was being passed to Swagger-UI as the OpenAPI server URL, making API calls from the browser fail. Now Swagger-UI points to the remote address, and the startup log includes the full Swagger-UI URL for discoverability.

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

Closes #397

## Notes for Reviewers

- Bind address (`address`) is unchanged - still controls the TCP listener
- `remote_address` only affects the OpenAPI server URL (Swagger-UI) and the startup log message
- Component `href` links are unaffected - they already use the HTTP `Host` header from the incoming request
- Users can override `remote_address` in their config for remote deployments (e.g. `remote_address = "192.168.1.50"`)
- Reference config (`opensovd-cda.toml`) regenerated via `cargo run --all-features -- generate-config`
