### PR TITLE
fix(doip): Detect DoIP version automatically

### DIFF
--- a/cda-comm-doip/src/config.rs
+++ b/cda-comm-doip/src/config.rs
@@ -20,8 +20,6 @@ use serde::{Deserialize, Serialize};
 /// `DoIP` (Diagnostics over IP) transport layer configuration.
 #[derive(Deserialize, Serialize, Clone, Debug, schemars::JsonSchema)]
 pub struct DoipConfig {
-    /// `DoIP` protocol version byte (e.g. 0x02 for ISO 13400-2:2012).
-    pub protocol_version: u8,
     /// IP address of the diagnostic tester interface.
     pub tester_address: String,
     /// Subnet mask for the tester network.
@@ -46,7 +44,6 @@ pub struct DoipConfig {
 impl Default for DoipConfig {
     fn default() -> Self {
         Self {
-            protocol_version: 0x02,
             tester_address: "127.0.0.1".to_owned(),
             tester_subnet: "255.255.0.0".to_owned(),
             gateway_port: 13400,

--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -957,7 +957,7 @@ mod tests {
     ) {
         let (client, server) = tokio::io::duplex(1024);
         let config = DoipSocketConfig {
-            protocol_version: ProtocolVersion::Iso13400_2010,
+            protocol_version: ProtocolVersion::Iso13400_2012,
             send_diagnostic_message_ack: false,
         };
         let server_conn = DoIPConnection::new(server, config);

--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -160,6 +160,7 @@ where
                 gateway_ip: discovered_gateway.ip.clone(),
                 name: discovered_gateway.ecu_name.clone(),
                 tester_address: gateway_ecu.tester_address().to_be_bytes(),
+                protocol_version: discovered_gateway.doip_protocol_version,
                 transport: transport.clone(),
             },
             routing_activation_request,
@@ -956,7 +957,7 @@ mod tests {
     ) {
         let (client, server) = tokio::io::duplex(1024);
         let config = DoipSocketConfig {
-            protocol_version: ProtocolVersion::Iso13400_2012,
+            protocol_version: ProtocolVersion::Iso13400_2010,
             send_diagnostic_message_ack: false,
         };
         let server_conn = DoIPConnection::new(server, config);
@@ -968,11 +969,12 @@ mod tests {
                 gateway_ip: "127.0.0.1".to_owned(),
                 name: String::new(),
                 tester_address: [0, 0],
+                protocol_version: ProtocolVersion::Iso13400_2010,
                 transport: DoipTransportConfig {
                     tester_ip: "127.0.0.1".to_owned(),
                     port: 13400,
                     tls_port: 0,
-                    socket: config,
+                    send_diagnostic_message_ack: false,
                     send_timeout: Duration::from_secs(5),
                     alive_check_interval,
                 },

--- a/cda-comm-doip/src/ecu_connection.rs
+++ b/cda-comm-doip/src/ecu_connection.rs
@@ -293,6 +293,13 @@ async fn connect_to_gateway(
     Ok(stream)
 }
 
+fn socket_config(config: &GatewayConnectionConfig) -> DoipSocketConfig {
+    DoipSocketConfig {
+        protocol_version: config.doip.protocol_version,
+        send_diagnostic_message_ack: config.doip.transport.send_diagnostic_message_ack,
+    }
+}
+
 #[tracing::instrument(
     skip_all,
     fields(
@@ -318,13 +325,9 @@ pub(crate) async fn establish_ecu_connection(
     )
     .await
     {
-        Ok(Ok(stream)) => EcuConnectionVariant::Plain(DoIPConnection::new(
-            stream,
-            DoipSocketConfig {
-                protocol_version: config.doip.protocol_version,
-                send_diagnostic_message_ack: config.doip.transport.send_diagnostic_message_ack,
-            },
-        )),
+        Ok(Ok(stream)) => {
+            EcuConnectionVariant::Plain(DoIPConnection::new(stream, socket_config(config)))
+        }
         Ok(Err(e)) => return Err(e),
         Err(_) => {
             return Err(ConnectionError::Timeout(
@@ -413,16 +416,7 @@ pub(crate) async fn establish_tls_ecu_connection(
     )
     .await
     {
-        Ok(Ok(stream)) => {
-            create_tls_stream(
-                stream,
-                DoipSocketConfig {
-                    protocol_version: config.doip.protocol_version,
-                    send_diagnostic_message_ack: config.doip.transport.send_diagnostic_message_ack,
-                },
-            )
-            .await?
-        }
+        Ok(Ok(stream)) => create_tls_stream(stream, socket_config(config)).await?,
         Ok(Err(e)) => {
             return Err(ConnectionError::ConnectionFailed(format!(
                 "Connect failed: {e:?}"

--- a/cda-comm-doip/src/ecu_connection.rs
+++ b/cda-comm-doip/src/ecu_connection.rs
@@ -318,9 +318,13 @@ pub(crate) async fn establish_ecu_connection(
     )
     .await
     {
-        Ok(Ok(stream)) => {
-            EcuConnectionVariant::Plain(DoIPConnection::new(stream, config.doip.transport.socket))
-        }
+        Ok(Ok(stream)) => EcuConnectionVariant::Plain(DoIPConnection::new(
+            stream,
+            DoipSocketConfig {
+                protocol_version: config.doip.protocol_version,
+                send_diagnostic_message_ack: config.doip.transport.send_diagnostic_message_ack,
+            },
+        )),
         Ok(Err(e)) => return Err(e),
         Err(_) => {
             return Err(ConnectionError::Timeout(
@@ -409,7 +413,16 @@ pub(crate) async fn establish_tls_ecu_connection(
     )
     .await
     {
-        Ok(Ok(stream)) => create_tls_stream(stream, config.doip.transport.socket).await?,
+        Ok(Ok(stream)) => {
+            create_tls_stream(
+                stream,
+                DoipSocketConfig {
+                    protocol_version: config.doip.protocol_version,
+                    send_diagnostic_message_ack: config.doip.transport.send_diagnostic_message_ack,
+                },
+            )
+            .await?
+        }
         Ok(Err(e)) => {
             return Err(ConnectionError::ConnectionFailed(format!(
                 "Connect failed: {e:?}"

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -40,7 +40,7 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     config::DoipConfig,
     connections::{EcuError, GatewayState},
-    socket::{DoIPUdpSocket, DoipSocketConfig},
+    socket::DoIPUdpSocket,
 };
 
 pub mod config;
@@ -1026,18 +1026,7 @@ pub fn create_udp_vir_socket(
     })?;
 
     let std_sock: std::net::UdpSocket = socket.into();
-    DoIPUdpSocket::new(
-        std_sock,
-        DoipSocketConfig {
-            // Using ::DefaultValue (0xFF) here, because this socket is used to send the VIR, where
-            // we do not know the protocol yet.
-            // The correct protocol will be set per gateway once we receive its VAM.
-            protocol_version: ProtocolVersion::DefaultValue,
-            // UDP socket only sends VIR frames; DiagMsgAck is TCP-only
-            send_diagnostic_message_ack: false,
-        },
-    )
-    .map_err(|e| {
+    DoIPUdpSocket::new(std_sock, ProtocolVersion::DefaultValue).map_err(|e| {
         DoipGatewaySetupError::SocketCreationFailed(format!(
             "DoipGateway: Failed to create DoIP socket from std socket: {e:?}"
         ))

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -145,7 +145,7 @@ pub(crate) struct GatewayDoipConfig {
     /// UDS address of the tester.
     pub(crate) tester_address: [u8; 2],
     /// The `DoIp` protocol version to use for this gateway connection.
-    /// Setup from the value in the VAM.
+    /// Set from the protocol version field in the VAM.
     pub(crate) protocol_version: ProtocolVersion,
     /// Shared transport-level settings (tester IP, ports, socket config, timeouts).
     pub(crate) transport: DoipTransportConfig,
@@ -967,8 +967,6 @@ fn create_netmask(tester_ip: &str, tester_subnet: &str) -> Result<u32, DoipGatew
 ///   resulting in a `DoipGatewaySetupError::PortBindFailed`.
 /// * Setting the `SO_BROADCAST` socket option fails,
 ///   resulting in a `DoipGatewaySetupError::SocketCreationFailed`.
-/// * Setting the socket to non-blocking mode fails,
-///   resulting in a `DoipGatewaySetupError::InvalidConfiguration`.
 /// * Binding the socket to the specified `tester_ip` and `gateway_port` fails,
 ///   resulting in a `DoipGatewaySetupError::SocketCreationFailed`.
 /// * The `DoIPUdpSocket` constructor fails to create the DoIP-specific socket from the standard UDP socket,
@@ -1031,7 +1029,7 @@ pub fn create_udp_vir_socket(
     DoIPUdpSocket::new(
         std_sock,
         DoipSocketConfig {
-            // Using ::DefaultValue here, because this socket is used to send the VIR, where
+            // Using ::DefaultValue (0xFF) here, because this socket is used to send the VIR, where
             // we do not know the protocol yet.
             // The correct protocol will be set per gateway once we receive its VAM.
             protocol_version: ProtocolVersion::DefaultValue,

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -111,6 +111,7 @@ pub(crate) struct DiscoveredGateway {
     pub(crate) ip: String,
     pub(crate) ecu_name: String,
     pub(crate) logical_address: u16,
+    pub(crate) doip_protocol_version: ProtocolVersion,
 }
 
 /// Transport-level settings shared across all `DoIP` gateway connections.
@@ -124,8 +125,8 @@ pub(crate) struct DoipTransportConfig {
     pub(crate) port: u16,
     /// TCP port for `DoIP` over TLS communication.
     pub(crate) tls_port: u16,
-    /// `DoIP` socket-level settings (protocol version, ack behavior).
-    pub(crate) socket: DoipSocketConfig,
+    /// Whether to send a `DiagnosticMessageAck` upon receiving a `DiagnosticMessage`.
+    pub(crate) send_diagnostic_message_ack: bool,
     /// Timeout for sending a single `DoIP` message.
     pub(crate) send_timeout: Duration,
     /// Interval between alive-check requests on idle connections (0 = disabled).
@@ -143,6 +144,9 @@ pub(crate) struct GatewayDoipConfig {
     pub(crate) name: String,
     /// UDS address of the tester.
     pub(crate) tester_address: [u8; 2],
+    /// The `DoIp` protocol version to use for this gateway connection.
+    /// Setup from the value in the VAM.
+    pub(crate) protocol_version: ProtocolVersion,
     /// Shared transport-level settings (tester IP, ports, socket config, timeouts).
     pub(crate) transport: DoipTransportConfig,
 }
@@ -258,7 +262,6 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
         F: Future<Output = ()> + Send + 'static,
     {
         let DoipConfig {
-            protocol_version,
             tester_address: tester_ip,
             tester_subnet,
             gateway_port,
@@ -273,14 +276,7 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
             tester_ip: tester_ip.to_owned(),
             port: gateway_port,
             tls_port: *tls_port,
-            socket: DoipSocketConfig {
-                protocol_version: ProtocolVersion::try_from(protocol_version).map_err(|err| {
-                    DoipGatewaySetupError::InvalidConfiguration(format!(
-                        "Invalid DoIP protocol version: {err}"
-                    ))
-                })?,
-                send_diagnostic_message_ack: *send_diagnostic_message_ack,
-            },
+            send_diagnostic_message_ack: *send_diagnostic_message_ack,
             send_timeout: Duration::from_millis(*send_timeout_ms),
             alive_check_interval: Duration::from_secs(*alive_check_interval_secs),
         };
@@ -960,24 +956,26 @@ fn create_netmask(tester_ip: &str, tester_subnet: &str) -> Result<u32, DoipGatew
 /// Creates a UDP socket for `DoIP` communication.
 ///
 /// # Errors
-///
-/// Returns [`DoipGatewaySetupError::InvalidConfiguration`] if `protocol_version` does not map
-/// to a valid [`ProtocolVersion`], or any error propagated from the underlying socket setup.
-pub fn create_socket(
+/// Returns errors when:
+/// * The provided `tester_ip` and `gateway_port` cannot be parsed into a valid `SocketAddr`,
+///   resulting in a `DoipGatewaySetupError::InvalidAddress`.
+/// * The underlying system call to create a new socket fails,
+///   resulting in a `DoipGatewaySetupError::SocketCreationFailed`.
+/// * Setting the `SO_REUSEADDR` socket option fails,
+///   resulting in a `DoipGatewaySetupError::InvalidAddress`.
+/// * On Unix-like systems, setting the `SO_REUSEPORT` socket option fails,
+///   resulting in a `DoipGatewaySetupError::PortBindFailed`.
+/// * Setting the `SO_BROADCAST` socket option fails,
+///   resulting in a `DoipGatewaySetupError::SocketCreationFailed`.
+/// * Setting the socket to non-blocking mode fails,
+///   resulting in a `DoipGatewaySetupError::InvalidConfiguration`.
+/// * Binding the socket to the specified `tester_ip` and `gateway_port` fails,
+///   resulting in a `DoipGatewaySetupError::SocketCreationFailed`.
+/// * The `DoIPUdpSocket` constructor fails to create the DoIP-specific socket from the standard UDP socket,
+///   resulting in a `DoipGatewaySetupError::SocketCreationFailed`.
+pub fn create_udp_vir_socket(
     tester_ip: &str,
     gateway_port: u16,
-    protocol_version: u8,
-) -> Result<DoIPUdpSocket, DoipGatewaySetupError> {
-    let protocol_version = ProtocolVersion::try_from(&protocol_version).map_err(|err| {
-        DoipGatewaySetupError::InvalidConfiguration(format!("Invalid DoIP protocol version: {err}"))
-    })?;
-    create_socket_with_protocol(tester_ip, gateway_port, protocol_version)
-}
-
-fn create_socket_with_protocol(
-    tester_ip: &str,
-    gateway_port: u16,
-    protocol_version: ProtocolVersion,
 ) -> Result<DoIPUdpSocket, DoipGatewaySetupError> {
     let tester_ip = match tester_ip {
         "127.0.0.1" => "0.0.0.0",
@@ -1030,7 +1028,18 @@ fn create_socket_with_protocol(
     })?;
 
     let std_sock: std::net::UdpSocket = socket.into();
-    DoIPUdpSocket::new(std_sock, protocol_version).map_err(|e| {
+    DoIPUdpSocket::new(
+        std_sock,
+        DoipSocketConfig {
+            // Using ::DefaultValue here, because this socket is used to send the VIR, where
+            // we do not know the protocol yet.
+            // The correct protocol will be set per gateway once we receive its VAM.
+            protocol_version: ProtocolVersion::DefaultValue,
+            // UDP socket only sends VIR frames; DiagMsgAck is TCP-only
+            send_diagnostic_message_ack: false,
+        },
+    )
+    .map_err(|e| {
         DoipGatewaySetupError::SocketCreationFailed(format!(
             "DoipGateway: Failed to create DoIP socket from std socket: {e:?}"
         ))

--- a/cda-comm-doip/src/socket.rs
+++ b/cda-comm-doip/src/socket.rs
@@ -78,7 +78,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> DoIPConnection<T> {
         let (read, write) = tokio::io::split(stream);
         (
             DoIPConnectionReadHalf::new(read),
-            DoIPConnectionWriteHalf::new(write, self.config),
+            DoIPConnectionWriteHalf::new(write, self.config.protocol_version),
         )
     }
 }
@@ -91,10 +91,10 @@ pub(crate) struct DoIPConnectionWriteHalf<T: AsyncWrite + Unpin> {
 }
 
 impl<T: AsyncWrite + Unpin> DoIPConnectionWriteHalf<T> {
-    pub fn new(io: WriteHalf<T>, config: DoipSocketConfig) -> Self {
+    pub fn new(io: WriteHalf<T>, protocol_version: ProtocolVersion) -> Self {
         Self {
             io: FramedWrite::new(io, DoipCodec {}),
-            protocol_version: config.protocol_version,
+            protocol_version,
         }
     }
 
@@ -115,18 +115,18 @@ impl<T: AsyncRead + Unpin> DoIPConnectionReadHalf<T> {
 
 pub struct DoIPUdpSocket {
     io: UdpFramed<DoipCodec, tokio::net::UdpSocket>,
-    config: DoipSocketConfig,
+    protocol_version: ProtocolVersion,
 }
 
 impl DoIPUdpSocket {
     pub(crate) fn new(
         socket: std::net::UdpSocket,
-        config: DoipSocketConfig,
+        protocol_version: ProtocolVersion,
     ) -> Result<Self, std::io::Error> {
         let tokio_socket = tokio::net::UdpSocket::from_std(socket)?;
         Ok(Self {
             io: UdpFramed::new(tokio_socket, DoipCodec {}),
-            config,
+            protocol_version,
         })
     }
 
@@ -136,7 +136,7 @@ impl DoIPUdpSocket {
         addr: SocketAddr,
     ) -> Result<(), ConnectionError> {
         let msg = DoipMessageBuilder::new()
-            .protocol_version(self.config.protocol_version)
+            .protocol_version(self.protocol_version)
             .payload(payload)
             .build();
         self.io

--- a/cda-comm-doip/src/socket.rs
+++ b/cda-comm-doip/src/socket.rs
@@ -87,19 +87,19 @@ pub(crate) struct DoIPConnectionReadHalf<T: AsyncRead + Unpin> {
 }
 pub(crate) struct DoIPConnectionWriteHalf<T: AsyncWrite + Unpin> {
     io: FramedWrite<WriteHalf<T>, DoipCodec>,
-    config: DoipSocketConfig,
+    protocol_version: ProtocolVersion,
 }
 
 impl<T: AsyncWrite + Unpin> DoIPConnectionWriteHalf<T> {
     pub fn new(io: WriteHalf<T>, config: DoipSocketConfig) -> Self {
         Self {
             io: FramedWrite::new(io, DoipCodec {}),
-            config,
+            protocol_version: config.protocol_version,
         }
     }
 
     pub async fn send(&mut self, msg: DoipPayload) -> Result<(), ConnectionError> {
-        send_doip(&mut self.io, self.config.protocol_version, msg).await
+        send_doip(&mut self.io, self.protocol_version, msg).await
     }
 }
 impl<T: AsyncRead + Unpin> DoIPConnectionReadHalf<T> {

--- a/cda-comm-doip/src/socket.rs
+++ b/cda-comm-doip/src/socket.rs
@@ -78,7 +78,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> DoIPConnection<T> {
         let (read, write) = tokio::io::split(stream);
         (
             DoIPConnectionReadHalf::new(read),
-            DoIPConnectionWriteHalf::new(write, self.config.protocol_version),
+            DoIPConnectionWriteHalf::new(write, self.config),
         )
     }
 }
@@ -87,19 +87,19 @@ pub(crate) struct DoIPConnectionReadHalf<T: AsyncRead + Unpin> {
 }
 pub(crate) struct DoIPConnectionWriteHalf<T: AsyncWrite + Unpin> {
     io: FramedWrite<WriteHalf<T>, DoipCodec>,
-    protocol_version: ProtocolVersion,
+    config: DoipSocketConfig,
 }
 
 impl<T: AsyncWrite + Unpin> DoIPConnectionWriteHalf<T> {
-    pub fn new(io: WriteHalf<T>, protocol_version: ProtocolVersion) -> Self {
+    pub fn new(io: WriteHalf<T>, config: DoipSocketConfig) -> Self {
         Self {
             io: FramedWrite::new(io, DoipCodec {}),
-            protocol_version,
+            config,
         }
     }
 
     pub async fn send(&mut self, msg: DoipPayload) -> Result<(), ConnectionError> {
-        send_doip(&mut self.io, self.protocol_version, msg).await
+        send_doip(&mut self.io, self.config.protocol_version, msg).await
     }
 }
 impl<T: AsyncRead + Unpin> DoIPConnectionReadHalf<T> {
@@ -115,18 +115,18 @@ impl<T: AsyncRead + Unpin> DoIPConnectionReadHalf<T> {
 
 pub struct DoIPUdpSocket {
     io: UdpFramed<DoipCodec, tokio::net::UdpSocket>,
-    protocol_version: ProtocolVersion,
+    config: DoipSocketConfig,
 }
 
 impl DoIPUdpSocket {
     pub(crate) fn new(
         socket: std::net::UdpSocket,
-        protocol_version: ProtocolVersion,
+        config: DoipSocketConfig,
     ) -> Result<Self, std::io::Error> {
         let tokio_socket = tokio::net::UdpSocket::from_std(socket)?;
         Ok(Self {
             io: UdpFramed::new(tokio_socket, DoipCodec {}),
-            protocol_version,
+            config,
         })
     }
 
@@ -136,7 +136,7 @@ impl DoIPUdpSocket {
         addr: SocketAddr,
     ) -> Result<(), ConnectionError> {
         let msg = DoipMessageBuilder::new()
-            .protocol_version(self.protocol_version)
+            .protocol_version(self.config.protocol_version)
             .payload(payload)
             .build();
         self.io

--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -14,7 +14,8 @@
 use std::{future::Future, sync::Arc, time::Duration};
 
 use cda_interfaces::{
-    DiagServiceError, DoipComParams, EcuAddresses, HashMap, HashMapExtensions, dlt_ctx,
+    DiagServiceError, DoipComParams, DoipGatewaySetupError, EcuAddresses, HashMap,
+    HashMapExtensions, dlt_ctx,
 };
 use doip_definitions::{
     header::PayloadType,
@@ -261,11 +262,7 @@ where
             let broadcast_socket = if transport_config.tester_ip == broadcast_ip {
                 Arc::clone(&state.socket)
             } else {
-                match crate::create_socket_with_protocol(
-                    broadcast_ip,
-                    transport_config.port,
-                    transport_config.socket.protocol_version,
-                ) {
+                match crate::create_udp_vir_socket(broadcast_ip, transport_config.port) {
                     Ok(sock) => Arc::new(Mutex::new(sock)),
                     Err(e) => {
                         tracing::warn!(
@@ -323,7 +320,7 @@ async fn handle_vam<T>(
     doip_msg: doip_definitions::message::DoipMessage,
     source_addr: std::net::SocketAddr,
     netmask: u32,
-) -> Result<Option<DiscoveredGateway>, String>
+) -> Result<Option<DiscoveredGateway>, DoipGatewaySetupError>
 where
     T: EcuAddresses,
 {
@@ -359,21 +356,25 @@ where
                     ecu_name = %ecu,
                     source_ip = %source_addr.ip(),
                     logical_address = %format!("{:#06x}", logical_address),
+                    protocol_version = ?doip_msg.header.protocol_version,
                     "Matching ECU found"
                 );
                 Ok(Some(DiscoveredGateway {
                     ip: source_addr.ip().to_string(),
                     ecu_name: ecu.clone(),
                     logical_address,
+                    doip_protocol_version: doip_msg.header.protocol_version,
                 }))
             } else {
                 tracing::warn!("VAM received but no matching ECU found");
-                Err(format!(
-                    "No matching ECU found for VAM: {:02x?}",
-                    vam.logical_address
-                ))
+                Err(DoipGatewaySetupError::UnknownECU {
+                    logical_address: u16::from_be_bytes(vam.logical_address),
+                    protocol_version: u8::from(doip_msg.header.protocol_version),
+                })
             }
         }
-        _ => Err(format!("Expected VAM, got: {doip_msg:?}")),
+        _ => Err(DoipGatewaySetupError::ResourceError(format!(
+            "Expected VAM, got: {doip_msg:?}"
+        ))),
     }
 }

--- a/cda-interfaces/src/lib.rs
+++ b/cda-interfaces/src/lib.rs
@@ -378,8 +378,6 @@ pub enum DiagServiceError {
 pub enum DoipGatewaySetupError {
     #[error("Invalid address: `{0}`")]
     InvalidAddress(String),
-    #[error("Invalid protocol: `{0}`")]
-    InvalidProtocol(String),
     #[error(
         "Received an unknown ECU in VAM (Logical Address: {logical_address}, Protocol Version: \
          {protocol_version}). Likely there is no MDD loaded for this ECU."

--- a/cda-interfaces/src/lib.rs
+++ b/cda-interfaces/src/lib.rs
@@ -378,6 +378,16 @@ pub enum DiagServiceError {
 pub enum DoipGatewaySetupError {
     #[error("Invalid address: `{0}`")]
     InvalidAddress(String),
+    #[error("Invalid protocol: `{0}`")]
+    InvalidProtocol(String),
+    #[error(
+        "Received an unknown ECU in VAM (Logical Address: {logical_address}, Protocol Version: \
+         {protocol_version}). Likely there is no MDD loaded for this ECU."
+    )]
+    UnknownECU {
+        logical_address: u16,
+        protocol_version: u8,
+    },
     #[error("Socket error: `{0}`")]
     SocketCreationFailed(String),
     #[error("Port error: `{0}`")]

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -224,9 +224,10 @@ impl From<DoipGatewaySetupError> for AppError {
             DoipGatewaySetupError::ServerError(_) => Self::ServerError(value.to_string()),
             DoipGatewaySetupError::UnknownECU {
                 logical_address,
-                protocol_version: u8,
+                protocol_version,
             } => Self::ConfigurationError(format!(
-                "Unknown ECU with logical address {logical_address} and protocol version {u8}"
+                "Unknown ECU with logical address {logical_address} and protocol version \
+                 {protocol_version}"
             )),
         }
     }

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -213,7 +213,6 @@ impl From<DoipGatewaySetupError> for AppError {
         match value {
             DoipGatewaySetupError::InvalidAddress(_) => Self::ConnectionError(value.to_string()),
             DoipGatewaySetupError::SocketCreationFailed(_)
-            | DoipGatewaySetupError::InvalidProtocol(_)
             | DoipGatewaySetupError::PortBindFailed(_) => {
                 Self::InitializationFailed(value.to_string())
             }

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -213,6 +213,7 @@ impl From<DoipGatewaySetupError> for AppError {
         match value {
             DoipGatewaySetupError::InvalidAddress(_) => Self::ConnectionError(value.to_string()),
             DoipGatewaySetupError::SocketCreationFailed(_)
+            | DoipGatewaySetupError::InvalidProtocol(_)
             | DoipGatewaySetupError::PortBindFailed(_) => {
                 Self::InitializationFailed(value.to_string())
             }
@@ -221,6 +222,12 @@ impl From<DoipGatewaySetupError> for AppError {
             }
             DoipGatewaySetupError::ResourceError(_) => Self::ResourceError(value.to_string()),
             DoipGatewaySetupError::ServerError(_) => Self::ServerError(value.to_string()),
+            DoipGatewaySetupError::UnknownECU {
+                logical_address,
+                protocol_version: u8,
+            } => Self::ConfigurationError(format!(
+                "Unknown ECU with logical address {logical_address} and protocol version {u8}"
+            )),
         }
     }
 }
@@ -704,12 +711,11 @@ pub async fn load_vehicle_data<
     };
 
     let update_guard = cda_sovd::UpdateGuardState::new();
-    let doip_socket = cda_comm_doip::create_socket(
-        &config.doip.tester_address,
-        config.doip.gateway_port,
-        config.doip.protocol_version,
-    )
-    .map_err(|e| AppError::InitializationFailed(format!("Failed to create DoIP socket: {e}")))?;
+    let doip_socket =
+        cda_comm_doip::create_udp_vir_socket(&config.doip.tester_address, config.doip.gateway_port)
+            .map_err(|e| {
+                AppError::InitializationFailed(format!("Failed to create DoIP socket: {e}"))
+            })?;
     let components = create_vehicle_components::<F, S>(
         config,
         &mdd_paths,

--- a/integration-tests/tests/sovd/custom_routes.rs
+++ b/integration-tests/tests/sovd/custom_routes.rs
@@ -134,12 +134,9 @@ async fn test_custom_demo_endpoint() {
         provider
     };
 
-    let doip_socket = cda_comm_doip::create_socket(
-        &doip_config.tester_address,
-        doip_config.gateway_port,
-        doip_config.protocol_version,
-    )
-    .expect("Failed to create DoIP socket");
+    let doip_socket =
+        cda_comm_doip::create_udp_vir_socket(&doip_config.tester_address, doip_config.gateway_port)
+            .expect("Failed to create DoIP socket");
     let gateway = opensovd_cda_lib::create_diagnostic_gateway(
         Arc::clone(&databases),
         &doip_config,

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -503,8 +503,6 @@
 # The name of the protocol to use.
 # Matched case-insensitive against the database.
 # protocol_name = "UDS_Ethernet_DoIP_DOBT"
-# `DoIP` protocol version byte (e.g. 0x02 for ISO 13400-2:2012).
-# protocol_version = 2
 # Whether to request a diagnostic message positive acknowledgement.
 # send_diagnostic_message_ack = true
 # Timeout in milliseconds for sending `DoIP` messages.


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

When creating the UDP socket to send the VIR, the
doip version is now set to 0xFF.
After receiving a VAM from a gateway, the gateway connection uses the DoIP version from the VAM instead of being hard coded to a fixed version instead.
This solves two issues:
1. The protocol version does not have to be configured anymore
2. The CDA is now compatible with networks of mixed DoIP versions.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

**The base branch for this PR is tests/tester-present (#390) which should be merged first. This is the case because #390 is refactoring a bunch of doip related communication already, using #390 as base branch makes this a lot easier to merge later and prevents duplicating similar work**