### PR TITLE
fix(connection): send alive response instead of request

### DIFF
--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -18,7 +18,7 @@ use cda_interfaces::{
     dlt_ctx, service_ids,
 };
 use doip_definitions::payload::{
-    ActivationType, AliveCheckRequest, DiagnosticAckCode, DiagnosticMessageAck, DoipPayload,
+    ActivationType, AliveCheckResponse, DiagnosticAckCode, DiagnosticMessageAck, DoipPayload,
     RoutingActivationRequest,
 };
 use thiserror::Error;
@@ -530,7 +530,7 @@ where
 
                     let (alive_response, conn_gateway_name, conn_gateway_ip) = {
                         (
-                            send_alive_request(&gateway_conn).await,
+                            send_alive_response(&gateway_conn, gateway_conn.tester_address).await,
                             gateway_conn.gateway_name.clone(),
                             gateway_conn.gateway_ip.clone(),
                         )
@@ -795,7 +795,10 @@ fn spawn_gateway_receiver_task<T>(
     });
 }
 
-async fn send_alive_request<T>(conn: &EcuConnectionTarget<T>) -> Result<(), ()>
+async fn send_alive_response<T>(
+    conn: &EcuConnectionTarget<T>,
+    tester_address: [u8; 2],
+) -> Result<(), ()>
 where
     T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
@@ -843,7 +846,9 @@ where
     };
     match sender
         .get_sender()
-        .send(DoipPayload::AliveCheckRequest(AliveCheckRequest {}))
+        .send(DoipPayload::AliveCheckResponse(AliveCheckResponse {
+            source_address: tester_address,
+        }))
         .await
     {
         Ok(()) => {
@@ -963,6 +968,7 @@ mod tests {
             ecu_connection_tx: Mutex::new(Some(EcuConnectionSendVariant::Plain(write_half))),
             gateway_name: String::new(),
             gateway_ip: String::new(),
+            tester_address: [0, 0],
         };
         (target, server_conn)
     }

--- a/cda-comm-doip/src/ecu_connection.rs
+++ b/cda-comm-doip/src/ecu_connection.rs
@@ -188,6 +188,7 @@ pub(crate) struct EcuConnectionTarget<
     pub(crate) ecu_connection_tx: Mutex<Option<EcuConnectionSendVariant<T>>>,
     pub(crate) gateway_name: String,
     pub(crate) gateway_ip: String,
+    pub(crate) tester_address: [u8; 2],
 }
 
 pub struct EcuConnectionSendGuard<'a, T: AsyncWrite + Unpin = TcpStream> {
@@ -375,6 +376,7 @@ pub(crate) async fn establish_ecu_connection(
                         ecu_connection_rx: Mutex::new(Some(read)),
                         gateway_name: gateway_name.to_owned(),
                         gateway_ip: gateway_ip.to_owned(),
+                        tester_address: routing_activation_request.source_address,
                     })
                 }
                 ActivationCode::DeniedRequestEncryptedTLSConnection => {
@@ -485,6 +487,7 @@ pub(crate) async fn establish_tls_ecu_connection(
                 ecu_connection_rx: Mutex::new(Some(read)),
                 gateway_name: gateway_name.to_owned(),
                 gateway_ip: gateway_ip.to_owned(),
+                tester_address: routing_activation_request.source_address,
             }) // Routing activated
         }
         Err(e) => Err(ConnectionError::RoutingError(format!(


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
per doip specification an alive response must be sent to keep a connection alive.
See SO 13400-2:2025 section 9.6 for details.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Solves #400 