### PR TITLE
refactor: improve EcuState handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,7 @@ dependencies = [
  "cda-interfaces",
  "cda-plugin-runtime-update",
  "futures",
+ "kameo",
  "serde_json",
  "socket2",
  "strum",
@@ -1034,6 +1035,12 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "downcast-rs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "dyn-clone"
@@ -1824,6 +1831,7 @@ dependencies = [
  "axum",
  "cda-build",
  "cda-comm-doip",
+ "cda-comm-uds",
  "cda-core",
  "cda-database",
  "cda-health",
@@ -1931,6 +1939,32 @@ dependencies = [
  "sha2",
  "signature",
  "simple_asn1",
+]
+
+[[package]]
+name = "kameo"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe998b05ae765a040027d9fe3187240cb840e6705fa29d86f3abaa5e96b36291"
+dependencies = [
+ "downcast-rs",
+ "dyn-clone",
+ "futures",
+ "kameo_macros",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "kameo_macros"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f200083477f64b12545688f8e0f562c31c1462827e163cb14dc2ed6c89eb888"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ cargo_toml = "0.22.3"
 libc = "0.2.177"
 crc32fast = "1.4"
 foldhash = "0.2.0"
+kameo = { version = "0.21", default-features = false, features = ["macros"] }
 memmap2 = "0.9"
 mockall = "0.14.0"
 tempfile = "3"

--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -226,7 +226,7 @@ where
     // Notify connectivity handler that ECUs behind this gateway are now online.
     // This sets their state to Online so the pre-send variant detection guard works correctly.
     connectivity_handler
-        .on_connected_bulk(&ecu_names_for_gateway)
+        .on_gateway_connected(&ecu_names_for_gateway)
         .await;
 
     Ok(discovered_gateway.logical_address)
@@ -383,7 +383,7 @@ fn spawn_connection_reset_task(
                                 );
                                 gateway
                                     .connectivity_handler
-                                    .on_connected_bulk(&gateway.ecu_names)
+                                    .on_gateway_connected(&gateway.ecu_names)
                                     .await;
                                 while !conn_reset_rx.is_empty() {
                                     // drain the receiver to avoid resetting the connection again
@@ -759,7 +759,9 @@ where
                             tracing::error!(error = ?e, "Failed to send connection reset request");
                         }
                         // Notify UDS layer that ECUs on this connection are disconnected
-                        connectivity_handler.on_disconnected_bulk(ecu_names).await;
+                        connectivity_handler
+                            .on_gateway_disconnected(ecu_names)
+                            .await;
                     }
                     _ => {
                         // for POC purposes we just log the error and do not reset the connection

--- a/cda-comm-doip/src/connections.rs
+++ b/cda-comm-doip/src/connections.rs
@@ -14,8 +14,8 @@
 use std::{sync::Arc, time::Duration};
 
 use cda_interfaces::{
-    DataParseError, DiagServiceError, DoipComParams, EcuAddresses, HashMap, HashMapExtensions,
-    dlt_ctx, service_ids,
+    DataParseError, DiagServiceError, DoipComParams, EcuAddresses, EcuConnectivityHandler, HashMap,
+    HashMapExtensions, dlt_ctx, service_ids,
 };
 use doip_definitions::payload::{
     ActivationType, AliveCheckResponse, DiagnosticAckCode, DiagnosticMessageAck, DoipPayload,
@@ -50,6 +50,20 @@ pub(crate) struct GatewayState<T> {
 struct GatewayConnectionHandles {
     sender: mpsc::Sender<DoipPayload>,
     receivers: HashMap<u16, broadcast::Receiver<Result<DiagnosticResponse, EcuError>>>,
+}
+
+/// Identity of a `DoIP` gateway (IP address and ECU name).
+#[derive(Debug)]
+struct GatewayIdentity {
+    ip: String,
+    name: String,
+}
+
+/// Channels used by the gateway receiver task for bidirectional flow control.
+struct ReceiverChannels {
+    send_pending_rx: watch::Receiver<bool>,
+    reset_tx: mpsc::Sender<ConnectionResetReason>,
+    send_tx: mpsc::Sender<DoipPayload>,
 }
 
 #[derive(Error, Debug, Clone)]
@@ -96,7 +110,7 @@ impl From<EcuError> for DiagServiceError {
 }
 
 #[tracing::instrument(
-    skip(transport, state),
+    skip(transport, state, connectivity_handler),
     fields(
         tester_ip = transport.tester_ip.clone(),
         port = transport.port,
@@ -111,7 +125,7 @@ pub(crate) async fn handle_gateway_connection<T>(
     discovered_gateway: DiscoveredGateway,
     transport: &DoipTransportConfig,
     state: &GatewayState<T>,
-    variant_detection: Option<(mpsc::Sender<Vec<String>>, Vec<String>)>,
+    connectivity_handler: Arc<dyn EcuConnectivityHandler>,
 ) -> Result<u16, EcuError>
 where
     T: EcuAddresses + DoipComParams,
@@ -140,6 +154,15 @@ where
             discovered_gateway.logical_address
         )));
     };
+
+    // Build list of ECU names behind this gateway for notifications
+    let mut ecu_names_for_gateway: Vec<String> = Vec::new();
+    for (name, ecu_lock) in state.ecus.iter() {
+        let ecu = ecu_lock.read().await;
+        if ecu_ids.contains(&ecu.logical_address()) {
+            ecu_names_for_gateway.push(name.clone());
+        }
+    }
 
     let gateway_ecu = match state.ecus.get(&discovered_gateway.ecu_name) {
         Some(ecu) => ecu.read().await,
@@ -172,7 +195,8 @@ where
             },
         },
         ecus: ecu_ids.clone(),
-        variant_detection,
+        ecu_names: ecu_names_for_gateway.clone(),
+        connectivity_handler: Arc::clone(&connectivity_handler),
     };
     let GatewayConnectionHandles { sender, receivers } =
         match connection_handler(gateway, Arc::clone(&state.connection_tasks)).await {
@@ -198,6 +222,12 @@ where
             ecus: doip_ecus,
             ip: discovered_gateway.ip,
         }));
+
+    // Notify connectivity handler that ECUs behind this gateway are now online.
+    // This sets their state to Online so the pre-send variant detection guard works correctly.
+    connectivity_handler
+        .on_connected_bulk(&ecu_names_for_gateway)
+        .await;
 
     Ok(discovered_gateway.logical_address)
 }
@@ -301,11 +331,14 @@ async fn connection_handler(
         send_pending_tx.clone(),
     ));
     tasks.spawn(spawn_gateway_receiver_task(
+        gateway,
         outtx,
         Arc::<EcuConnectionTarget>::clone(&gateway_conn),
-        send_pending_rx,
-        conn_reset_tx,
-        intx.clone(),
+        ReceiverChannels {
+            send_pending_rx,
+            reset_tx: conn_reset_tx,
+            send_tx: intx.clone(),
+        },
     ));
     drop(tasks);
 
@@ -348,28 +381,16 @@ fn spawn_connection_reset_task(
                                     &mut conn_guard,
                                     conn,
                                 );
+                                gateway
+                                    .connectivity_handler
+                                    .on_connected_bulk(&gateway.ecu_names)
+                                    .await;
                                 while !conn_reset_rx.is_empty() {
                                     // drain the receiver to avoid resetting the connection again
                                     // immediately after a reset
                                     if conn_reset_rx.recv().await.is_none() {
                                         tracing::warn!("Connection reset receiver closed");
                                         return;
-                                    }
-                                }
-                                // Trigger variant detection after successful reconnection
-                                // so that ECUs transition back to Online.
-                                if let Some((ref vd_tx, ref ecu_names)) = gateway.variant_detection
-                                {
-                                    if let Err(e) = vd_tx.send(ecu_names.clone()).await {
-                                        tracing::error!(
-                                            error = ?e,
-                                            "Failed to trigger variant detection after reconnect"
-                                        );
-                                    } else {
-                                        tracing::info!(
-                                            ecus = ?ecu_names,
-                                            "Triggered variant detection after reconnect"
-                                        );
                                     }
                                 }
                                 break 'reconnect;
@@ -571,7 +592,7 @@ where
     reason = "Contains two private inline functions that should remain in scope"
 )]
 #[tracing::instrument(
-    skip(outtx, gateway_conn, send_pending_rx, reset_tx),
+    skip_all,
     fields(
         gateway_ip = %gateway_conn.gateway_doip_config.gateway_ip,
         gateway_name = %gateway_conn.gateway_doip_config.name,
@@ -580,30 +601,37 @@ where
     )
 )]
 fn spawn_gateway_receiver_task<T>(
+    gateway: GatewaySetup,
     outtx: HashMap<u16, broadcast::Sender<Result<DiagnosticResponse, EcuError>>>,
     gateway_conn: Arc<EcuConnectionTarget<T>>,
-    mut send_pending_rx: watch::Receiver<bool>,
-    reset_tx: mpsc::Sender<ConnectionResetReason>,
-    send_tx: mpsc::Sender<DoipPayload>,
+    channels: ReceiverChannels,
 ) -> tokio::task::JoinHandle<()>
 where
     T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
-    let gateway_ip = gateway_conn.gateway_doip_config.gateway_ip.clone();
-    let gateway_name = gateway_conn.gateway_doip_config.name.clone();
+    let gateway_id = GatewayIdentity {
+        ip: gateway.connection.doip.gateway_ip,
+        name: gateway.connection.doip.name,
+    };
+    let ReceiverChannels {
+        mut send_pending_rx,
+        reset_tx,
+        send_tx,
+    } = channels;
+    let ecu_names = gateway.ecu_names;
+    let connectivity_handler = gateway.connectivity_handler;
     // note: the handlers are defined here, as rustfmt cannot format the correctly inside the
     // tokio::select! macro block
     async fn handle_send_pending(
-        gateway_name: &str,
-        gateway_ip: &str,
+        gateway: &GatewayIdentity,
         send_pending_rx: &mut watch::Receiver<bool>,
         send_pending_result: Result<(), watch::error::RecvError>,
     ) -> Result<(), ()> {
         let request_received = std::time::Instant::now();
         if send_pending_result.is_ok() {
             tracing::debug!(
-                gateway_name = %gateway_name,
-                gateway_ip = %gateway_ip,
+                gateway_name = %gateway.name,
+                gateway_ip = %gateway.ip,
                 "Received tx request, unlocking connection"
             );
             let send_pending = *send_pending_rx.borrow();
@@ -611,16 +639,16 @@ where
                 match send_pending_rx.changed().await {
                     Ok(()) => {
                         tracing::debug!(
-                            gateway_name = %gateway_name,
-                            gateway_ip = %gateway_ip,
+                            gateway_name = %gateway.name,
+                            gateway_ip = %gateway.ip,
                             request_duration = ?request_received.elapsed(),
                             "Send done, continue rx await"
                         );
                     }
                     Err(e) => {
                         tracing::warn!(
-                            gateway_name = %gateway_name,
-                            gateway_ip = %gateway_ip,
+                            gateway_name = %gateway.name,
+                            gateway_ip = %gateway.ip,
                             error = ?e,
                             "Send pending receiver closed"
                         );
@@ -631,8 +659,8 @@ where
             Ok(())
         } else {
             tracing::warn!(
-                gateway_name = %gateway_name,
-                gateway_ip = %gateway_ip,
+                gateway_name = %gateway.name,
+                gateway_ip = %gateway.ip,
                 "Send pending receiver closed"
             );
             Err(())
@@ -644,20 +672,21 @@ where
         fields(dlt_context = dlt_ctx!("DOIP"))
     )]
     async fn handle_response(
-        gateway_name: &str,
-        gateway_ip: &str,
+        gateway: &GatewayIdentity,
         outtx: &HashMap<u16, broadcast::Sender<Result<DiagnosticResponse, EcuError>>>,
         reset_tx: &mpsc::Sender<ConnectionResetReason>,
         ack_tx: &mpsc::Sender<DoipPayload>,
         response: Option<Result<DiagnosticResponse, ConnectionError>>,
+        ecu_names: &[String],
+        connectivity_handler: &Arc<dyn EcuConnectivityHandler>,
     ) {
         match response {
             Some(Ok(response)) => {
                 match response {
                     DiagnosticResponse::Ack((source_address, _)) => {
                         tracing::debug!(
-                            gateway_name = %gateway_name,
-                            gateway_ip = %gateway_ip,
+                            gateway_name = %gateway.name,
+                            gateway_ip = %gateway.ip,
                             source_address = %source_address,
                             "Received ACK"
                         );
@@ -687,8 +716,8 @@ where
                             .inspect_err(|e| {
                                 tracing::error!(
                                     error = ?e,
-                                    gateway_name = %gateway_name,
-                                    gateway_ip = %gateway_ip,
+                                    gateway_name = %gateway.name,
+                                    gateway_ip = %gateway.ip,
                                     source_address = %addr,
                                     target_address = %target_addr,
                                     "Failed to send DiagnosticMessageAck"
@@ -729,6 +758,8 @@ where
                         {
                             tracing::error!(error = ?e, "Failed to send connection reset request");
                         }
+                        // Notify UDS layer that ECUs on this connection are disconnected
+                        connectivity_handler.on_disconnected_bulk(ecu_names).await;
                     }
                     _ => {
                         // for POC purposes we just log the error and do not reset the connection
@@ -745,7 +776,7 @@ where
         }
     }
 
-    cda_interfaces::spawn_named!(&format!("gateway-receiver-{gateway_ip}"), async move {
+    cda_interfaces::spawn_named!(&format!("gateway-receiver-{}", gateway_id.ip), async move {
         'receive: loop {
             if outtx.iter().all(|(_, tx)| tx.receiver_count() == 0) {
                 tracing::debug!("All out channels closed. Shutting down connection");
@@ -759,8 +790,7 @@ where
             tokio::select! {
                 send_pending_result = send_pending_rx.changed() => {
                     if let Err(()) = handle_send_pending(
-                        &gateway_name,
-                        &gateway_ip,
+                        &gateway_id,
                         &mut send_pending_rx,
                         send_pending_result
                     ).await {
@@ -781,12 +811,13 @@ where
                 } => {
                     if let Some(response) = response {
                         handle_response(
-                            &gateway_name,
-                            &gateway_ip,
+                            &gateway_id,
                             &outtx,
                             &reset_tx,
                             &send_tx,
-                            response
+                            response,
+                            &ecu_names,
+                            &connectivity_handler,
                         ).await;
                     }
                 }

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -18,8 +18,9 @@ use std::{
 };
 
 use cda_interfaces::{
-    DiagServiceError, DoipComParams, DoipGatewaySetupError, EcuAddresses, EcuGateway, HashMap,
-    HashMapExtensions, ServicePayload, TransmissionParameters, UdsResponse, dlt_ctx,
+    DiagServiceError, DoipComParams, DoipGatewaySetupError, EcuAddresses, EcuConnectivityHandler,
+    EcuGateway, HashMap, HashMapExtensions, ServicePayload, TransmissionParameters, UdsResponse,
+    dlt_ctx,
     util::{self, tokio_ext},
 };
 use doip_definitions::{
@@ -171,13 +172,14 @@ pub(crate) struct GatewayConnectionConfig {
 }
 
 /// One-shot setup bundle consumed by `connection_handler` when bringing up a new gateway.
-/// Carries `GatewayConnectionConfig` plus the data that is only needed during initial
-/// channel creation (`ecus`) and reconnection signlling (`variant_detection`).
+/// Carries `GatewayConnectionConfig` plus the ECU list needed during initial channel creation
+/// and the `ConnectivityHandler` for propagating connection events.
 #[derive(Clone)]
 pub(crate) struct GatewaySetup {
     pub(crate) connection: GatewayConnectionConfig,
     pub(crate) ecus: Vec<u16>,
-    pub(crate) variant_detection: Option<(mpsc::Sender<Vec<String>>, Vec<String>)>,
+    pub(crate) ecu_names: Vec<String>,
+    pub(crate) connectivity_handler: Arc<dyn EcuConnectivityHandler>,
 }
 
 struct DoipEcu {
@@ -243,7 +245,7 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
     /// # Errors
     /// Returns `String` if initialization fails, e.g. when socket creation fails.
     #[tracing::instrument(
-        skip(doip_config, ecus, variant_detection, shutdown_signal, doip_socket),
+        skip(doip_config, ecus, variant_detection, connectivity_handler, shutdown_signal, doip_socket),
         fields(
             tester_ip = doip_config.tester_address,
             gateway_port = doip_config.gateway_port,
@@ -255,6 +257,7 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
         doip_config: &DoipConfig,
         ecus: Arc<HashMap<String, RwLock<T>>>,
         variant_detection: mpsc::Sender<Vec<String>>,
+        connectivity_handler: Arc<dyn EcuConnectivityHandler>,
         shutdown_signal: F,
         doip_socket: Arc<Mutex<DoIPUdpSocket>>,
     ) -> Result<Self, DoipGatewaySetupError>
@@ -334,11 +337,6 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
             let mut logical_address_to_connection = HashMap::new();
 
             for gateway in gateways {
-                let ecu_names_for_gateway = gateway_ecu_name_map
-                    .get(&gateway.logical_address)
-                    .cloned()
-                    .unwrap_or_default();
-
                 if let Ok(logical_address) = connections::handle_gateway_connection::<T>(
                     gateway,
                     &transport_config,
@@ -348,7 +346,7 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
                         gateway_ecu_map: gateway_ecu_map.clone(),
                         connection_tasks: Arc::clone(&connection_tasks),
                     },
-                    Some((variant_detection.clone(), ecu_names_for_gateway)),
+                    Arc::clone(&connectivity_handler),
                 )
                 .await
                 {
@@ -373,6 +371,7 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
             mask,
             state.clone(),
             variant_detection,
+            connectivity_handler,
             shared_shutdown_signal,
             cancel_token.child_token(),
         )

--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -14,8 +14,8 @@
 use std::{future::Future, sync::Arc, time::Duration};
 
 use cda_interfaces::{
-    DiagServiceError, DoipComParams, DoipGatewaySetupError, EcuAddresses, HashMap,
-    HashMapExtensions, dlt_ctx,
+    DiagServiceError, DoipComParams, DoipGatewaySetupError, EcuAddresses, EcuConnectivityHandler,
+    HashMap, HashMapExtensions, dlt_ctx,
 };
 use doip_definitions::{
     header::PayloadType,
@@ -109,6 +109,7 @@ pub(crate) async fn listen_for_vams<T, F>(
     netmask: u32,
     state: DoipGatewayState<T>,
     variant_detection: mpsc::Sender<Vec<String>>,
+    connectivity_handler: Arc<dyn EcuConnectivityHandler>,
     mut shutdown_signal: futures::future::Shared<F>,
     cancel_token: CancellationToken,
 ) -> tokio::task::JoinHandle<()>
@@ -129,6 +130,7 @@ where
             gateway_ecu_map,
             gateway_ecu_name_map,
             variant_detection,
+            connectivity_handler,
             transport_config
         ),
         fields(
@@ -142,6 +144,7 @@ where
         gateway_ecu_map: &HashMap<u16, Vec<u16>>,
         gateway_ecu_name_map: &HashMap<u16, Vec<String>>,
         variant_detection: mpsc::Sender<Vec<String>>,
+        connectivity_handler: Arc<dyn EcuConnectivityHandler>,
     ) {
         let DoipMessageContext {
             doip_msg,
@@ -173,10 +176,6 @@ where
                 } else {
                     tracing::info!(ecu_name = %doip_target.ecu_name, "New Gateway ECU detected");
 
-                    let ecu_names_for_gateway = gateway_ecu_name_map
-                        .get(&doip_target.logical_address)
-                        .cloned()
-                        .unwrap_or_default();
                     match handle_gateway_connection::<T>(
                         doip_target,
                         transport_config,
@@ -186,7 +185,7 @@ where
                             gateway_ecu_map: gateway_ecu_map.clone(),
                             connection_tasks: Arc::clone(&state.connection_tasks),
                         },
-                        Some((variant_detection.clone(), ecu_names_for_gateway)),
+                        connectivity_handler,
                     )
                     .await
                     {
@@ -305,6 +304,7 @@ where
                                 &gateway_ecu_map,
                                 &gateway_ecu_name_map,
                                 variant_detection.clone(),
+                                Arc::clone(&connectivity_handler),
                             ).await;
                         }
                     },

--- a/cda-comm-uds/Cargo.toml
+++ b/cda-comm-uds/Cargo.toml
@@ -39,6 +39,9 @@ futures = { workspace = true }
 
 serde_json = { workspace = true }
 
+# actor framework
+kameo = { workspace = true }
+
 # logging & tracing
 tracing = { workspace = true }
 strum = { workspace = true, features = ["derive"] }

--- a/cda-comm-uds/src/coordinator.rs
+++ b/cda-comm-uds/src/coordinator.rs
@@ -248,14 +248,14 @@ impl Message<EcuConnected> for EcuCoordinator {
 ///
 /// Uses `ask` (request-response) to guarantee the suppression is active
 /// before variant detection sends begin.
-pub struct PrepareVariantDetection;
+pub struct SuppressDisconnectHandling;
 
-impl Message<PrepareVariantDetection> for EcuCoordinator {
+impl Message<SuppressDisconnectHandling> for EcuCoordinator {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        _msg: PrepareVariantDetection,
+        _msg: SuppressDisconnectHandling,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         tracing::debug!(
@@ -267,14 +267,14 @@ impl Message<PrepareVariantDetection> for EcuCoordinator {
 }
 
 /// Re-enable disconnect events after variant detection completes.
-pub struct FinishVariantDetection;
+pub struct RestoreDisconnectHandling;
 
-impl Message<FinishVariantDetection> for EcuCoordinator {
+impl Message<RestoreDisconnectHandling> for EcuCoordinator {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        _msg: FinishVariantDetection,
+        _msg: RestoreDisconnectHandling,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         tracing::debug!(
@@ -282,27 +282,6 @@ impl Message<FinishVariantDetection> for EcuCoordinator {
             "Variant detection finished. Re-enabling disconnect events"
         );
         self.suppress_disconnect = false;
-    }
-}
-
-/// Clear the variant to trigger re-detection on the next UDS send.
-pub struct ClearVariantForRedetect;
-
-impl Message<ClearVariantForRedetect> for EcuCoordinator {
-    type Reply = ();
-
-    async fn handle(
-        &mut self,
-        _msg: ClearVariantForRedetect,
-        _ctx: &mut Context<Self, Self::Reply>,
-    ) -> Self::Reply {
-        tracing::info!(
-            ecu = %self.ecu_name,
-            "Clearing variant for re-detection"
-        );
-        let mut ecu_state = std_ext::lock_write(&self.state.ecu_state);
-        ecu_state.variant_state = VariantState::NotTested;
-        ecu_state.variant_index = None;
     }
 }
 
@@ -514,34 +493,6 @@ mod tests {
             }
         );
         assert_eq!(status.variant_index, Some(3));
-    }
-
-    #[tokio::test]
-    async fn clear_variant_for_redetect_sets_not_tested() {
-        let handle = spawn_test_coordinator("TestECU");
-        {
-            let mut ecu_state = handle.state.ecu_state.write().unwrap();
-            ecu_state.connectivity = Connectivity::Online;
-            ecu_state.variant_state = VariantState::Detected {
-                name: "V1".to_owned(),
-                is_base_variant: true,
-                is_fallback: false,
-            };
-            ecu_state.variant_index = Some(1);
-        }
-
-        handle
-            .actor_ref
-            .tell(ClearVariantForRedetect)
-            .await
-            .expect("Actor should be alive");
-        tokio::task::yield_now().await;
-
-        let status = handle.ecu_status();
-        assert_eq!(status.variant_state, VariantState::NotTested);
-        assert_eq!(status.variant_index, None);
-        // Connectivity preserved
-        assert_eq!(status.connectivity, Connectivity::Online);
     }
 
     #[tokio::test]

--- a/cda-comm-uds/src/coordinator.rs
+++ b/cda-comm-uds/src/coordinator.rs
@@ -1,0 +1,631 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Per-ECU state coordinator implemented as a kameo actor.
+//!
+//! The [`EcuCoordinator`] actor serializes connectivity state mutations for a single ECU.
+//! Variant detection writes happen directly via `std::sync::RwLock` (from `EcuManager`),
+//! while disconnect events go through the actor to avoid races.
+//!
+//! Reads go directly through [`EcuCoordinatorHandle::state`] (a `std::sync::RwLock`)
+//! without touching the actor mailbox.
+
+use cda_interfaces::{
+    Connectivity, EcuRuntimeState, EcuState, VariantState, dlt_ctx, util::std_ext,
+};
+use kameo::{
+    Actor,
+    actor::{ActorRef, Spawn},
+    message::{Context, Message},
+};
+
+/// The kameo actor that serializes connectivity state mutations for one ECU.
+#[derive(Actor)]
+pub struct EcuCoordinator {
+    /// Shared runtime state, also held by [`EcuCoordinatorHandle`] for direct synchronous reads.
+    state: EcuRuntimeState,
+    ecu_name: String,
+    /// When `true`, `EcuDisconnected` messages are suppressed.
+    /// Set during variant detection to prevent timeout-triggered disconnects
+    /// from racing with the detection result.
+    suppress_disconnect: bool,
+}
+
+/// Cloneable handle providing read access and actor messaging for one ECU.
+///
+/// Distributed to all components that need to read or mutate ECU runtime state.
+/// Direct reads via [`Self::state`] bypass the mailbox; mutations go through
+/// [`Self::actor_ref`].
+#[derive(Clone)]
+pub struct EcuCoordinatorHandle {
+    /// Actor reference for sending mutation messages.
+    pub actor_ref: ActorRef<EcuCoordinator>,
+    /// Shared state for direct synchronous reads. The actor is the sole writer
+    /// for connectivity; variant detection writes directly.
+    pub state: EcuRuntimeState,
+}
+
+impl EcuCoordinatorHandle {
+    /// Spawn a new coordinator actor for the given ECU.
+    ///
+    /// Returns a handle that can be cloned and distributed to all consumers.
+    #[must_use]
+    pub fn spawn(ecu_name: String) -> Self {
+        let state = EcuRuntimeState::new();
+        Self::spawn_with_state(ecu_name, state)
+    }
+
+    /// Spawn a coordinator actor sharing an existing [`EcuRuntimeState`].
+    ///
+    /// Use this when the `EcuManager` already owns the `EcuRuntimeState`
+    /// and the coordinator should operate on the same instance.
+    #[must_use]
+    pub fn spawn_with_state(ecu_name: String, state: EcuRuntimeState) -> Self {
+        let actor_ref = EcuCoordinator::spawn(EcuCoordinator {
+            state: state.clone(),
+            ecu_name,
+            suppress_disconnect: false,
+        });
+        Self { actor_ref, state }
+    }
+
+    /// Read the current ECU status (synchronous, no mailbox round-trip).
+    #[must_use]
+    pub fn ecu_status(&self) -> EcuState {
+        self.state.status()
+    }
+
+    /// Read the current connectivity (synchronous).
+    #[must_use]
+    pub fn connectivity(&self) -> Connectivity {
+        std_ext::lock_read(&self.state.ecu_state).connectivity
+    }
+
+    /// Read a service state by SID (synchronous).
+    #[must_use]
+    pub fn get_service_state(&self, sid: u8) -> Option<String> {
+        std_ext::lock_read(&self.state.service_states)
+            .get(&sid)
+            .cloned()
+    }
+}
+
+/// Set a single service state entry (e.g. session or security level after UDS response).
+pub struct SetServiceState {
+    /// UDS service identifier (SID).
+    pub sid: u8,
+    /// New state value (e.g. "extended", "`level_42`").
+    pub value: String,
+}
+
+impl Message<SetServiceState> for EcuCoordinator {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: SetServiceState,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        tracing::debug!(
+            ecu = %self.ecu_name,
+            sid = msg.sid,
+            value = %msg.value,
+            "Setting service state"
+        );
+        std_ext::lock_write(&self.state.service_states).insert(msg.sid, msg.value);
+    }
+}
+
+/// Set default service states (session, security, DTC, comm control) if not already present.
+pub struct SetDefaultStates {
+    /// Default values to insert if missing: `(SID, default_value)`.
+    pub defaults: Vec<(u8, String)>,
+}
+
+impl Message<SetDefaultStates> for EcuCoordinator {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: SetDefaultStates,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let mut service_states = std_ext::lock_write(&self.state.service_states);
+        for (sid, default_value) in msg.defaults {
+            service_states.entry(sid).or_insert(default_value);
+        }
+    }
+}
+
+/// Clear all service states message
+pub struct ClearServiceStates;
+
+impl Message<ClearServiceStates> for EcuCoordinator {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: ClearServiceStates,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        tracing::info!(
+            ecu = %self.ecu_name,
+            "Clearing all service states"
+        );
+        std_ext::lock_write(&self.state.service_states).clear();
+    }
+}
+
+/// ECU disconnected event -> sets connectivity to Offline, preserving variant state.
+///
+/// Only transitions from `Online` to `Offline`. If already `Offline`, this is a no-op.
+/// Variant state is preserved.
+pub struct EcuDisconnected;
+
+impl Message<EcuDisconnected> for EcuCoordinator {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: EcuDisconnected,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if self.suppress_disconnect {
+            tracing::debug!(
+                ecu = %self.ecu_name,
+                "ECU disconnect suppressed during variant detection"
+            );
+            return;
+        }
+
+        let mut ecu_state = std_ext::lock_write(&self.state.ecu_state);
+
+        if ecu_state.connectivity == Connectivity::Online {
+            tracing::info!(
+                ecu = %self.ecu_name,
+                dlt_context = dlt_ctx!("UDS"),
+                "ECU disconnected. Setting connectivity to Offline"
+            );
+            ecu_state.connectivity = Connectivity::Offline;
+        } else {
+            tracing::debug!(
+                ecu = %self.ecu_name,
+                current = ?ecu_state.connectivity,
+                "ECU disconnect received but already Offline..skipping"
+            );
+        }
+    }
+}
+
+/// ECU connected event -> sets connectivity to Online and clears variant for re-detection.
+///
+/// Only transitions from `Offline` to `Online`. If already `Online`, this is a no-op.
+/// Variant state is cleared to `NotTested` because the ECU may have rebooted while offline
+/// (e.g. into a different session/variant). The pre-send guard will trigger re-detection
+/// on the next UDS request.
+pub struct EcuConnected;
+
+impl Message<EcuConnected> for EcuCoordinator {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: EcuConnected,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let mut ecu_state = std_ext::lock_write(&self.state.ecu_state);
+
+        if ecu_state.connectivity == Connectivity::Offline {
+            tracing::info!(
+                ecu = %self.ecu_name,
+                dlt_context = dlt_ctx!("UDS"),
+                "ECU connected. Setting connectivity to Online"
+            );
+            ecu_state.connectivity = Connectivity::Online;
+            ecu_state.variant_state = VariantState::NotTested;
+            ecu_state.variant_index = None;
+        } else {
+            tracing::debug!(
+                ecu = %self.ecu_name,
+                current = ?ecu_state.connectivity,
+                "ECU connected received but already Online..skipping"
+            );
+        }
+    }
+}
+
+/// Suppress disconnect events for this ECU during variant detection.
+///
+/// Uses `ask` (request-response) to guarantee the suppression is active
+/// before variant detection sends begin.
+pub struct PrepareVariantDetection;
+
+impl Message<PrepareVariantDetection> for EcuCoordinator {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: PrepareVariantDetection,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        tracing::debug!(
+            ecu = %self.ecu_name,
+            "Variant detection starting. Suppressing disconnect events"
+        );
+        self.suppress_disconnect = true;
+    }
+}
+
+/// Re-enable disconnect events after variant detection completes.
+pub struct FinishVariantDetection;
+
+impl Message<FinishVariantDetection> for EcuCoordinator {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: FinishVariantDetection,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        tracing::debug!(
+            ecu = %self.ecu_name,
+            "Variant detection finished. Re-enabling disconnect events"
+        );
+        self.suppress_disconnect = false;
+    }
+}
+
+/// Clear the variant to trigger re-detection on the next UDS send.
+pub struct ClearVariantForRedetect;
+
+impl Message<ClearVariantForRedetect> for EcuCoordinator {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: ClearVariantForRedetect,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        tracing::info!(
+            ecu = %self.ecu_name,
+            "Clearing variant for re-detection"
+        );
+        let mut ecu_state = std_ext::lock_write(&self.state.ecu_state);
+        ecu_state.variant_state = VariantState::NotTested;
+        ecu_state.variant_index = None;
+    }
+}
+
+/// Mark ECU as having duplicate logical addresses.
+pub struct MarkAsDuplicate;
+
+impl Message<MarkAsDuplicate> for EcuCoordinator {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: MarkAsDuplicate,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        tracing::warn!(
+            ecu = %self.ecu_name,
+            "Marking ECU as duplicate"
+        );
+        let mut ecu_state = std_ext::lock_write(&self.state.ecu_state);
+        ecu_state.variant_state = VariantState::Duplicate;
+        ecu_state.variant_index = None;
+    }
+}
+
+/// Mark ECU as having no variant detected (detection failed, no fallback).
+pub struct MarkAsNoVariantDetected;
+
+impl Message<MarkAsNoVariantDetected> for EcuCoordinator {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: MarkAsNoVariantDetected,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        tracing::warn!(
+            ecu = %self.ecu_name,
+            "Marking ECU as no-variant-detected"
+        );
+        let mut ecu_state = std_ext::lock_write(&self.state.ecu_state);
+        ecu_state.variant_state = VariantState::NotDetected;
+        ecu_state.variant_index = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cda_interfaces::{Connectivity, VariantState, service_ids};
+
+    use super::*;
+
+    fn spawn_test_coordinator(ecu_name: &str) -> EcuCoordinatorHandle {
+        EcuCoordinatorHandle::spawn(ecu_name.to_owned())
+    }
+
+    #[tokio::test]
+    async fn initial_state_is_offline_not_tested() {
+        let handle = spawn_test_coordinator("TestECU");
+        let status = handle.ecu_status();
+        assert_eq!(status.connectivity, Connectivity::Offline);
+        assert_eq!(status.variant_state, VariantState::NotTested);
+    }
+
+    #[tokio::test]
+    async fn set_service_state_updates_state() {
+        let handle = spawn_test_coordinator("TestECU");
+        handle
+            .actor_ref
+            .tell(SetServiceState {
+                sid: service_ids::SESSION_CONTROL,
+                value: "extended".to_owned(),
+            })
+            .await
+            .expect("Actor should be alive");
+        tokio::task::yield_now().await;
+
+        let session = handle.get_service_state(service_ids::SESSION_CONTROL);
+        assert_eq!(session, Some("extended".to_owned()));
+    }
+
+    #[tokio::test]
+    async fn set_default_states_does_not_override_existing() {
+        let handle = spawn_test_coordinator("TestECU");
+
+        handle
+            .actor_ref
+            .tell(SetServiceState {
+                sid: service_ids::SESSION_CONTROL,
+                value: "programming".to_owned(),
+            })
+            .await
+            .expect("Actor should be alive");
+        tokio::task::yield_now().await;
+
+        handle
+            .actor_ref
+            .tell(SetDefaultStates {
+                defaults: vec![
+                    (service_ids::SESSION_CONTROL, "default".to_owned()),
+                    (service_ids::SECURITY_ACCESS, "locked".to_owned()),
+                ],
+            })
+            .await
+            .expect("Actor should be alive");
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            handle.get_service_state(service_ids::SESSION_CONTROL),
+            Some("programming".to_owned()),
+            "Existing state must not be overridden"
+        );
+        assert_eq!(
+            handle.get_service_state(service_ids::SECURITY_ACCESS),
+            Some("locked".to_owned()),
+            "Missing state should be inserted"
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_service_states_empties_map() {
+        let handle = spawn_test_coordinator("TestECU");
+        handle
+            .actor_ref
+            .tell(SetServiceState {
+                sid: service_ids::SESSION_CONTROL,
+                value: "extended".to_owned(),
+            })
+            .await
+            .expect("Actor should be alive");
+        tokio::task::yield_now().await;
+
+        handle
+            .actor_ref
+            .tell(ClearServiceStates)
+            .await
+            .expect("Actor should be alive");
+        tokio::task::yield_now().await;
+
+        assert!(
+            handle
+                .get_service_state(service_ids::SESSION_CONTROL)
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn ecu_disconnected_transitions_online_to_offline() {
+        let handle = spawn_test_coordinator("TestECU");
+        // Set to Online first
+        handle.state.ecu_state.write().unwrap().connectivity = Connectivity::Online;
+
+        handle
+            .actor_ref
+            .tell(EcuDisconnected)
+            .await
+            .expect("Actor should be alive");
+        tokio::task::yield_now().await;
+
+        assert_eq!(handle.connectivity(), Connectivity::Offline);
+        // Variant state should be untouched
+        assert_eq!(handle.ecu_status().variant_state, VariantState::NotTested);
+    }
+
+    #[tokio::test]
+    async fn ecu_disconnected_is_noop_when_already_offline() {
+        let handle = spawn_test_coordinator("TestECU");
+        // Initial state is Offline
+
+        handle
+            .actor_ref
+            .tell(EcuDisconnected)
+            .await
+            .expect("Actor should be alive");
+        tokio::task::yield_now().await;
+
+        assert_eq!(handle.connectivity(), Connectivity::Offline);
+    }
+
+    #[tokio::test]
+    async fn ecu_disconnected_preserves_variant() {
+        let handle = spawn_test_coordinator("TestECU");
+        // Set Online + Detected variant
+        {
+            let mut ecu_state = handle.state.ecu_state.write().unwrap();
+            ecu_state.connectivity = Connectivity::Online;
+            ecu_state.variant_state = VariantState::Detected {
+                name: "MyVariant".to_owned(),
+                is_base_variant: false,
+                is_fallback: false,
+            };
+            ecu_state.variant_index = Some(3);
+        }
+
+        handle
+            .actor_ref
+            .tell(EcuDisconnected)
+            .await
+            .expect("Actor should be alive");
+        tokio::task::yield_now().await;
+
+        let status = handle.ecu_status();
+        assert_eq!(status.connectivity, Connectivity::Offline);
+        assert_eq!(
+            status.variant_state,
+            VariantState::Detected {
+                name: "MyVariant".to_owned(),
+                is_base_variant: false,
+                is_fallback: false,
+            }
+        );
+        assert_eq!(status.variant_index, Some(3));
+    }
+
+    #[tokio::test]
+    async fn clear_variant_for_redetect_sets_not_tested() {
+        let handle = spawn_test_coordinator("TestECU");
+        {
+            let mut ecu_state = handle.state.ecu_state.write().unwrap();
+            ecu_state.connectivity = Connectivity::Online;
+            ecu_state.variant_state = VariantState::Detected {
+                name: "V1".to_owned(),
+                is_base_variant: true,
+                is_fallback: false,
+            };
+            ecu_state.variant_index = Some(1);
+        }
+
+        handle
+            .actor_ref
+            .tell(ClearVariantForRedetect)
+            .await
+            .expect("Actor should be alive");
+        tokio::task::yield_now().await;
+
+        let status = handle.ecu_status();
+        assert_eq!(status.variant_state, VariantState::NotTested);
+        assert_eq!(status.variant_index, None);
+        // Connectivity preserved
+        assert_eq!(status.connectivity, Connectivity::Online);
+    }
+
+    #[tokio::test]
+    async fn mark_as_duplicate_sets_state() {
+        let handle = spawn_test_coordinator("TestECU");
+        handle
+            .actor_ref
+            .tell(MarkAsDuplicate)
+            .await
+            .expect("Actor should be alive");
+        tokio::task::yield_now().await;
+
+        assert_eq!(handle.ecu_status().variant_state, VariantState::Duplicate);
+    }
+
+    #[tokio::test]
+    async fn ecu_connected_transitions_offline_to_online() {
+        let handle = spawn_test_coordinator("TestECU");
+        // Initial state is Offline + NotTested
+
+        handle
+            .actor_ref
+            .tell(EcuConnected)
+            .await
+            .expect("Actor should be alive");
+        tokio::task::yield_now().await;
+
+        assert_eq!(handle.connectivity(), Connectivity::Online);
+        assert_eq!(handle.ecu_status().variant_state, VariantState::NotTested);
+    }
+
+    #[tokio::test]
+    async fn ecu_connected_clears_variant_for_redetection() {
+        let handle = spawn_test_coordinator("TestECU");
+        // Simulate: was Online+Detected, then disconnected (Offline+Detected)
+        {
+            let mut ecu_state = handle.state.ecu_state.write().unwrap();
+            ecu_state.connectivity = Connectivity::Offline;
+            ecu_state.variant_state = VariantState::Detected {
+                name: "Application".to_owned(),
+                is_base_variant: false,
+                is_fallback: false,
+            };
+            ecu_state.variant_index = Some(2);
+        }
+
+        handle
+            .actor_ref
+            .tell(EcuConnected)
+            .await
+            .expect("Actor should be alive");
+        tokio::task::yield_now().await;
+
+        let status = handle.ecu_status();
+        assert_eq!(status.connectivity, Connectivity::Online);
+        assert_eq!(status.variant_state, VariantState::NotTested);
+        assert_eq!(status.variant_index, None);
+    }
+
+    #[tokio::test]
+    async fn ecu_connected_is_noop_when_already_online() {
+        let handle = spawn_test_coordinator("TestECU");
+        handle.state.ecu_state.write().unwrap().connectivity = Connectivity::Online;
+
+        handle
+            .actor_ref
+            .tell(EcuConnected)
+            .await
+            .expect("Actor should be alive");
+        tokio::task::yield_now().await;
+
+        assert_eq!(handle.connectivity(), Connectivity::Online);
+    }
+
+    #[tokio::test]
+    async fn mark_as_no_variant_detected_sets_state() {
+        let handle = spawn_test_coordinator("TestECU");
+        handle
+            .actor_ref
+            .tell(MarkAsNoVariantDetected)
+            .await
+            .expect("Actor should be alive");
+        tokio::task::yield_now().await;
+
+        assert_eq!(handle.ecu_status().variant_state, VariantState::NotDetected);
+    }
+}

--- a/cda-comm-uds/src/functional_group.rs
+++ b/cda-comm-uds/src/functional_group.rs
@@ -15,9 +15,9 @@ use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use cda_interfaces::{
-    DiagComm, DiagServiceError, DynamicPlugin, EcuGateway, EcuManager, EcuState, HashMap,
-    HashMapExtensions, PayloadDecoder, ServicePayload, TransmissionParameters, UdsFunctionalGroup,
-    UdsResponse, UdsTransport,
+    DiagComm, DiagServiceError, DynamicPlugin, EcuGateway, EcuManager, HashMap, HashMapExtensions,
+    PayloadDecoder, ServicePayload, TransmissionParameters, UdsFunctionalGroup, UdsResponse,
+    UdsTransport,
     datatypes::{ComponentDataInfo, ComponentOperationsInfo, RoutineSubfunctions},
     diagservices::{DiagServiceResponse, DiagServiceResponseType, UdsPayloadData},
     dlt_ctx,
@@ -253,11 +253,12 @@ impl<S: EcuGateway, T: EcuManager> UdsFunctionalGroup for UdsManager<S, T> {
                     continue;
                 }
 
-                let ecu_state = ecu_lock.variant().state;
-                if ecu_state != EcuState::Online {
+                let ecu_status = ecu_lock.ecu_status();
+                if !ecu_status.is_online_and_detected() {
                     tracing::debug!(
                         ecu = %ecu_name,
-                        ecu_state = %ecu_state,
+                        connectivity = ?ecu_status.connectivity,
+                        variant_state = ?ecu_status.variant_state,
                         "Skipping ECU that is not online"
                     );
                     continue;

--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -23,18 +23,24 @@ use tokio::{
     task::JoinHandle,
 };
 
+pub mod coordinator;
 mod data_transfer;
 mod dtc;
 mod functional_group;
 mod query;
 mod security;
 mod session;
+pub mod state_coordinator;
 mod tester_present;
 mod transport;
 mod types;
 mod util;
 mod variant;
 
+#[cfg(test)]
+mod test_helpers;
+
+pub use state_coordinator::EcuStateCoordinator;
 pub use types::TesterPresentTask;
 use types::{EcuDataTransfer, EcuIdentifier};
 
@@ -46,6 +52,7 @@ pub struct UdsManager<S: EcuGateway, T: UdsEcuDb> {
     tester_present_tasks: Arc<RwLock<HashMap<EcuIdentifier, TesterPresentTask>>>,
     session_reset_tasks: Arc<RwLock<HashMap<EcuIdentifier, JoinHandle<()>>>>,
     security_reset_tasks: Arc<RwLock<HashMap<EcuIdentifier, JoinHandle<()>>>>,
+    state_coordinator: EcuStateCoordinator,
     functional_description_database: String,
     fault_config: FaultConfig,
     update_in_progress: Arc<AtomicBool>,
@@ -78,10 +85,12 @@ impl<S: EcuGateway, T: UdsEcuDb> UdsManager<S, T> {
 }
 
 impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
+    /// Create a new [`UdsManager`].
     pub fn new(
         gateway: S,
         ecus: Arc<HashMap<String, RwLock<T>>>,
         mut variant_detection_receiver: mpsc::Receiver<Vec<String>>,
+        state_coordinator: EcuStateCoordinator,
         functional_description_config: &FunctionalDescriptionConfig,
         fault_config: FaultConfig,
         update_in_progress: Arc<AtomicBool>,
@@ -94,6 +103,7 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
             tester_present_tasks: Arc::new(RwLock::new(HashMap::new())),
             session_reset_tasks: Arc::new(RwLock::new(HashMap::new())),
             security_reset_tasks: Arc::new(RwLock::new(HashMap::new())),
+            state_coordinator,
             functional_description_database: functional_description_config
                 .description_database
                 .clone(),
@@ -134,6 +144,12 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
         }
     }
 
+    /// Returns a clone of the state coordinator for use by the `DoIP` layer.
+    /// The coordinator implements `EcuStateEvents` and propagates disconnect events.
+    pub fn state_coordinator(&self) -> EcuStateCoordinator {
+        self.state_coordinator.clone()
+    }
+
     /// Abort all background tasks owned by this instance. Idempotent.
     pub async fn shutdown(&self) {
         let mut tester_present_tasks = self.tester_present_tasks.write().await;
@@ -160,6 +176,7 @@ impl<S: Clone + EcuGateway, T: UdsEcuDb> Clone for UdsManager<S, T> {
             tester_present_tasks: Arc::clone(&self.tester_present_tasks),
             session_reset_tasks: Arc::clone(&self.session_reset_tasks),
             security_reset_tasks: Arc::clone(&self.security_reset_tasks),
+            state_coordinator: self.state_coordinator.clone(),
             functional_description_database: self.functional_description_database.clone(),
             fault_config: self.fault_config.clone(),
             update_in_progress: Arc::clone(&self.update_in_progress),

--- a/cda-comm-uds/src/query.rs
+++ b/cda-comm-uds/src/query.rs
@@ -101,7 +101,7 @@ impl<S: EcuGateway, T: EcuManager> UdsQuery for UdsManager<S, T> {
             let ecu_name = ecu.ecu_name();
             Ecu {
                 qualifier: ecu_name.clone(),
-                variant: ecu.variant(),
+                variant: ecu.ecu_status(),
                 logical_address: logical_address_string,
                 logical_link: format!("{}_on_{}", ecu_name, ecu.protocol()),
             }

--- a/cda-comm-uds/src/state_coordinator.rs
+++ b/cda-comm-uds/src/state_coordinator.rs
@@ -17,8 +17,8 @@ use async_trait::async_trait;
 use cda_interfaces::{EcuConnectivityHandler, EcuRuntimeState, HashMap, dlt_ctx};
 
 use crate::coordinator::{
-    EcuConnected, EcuCoordinatorHandle, EcuDisconnected, FinishVariantDetection,
-    PrepareVariantDetection,
+    EcuConnected, EcuCoordinatorHandle, EcuDisconnected, RestoreDisconnectHandling,
+    SuppressDisconnectHandling,
 };
 
 /// Coordinates ECU state transitions in response to connectivity events.
@@ -95,29 +95,29 @@ impl EcuStateCoordinator {
     ///
     /// Uses `ask` (request-response) to guarantee suppression is active before
     /// variant detection sends begin.
-    pub(crate) async fn prepare_variant_detection(&self, ecu_name: &str) {
+    pub(crate) async fn suppress_disconnect_handling(&self, ecu_name: &str) {
         if let Some(handle) = self.handles.get(ecu_name) {
-            let _ = handle.actor_ref.ask(PrepareVariantDetection).await;
+            let _ = handle.actor_ref.ask(SuppressDisconnectHandling).await;
         }
     }
 
     /// Re-enable disconnect events for the given ECU after variant detection completes.
-    pub(crate) async fn finish_variant_detection(&self, ecu_name: &str) {
+    pub(crate) async fn restore_disconnect_handling(&self, ecu_name: &str) {
         if let Some(handle) = self.handles.get(ecu_name) {
-            let _ = handle.actor_ref.tell(FinishVariantDetection).await;
+            let _ = handle.actor_ref.tell(RestoreDisconnectHandling).await;
         }
     }
 }
 
 #[async_trait]
 impl EcuConnectivityHandler for EcuStateCoordinator {
-    async fn on_connected_bulk(&self, ecu_names: &[String]) {
+    async fn on_gateway_connected(&self, ecu_names: &[String]) {
         for ecu_name in ecu_names {
             self.handle_ecu_connected(ecu_name).await;
         }
     }
 
-    async fn on_disconnected_bulk(&self, ecu_names: &[String]) {
+    async fn on_gateway_disconnected(&self, ecu_names: &[String]) {
         for ecu_name in ecu_names {
             self.handle_ecu_disconnected(ecu_name).await;
         }
@@ -134,9 +134,9 @@ mod tests {
         let runtime_state = EcuRuntimeState::new();
         // Set variant to Online + Detected so disconnect can change connectivity
         {
-            let mut es = runtime_state.ecu_state.write().unwrap();
-            es.connectivity = Connectivity::Online;
-            es.variant_state = VariantState::Detected {
+            let mut ecu_state = runtime_state.ecu_state.write().unwrap();
+            ecu_state.connectivity = Connectivity::Online;
+            ecu_state.variant_state = VariantState::Detected {
                 name: "TestVariant".to_owned(),
                 is_base_variant: true,
                 is_fallback: false,

--- a/cda-comm-uds/src/state_coordinator.rs
+++ b/cda-comm-uds/src/state_coordinator.rs
@@ -1,0 +1,215 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cda_interfaces::{EcuConnectivityHandler, EcuRuntimeState, HashMap, dlt_ctx};
+
+use crate::coordinator::{
+    EcuConnected, EcuCoordinatorHandle, EcuDisconnected, FinishVariantDetection,
+    PrepareVariantDetection,
+};
+
+/// Coordinates ECU state transitions in response to connectivity events.
+///
+/// Holds per-ECU [`EcuCoordinatorHandle`]s that provide actor-serialized state mutations.
+/// Passed to the transport layer so connectivity events can propagate to the diagnostic
+/// layer without acquiring any `RwLock<EcuManager>`.
+///
+/// On disconnect only the variant is cleared (marked for re-detection).
+/// Session and security state are preserved, as they are owned by the
+/// respective protocol flows (lock release, hard reset) and not by the
+/// transport layer.
+#[derive(Clone)]
+pub struct EcuStateCoordinator {
+    handles: Arc<HashMap<String, EcuCoordinatorHandle>>,
+}
+
+impl EcuStateCoordinator {
+    /// Create coordinator handles for all ECUs in the map.
+    ///
+    /// Each ECU gets its own actor spawned, sharing the `EcuRuntimeState` from the
+    /// `EcuManager` stored in `ecus`.
+    #[must_use]
+    pub fn new(runtime_states: HashMap<String, EcuRuntimeState>) -> Self {
+        let handles: HashMap<String, EcuCoordinatorHandle> = runtime_states
+            .into_iter()
+            .map(|(ecu_name, state)| {
+                let handle = EcuCoordinatorHandle::spawn_with_state(ecu_name.clone(), state);
+                (ecu_name, handle)
+            })
+            .collect();
+
+        Self {
+            handles: Arc::new(handles),
+        }
+    }
+
+    /// Mark the ECU as connected (Online) on the next request.
+    ///
+    /// Sends a fire-and-forget message to the ECU's coordinator actor.
+    /// Does NOT acquire any `RwLock<EcuManager>` - safe to call from any context.
+    #[tracing::instrument(skip_all, fields(ecu_name, dlt_context = dlt_ctx!("UDS")))]
+    pub(crate) async fn handle_ecu_connected(&self, ecu_name: &str) {
+        tracing::info!(ecu_name, "ECU connected - setting connectivity to Online");
+
+        if let Some(handle) = self.handles.get(ecu_name) {
+            let _ = handle.actor_ref.tell(EcuConnected).await;
+        }
+    }
+
+    /// Mark the ECU's variant for re-detection on the next request.
+    ///
+    /// Sends a fire-and-forget message to the ECU's coordinator actor.
+    /// Does NOT acquire any `RwLock<EcuManager>` - safe to call from any context.
+    #[tracing::instrument(skip_all, fields(ecu_name, dlt_context = dlt_ctx!("UDS")))]
+    pub(crate) async fn handle_ecu_disconnected(&self, ecu_name: &str) {
+        tracing::info!(
+            ecu_name,
+            "ECU disconnected - setting connectivity to Offline"
+        );
+
+        if let Some(handle) = self.handles.get(ecu_name) {
+            let _ = handle.actor_ref.tell(EcuDisconnected).await;
+        }
+    }
+
+    /// Get the coordinator handle for a specific ECU.
+    #[must_use]
+    pub fn get_handle(&self, ecu_name: &str) -> Option<&EcuCoordinatorHandle> {
+        self.handles.get(ecu_name)
+    }
+
+    /// Suppress disconnect events for the given ECU during variant detection.
+    ///
+    /// Uses `ask` (request-response) to guarantee suppression is active before
+    /// variant detection sends begin.
+    pub(crate) async fn prepare_variant_detection(&self, ecu_name: &str) {
+        if let Some(handle) = self.handles.get(ecu_name) {
+            let _ = handle.actor_ref.ask(PrepareVariantDetection).await;
+        }
+    }
+
+    /// Re-enable disconnect events for the given ECU after variant detection completes.
+    pub(crate) async fn finish_variant_detection(&self, ecu_name: &str) {
+        if let Some(handle) = self.handles.get(ecu_name) {
+            let _ = handle.actor_ref.tell(FinishVariantDetection).await;
+        }
+    }
+}
+
+#[async_trait]
+impl EcuConnectivityHandler for EcuStateCoordinator {
+    async fn on_connected_bulk(&self, ecu_names: &[String]) {
+        for ecu_name in ecu_names {
+            self.handle_ecu_connected(ecu_name).await;
+        }
+    }
+
+    async fn on_disconnected_bulk(&self, ecu_names: &[String]) {
+        for ecu_name in ecu_names {
+            self.handle_ecu_disconnected(ecu_name).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cda_interfaces::{Connectivity, EcuRuntimeState, HashMap, VariantState};
+
+    use super::EcuStateCoordinator;
+
+    fn make_coordinator() -> (EcuStateCoordinator, EcuRuntimeState) {
+        let runtime_state = EcuRuntimeState::new();
+        // Set variant to Online + Detected so disconnect can change connectivity
+        {
+            let mut es = runtime_state.ecu_state.write().unwrap();
+            es.connectivity = Connectivity::Online;
+            es.variant_state = VariantState::Detected {
+                name: "TestVariant".to_owned(),
+                is_base_variant: true,
+                is_fallback: false,
+            };
+        }
+
+        let runtime_states: HashMap<String, EcuRuntimeState> =
+            HashMap::from_iter([("TestECU".to_string(), runtime_state.clone())]);
+
+        let coordinator = EcuStateCoordinator::new(runtime_states);
+        (coordinator, runtime_state)
+    }
+
+    #[tokio::test]
+    async fn disconnected_preserves_variant() {
+        let (coordinator, runtime_state) = make_coordinator();
+
+        coordinator.handle_ecu_disconnected("TestECU").await;
+
+        // Give actor time to process
+        cda_interfaces::util::tokio_ext::sleep_for(std::time::Duration::from_millis(10)).await;
+
+        let state = runtime_state.ecu_state.read().unwrap();
+        assert_eq!(
+            state.connectivity,
+            Connectivity::Offline,
+            "ECU should be marked as disconnected"
+        );
+        assert_eq!(
+            state.variant_state,
+            VariantState::Detected {
+                name: "TestVariant".to_owned(),
+                is_base_variant: true,
+                is_fallback: false,
+            },
+            "Variant should be preserved after disconnect"
+        );
+    }
+
+    #[tokio::test]
+    async fn disconnected_unknown_ecu_is_noop() {
+        let (coordinator, runtime_state) = make_coordinator();
+
+        coordinator.handle_ecu_disconnected("UnknownECU").await;
+
+        // Give actor time to process (nothing should happen)
+        cda_interfaces::util::tokio_ext::sleep_for(std::time::Duration::from_millis(10)).await;
+
+        let state = runtime_state.ecu_state.read().unwrap();
+        assert_eq!(
+            state.connectivity,
+            Connectivity::Online,
+            "Nothing should happen for unknown ECU"
+        );
+    }
+
+    #[tokio::test]
+    async fn connected_event_sets_online() {
+        let runtime_state = EcuRuntimeState::new();
+        let runtime_states: HashMap<String, EcuRuntimeState> =
+            HashMap::from_iter([("TestECU".to_string(), runtime_state.clone())]);
+        let coordinator = EcuStateCoordinator::new(runtime_states);
+
+        coordinator.handle_ecu_connected("TestECU").await;
+
+        // Give actor time to process
+        cda_interfaces::util::tokio_ext::sleep_for(std::time::Duration::from_millis(10)).await;
+
+        let state = runtime_state.ecu_state.read().unwrap();
+        assert_eq!(
+            state.connectivity,
+            Connectivity::Online,
+            "ECU should be marked as Online after connected event"
+        );
+    }
+}

--- a/cda-comm-uds/src/state_coordinator.rs
+++ b/cda-comm-uds/src/state_coordinator.rs
@@ -102,9 +102,12 @@ impl EcuStateCoordinator {
     }
 
     /// Re-enable disconnect events for the given ECU after variant detection completes.
+    ///
+    /// Uses `ask` (request-response) to guarantee the restore has been processed
+    /// before returning, so concurrent suppress/restore calls cannot interleave.
     pub(crate) async fn restore_disconnect_handling(&self, ecu_name: &str) {
         if let Some(handle) = self.handles.get(ecu_name) {
-            let _ = handle.actor_ref.tell(RestoreDisconnectHandling).await;
+            let _ = handle.actor_ref.ask(RestoreDisconnectHandling).await;
         }
     }
 }

--- a/cda-comm-uds/src/test_helpers.rs
+++ b/cda-comm-uds/src/test_helpers.rs
@@ -1,0 +1,225 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Shared test doubles for `cda-comm-uds` tests.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use cda_interfaces::{
+    DiagComm, DiagServiceError, DoipComParams, EcuAddresses, EcuState, EcuStateManager, HashMap,
+    HashMapExtensions, UdsComParams, VariantDetection,
+    datatypes::{AddressingMode, RetryPolicy, TesterPresentSendType},
+    diagservices::DiagServiceResponse,
+};
+
+/// Minimal test double satisfying `UdsEcuDb + VariantDetection`.
+///
+/// Observable side-effects are tracked via atomic counters/flags.
+pub(crate) struct TestEcuDb {
+    service_states: tokio::sync::Mutex<std::collections::HashMap<u8, String>>,
+    /// Set to `true` when `clear_variant_for_redetect` is called.
+    pub variant_cleared: Arc<AtomicBool>,
+}
+
+impl TestEcuDb {
+    pub fn new() -> Self {
+        Self {
+            service_states: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            variant_cleared: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+impl Default for TestEcuDb {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EcuAddresses for TestEcuDb {
+    fn tester_address(&self) -> u16 {
+        0x0E00
+    }
+    fn logical_address(&self) -> u16 {
+        0x0001
+    }
+    fn logical_gateway_address(&self) -> u16 {
+        0x0000
+    }
+    fn logical_functional_address(&self) -> u16 {
+        0xFFFF
+    }
+    fn ecu_name(&self) -> String {
+        "TestECU".to_string()
+    }
+    fn logical_address_eq<T: EcuAddresses>(&self, other: &T) -> bool {
+        self.logical_address() == other.logical_address()
+    }
+}
+
+impl DoipComParams for TestEcuDb {
+    fn nack_number_of_retries(&self) -> &HashMap<u8, u32> {
+        static EMPTY: std::sync::OnceLock<HashMap<u8, u32>> = std::sync::OnceLock::new();
+        EMPTY.get_or_init(HashMap::new)
+    }
+    fn diagnostic_ack_timeout(&self) -> Duration {
+        Duration::from_secs(2)
+    }
+    fn retry_period(&self) -> Duration {
+        Duration::from_millis(100)
+    }
+    fn routing_activation_timeout(&self) -> Duration {
+        Duration::from_secs(5)
+    }
+    fn repeat_request_count_transmission(&self) -> u32 {
+        3
+    }
+    fn connection_timeout(&self) -> Duration {
+        Duration::from_secs(5)
+    }
+    fn connection_retry_delay(&self) -> Duration {
+        Duration::from_secs(1)
+    }
+    fn connection_retry_attempts(&self) -> u32 {
+        3
+    }
+}
+
+impl UdsComParams for TestEcuDb {
+    fn tester_present_retry_policy(&self) -> bool {
+        false
+    }
+    fn tester_present_addr_mode(self) -> AddressingMode {
+        unimplemented!()
+    }
+    fn tester_present_response_expected(self) -> bool {
+        unimplemented!()
+    }
+    fn tester_present_send_type(self) -> TesterPresentSendType {
+        unimplemented!()
+    }
+    fn tester_present_message(self) -> Vec<u8> {
+        unimplemented!()
+    }
+    fn tester_present_exp_pos_resp(self) -> Vec<u8> {
+        unimplemented!()
+    }
+    fn tester_present_exp_neg_resp(self) -> Vec<u8> {
+        unimplemented!()
+    }
+    fn tester_present_time(&self) -> Duration {
+        Duration::from_secs(2)
+    }
+    fn repeat_req_count_app(&self) -> u32 {
+        3
+    }
+    fn rc_21_retry_policy(&self) -> RetryPolicy {
+        RetryPolicy::ContinueUntilTimeout
+    }
+    fn rc_21_completion_timeout(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+    fn rc_21_repeat_request_time(&self) -> Duration {
+        Duration::from_millis(10)
+    }
+    fn rc_78_retry_policy(&self) -> RetryPolicy {
+        RetryPolicy::ContinueUntilTimeout
+    }
+    fn rc_78_completion_timeout(&self) -> Duration {
+        Duration::from_secs(30)
+    }
+    fn rc_78_timeout(&self) -> Duration {
+        Duration::from_secs(5)
+    }
+    fn rc_94_retry_policy(&self) -> RetryPolicy {
+        RetryPolicy::ContinueUntilTimeout
+    }
+    fn rc_94_completion_timeout(&self) -> Duration {
+        Duration::from_secs(10)
+    }
+    fn rc_94_repeat_request_time(&self) -> Duration {
+        Duration::from_millis(10)
+    }
+    fn timeout_default(&self) -> Duration {
+        Duration::from_secs(5)
+    }
+}
+
+impl EcuStateManager for TestEcuDb {
+    fn set_service_state(&self, sid: u8, value: String) -> impl Future<Output = ()> + Send {
+        let states = &self.service_states;
+        async move {
+            states.lock().await.insert(sid, value);
+        }
+    }
+
+    fn get_service_state(&self, sid: u8) -> impl Future<Output = Option<String>> + Send {
+        let states = &self.service_states;
+        async move { states.lock().await.get(&sid).cloned() }
+    }
+
+    async fn session(&self) -> Result<String, DiagServiceError> {
+        Ok("default".to_string())
+    }
+
+    fn default_session(&self) -> Result<String, DiagServiceError> {
+        Ok("default".to_string())
+    }
+
+    async fn security_access(&self) -> Result<String, DiagServiceError> {
+        Ok("locked".to_string())
+    }
+
+    async fn lookup_session_change(&self, _session: &str) -> Result<DiagComm, DiagServiceError> {
+        unimplemented!()
+    }
+
+    async fn set_default_states(&self) -> Result<(), DiagServiceError> {
+        Ok(())
+    }
+}
+
+impl VariantDetection for TestEcuDb {
+    fn ecu_status(&self) -> EcuState {
+        unimplemented!()
+    }
+
+    async fn detect_variant<T: DiagServiceResponse + Sized>(
+        &mut self,
+        _service_responses: HashMap<String, T>,
+    ) -> Result<(), DiagServiceError> {
+        unimplemented!()
+    }
+
+    fn get_variant_detection_requests(&self) -> &HashMap<String, DiagComm> {
+        unimplemented!()
+    }
+
+    fn mark_as_duplicate(&mut self) {
+        unimplemented!()
+    }
+
+    fn mark_as_no_variant_detected(&mut self) {
+        unimplemented!()
+    }
+
+    fn clear_variant_for_redetect(&mut self) {
+        self.variant_cleared.store(true, Ordering::Relaxed);
+    }
+}

--- a/cda-comm-uds/src/test_helpers.rs
+++ b/cda-comm-uds/src/test_helpers.rs
@@ -13,13 +13,7 @@
 
 //! Shared test doubles for `cda-comm-uds` tests.
 
-use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
-    time::Duration,
-};
+use std::time::Duration;
 
 use cda_interfaces::{
     DiagComm, DiagServiceError, DoipComParams, EcuAddresses, EcuState, EcuStateManager, HashMap,
@@ -29,19 +23,14 @@ use cda_interfaces::{
 };
 
 /// Minimal test double satisfying `UdsEcuDb + VariantDetection`.
-///
-/// Observable side-effects are tracked via atomic counters/flags.
 pub(crate) struct TestEcuDb {
     service_states: tokio::sync::Mutex<std::collections::HashMap<u8, String>>,
-    /// Set to `true` when `clear_variant_for_redetect` is called.
-    pub variant_cleared: Arc<AtomicBool>,
 }
 
 impl TestEcuDb {
     pub fn new() -> Self {
         Self {
             service_states: tokio::sync::Mutex::new(std::collections::HashMap::new()),
-            variant_cleared: Arc::new(AtomicBool::new(false)),
         }
     }
 }
@@ -217,9 +206,5 @@ impl VariantDetection for TestEcuDb {
 
     fn mark_as_no_variant_detected(&mut self) {
         unimplemented!()
-    }
-
-    fn clear_variant_for_redetect(&mut self) {
-        self.variant_cleared.store(true, Ordering::Relaxed);
     }
 }

--- a/cda-comm-uds/src/tester_present.rs
+++ b/cda-comm-uds/src/tester_present.rs
@@ -13,7 +13,7 @@
 
 use async_trait::async_trait;
 use cda_interfaces::{
-    DiagServiceError, EcuGateway, EcuManager, EcuState, SUPPRESS_POSITIVE_RESPONSE_BIT,
+    Connectivity, DiagServiceError, EcuGateway, EcuManager, SUPPRESS_POSITIVE_RESPONSE_BIT,
     ServicePayload, TesterPresentControlMessage, TesterPresentMode, TesterPresentType,
     UdsFunctionalGroup, UdsTesterPresent, dlt_ctx, service_ids,
 };
@@ -78,8 +78,9 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
                             // Skip sending if the ECU is not online; the loop will
                             // naturally resume once the ECU is detected online again.
                             if let Ok(ecu) = uds.uds_ecu_db(&control_msg.ecu) {
-                                let ecu_state = ecu.read().await.variant().state;
-                                if ecu_state != EcuState::Online {
+                                let ecu_state =
+                                    ecu.read().await.runtime_state().status().connectivity;
+                                if ecu_state != Connectivity::Online {
                                     tracing::debug!(
                                         ecu = %control_msg.ecu,
                                         ecu_state = %ecu_state,
@@ -88,6 +89,7 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
                                     continue;
                                 }
                             }
+
                             // abort sending if it takes longer than `interval` and log an
                             // error, but try to continue sending tester present afterwards.
                             if let Ok(r) = tokio::time::timeout(

--- a/cda-comm-uds/src/transport.rs
+++ b/cda-comm-uds/src/transport.rs
@@ -17,8 +17,8 @@ use std::{
 };
 
 use cda_interfaces::{
-    DiagComm, DiagServiceError, DynamicPlugin, EcuGateway, EcuManager, PayloadDecoder,
-    ServicePayload, TransmissionParameters, UdsResponse, UdsTransport, UdsVariant,
+    Connectivity, DiagComm, DiagServiceError, DynamicPlugin, EcuGateway, EcuManager, EcuState,
+    PayloadDecoder, ServicePayload, TransmissionParameters, UdsResponse, UdsTransport, UdsVariant,
     VariantDetection, VariantState, datatypes::RetryPolicy, diagservices::UdsPayloadData, dlt_ctx,
     service_ids,
 };
@@ -47,15 +47,17 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
     ) -> Result<<T as PayloadDecoder>::Response, DiagServiceError> {
         let ecu = self.uds_ecu_db(ecu_name)?;
 
-        // Pre-send: if variant has not been tested yet, attempt detection before proceeding.
-        // This handles initial boot and reconnect (EcuConnected clears variant to NotTested).
+        // Pre-send: run variant detection when required (see
+        // `needs_variant_detection`). Detection also acts as a reachability
+        // probe for ECUs marked Offline.
         {
             let status = ecu.read().await.ecu_status();
-            let needs_detection = matches!(status.variant_state, VariantState::NotTested);
-            if needs_detection {
+            if needs_variant_detection(&status) {
                 tracing::info!(
                     ecu_name,
-                    "No variant detected -> triggering variant detection before send"
+                    connectivity = ?status.connectivity,
+                    variant_state = ?status.variant_state,
+                    "Triggering variant detection before send"
                 );
                 if let Err(e) = self.detect_variant(ecu_name).await {
                     tracing::warn!(
@@ -63,6 +65,13 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
                         error = %e,
                         "Pre-send variant detection failed"
                     );
+                }
+
+                // Detection doubles as a reachability probe: if the ECU is still
+                // Offline afterwards, the actual send is doomed to time out as
+                // well - fail fast instead of waiting for a second timeout.
+                if ecu.read().await.ecu_status().connectivity == Connectivity::Offline {
+                    return Err(DiagServiceError::EcuOffline(ecu_name.to_owned()));
                 }
             }
         }
@@ -489,6 +498,28 @@ impl<S: EcuGateway, T: EcuManager> UdsTransport for UdsManager<S, T> {
     }
 }
 
+/// Decide whether variant detection must run before sending a UDS request.
+///
+/// Detection is required when
+/// - the variant has not been tested yet (initial boot, or reconnect cleared
+///   the variant to `NotTested`), or
+/// - the ECU is `Offline` with a previously known variant state
+///   (`Detected`/`NotDetected`). This covers ECUs behind a gateway: they share
+///   the gateway's transport connection and never receive a per-ECU reconnect
+///   event, so detection doubles as a reachability probe to bring them back
+///   `Online`.
+///
+/// `Duplicate` ECUs are excluded: resolving a duplicate requires manual
+/// intervention, re-running detection on every send would be pointless.
+pub(crate) fn needs_variant_detection(status: &EcuState) -> bool {
+    matches!(status.variant_state, VariantState::NotTested)
+        || (status.connectivity == Connectivity::Offline
+            && matches!(
+                status.variant_state,
+                VariantState::Detected { .. } | VariantState::NotDetected
+            ))
+}
+
 #[tracing::instrument(skip_all,
     fields(dlt_context = dlt_ctx!("UDS"))
 )]
@@ -583,6 +614,75 @@ mod tests {
             &Duration::from_secs(1),
         );
         assert!(result.is_ok());
+    }
+
+    fn ecu_state(connectivity: Connectivity, variant_state: VariantState) -> EcuState {
+        EcuState {
+            connectivity,
+            variant_state,
+            variant_index: None,
+        }
+    }
+
+    fn detected_variant() -> VariantState {
+        VariantState::Detected {
+            name: "TestVariant".to_owned(),
+            is_base_variant: false,
+            is_fallback: false,
+        }
+    }
+
+    #[test]
+    fn test_needs_variant_detection_not_tested() {
+        // NotTested always triggers detection, regardless of connectivity.
+        assert!(needs_variant_detection(&ecu_state(
+            Connectivity::Online,
+            VariantState::NotTested
+        )));
+        assert!(needs_variant_detection(&ecu_state(
+            Connectivity::Offline,
+            VariantState::NotTested
+        )));
+    }
+
+    #[test]
+    fn test_needs_variant_detection_offline_with_known_variant() {
+        // Offline ECUs with a previously known variant state must be re-probed.
+        // This is the recovery path for ECUs behind a gateway, which never
+        // receive a per-ECU reconnect event.
+        assert!(needs_variant_detection(&ecu_state(
+            Connectivity::Offline,
+            detected_variant()
+        )));
+        assert!(needs_variant_detection(&ecu_state(
+            Connectivity::Offline,
+            VariantState::NotDetected
+        )));
+    }
+
+    #[test]
+    fn test_needs_variant_detection_online_skips_detection() {
+        assert!(!needs_variant_detection(&ecu_state(
+            Connectivity::Online,
+            detected_variant()
+        )));
+        assert!(!needs_variant_detection(&ecu_state(
+            Connectivity::Online,
+            VariantState::NotDetected
+        )));
+    }
+
+    #[test]
+    fn test_needs_variant_detection_duplicate_never_triggers() {
+        // Duplicates require manual resolution, no automatic re-detection.
+        assert!(!needs_variant_detection(&ecu_state(
+            Connectivity::Online,
+            VariantState::Duplicate
+        )));
+        assert!(!needs_variant_detection(&ecu_state(
+            Connectivity::Offline,
+            VariantState::Duplicate
+        )));
     }
 }
 

--- a/cda-comm-uds/src/transport.rs
+++ b/cda-comm-uds/src/transport.rs
@@ -18,8 +18,9 @@ use std::{
 
 use cda_interfaces::{
     DiagComm, DiagServiceError, DynamicPlugin, EcuGateway, EcuManager, PayloadDecoder,
-    ServicePayload, TransmissionParameters, UdsResponse, UdsTransport, datatypes::RetryPolicy,
-    diagservices::UdsPayloadData, dlt_ctx, service_ids,
+    ServicePayload, TransmissionParameters, UdsResponse, UdsTransport, UdsVariant,
+    VariantDetection, VariantState, datatypes::RetryPolicy, diagservices::UdsPayloadData, dlt_ctx,
+    service_ids,
 };
 use tokio::sync::{RwLock, Semaphore, mpsc};
 
@@ -44,14 +45,59 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
         map_to_json: bool,
         timeout: Option<Duration>,
     ) -> Result<<T as PayloadDecoder>::Response, DiagServiceError> {
+        let ecu = self.uds_ecu_db(ecu_name)?;
+
+        // Pre-send: if variant has not been tested yet, attempt detection before proceeding.
+        // This handles initial boot and reconnect (EcuConnected clears variant to NotTested).
+        {
+            let status = ecu.read().await.ecu_status();
+            let needs_detection = matches!(status.variant_state, VariantState::NotTested);
+            if needs_detection {
+                tracing::info!(
+                    ecu_name,
+                    "No variant detected -> triggering variant detection before send"
+                );
+                if let Err(e) = self.detect_variant(ecu_name).await {
+                    tracing::warn!(
+                        ecu_name,
+                        error = %e,
+                        "Pre-send variant detection failed"
+                    );
+                }
+            }
+        }
+
+        self.send_without_variant_guard(
+            ecu_name,
+            service,
+            security_plugin,
+            payload,
+            map_to_json,
+            timeout,
+        )
+        .await
+    }
+
+    /// Inner send path that skips the variant detection guard.
+    /// Used by `detect_variant` to avoid infinite recursion.
+    pub(crate) async fn send_without_variant_guard(
+        &self,
+        ecu_name: &str,
+        service: DiagComm,
+        security_plugin: &DynamicPlugin,
+        payload: Option<UdsPayloadData>,
+        map_to_json: bool,
+        timeout: Option<Duration>,
+    ) -> Result<<T as PayloadDecoder>::Response, DiagServiceError> {
         let start = Instant::now();
         tracing::debug!(
             service = ?service,
             payload = ?payload.as_ref()
-                .map(std::string::ToString::to_string),
+                .map(ToString::to_string),
             "Sending UDS request"
         );
         let ecu = self.uds_ecu_db(ecu_name)?;
+
         let payload = {
             let ecu = ecu.read().await;
             ecu.create_uds_payload(&service, security_plugin, payload, None)
@@ -98,7 +144,7 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
     }
 }
 
-impl<S: EcuGateway, T: UdsEcuDb> UdsManager<S, T> {
+impl<S: EcuGateway, T: UdsEcuDb + VariantDetection> UdsManager<S, T> {
     #[allow(
         clippy::needless_continue,
         reason = "Explicit continue improves readability to make it clearer, which loop is being \
@@ -299,6 +345,17 @@ impl<S: EcuGateway, T: UdsEcuDb> UdsManager<S, T> {
         };
         drop(response_rx);
         drop(ecu_sem);
+
+        // Post-send: if a service send (not tester present) timed out,
+        // the ECU is unreachable - notify the coordinator.
+        // The coordinator will suppress this if variant detection is in progress.
+        if matches!(response, Err(DiagServiceError::Timeout))
+            && sent_sid != service_ids::TESTER_PRESENT
+        {
+            self.state_coordinator
+                .handle_ecu_disconnected(ecu_name)
+                .await;
+        }
 
         if let Ok(ref msg) = response
             && msg.is_positive_response_for_sid(sent_sid)
@@ -537,15 +594,17 @@ mod send_tests {
     };
 
     use cda_interfaces::{
-        DiagComm, DiagServiceError, EcuAddresses, EcuGateway, EcuStateManager, HashMap,
-        HashMapExtensions, ServicePayload, TransmissionParameters, UdsResponse,
-        datatypes::{AddressingMode, FaultConfig, RetryPolicy, TesterPresentSendType},
+        DiagServiceError, EcuAddresses, EcuGateway, EcuRuntimeState, EcuStateManager, HashMap,
+        HashMapExtensions, ServicePayload, TransmissionParameters, UdsResponse, VariantDetection,
+        datatypes::FaultConfig,
     };
     use tokio::sync::{RwLock, mpsc};
 
-    use crate::{UdsEcuDb, UdsManager};
+    use crate::{
+        UdsEcuDb, UdsManager, state_coordinator::EcuStateCoordinator, test_helpers::TestEcuDb,
+    };
 
-    impl<S: EcuGateway, T: UdsEcuDb> UdsManager<S, T> {
+    impl<S: EcuGateway, T: UdsEcuDb + VariantDetection + EcuAddresses> UdsManager<S, T> {
         /// Test-only constructor that creates a `UdsManager` without spawning
         /// background tasks (variant detection, etc.), so `T` only needs the
         /// narrower trait bounds required by `send_with_raw_payload`.
@@ -555,6 +614,11 @@ mod send_tests {
             fault_config: FaultConfig,
             update_in_progress: Arc<AtomicBool>,
         ) -> Self {
+            let runtime_states: HashMap<String, EcuRuntimeState> = ecus
+                .keys()
+                .map(|name| (name.clone(), EcuRuntimeState::new()))
+                .collect();
+            let state_coordinator = EcuStateCoordinator::new(runtime_states);
             Self {
                 ecus,
                 gateway,
@@ -563,6 +627,7 @@ mod send_tests {
                 tester_present_tasks: Arc::new(RwLock::new(HashMap::default())),
                 session_reset_tasks: Arc::new(RwLock::new(HashMap::default())),
                 security_reset_tasks: Arc::new(RwLock::new(HashMap::default())),
+                state_coordinator,
                 functional_description_database: String::new(),
                 fault_config,
                 update_in_progress,
@@ -617,168 +682,6 @@ mod send_tests {
         ) -> Result<HashMap<String, Result<UdsResponse, DiagServiceError>>, DiagServiceError>
         {
             Ok(HashMap::new())
-        }
-    }
-
-    // Manual mock: TestEcuDb
-
-    /// Minimal mock for testing `send_with_raw_payload`. Only implements the
-    /// traits actually needed: `EcuStateProvider`, `UdsComParamProvider`,
-    /// `DoipComParamProvider`, and `EcuAddressProvider`.
-    struct TestEcuDb {
-        service_states: tokio::sync::Mutex<std::collections::HashMap<u8, String>>,
-    }
-
-    impl TestEcuDb {
-        fn new() -> Self {
-            Self {
-                service_states: tokio::sync::Mutex::new(std::collections::HashMap::new()),
-            }
-        }
-    }
-
-    // EcuAddressProvider
-    impl EcuAddresses for TestEcuDb {
-        fn tester_address(&self) -> u16 {
-            0x0E00
-        }
-        fn logical_address(&self) -> u16 {
-            0x0001
-        }
-        fn logical_gateway_address(&self) -> u16 {
-            0x0000
-        }
-        fn logical_functional_address(&self) -> u16 {
-            0xFFFF
-        }
-        fn ecu_name(&self) -> String {
-            "TestECU".to_string()
-        }
-        fn logical_address_eq<T: EcuAddresses>(&self, other: &T) -> bool {
-            self.logical_address() == other.logical_address()
-        }
-    }
-
-    // DoipComParamProvider
-    impl cda_interfaces::DoipComParams for TestEcuDb {
-        fn nack_number_of_retries(&self) -> &HashMap<u8, u32> {
-            // Return a static reference by leaking - acceptable in tests only
-            static EMPTY: std::sync::OnceLock<HashMap<u8, u32>> = std::sync::OnceLock::new();
-            EMPTY.get_or_init(HashMap::new)
-        }
-        fn diagnostic_ack_timeout(&self) -> Duration {
-            Duration::from_secs(2)
-        }
-        fn retry_period(&self) -> Duration {
-            Duration::from_millis(100)
-        }
-        fn routing_activation_timeout(&self) -> Duration {
-            Duration::from_secs(5)
-        }
-        fn repeat_request_count_transmission(&self) -> u32 {
-            3
-        }
-        fn connection_timeout(&self) -> Duration {
-            Duration::from_secs(5)
-        }
-        fn connection_retry_delay(&self) -> Duration {
-            Duration::from_secs(1)
-        }
-        fn connection_retry_attempts(&self) -> u32 {
-            3
-        }
-    }
-
-    // UdsComParamProvider
-    impl cda_interfaces::UdsComParams for TestEcuDb {
-        fn tester_present_retry_policy(&self) -> bool {
-            false
-        }
-        fn tester_present_addr_mode(self) -> AddressingMode {
-            unimplemented!()
-        }
-        fn tester_present_response_expected(self) -> bool {
-            unimplemented!()
-        }
-        fn tester_present_send_type(self) -> TesterPresentSendType {
-            unimplemented!()
-        }
-        fn tester_present_message(self) -> Vec<u8> {
-            unimplemented!()
-        }
-        fn tester_present_exp_pos_resp(self) -> Vec<u8> {
-            unimplemented!()
-        }
-        fn tester_present_exp_neg_resp(self) -> Vec<u8> {
-            unimplemented!()
-        }
-        fn tester_present_time(&self) -> Duration {
-            Duration::from_secs(2)
-        }
-        fn repeat_req_count_app(&self) -> u32 {
-            3
-        }
-        fn rc_21_retry_policy(&self) -> RetryPolicy {
-            RetryPolicy::ContinueUntilTimeout
-        }
-        fn rc_21_completion_timeout(&self) -> Duration {
-            Duration::from_secs(10)
-        }
-        fn rc_21_repeat_request_time(&self) -> Duration {
-            Duration::from_millis(10)
-        }
-        fn rc_78_retry_policy(&self) -> RetryPolicy {
-            RetryPolicy::ContinueUntilTimeout
-        }
-        fn rc_78_completion_timeout(&self) -> Duration {
-            Duration::from_secs(30)
-        }
-        fn rc_78_timeout(&self) -> Duration {
-            Duration::from_secs(5)
-        }
-        fn rc_94_retry_policy(&self) -> RetryPolicy {
-            RetryPolicy::ContinueUntilTimeout
-        }
-        fn rc_94_completion_timeout(&self) -> Duration {
-            Duration::from_secs(10)
-        }
-        fn rc_94_repeat_request_time(&self) -> Duration {
-            Duration::from_millis(10)
-        }
-        fn timeout_default(&self) -> Duration {
-            Duration::from_secs(5)
-        }
-    }
-
-    // EcuStateProvider
-    impl EcuStateManager for TestEcuDb {
-        fn set_service_state(&self, sid: u8, value: String) -> impl Future<Output = ()> + Send {
-            let states = &self.service_states;
-            async move {
-                states.lock().await.insert(sid, value);
-            }
-        }
-        fn get_service_state(&self, sid: u8) -> impl Future<Output = Option<String>> + Send {
-            let states = &self.service_states;
-            async move { states.lock().await.get(&sid).cloned() }
-        }
-        async fn session(&self) -> Result<String, DiagServiceError> {
-            Ok("default".to_string())
-        }
-        fn default_session(&self) -> Result<String, DiagServiceError> {
-            Ok("default".to_string())
-        }
-        async fn security_access(&self) -> Result<String, DiagServiceError> {
-            Ok("locked".to_string())
-        }
-        async fn lookup_session_change(
-            &self,
-            _session: &str,
-        ) -> Result<DiagComm, DiagServiceError> {
-            unimplemented!()
-        }
-        async fn set_default_states(&self) -> Result<(), DiagServiceError> {
-            Ok(())
         }
     }
 

--- a/cda-comm-uds/src/variant.rs
+++ b/cda-comm-uds/src/variant.rs
@@ -86,8 +86,10 @@ impl<S: EcuGateway, T: EcuManager> UdsVariant for UdsManager<S, T> {
 
         let mut service_responses = HashMap::new();
         'variant_detection_calls: {
+            // Suppress disconnect events while UDS requests are in-flight to
+            // prevent a timeout from re-triggering variant detection in a loop.
             self.state_coordinator
-                .prepare_variant_detection(ecu_name)
+                .suppress_disconnect_handling(ecu_name)
                 .await;
             for (name, service) in requests {
                 let response = match self
@@ -114,8 +116,9 @@ impl<S: EcuGateway, T: EcuManager> UdsVariant for UdsManager<S, T> {
                 service_responses.insert(name, response);
             }
         }
+        // Re-enable disconnect events now that UDS sends are complete.
         self.state_coordinator
-            .finish_variant_detection(ecu_name)
+            .restore_disconnect_handling(ecu_name)
             .await;
 
         // No responses gathered -> ECU is unreachable.
@@ -255,7 +258,7 @@ impl<S: EcuGateway, T: EcuManager> UdsVariant for UdsManager<S, T> {
         Ok(())
     }
 
-    async fn get_ecu_status(&self, ecu_name: &str) -> Result<EcuState, DiagServiceError> {
+    async fn get_ecu_state(&self, ecu_name: &str) -> Result<EcuState, DiagServiceError> {
         let ecu = self.uds_ecu_db(ecu_name)?;
         let status = ecu.read().await.ecu_status();
         Ok(status)

--- a/cda-comm-uds/src/variant.rs
+++ b/cda-comm-uds/src/variant.rs
@@ -15,8 +15,8 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use cda_interfaces::{
-    DiagComm, DiagServiceError, DynamicPlugin, EcuGateway, EcuManager, EcuVariant, HashMap,
-    HashMapExtensions, PayloadDecoder, UdsTransport, UdsVariant, dlt_ctx,
+    DiagComm, DiagServiceError, DynamicPlugin, EcuGateway, EcuManager, EcuState, HashMap,
+    HashMapExtensions, PayloadDecoder, UdsVariant, dlt_ctx,
 };
 
 use crate::UdsManager;
@@ -86,15 +86,18 @@ impl<S: EcuGateway, T: EcuManager> UdsVariant for UdsManager<S, T> {
 
         let mut service_responses = HashMap::new();
         'variant_detection_calls: {
+            self.state_coordinator
+                .prepare_variant_detection(ecu_name)
+                .await;
             for (name, service) in requests {
                 let response = match self
-                    .send_with_timeout(
+                    .send_without_variant_guard(
                         ecu_name,
                         service,
                         &(Box::new(()) as DynamicPlugin),
                         None,
                         true,
-                        Duration::from_secs(10),
+                        Some(Duration::from_secs(10)),
                     )
                     .await
                 {
@@ -110,6 +113,46 @@ impl<S: EcuGateway, T: EcuManager> UdsVariant for UdsManager<S, T> {
                 };
                 service_responses.insert(name, response);
             }
+        }
+        self.state_coordinator
+            .finish_variant_detection(ecu_name)
+            .await;
+
+        // No responses gathered -> ECU is unreachable.
+        // Call detect_variant with empty responses to set appropriate state
+        // (Disconnected if was online, Offline if never tested).
+        // If this ECU has duplicates, set them all to disconnected as well.
+        if service_responses.is_empty() {
+            ecu.write()
+                .await
+                .detect_variant::<<T as PayloadDecoder>::Response>(HashMap::new())
+                .await
+                .map_err(|e| {
+                    DiagServiceError::VariantDetectionError(format!(
+                        "Failed to detect variant: {e:?}"
+                    ))
+                })?;
+
+            // Also set all duplicates to the same state
+            if let Some(duplicates) = ecu
+                .read()
+                .await
+                .duplicating_ecu_names()
+                .cloned()
+                .filter(|d| !d.is_empty())
+            {
+                for dup_name in &duplicates {
+                    if let Some(dup_ecu) = self.ecus.get(dup_name) {
+                        let _ = dup_ecu
+                            .write()
+                            .await
+                            .detect_variant::<<T as PayloadDecoder>::Response>(HashMap::new())
+                            .await;
+                    }
+                }
+            }
+
+            return Ok(());
         }
 
         let Some(mut duplicated_ecus) = ecu
@@ -158,14 +201,14 @@ impl<S: EcuGateway, T: EcuManager> UdsVariant for UdsManager<S, T> {
                     continue;
                 }
 
-                let variant = ecu.read().await.variant();
-                if variant.state != cda_interfaces::EcuState::Online {
+                let status = ecu.read().await.ecu_status();
+                if !status.is_online_and_detected() {
                     continue;
                 }
 
                 any_online = true;
 
-                if variant.is_fallback {
+                if status.is_fallback() {
                     first_fallback.get_or_insert(ecu_name);
                 } else {
                     result = Some(VariantDetectionResult::ExactMatch(ecu_name));
@@ -212,10 +255,10 @@ impl<S: EcuGateway, T: EcuManager> UdsVariant for UdsManager<S, T> {
         Ok(())
     }
 
-    async fn get_variant(&self, ecu_name: &str) -> Result<EcuVariant, DiagServiceError> {
+    async fn get_ecu_status(&self, ecu_name: &str) -> Result<EcuState, DiagServiceError> {
         let ecu = self.uds_ecu_db(ecu_name)?;
-        let variant = ecu.read().await.variant();
-        Ok(variant)
+        let status = ecu.read().await.ecu_status();
+        Ok(status)
     }
 
     #[tracing::instrument(skip_all,
@@ -234,7 +277,8 @@ impl<S: EcuGateway, T: EcuManager> UdsVariant for UdsManager<S, T> {
             if let Err(DiagServiceError::EcuOffline(_)) =
                 self.gateway.ecu_online(ecu_name, db).await
             {
-                // empty response means ECU is offline
+                // ECU is offline -> call detect_variant with empty responses to set
+                // appropriate state (Disconnected if was online, Offline if never tested)
                 if let Err(e) = db
                     .write()
                     .await
@@ -260,5 +304,11 @@ impl<S: EcuGateway, T: EcuManager> UdsVariant for UdsManager<S, T> {
         }
         let cloned = self.clone();
         cloned.start_variant_detection_for_ecus(ecus);
+    }
+
+    async fn get_logical_address(&self, ecu_name: &str) -> Result<u16, DiagServiceError> {
+        let ecu = self.uds_ecu_db(ecu_name)?;
+        let logical_address = ecu.read().await.logical_address();
+        Ok(logical_address)
     }
 }

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -11,21 +11,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use cda_database::datatypes;
 use cda_interfaces::{
-    DiagServiceError, EcuManagerType, EcuState, EcuStateManager, EcuVariant, HashMap,
-    HashMapExtensions, HashSet, PayloadDecoder, Protocol,
+    Connectivity, DiagServiceError, EcuManagerType, EcuRuntimeState, EcuStateManager, HashMap,
+    HashMapExtensions, HashSet, PayloadDecoder, Protocol, VariantState,
     datatypes::{
         AddressingMode, ComParamConfig, ComParamPrecedence, ComParams, ComplexComParamValue,
         DatabaseNamingConvention, DiagnosticServiceAffixPosition, RetryPolicy, SdSdg,
         TesterPresentSendType,
     },
     dlt_ctx,
+    util::std_ext,
 };
 use cda_plugin_security::SecurityPlugin;
-use tokio::sync::RwLock;
 
 use super::service_lookup::DbCache;
 use crate::diag_kernel::{
@@ -100,8 +100,6 @@ pub struct EcuManager<S: SecurityPlugin> {
     pub(in crate::diag_kernel) connection_retry_attempts: u32,
 
     pub(in crate::diag_kernel) variant_detection: variant_detection::VariantDetection,
-    pub(in crate::diag_kernel) variant_index: Option<usize>,
-    pub(in crate::diag_kernel) variant: EcuVariant,
     pub(in crate::diag_kernel) fallback_to_base_variant: bool,
     pub(in crate::diag_kernel) strict_parameter_validation: bool,
     pub(in crate::diag_kernel) duplicating_ecu_names: Option<HashSet<String>>,
@@ -109,7 +107,10 @@ pub struct EcuManager<S: SecurityPlugin> {
     pub(in crate::diag_kernel) protocol: Protocol,
     // functional group: protocol prefixed or postfixed
     pub(in crate::diag_kernel) fg_protocol_position: DiagnosticServiceAffixPosition,
-    pub(in crate::diag_kernel) ecu_service_states: Arc<RwLock<HashMap<u8, String>>>,
+
+    /// Shared runtime state.
+    /// Also held by the coordinator actor for external event-driven mutations.
+    pub(in crate::diag_kernel) runtime_state: EcuRuntimeState,
 
     pub(in crate::diag_kernel) tester_present_retry_policy: bool,
     pub(in crate::diag_kernel) tester_present_addr_mode: AddressingMode,
@@ -165,10 +166,6 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
     type Response = <Self as PayloadDecoder>::Response;
     fn is_physical_ecu(&self) -> bool {
         self.description_type == EcuManagerType::Ecu
-    }
-
-    fn state(&self) -> EcuState {
-        self.variant.state
     }
 
     fn protocol(&self) -> &Protocol {
@@ -313,6 +310,10 @@ impl<S: SecurityPlugin> cda_interfaces::EcuManager for EcuManager<S> {
             .ok()
             .and_then(|s| s.revision())
             .map_or_else(|| "0.0.0".to_owned(), ToOwned::to_owned)
+    }
+
+    fn runtime_state(&self) -> EcuRuntimeState {
+        self.runtime_state.clone()
     }
 }
 
@@ -496,20 +497,12 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 &com_params.doip.connection_retry_attempts,
             )?,
             variant_detection,
-            variant_index: None,
-            variant: EcuVariant {
-                name: None,
-                is_base_variant: false,
-                is_fallback: false,
-                state: EcuState::NotTested,
-                logical_address: logical_ecu_address,
-            },
             fallback_to_base_variant: config.fallback_to_base_variant,
             strict_parameter_validation: config.strict_parameter_validation,
             duplicating_ecu_names: None,
             protocol,
             fg_protocol_position: func_description_config.protocol_position.clone(),
-            ecu_service_states: Arc::new(RwLock::default()),
+            runtime_state: EcuRuntimeState::new(),
             tester_present_retry_policy: database
                 .find_com_param(
                     data_protocol_ref,
@@ -613,20 +606,12 @@ impl<S: SecurityPlugin> EcuManager<S> {
             variant_detection: VariantDetection {
                 diag_service_requests: HashMap::new(),
             },
-            variant_index: None,
-            variant: EcuVariant {
-                name: None,
-                is_base_variant: false,
-                is_fallback: false,
-                state: EcuState::NotTested,
-                logical_address: logical_ecu_address,
-            },
             fallback_to_base_variant: config.fallback_to_base_variant,
             strict_parameter_validation: config.strict_parameter_validation,
             duplicating_ecu_names: None,
             protocol,
             fg_protocol_position: func_description_config.protocol_position.clone(),
-            ecu_service_states: Arc::new(RwLock::default()),
+            runtime_state: EcuRuntimeState::new(),
             tester_present_retry_policy: com_params
                 .uds
                 .tester_present_retry_policy
@@ -661,15 +646,20 @@ impl<S: SecurityPlugin> EcuManager<S> {
     }
 
     pub(crate) fn variant(&self) -> Option<datatypes::Variant<'_>> {
-        let idx = self.variant_index?;
+        let idx = std_ext::lock_read(&self.runtime_state.ecu_state).variant_index?;
         let variants = self.diag_database.ecu_data().ok()?.variants()?;
         Some(variants.get(idx).into())
     }
 
-    pub(crate) async fn set_variant(
-        &mut self,
-        variant: VariantData,
-    ) -> Result<(), DiagServiceError> {
+    /// Returns a clone of the shared runtime state.
+    ///
+    /// Used by the coordinator actor to share access to the same underlying state.
+    #[must_use]
+    pub fn runtime_state(&self) -> EcuRuntimeState {
+        self.runtime_state.clone()
+    }
+
+    pub(crate) async fn set_variant(&self, variant: VariantData) -> Result<(), DiagServiceError> {
         let variant_name = &variant.name;
         let variant_index = self.diag_database.ecu_data().ok().and_then(|ecu_data| {
             ecu_data.variants().and_then(|variants| {
@@ -682,28 +672,30 @@ impl<S: SecurityPlugin> EcuManager<S> {
             })
         });
 
-        if self.variant_index != variant_index {
-            self.variant_index = variant_index;
+        let current_variant_index = std_ext::lock_read(&self.runtime_state.ecu_state).variant_index;
+        if current_variant_index != variant_index {
             // reset cache, because services may have the same lookup names
             // but differ in parameters etc. between variants
             self.db_cache.reset().await;
         }
 
-        let state = if variant_index.is_none() {
-            tracing::warn!("Variant '{variant_name}' not found in database variants");
-            EcuState::NoVariantDetected
-        } else {
-            EcuState::Online
-        };
+        tracing::debug!("Setting variant to '{variant_name}'");
+        {
+            let mut ecu_state = std_ext::lock_write(&self.runtime_state.ecu_state);
 
-        tracing::debug!("Setting variant to '{variant_name}' with state {state:?}");
-        self.variant = EcuVariant {
-            name: Some(variant.name.clone()),
-            is_base_variant: variant.is_base_variant,
-            is_fallback: variant.is_fallback,
-            state,
-            logical_address: self.logical_address,
-        };
+            if variant_index.is_some() {
+                ecu_state.connectivity = Connectivity::Online;
+                ecu_state.variant_state = VariantState::Detected {
+                    name: variant.name.clone(),
+                    is_base_variant: variant.is_base_variant,
+                    is_fallback: variant.is_fallback,
+                };
+            } else {
+                tracing::warn!("Variant '{variant_name}' not found in database variants");
+                ecu_state.variant_state = VariantState::NotDetected;
+            }
+            ecu_state.variant_index = variant_index;
+        }
 
         self.set_default_states().await
     }
@@ -764,10 +756,9 @@ mod tests {
 
     async fn detect_variant(
         variant_id: u8,
-        is_base: bool,
-        name: String,
-        state: EcuState,
         ecu_manger: Option<super::EcuManager<DefaultSecurityPluginData>>,
+        connectivity_state: Connectivity,
+        variant_state: VariantState,
     ) {
         let mut ecu_manager = ecu_manger.unwrap_or(create_ecu_manager_variant_detection(true));
 
@@ -782,52 +773,42 @@ mod tests {
         service_responses.insert("ReadVariantData".to_owned(), response);
 
         ecu_manager.detect_variant(service_responses).await.unwrap();
-        assert_eq!(ecu_manager.variant.name, Some(name));
-        assert_eq!(ecu_manager.variant.is_base_variant, is_base);
-        assert_eq!(ecu_manager.variant.state, state);
-    }
-
-    #[tokio::test]
-    async fn test_detect_variant_with_empty_responses_to_disconnected() {
-        let mut ecu_manager = create_ecu_manager_variant_detection(true);
-
-        for state in [
-            EcuState::Online,
-            EcuState::NoVariantDetected,
-            EcuState::Duplicate,
-            EcuState::Disconnected,
-        ] {
-            ecu_manager.variant.state = state;
-
-            let service_responses: HashMap<String, DiagServiceResponseStruct> = HashMap::default();
-            ecu_manager
-                .detect_variant::<DiagServiceResponseStruct>(service_responses)
-                .await
-                .unwrap();
-
-            assert_eq!(ecu_manager.variant.name, None);
-            assert!(!ecu_manager.variant.is_base_variant);
-            assert_eq!(
-                ecu_manager.variant.state,
-                EcuState::Disconnected,
-                "State should transition to Disconnected from {state:?} with empty responses",
-            );
-        }
+        let rs = ecu_manager.runtime_state.ecu_state.read().unwrap();
+        assert_eq!(rs.variant_state.name(), variant_state.name());
+        assert_eq!(
+            rs.variant_state.is_base_variant(),
+            variant_state.is_base_variant()
+        );
+        assert_eq!(rs.connectivity, connectivity_state);
+        assert_eq!(rs.variant_state, variant_state);
     }
 
     #[tokio::test]
     async fn test_detect_base_variant() {
-        detect_variant(0, true, "BaseVariant".to_owned(), EcuState::Online, None).await;
+        detect_variant(
+            0,
+            None,
+            Connectivity::Online,
+            VariantState::Detected {
+                name: "BaseVariant".to_owned(),
+                is_base_variant: true,
+                is_fallback: false,
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn test_detect_specific_variant() {
         detect_variant(
             1,
-            false,
-            "SpecificVariant".to_owned(),
-            EcuState::Online,
             None,
+            Connectivity::Online,
+            VariantState::Detected {
+                name: "SpecificVariant".to_owned(),
+                is_base_variant: false,
+                is_fallback: false,
+            },
         )
         .await;
     }
@@ -854,17 +835,52 @@ mod tests {
             )
         );
 
-        assert!(ecu_manager.variant.name.is_none());
+        assert!(
+            ecu_manager
+                .runtime_state
+                .ecu_state
+                .read()
+                .unwrap()
+                .variant_state
+                .name()
+                .is_none()
+        );
         assert!(!ecu_manager.diag_database.is_loaded());
-        assert!(!ecu_manager.variant.is_base_variant);
-        assert_eq!(ecu_manager.variant.state, EcuState::NoVariantDetected);
+        assert!(
+            !ecu_manager
+                .runtime_state
+                .ecu_state
+                .read()
+                .unwrap()
+                .variant_state
+                .is_base_variant()
+        );
+        assert_eq!(
+            ecu_manager.runtime_state.status().variant_state,
+            VariantState::NotDetected
+        );
     }
 
     #[tokio::test]
     async fn test_detect_variant_with_response_from_offline_to_online() {
-        let mut ecu_manager = create_ecu_manager_variant_detection(true);
-        ecu_manager.variant.state = EcuState::Offline;
-        detect_variant(0, true, "BaseVariant".to_owned(), EcuState::Online, None).await;
+        let ecu_manager = create_ecu_manager_variant_detection(true);
+        ecu_manager
+            .runtime_state
+            .ecu_state
+            .write()
+            .unwrap()
+            .connectivity = Connectivity::Offline;
+        detect_variant(
+            0,
+            Some(ecu_manager),
+            Connectivity::Online,
+            VariantState::Detected {
+                name: "BaseVariant".to_owned(),
+                is_base_variant: true,
+                is_fallback: false,
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -882,10 +898,23 @@ mod tests {
 
         ecu_manager.detect_variant(service_responses).await.unwrap();
 
-        assert_eq!(ecu_manager.variant.name, Some("BaseVariant".to_owned()));
-        assert!(ecu_manager.variant.is_base_variant);
-        assert_eq!(ecu_manager.variant.state, EcuState::Online);
+        let rs = ecu_manager.runtime_state.ecu_state.read().unwrap();
+        assert_eq!(
+            rs.variant_state.name().map(ToOwned::to_owned),
+            Some("BaseVariant".to_owned())
+        );
+        assert!(rs.variant_state.is_base_variant());
+        assert_eq!(rs.connectivity, Connectivity::Online);
+        drop(rs);
         assert!(ecu_manager.diag_database.is_loaded());
-        assert!(ecu_manager.variant_index.is_some());
+        assert!(
+            ecu_manager
+                .runtime_state
+                .ecu_state
+                .read()
+                .unwrap()
+                .variant_index
+                .is_some()
+        );
     }
 }

--- a/cda-core/src/diag_kernel/payload_decode.rs
+++ b/cda-core/src/diag_kernel/payload_decode.rs
@@ -143,9 +143,8 @@ impl<S: SecurityPlugin> PayloadDecoder for EcuManager<S> {
             let response_type = response.response_type().try_into()?;
             // in case of a positive response update potential session or security access changes
             if response_type == datatypes::ResponseType::Positive {
-                let (new_session, new_security) = self
-                    .lookup_state_transition_by_diagcomm_for_active(&mapped_diag_comm)
-                    .await;
+                let (new_session, new_security) =
+                    self.lookup_state_transition_by_diagcomm_for_active(&mapped_diag_comm);
 
                 if let Some(new_session) = new_session {
                     self.set_service_state(service_ids::SESSION_CONTROL, new_session)

--- a/cda-core/src/diag_kernel/payload_encode.rs
+++ b/cda-core/src/diag_kernel/payload_encode.rs
@@ -60,9 +60,8 @@ impl<S: SecurityPlugin> PayloadEncoder for EcuManager<S> {
         self.check_service_access(security_plugin, mapped_service)
             .await?;
 
-        let (new_session, new_security) = self
-            .lookup_state_transition_by_diagcomm_for_active(&mapped_dc)
-            .await;
+        let (new_session, new_security) =
+            self.lookup_state_transition_by_diagcomm_for_active(&mapped_dc);
 
         Ok(ServicePayload {
             data: rawdata,
@@ -157,9 +156,8 @@ impl<S: SecurityPlugin> PayloadEncoder for EcuManager<S> {
             }
         }
 
-        let (new_session, new_security) = self
-            .lookup_state_transition_by_diagcomm_for_active(&(mapped_dc.into()))
-            .await;
+        let (new_session, new_security) =
+            self.lookup_state_transition_by_diagcomm_for_active(&(mapped_dc.into()));
         tracing::Span::current().record("output", util::tracing::print_hex(&uds, 10));
         Ok(ServicePayload {
             data: uds,

--- a/cda-core/src/diag_kernel/security.rs
+++ b/cda-core/src/diag_kernel/security.rs
@@ -14,7 +14,8 @@
 use cda_database::datatypes;
 use cda_interfaces::{
     DiagServiceError, DynamicPlugin, EcuSecurity, EcuStateManager, HashSet, SecurityAccess,
-    dlt_ctx, service_ids, util::contains_ignore_ascii_case,
+    dlt_ctx, service_ids,
+    util::{contains_ignore_ascii_case, std_ext},
 };
 use cda_plugin_security::SecurityPlugin;
 
@@ -154,11 +155,11 @@ impl<S: SecurityPlugin> EcuManager<S> {
             .ok_or(DiagServiceError::InvalidDatabase(
                 "Service has no DiagComm".to_owned(),
             ))?;
-        self.check_service_preconditions(&diag_comm.into()).await?;
+        self.check_service_preconditions(&diag_comm.into())?;
         check_security_plugin::<S>(security_plugin, service)
     }
 
-    async fn check_service_preconditions(
+    fn check_service_preconditions(
         &self,
         diag_comm: &datatypes::DiagComm<'_>,
     ) -> Result<(), DiagServiceError> {
@@ -177,9 +178,9 @@ impl<S: SecurityPlugin> EcuManager<S> {
 
         // Get current ECU states
         let (ecu_session, ecu_security_level) = {
-            let ecu_states = self.ecu_service_states.read().await;
+            let service_states = std_ext::lock_read(&self.runtime_state.service_states);
 
-            let session = ecu_states
+            let session = service_states
                 .get(&service_ids::SESSION_CONTROL)
                 .cloned()
                 .ok_or(DiagServiceError::InvalidState(
@@ -187,7 +188,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 ))?
                 .to_ascii_lowercase();
 
-            let security = ecu_states
+            let security = service_states
                 .get(&service_ids::SECURITY_ACCESS)
                 .cloned()
                 .ok_or(DiagServiceError::InvalidState(
@@ -332,9 +333,9 @@ mod tests {
         let (ecu_manager, _, request_seed_12_name, _) =
             create_ecu_manager_with_security_access_services();
         {
-            let mut states = ecu_manager.ecu_service_states.write().await;
-            states.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_owned());
-            states.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
+            let mut guard = ecu_manager.runtime_state.service_states.write().unwrap();
+            guard.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_owned());
+            guard.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
         }
 
         let result = ecu_manager
@@ -359,9 +360,9 @@ mod tests {
         let (ecu_manager, _, request_seed_12_name, _) =
             create_ecu_manager_with_security_access_services();
         {
-            let mut states = ecu_manager.ecu_service_states.write().await;
-            states.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_owned());
-            states.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
+            let mut guard = ecu_manager.runtime_state.service_states.write().unwrap();
+            guard.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_owned());
+            guard.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
         }
 
         // "access_12" -> trailing "12" -> from_str_radix("12", 16) = 18 -> sub-func 0x12
@@ -385,9 +386,9 @@ mod tests {
     async fn test_lookup_security_access_request_seed_not_found() {
         let (ecu_manager, ..) = create_ecu_manager_with_security_access_services();
         {
-            let mut states = ecu_manager.ecu_service_states.write().await;
-            states.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_owned());
-            states.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
+            let mut guard = ecu_manager.runtime_state.service_states.write().unwrap();
+            guard.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_owned());
+            guard.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
         }
 
         // "unknown_99" - name not in any service, sub-func 99 (0x63) is outside
@@ -411,9 +412,9 @@ mod tests {
         let (ecu_manager, _, _, send_key_01_name) =
             create_ecu_manager_with_security_access_services();
         {
-            let mut states = ecu_manager.ecu_service_states.write().await;
-            states.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_owned());
-            states.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
+            let mut guard = ecu_manager.runtime_state.service_states.write().unwrap();
+            guard.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_owned());
+            guard.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
         }
 
         // Transition LockedSecurity -> ExtendedSecurity; SendKey_level_01 carries that ref.

--- a/cda-core/src/diag_kernel/service_lookup.rs
+++ b/cda-core/src/diag_kernel/service_lookup.rs
@@ -36,6 +36,14 @@ impl DbCache {
     pub(in crate::diag_kernel) async fn reset(&self) {
         self.diag_services.write().await.clear();
     }
+
+    /// Synchronous cache reset. Used when the DB is unloaded (no async context needed
+    /// because no one should be concurrently reading the cache during unload).
+    pub(in crate::diag_kernel) fn reset_sync(&self) {
+        if let Ok(mut guard) = self.diag_services.try_write() {
+            guard.clear();
+        }
+    }
 }
 
 pub(in crate::diag_kernel) enum CacheLocation {

--- a/cda-core/src/diag_kernel/state.rs
+++ b/cda-core/src/diag_kernel/state.rs
@@ -12,7 +12,7 @@
  */
 
 use cda_database::datatypes;
-use cda_interfaces::{DiagServiceError, EcuStateManager, dlt_ctx, service_ids};
+use cda_interfaces::{DiagServiceError, EcuStateManager, dlt_ctx, service_ids, util::std_ext};
 use cda_plugin_security::SecurityPlugin;
 
 use super::ecumanager::EcuManager;
@@ -20,17 +20,17 @@ use super::ecumanager::EcuManager;
 impl<S: SecurityPlugin> EcuStateManager for EcuManager<S> {
     async fn set_service_state(&self, sid: u8, value: String) {
         tracing::debug!("Setting service state: SID: {sid}, Value: {value}");
-        self.ecu_service_states.write().await.insert(sid, value);
+        std_ext::lock_write(&self.runtime_state.service_states).insert(sid, value);
     }
 
     async fn get_service_state(&self, sid: u8) -> Option<String> {
-        self.ecu_service_states.read().await.get(&sid).cloned()
+        std_ext::lock_read(&self.runtime_state.service_states)
+            .get(&sid)
+            .cloned()
     }
 
     async fn session(&self) -> Result<String, DiagServiceError> {
-        self.ecu_service_states
-            .read()
-            .await
+        std_ext::lock_read(&self.runtime_state.service_states)
             .get(&service_ids::SESSION_CONTROL)
             .cloned()
             .ok_or(DiagServiceError::InvalidState(
@@ -43,9 +43,7 @@ impl<S: SecurityPlugin> EcuStateManager for EcuManager<S> {
     }
 
     async fn security_access(&self) -> Result<String, DiagServiceError> {
-        self.ecu_service_states
-            .read()
-            .await
+        std_ext::lock_read(&self.runtime_state.service_states)
             .get(&service_ids::SECURITY_ACCESS)
             .cloned()
             .ok_or(DiagServiceError::InvalidState(
@@ -57,10 +55,7 @@ impl<S: SecurityPlugin> EcuStateManager for EcuManager<S> {
         &self,
         target_session_name: &str,
     ) -> Result<cda_interfaces::DiagComm, DiagServiceError> {
-        let current_session_name = self
-            .ecu_service_states
-            .read()
-            .await
+        let current_session_name = std_ext::lock_read(&self.runtime_state.service_states)
             .get(&service_ids::SESSION_CONTROL)
             .cloned()
             .ok_or(DiagServiceError::InvalidState(
@@ -85,18 +80,14 @@ impl<S: SecurityPlugin> EcuStateManager for EcuManager<S> {
         // For example when switching to 'extended' immediately after the service
         // signals 'ready'
 
-        let mut states = self.ecu_service_states.write().await;
-        states
-            .entry(service_ids::SESSION_CONTROL)
+        let mut ss = std_ext::lock_write(&self.runtime_state.service_states);
+        ss.entry(service_ids::SESSION_CONTROL)
             .or_insert(self.default_state(&self.database_naming_convention.semantics.session)?);
-        states
-            .entry(service_ids::SECURITY_ACCESS)
+        ss.entry(service_ids::SECURITY_ACCESS)
             .or_insert(self.default_state(&self.database_naming_convention.semantics.security)?);
-        states
-            .entry(service_ids::CONTROL_DTC_SETTING)
+        ss.entry(service_ids::CONTROL_DTC_SETTING)
             .or_insert_with(|| "on".to_owned());
-        states
-            .entry(service_ids::COMMUNICATION_CONTROL)
+        ss.entry(service_ids::COMMUNICATION_CONTROL)
             .or_insert_with(|| "enablerxandenabletx".to_owned());
         Ok(())
     }
@@ -141,7 +132,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
             })
     }
 
-    pub(in crate::diag_kernel) async fn lookup_state_transition_by_diagcomm_for_active(
+    pub(in crate::diag_kernel) fn lookup_state_transition_by_diagcomm_for_active(
         &self,
         diag_comm: &datatypes::DiagComm<'_>,
     ) -> (Option<String>, Option<String>) {
@@ -179,10 +170,10 @@ impl<S: SecurityPlugin> EcuManager<S> {
             );
         }
 
-        let states = self.ecu_service_states.write().await;
+        let ss = std_ext::lock_read(&self.runtime_state.service_states);
 
-        let current_session = states.get(&service_ids::SESSION_CONTROL);
-        let current_security = states.get(&service_ids::SECURITY_ACCESS);
+        let current_session = ss.get(&service_ids::SESSION_CONTROL);
+        let current_security = ss.get(&service_ids::SECURITY_ACCESS);
 
         if current_session.is_none() {
             tracing::warn!(
@@ -205,7 +196,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
             state_chart_security
                 .and_then(|sc| Self::lookup_state_transition(diag_comm, &(sc.into()), security))
         });
-        drop(states);
+        drop(ss);
 
         tracing::debug!(
             diag_comm_name = ?diag_comm.short_name(),
@@ -361,9 +352,9 @@ mod tests {
             create_ecu_manager_with_state_transitions(ServiceSecurityTransition::LockedToExtended);
 
         {
-            let mut ecu_states = ecu_manager.ecu_service_states.write().await;
-            ecu_states.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_string());
-            ecu_states.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_string());
+            let mut guard = std_ext::lock_write(&ecu_manager.runtime_state.service_states);
+            guard.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_string());
+            guard.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_string());
         }
 
         let payload_data = UdsPayloadData::Raw(vec![service_ids::WRITE_DATA_BY_IDENTIFIER]);
@@ -385,9 +376,9 @@ mod tests {
             create_ecu_manager_with_state_transitions(ServiceSecurityTransition::LockedToExtended);
 
         {
-            let mut ecu_states = ecu_manager.ecu_service_states.write().await;
-            ecu_states.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_string());
-            ecu_states.insert(
+            let mut guard = std_ext::lock_write(&ecu_manager.runtime_state.service_states);
+            guard.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_string());
+            guard.insert(
                 service_ids::SECURITY_ACCESS,
                 "ProgrammingSecurity".to_string(),
             );
@@ -412,9 +403,9 @@ mod tests {
         );
 
         {
-            let mut ecu_states = ecu_manager.ecu_service_states.write().await;
-            ecu_states.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_string());
-            ecu_states.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_string());
+            let mut guard = std_ext::lock_write(&ecu_manager.runtime_state.service_states);
+            guard.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_string());
+            guard.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_string());
         }
 
         let payload_data = UdsPayloadData::Raw(vec![service_ids::WRITE_DATA_BY_IDENTIFIER]);
@@ -435,9 +426,9 @@ mod tests {
         let (ecu_manager, dc, sid) = create_ecu_manager_with_preconditions_and_functional_group();
 
         {
-            let mut ecu_states = ecu_manager.ecu_service_states.write().await;
-            ecu_states.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_string());
-            ecu_states.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_string());
+            let mut guard = std_ext::lock_write(&ecu_manager.runtime_state.service_states);
+            guard.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_string());
+            guard.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_string());
         }
 
         let variant_result = ecu_manager
@@ -473,9 +464,9 @@ mod tests {
         let (ecu_manager, _dc) =
             create_ecu_manager_with_state_transitions(ServiceSecurityTransition::LockedToExtended);
         {
-            let mut states = ecu_manager.ecu_service_states.write().await;
-            states.insert(service_ids::SESSION_CONTROL, "defaultSession".to_owned());
-            states.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
+            let mut guard = std_ext::lock_write(&ecu_manager.runtime_state.service_states);
+            guard.insert(service_ids::SESSION_CONTROL, "defaultSession".to_owned());
+            guard.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
         }
         let result = ecu_manager.lookup_session_change("extendedSessioN").await;
         assert!(
@@ -489,11 +480,11 @@ mod tests {
         let (ecu_manager, _dc) =
             create_ecu_manager_with_state_transitions(ServiceSecurityTransition::LockedToExtended);
         {
-            let mut states = ecu_manager.ecu_service_states.write().await;
+            let mut guard = std_ext::lock_write(&ecu_manager.runtime_state.service_states);
             // ECU is already in ExtendedSession - the service's session transition is
             // DefaultSession -> ExtendedSession, which does not start from Extended.
-            states.insert(service_ids::SESSION_CONTROL, "ExtendedSession".to_owned());
-            states.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
+            guard.insert(service_ids::SESSION_CONTROL, "ExtendedSession".to_owned());
+            guard.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
         }
         // There is no service whose session transition starts from ExtendedSession, so
         // lookup_session_change to ProgrammingSession must fail.
@@ -511,12 +502,12 @@ mod tests {
         let (ecu_manager, dc) =
             create_ecu_manager_with_state_transitions(ServiceSecurityTransition::LockedToExtended);
         {
-            let mut states = ecu_manager.ecu_service_states.write().await;
-            states.insert(
+            let mut guard = std_ext::lock_write(&ecu_manager.runtime_state.service_states);
+            guard.insert(
                 service_ids::SESSION_CONTROL,
                 "Programmingsession".to_owned(),
             );
-            states.insert(
+            guard.insert(
                 service_ids::SECURITY_ACCESS,
                 "programmingsecurity".to_owned(),
             );
@@ -546,9 +537,9 @@ mod tests {
         let (ecu_manager, dc) =
             create_ecu_manager_with_state_transitions(ServiceSecurityTransition::LockedToExtended);
         {
-            let mut states = ecu_manager.ecu_service_states.write().await;
-            states.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_owned());
-            states.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
+            let mut guard = std_ext::lock_write(&ecu_manager.runtime_state.service_states);
+            guard.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_owned());
+            guard.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_owned());
         }
         let payload_data = UdsPayloadData::Raw(vec![service_ids::WRITE_DATA_BY_IDENTIFIER]);
         let result = ecu_manager

--- a/cda-core/src/diag_kernel/state.rs
+++ b/cda-core/src/diag_kernel/state.rs
@@ -80,14 +80,18 @@ impl<S: SecurityPlugin> EcuStateManager for EcuManager<S> {
         // For example when switching to 'extended' immediately after the service
         // signals 'ready'
 
-        let mut ss = std_ext::lock_write(&self.runtime_state.service_states);
-        ss.entry(service_ids::SESSION_CONTROL)
+        let mut service_state = std_ext::lock_write(&self.runtime_state.service_states);
+        service_state
+            .entry(service_ids::SESSION_CONTROL)
             .or_insert(self.default_state(&self.database_naming_convention.semantics.session)?);
-        ss.entry(service_ids::SECURITY_ACCESS)
+        service_state
+            .entry(service_ids::SECURITY_ACCESS)
             .or_insert(self.default_state(&self.database_naming_convention.semantics.security)?);
-        ss.entry(service_ids::CONTROL_DTC_SETTING)
+        service_state
+            .entry(service_ids::CONTROL_DTC_SETTING)
             .or_insert_with(|| "on".to_owned());
-        ss.entry(service_ids::COMMUNICATION_CONTROL)
+        service_state
+            .entry(service_ids::COMMUNICATION_CONTROL)
             .or_insert_with(|| "enablerxandenabletx".to_owned());
         Ok(())
     }
@@ -170,10 +174,10 @@ impl<S: SecurityPlugin> EcuManager<S> {
             );
         }
 
-        let ss = std_ext::lock_read(&self.runtime_state.service_states);
+        let service_state = std_ext::lock_read(&self.runtime_state.service_states);
 
-        let current_session = ss.get(&service_ids::SESSION_CONTROL);
-        let current_security = ss.get(&service_ids::SECURITY_ACCESS);
+        let current_session = service_state.get(&service_ids::SESSION_CONTROL);
+        let current_security = service_state.get(&service_ids::SECURITY_ACCESS);
 
         if current_session.is_none() {
             tracing::warn!(
@@ -196,7 +200,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
             state_chart_security
                 .and_then(|sc| Self::lookup_state_transition(diag_comm, &(sc.into()), security))
         });
-        drop(ss);
+        drop(service_state);
 
         tracing::debug!(
             diag_comm_name = ?diag_comm.short_name(),

--- a/cda-core/src/diag_kernel/test_utils/ecu_manager_builder.rs
+++ b/cda-core/src/diag_kernel/test_utils/ecu_manager_builder.rs
@@ -14,8 +14,9 @@
 //! Factory helpers for constructing [`EcuManager`] instances in tests.
 
 use cda_interfaces::{
-    EcuManagerType, EcuState, EcuVariant, Protocol,
+    Connectivity, EcuManagerType, Protocol, VariantState,
     datatypes::{ComParams, DatabaseNamingConvention},
+    util::std_ext,
 };
 use cda_plugin_security::DefaultSecurityPluginData;
 
@@ -32,7 +33,7 @@ pub(crate) const SID_PARM_NAME: &str = "sid";
 pub(crate) fn new_ecu_manager(
     db: cda_database::datatypes::DiagnosticDatabase,
 ) -> EcuManager<DefaultSecurityPluginData> {
-    let mut manager = EcuManager::new(
+    let manager = EcuManager::new(
         db,
         Protocol::default(),
         &ComParams::default(),
@@ -51,14 +52,16 @@ pub(crate) fn new_ecu_manager(
     .expect("Failed to create EcuManager");
 
     // not using set_variant here, because that would require us to build state charts etc.
-    manager.variant = EcuVariant {
-        name: Some(TEST_DIAG_LAYER.to_owned()),
-        is_base_variant: true,
-        is_fallback: false,
-        state: EcuState::Online,
-        logical_address: 0,
-    };
-    manager.variant_index = Some(0);
+    {
+        let mut es = std_ext::lock_write(&manager.runtime_state.ecu_state);
+        es.connectivity = Connectivity::Online;
+        es.variant_state = VariantState::Detected {
+            name: TEST_DIAG_LAYER.to_owned(),
+            is_base_variant: true,
+            is_fallback: false,
+        };
+        es.variant_index = Some(0);
+    }
 
     manager
 }

--- a/cda-core/src/diag_kernel/test_utils/ecu_manager_builder.rs
+++ b/cda-core/src/diag_kernel/test_utils/ecu_manager_builder.rs
@@ -53,14 +53,14 @@ pub(crate) fn new_ecu_manager(
 
     // not using set_variant here, because that would require us to build state charts etc.
     {
-        let mut es = std_ext::lock_write(&manager.runtime_state.ecu_state);
-        es.connectivity = Connectivity::Online;
-        es.variant_state = VariantState::Detected {
+        let mut ecu_state = std_ext::lock_write(&manager.runtime_state.ecu_state);
+        ecu_state.connectivity = Connectivity::Online;
+        ecu_state.variant_state = VariantState::Detected {
             name: TEST_DIAG_LAYER.to_owned(),
             is_base_variant: true,
             is_fallback: false,
         };
-        es.variant_index = Some(0);
+        ecu_state.variant_index = Some(0);
     }
 
     manager

--- a/cda-core/src/diag_kernel/variant.rs
+++ b/cda-core/src/diag_kernel/variant.rs
@@ -13,8 +13,8 @@
 
 // Needed so that `self.load()` is callable inside the EcuVariantProvider impl
 use cda_interfaces::{
-    DiagComm, DiagServiceError, EcuManager as EcuManagerTrait, EcuState, EcuVariant, HashMap,
-    VariantDetection, diagservices::DiagServiceResponse, dlt_ctx,
+    Connectivity, DiagComm, DiagServiceError, EcuManager as EcuManagerTrait, EcuState, HashMap,
+    VariantDetection, VariantState, diagservices::DiagServiceResponse, dlt_ctx, util::std_ext,
 };
 use cda_plugin_security::SecurityPlugin;
 
@@ -22,8 +22,8 @@ use super::ecumanager::{EcuManager, VariantData};
 use crate::diag_kernel::variant_detection;
 
 impl<S: SecurityPlugin> VariantDetection for EcuManager<S> {
-    fn variant(&self) -> EcuVariant {
-        self.variant.clone()
+    fn ecu_status(&self) -> EcuState {
+        self.runtime_state.status()
     }
 
     #[tracing::instrument(
@@ -44,27 +44,12 @@ impl<S: SecurityPlugin> VariantDetection for EcuManager<S> {
         }
 
         if service_responses.is_empty() {
-            let state = if matches!(
-                self.variant.state,
-                EcuState::Online
-                    | EcuState::Duplicate
-                    | EcuState::Disconnected
-                    | EcuState::NoVariantDetected
-            ) {
-                EcuState::Disconnected
-            } else {
-                EcuState::Offline
-            };
-
-            self.variant = EcuVariant {
-                name: None,
-                is_base_variant: false,
-                is_fallback: false,
-                state,
-                logical_address: self.logical_address,
-            };
+            // No responses means ECU is unreachable -> set connectivity to Offline.
+            // Variant state is intentionally preserved (we still know what variant it was).
+            std_ext::lock_write(&self.runtime_state.ecu_state).connectivity = Connectivity::Offline;
             return Ok(());
         }
+
         match variant_detection::evaluate_variant(service_responses, &self.diag_database) {
             Ok(v) => {
                 let variant_data = VariantData::from_variant_and_fallback(&v, false);
@@ -72,13 +57,13 @@ impl<S: SecurityPlugin> VariantDetection for EcuManager<S> {
             }
             Err(e) => {
                 if !self.fallback_to_base_variant {
-                    self.variant = EcuVariant {
-                        name: None,
-                        is_base_variant: false,
-                        is_fallback: false,
-                        state: EcuState::NoVariantDetected,
-                        logical_address: self.logical_address,
-                    };
+                    let mut es = std_ext::lock_write(&self.runtime_state.ecu_state);
+
+                    es.variant_state = VariantState::NotDetected;
+                    es.variant_index = None;
+                    // Connectivity is Online. We got responses but couldn't match a variant
+                    es.connectivity = Connectivity::Online;
+                    drop(es);
                     self.diag_database.unload();
                     tracing::debug!(
                         "No variant detected, fallback to base variant disabled, unloading DB"
@@ -89,13 +74,11 @@ impl<S: SecurityPlugin> VariantDetection for EcuManager<S> {
                 let base_variant = match self.diag_database.base_variant() {
                     Ok(base_variant) => base_variant,
                     Err(e) => {
-                        self.variant = EcuVariant {
-                            name: None,
-                            is_base_variant: false,
-                            is_fallback: false,
-                            state: EcuState::NoVariantDetected,
-                            logical_address: self.logical_address,
-                        };
+                        let mut es = std_ext::lock_write(&self.runtime_state.ecu_state);
+                        es.variant_state = VariantState::NotDetected;
+                        es.variant_index = None;
+                        es.connectivity = Connectivity::Online;
+                        drop(es);
                         self.diag_database.unload();
                         tracing::debug!(
                             "No variant detected, and no base variant found in DB, unloading DB"
@@ -115,12 +98,30 @@ impl<S: SecurityPlugin> VariantDetection for EcuManager<S> {
     }
 
     fn mark_as_duplicate(&mut self) {
-        self.variant.state = EcuState::Duplicate;
+        let mut es = std_ext::lock_write(&self.runtime_state.ecu_state);
+        es.variant_state = VariantState::Duplicate;
+        es.variant_index = None;
+        drop(es);
+        self.db_cache.reset_sync();
         self.diag_database.unload();
     }
 
     fn mark_as_no_variant_detected(&mut self) {
-        self.variant.state = EcuState::NoVariantDetected;
+        let mut es = std_ext::lock_write(&self.runtime_state.ecu_state);
+        es.variant_state = VariantState::NotDetected;
+        es.variant_index = None;
+        drop(es);
+        self.db_cache.reset_sync();
         self.diag_database.unload();
+    }
+
+    fn clear_variant_for_redetect(&mut self) {
+        tracing::debug!(
+            ecu = %self.ecu_name,
+            "Clearing variant to trigger re-detection on next request"
+        );
+        let mut es = std_ext::lock_write(&self.runtime_state.ecu_state);
+        es.variant_state = VariantState::NotDetected;
+        es.variant_index = None;
     }
 }

--- a/cda-core/src/diag_kernel/variant.rs
+++ b/cda-core/src/diag_kernel/variant.rs
@@ -57,13 +57,13 @@ impl<S: SecurityPlugin> VariantDetection for EcuManager<S> {
             }
             Err(e) => {
                 if !self.fallback_to_base_variant {
-                    let mut es = std_ext::lock_write(&self.runtime_state.ecu_state);
+                    let mut ecu_state = std_ext::lock_write(&self.runtime_state.ecu_state);
 
-                    es.variant_state = VariantState::NotDetected;
-                    es.variant_index = None;
+                    ecu_state.variant_state = VariantState::NotDetected;
+                    ecu_state.variant_index = None;
                     // Connectivity is Online. We got responses but couldn't match a variant
-                    es.connectivity = Connectivity::Online;
-                    drop(es);
+                    ecu_state.connectivity = Connectivity::Online;
+                    drop(ecu_state);
                     self.diag_database.unload();
                     tracing::debug!(
                         "No variant detected, fallback to base variant disabled, unloading DB"
@@ -74,11 +74,11 @@ impl<S: SecurityPlugin> VariantDetection for EcuManager<S> {
                 let base_variant = match self.diag_database.base_variant() {
                     Ok(base_variant) => base_variant,
                     Err(e) => {
-                        let mut es = std_ext::lock_write(&self.runtime_state.ecu_state);
-                        es.variant_state = VariantState::NotDetected;
-                        es.variant_index = None;
-                        es.connectivity = Connectivity::Online;
-                        drop(es);
+                        let mut ecu_state = std_ext::lock_write(&self.runtime_state.ecu_state);
+                        ecu_state.variant_state = VariantState::NotDetected;
+                        ecu_state.variant_index = None;
+                        ecu_state.connectivity = Connectivity::Online;
+                        drop(ecu_state);
                         self.diag_database.unload();
                         tracing::debug!(
                             "No variant detected, and no base variant found in DB, unloading DB"
@@ -98,30 +98,20 @@ impl<S: SecurityPlugin> VariantDetection for EcuManager<S> {
     }
 
     fn mark_as_duplicate(&mut self) {
-        let mut es = std_ext::lock_write(&self.runtime_state.ecu_state);
-        es.variant_state = VariantState::Duplicate;
-        es.variant_index = None;
-        drop(es);
+        let mut ecu_state = std_ext::lock_write(&self.runtime_state.ecu_state);
+        ecu_state.variant_state = VariantState::Duplicate;
+        ecu_state.variant_index = None;
+        drop(ecu_state);
         self.db_cache.reset_sync();
         self.diag_database.unload();
     }
 
     fn mark_as_no_variant_detected(&mut self) {
-        let mut es = std_ext::lock_write(&self.runtime_state.ecu_state);
-        es.variant_state = VariantState::NotDetected;
-        es.variant_index = None;
-        drop(es);
+        let mut ecu_state = std_ext::lock_write(&self.runtime_state.ecu_state);
+        ecu_state.variant_state = VariantState::NotDetected;
+        ecu_state.variant_index = None;
+        drop(ecu_state);
         self.db_cache.reset_sync();
         self.diag_database.unload();
-    }
-
-    fn clear_variant_for_redetect(&mut self) {
-        tracing::debug!(
-            ecu = %self.ecu_name,
-            "Clearing variant to trigger re-detection on next request"
-        );
-        let mut es = std_ext::lock_write(&self.runtime_state.ecu_state);
-        es.variant_state = VariantState::NotDetected;
-        es.variant_index = None;
     }
 }

--- a/cda-interfaces/src/datatypes/networkstructure.rs
+++ b/cda-interfaces/src/datatypes/networkstructure.rs
@@ -11,38 +11,47 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use serde::Serialize;
+use crate::EcuState;
 
-use crate::EcuVariant;
-
-#[derive(Serialize)]
-#[serde(rename_all = "PascalCase")]
+/// Internal ECU record produced by the UDS layer.
+///
+/// Converted to the SOVD JSON representation via [`IntoSovd`] in `cda-sovd`
 pub struct Ecu {
-    pub qualifier: String,   // name
-    pub variant: EcuVariant, // variant
-    pub logical_address: String,
-    pub logical_link: String, // ${qualifier}_on_${protocol}
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct Gateway {
-    pub name: String,
-    pub network_address: String,
-    pub logical_address: String,
-    pub ecus: Vec<Ecu>,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct FunctionalGroup {
+    /// ECU qualifier (name).
     pub qualifier: String,
+    /// Current variant/connectivity status. Mapped to `Variant` and `EcuState` strings by the
+    /// SOVD layer.
+    pub variant: EcuState,
+    /// Logical address formatted as a hex string (e.g. `"0x2000"`).
+    pub logical_address: String,
+    /// Logical link name (e.g. `"ECU_on_UDS_Ethernet_DoIP"`).
+    pub logical_link: String,
+}
+
+/// Gateway record, converted to SOVD JSON via [`IntoSovd`]
+pub struct Gateway {
+    /// Gateway name.
+    pub name: String,
+    /// Network address of the gateway.
+    pub network_address: String,
+    /// Logical address formatted as a hex string.
+    pub logical_address: String,
+    /// ECUs reachable through this gateway.
     pub ecus: Vec<Ecu>,
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "PascalCase")]
+/// Functional group record, converted to SOVD JSON via [`IntoSovd`]
+pub struct FunctionalGroup {
+    /// Functional group qualifier.
+    pub qualifier: String,
+    /// ECUs belonging to this functional group.
+    pub ecus: Vec<Ecu>,
+}
+
+/// Top-level network structure, converted to SOVD JSON via [`IntoSovd`]
 pub struct NetworkStructure {
+    /// All functional groups in the network.
     pub functional_groups: Vec<FunctionalGroup>,
+    /// All gateways in the network.
     pub gateways: Vec<Gateway>,
 }

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -10,11 +10,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+use std::{fmt::Display, future::Future};
+
+use async_trait::async_trait;
 use serde::Serialize;
 
 use crate::{
-    DiagComm, DiagServiceError, DoipComParams, DynamicPlugin, EcuSchemas, HashMap, HashSet,
-    SecurityAccess, UDS_ID_RESPONSE_BITMASK, UdsComParams,
+    DiagComm, DiagServiceError, DoipComParams, DynamicPlugin, EcuSchemas, HashMap,
+    HashMapExtensions, HashSet, SecurityAccess, UDS_ID_RESPONSE_BITMASK, UdsComParams,
     datatypes::{
         ComplexComParamValue, ComponentConfigurationsInfo, ComponentDataInfo,
         ComponentOperationsInfo, DtcLookup, DtcReadInformationFunction, RoutineSubfunctions, SdSdg,
@@ -22,6 +26,7 @@ use crate::{
     },
     diagservices::{DiagServiceResponse, UdsPayloadData},
     service_ids,
+    util::std_ext,
 };
 
 /// Metadata for a service parameter, including constant values for discovery
@@ -123,26 +128,169 @@ pub struct MuxCaseInfo {
     pub upper_limit: Option<String>,
 }
 
-#[derive(Clone, Copy, Debug, Serialize, PartialEq)]
-pub enum EcuState {
+/// Combined ECU state as exposed in the SOVD API.
+///
+/// Derived from [`Connectivity`] + [`VariantState`] via [`EcuStatus::to_ecu_state()`].
+///
+/// ECU connectivity state, eg. reachable via underlying transport
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+pub enum Connectivity {
+    /// ECU responded to the last communication attempt.
     Online,
+    /// ECU is currently unreachable (never connected, or lost connection).
     Offline,
-    NotTested,
-    Duplicate,
-    Disconnected,
-    NoVariantDetected,
 }
 
-#[derive(Clone, Serialize)]
-pub struct EcuVariant {
-    pub name: Option<String>,
-    pub is_base_variant: bool,
-    /// Indicates whether this variant was selected as a fallback when no specific variant matched.
-    /// When true, this is a fallback scenario.
-    /// When false, it's an exact match (even if `is_base_variant` is true).
-    pub is_fallback: bool,
-    pub state: EcuState,
-    pub logical_address: u16,
+impl Display for Connectivity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Online => f.write_str("Online"),
+            Self::Offline => f.write_str("Offline"),
+        }
+    }
+}
+
+/// ECU variant detection result.
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub enum VariantState {
+    /// Never attempted detection.
+    NotTested,
+    /// Successfully detected variant.
+    Detected {
+        /// Variant name from the database.
+        name: String,
+        /// Whether this is the base (top-level) variant.
+        is_base_variant: bool,
+        /// Whether this variant was selected as a fallback when no specific variant matched.
+        is_fallback: bool,
+    },
+    /// Ambiguous among duplicate ECUs sharing the same logical address.
+    /// Overrides connectivity in SOVD API mapping.
+    Duplicate,
+    /// Detection attempted but no variant matched (and no fallback available).
+    NotDetected,
+}
+
+impl VariantState {
+    /// Returns the variant name if detected, `None` otherwise.
+    #[must_use]
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            Self::Detected { name, .. } => Some(name),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if the variant is the base variant.
+    #[must_use]
+    pub fn is_base_variant(&self) -> bool {
+        matches!(
+            self,
+            Self::Detected {
+                is_base_variant: true,
+                ..
+            }
+        )
+    }
+
+    /// Returns `true` if the variant was selected as a fallback.
+    #[must_use]
+    pub fn is_fallback(&self) -> bool {
+        matches!(
+            self,
+            Self::Detected {
+                is_fallback: true,
+                ..
+            }
+        )
+    }
+}
+
+/// Combined ECU status snapshot (connectivity + variant + detection index).
+#[derive(Clone, Debug)]
+pub struct EcuState {
+    /// Whether the ECU is currently reachable.
+    pub connectivity: Connectivity,
+    /// Variant detection result.
+    pub variant_state: VariantState,
+    /// Index into the diagnostic database's variant list. `None` until detection succeeds.
+    pub variant_index: Option<usize>,
+}
+
+impl EcuState {
+    /// Returns the variant name if detected, `None` otherwise.
+    #[must_use]
+    pub fn name(&self) -> Option<&str> {
+        self.variant_state.name()
+    }
+
+    /// Returns `true` if the variant is the base variant.
+    #[must_use]
+    pub fn is_base_variant(&self) -> bool {
+        self.variant_state.is_base_variant()
+    }
+
+    /// Returns `true` if the variant was selected as a fallback.
+    #[must_use]
+    pub fn is_fallback(&self) -> bool {
+        self.variant_state.is_fallback()
+    }
+
+    /// Returns `true` if the ECU is online with a successfully detected variant.
+    #[must_use]
+    pub fn is_online_and_detected(&self) -> bool {
+        self.connectivity == Connectivity::Online
+            && matches!(self.variant_state, VariantState::Detected { .. })
+    }
+}
+
+impl Default for EcuState {
+    fn default() -> Self {
+        Self {
+            connectivity: Connectivity::Offline,
+            variant_state: VariantState::NotTested,
+            variant_index: None,
+        }
+    }
+}
+
+/// Shared ECU runtime state, held by both `EcuManager` and the coordinator actor.
+///
+/// Cheap to clone (two `Arc` handles). The split into separate locks ensures that
+/// variant-identity reads (needed for DB lookups) never deadlock with service-state
+/// writes (session/security mutations).
+/// `std::sync::RwLock` is used intentionally here rather than a tokio async lock:
+/// all critical sections are short-lived (field reads/writes only, no I/O),
+/// so blocking is negligible and the sync lock avoids pervasive `.await` at every state access.
+#[derive(Debug, Clone)]
+pub struct EcuRuntimeState {
+    /// ECU identity: connectivity + variant detection result.
+    pub ecu_state: std::sync::Arc<std::sync::RwLock<EcuState>>,
+    /// Active service states keyed by SID (0x10 = session, 0x27 = security, etc.).
+    pub service_states: std::sync::Arc<std::sync::RwLock<HashMap<u8, String>>>,
+}
+
+impl EcuRuntimeState {
+    /// Create initial state for a newly constructed ECU (not yet variant-detected).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            ecu_state: std::sync::Arc::new(std::sync::RwLock::new(EcuState::default())),
+            service_states: std::sync::Arc::new(std::sync::RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Convenience: get an [`EcuState`] snapshot.
+    #[must_use]
+    pub fn status(&self) -> EcuState {
+        std_ext::lock_read(&self.ecu_state).clone()
+    }
+}
+
+impl Default for EcuRuntimeState {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -601,9 +749,9 @@ pub trait Dtc: Send + Sync + 'static {
 
 /// Provides variant detection and ECU variant identity.
 pub trait VariantDetection: Send + Sync + 'static {
-    /// Returns the current ECU variant (name, state, flags).
+    /// Returns the current ECU status (connectivity + variant state).
     #[must_use]
-    fn variant(&self) -> EcuVariant;
+    fn ecu_status(&self) -> EcuState;
 
     /// Runs variant detection against the provided service responses.
     /// # Errors
@@ -617,13 +765,27 @@ pub trait VariantDetection: Send + Sync + 'static {
     #[must_use]
     fn get_variant_detection_requests(&self) -> &HashMap<String, DiagComm>;
 
-    /// Mark this ECU as duplicate. Sets the state to `EcuState::Duplicate` and unloads the
-    /// database. Database will be reloaded before next variant detection.
+    /// Mark this ECU as duplicate. Sets the variant state to [`VariantState::Duplicate`] and
+    /// unloads the database. Database will be reloaded before next variant detection.
     fn mark_as_duplicate(&mut self);
 
-    /// Mark this ECU as having no variant detected. Sets the state to
-    /// `EcuState::NoVariantDetected` and unloads the database.
+    /// Mark this ECU as having no variant detected. Sets the variant state to
+    /// [`VariantState::NotDetected`] and unloads the database.
     fn mark_as_no_variant_detected(&mut self);
+
+    /// Clear the current variant to trigger re-detection on the next send.
+    /// Sets variant state to [`VariantState::NotDetected`] and clears the variant name.
+    fn clear_variant_for_redetect(&mut self);
+}
+
+/// Callback interface for transport-level ECU connectivity changes.
+#[async_trait]
+pub trait EcuConnectivityHandler: Send + Sync + 'static {
+    /// Called when a connection is established or re-established for an ECU.
+    async fn on_connected_bulk(&self, ecu_names: &[String]);
+
+    /// Called when a connection is lost for an ECU.
+    async fn on_disconnected_bulk(&self, ecu_names: &[String]);
 }
 
 /// Resolves `DiagComm` handles from the database by various search criteria.
@@ -696,10 +858,6 @@ pub trait EcuManager:
     #[must_use]
     fn is_physical_ecu(&self) -> bool;
 
-    /// Returns the current ECU state.
-    #[must_use]
-    fn state(&self) -> EcuState;
-
     #[must_use]
     fn protocol(&self) -> &Protocol;
 
@@ -735,25 +893,19 @@ pub trait EcuManager:
 
     /// Retrieve the revision of the ECU variant if available, otherwise return 0.0.0.
     fn revision(&self) -> String;
+
+    /// Returns a clone of the shared runtime state.
+    ///
+    /// Cheap (two `Arc` clones). Used by the coordinator actor to share access to
+    /// the same underlying locks for connectivity/variant and service states.
+    #[must_use]
+    fn runtime_state(&self) -> EcuRuntimeState;
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum EcuManagerType {
     Ecu,
     FunctionalDescription,
-}
-
-impl std::fmt::Display for EcuState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            EcuState::Online => write!(f, "Online"),
-            EcuState::Offline => write!(f, "Offline"),
-            EcuState::NotTested => write!(f, "NotTested"),
-            EcuState::Duplicate => write!(f, "Duplicate"),
-            EcuState::Disconnected => write!(f, "Disconnected"),
-            EcuState::NoVariantDetected => write!(f, "NoVariantDetected"),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -772,20 +772,20 @@ pub trait VariantDetection: Send + Sync + 'static {
     /// Mark this ECU as having no variant detected. Sets the variant state to
     /// [`VariantState::NotDetected`] and unloads the database.
     fn mark_as_no_variant_detected(&mut self);
-
-    /// Clear the current variant to trigger re-detection on the next send.
-    /// Sets variant state to [`VariantState::NotDetected`] and clears the variant name.
-    fn clear_variant_for_redetect(&mut self);
 }
 
-/// Callback interface for transport-level ECU connectivity changes.
+/// Callback interface for connectivity changes for ECUs behind a `DoIP` gateway.
 #[async_trait]
 pub trait EcuConnectivityHandler: Send + Sync + 'static {
-    /// Called when a connection is established or re-established for an ECU.
-    async fn on_connected_bulk(&self, ecu_names: &[String]);
+    /// Called when a `DoIP` gateway connection is established or re-established.
+    ///
+    /// Notifies for all ECUs behind (and including) the gateway.
+    async fn on_gateway_connected(&self, ecu_names: &[String]);
 
-    /// Called when a connection is lost for an ECU.
-    async fn on_disconnected_bulk(&self, ecu_names: &[String]);
+    /// Called when a `DoIP` gateway connection is lost.
+    ///
+    /// Notifies for all ECUs behind (and including) the gateway.
+    async fn on_gateway_disconnected(&self, ecu_names: &[String]);
 }
 
 /// Resolves `DiagComm` handles from the database by various search criteria.

--- a/cda-interfaces/src/ecuuds.rs
+++ b/cda-interfaces/src/ecuuds.rs
@@ -574,10 +574,10 @@ pub trait UdsVariant {
     /// does not exist or no service for variant detection is available.
     async fn detect_variant(&self, ecu_name: &str) -> Result<(), DiagServiceError>;
 
-    /// Get the ECU status (connectivity + variant state) for the given ECU.
+    /// Get the ECU state (connectivity + variant state) for the given ECU.
     /// # Errors
     /// Will return Err if the ECU does not exist.
-    async fn get_ecu_status(&self, ecu_name: &str) -> Result<EcuState, DiagServiceError>;
+    async fn get_ecu_state(&self, ecu_name: &str) -> Result<EcuState, DiagServiceError>;
 
     /// trigger the variant detection process for all ECUs.
     /// Main work will be done in the background, there is no result returned,
@@ -948,7 +948,7 @@ pub mod mock {
                 &self,
                 ecu_name: &str,
             ) -> Result<(), DiagServiceError>;
-            async fn get_ecu_status(
+            async fn get_ecu_state(
                 &self,
                 ecu_name: &str,
             ) -> Result<EcuState, DiagServiceError>;

--- a/cda-interfaces/src/ecuuds.rs
+++ b/cda-interfaces/src/ecuuds.rs
@@ -16,8 +16,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 
 use crate::{
-    DiagComm, DiagServiceError, DoipComParams, DynamicPlugin, EcuAddresses, EcuStateManager,
-    EcuVariant, HashMap, SecurityAccess, TesterPresentType, UdsComParams,
+    DiagComm, DiagServiceError, DoipComParams, DynamicPlugin, EcuAddresses, EcuState,
+    EcuStateManager, HashMap, SecurityAccess, TesterPresentType, UdsComParams,
     datatypes::{
         ComplexComParamValue, ComponentConfigurationsInfo, ComponentDataInfo,
         ComponentOperationsInfo, DataTransferMetaData, DtcCode, DtcExtendedInfo,
@@ -574,16 +574,20 @@ pub trait UdsVariant {
     /// does not exist or no service for variant detection is available.
     async fn detect_variant(&self, ecu_name: &str) -> Result<(), DiagServiceError>;
 
-    /// Get the name of the variant for the given ECU.
+    /// Get the ECU status (connectivity + variant state) for the given ECU.
     /// # Errors
     /// Will return Err if the ECU does not exist.
-    /// If the variant is cannot be resolved, "Unknown" will be returned.
-    async fn get_variant(&self, ecu_name: &str) -> Result<EcuVariant, DiagServiceError>;
+    async fn get_ecu_status(&self, ecu_name: &str) -> Result<EcuState, DiagServiceError>;
 
     /// trigger the variant detection process for all ECUs.
     /// Main work will be done in the background, there is no result returned,
     /// as the data is internally stored and used in `EcuUds`
     async fn start_variant_detection(&self);
+
+    /// Get the logical address of the given ECU.
+    /// # Errors
+    /// Will return Err if the ECU does not exist.
+    async fn get_logical_address(&self, ecu_name: &str) -> Result<u16, DiagServiceError>;
 }
 
 /// UDS communication interface - composite supertrait combining all UDS subtraits.
@@ -642,7 +646,7 @@ pub mod mock {
 
     use super::FlashTransferStartParams;
     use crate::{
-        DiagComm, DiagServiceError, DynamicPlugin, EcuVariant, HashMap, SecurityAccess,
+        DiagComm, DiagServiceError, DynamicPlugin, EcuState, HashMap, SecurityAccess,
         TesterPresentType, UdsDataTransfer, UdsDtc, UdsEcu, UdsFunctionalGroup, UdsQuery,
         UdsSecurity, UdsSession, UdsTesterPresent, UdsTransport, UdsVariant,
         datatypes::{
@@ -944,11 +948,15 @@ pub mod mock {
                 &self,
                 ecu_name: &str,
             ) -> Result<(), DiagServiceError>;
-            async fn get_variant(
+            async fn get_ecu_status(
                 &self,
                 ecu_name: &str,
-            ) -> Result<EcuVariant, DiagServiceError>;
+            ) -> Result<EcuState, DiagServiceError>;
             async fn start_variant_detection(&self);
+            async fn get_logical_address(
+                &self,
+                ecu_name: &str,
+            ) -> Result<u16, DiagServiceError>;
         }
 
         #[async_trait]

--- a/cda-interfaces/src/util.rs
+++ b/cda-interfaces/src/util.rs
@@ -177,6 +177,7 @@ pub mod std_ext {
             Ok(guard) => guard,
             Err(poisoned) => {
                 tracing::warn!("RwLock poisoned, proceeding with poisoned read lock");
+                lock.clear_poison();
                 poisoned.into_inner()
             }
         }
@@ -188,6 +189,7 @@ pub mod std_ext {
             Ok(guard) => guard,
             Err(poisoned) => {
                 tracing::warn!("RwLock poisoned, proceeding with poisoned write lock");
+                lock.clear_poison();
                 poisoned.into_inner()
             }
         }

--- a/cda-interfaces/src/util.rs
+++ b/cda-interfaces/src/util.rs
@@ -170,6 +170,30 @@ pub mod serde_ext {
     }
 }
 
+pub mod std_ext {
+    #[inline]
+    pub fn lock_read<T>(lock: &std::sync::RwLock<T>) -> std::sync::RwLockReadGuard<'_, T> {
+        match lock.read() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                tracing::warn!("RwLock poisoned, proceeding with poisoned read lock");
+                poisoned.into_inner()
+            }
+        }
+    }
+
+    #[inline]
+    pub fn lock_write<T>(lock: &std::sync::RwLock<T>) -> std::sync::RwLockWriteGuard<'_, T> {
+        match lock.write() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                tracing::warn!("RwLock poisoned, proceeding with poisoned write lock");
+                poisoned.into_inner()
+            }
+        }
+    }
+}
+
 /// Pad a byte slice to 4 bytes for u32 conversion.
 /// # Errors
 /// Returns `DiagServiceError::ParameterConversionError` if the input slice is longer than 4 bytes.

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -14,12 +14,12 @@
 use std::{future::Future, path::PathBuf, sync::Arc};
 
 use cda_comm_doip::{DoipDiagGateway, config::DoipConfig};
-use cda_comm_uds::UdsManager;
+use cda_comm_uds::{UdsManager, state_coordinator::EcuStateCoordinator};
 use cda_core::EcuManager;
 use cda_database::FileManager;
 use cda_interfaces::{
-    DiagServiceError, DoipGatewaySetupError, FunctionalDescriptionConfig, HashMap, UdsQuery,
-    UdsVariant,
+    DiagServiceError, DoipGatewaySetupError, EcuConnectivityHandler, FunctionalDescriptionConfig,
+    HashMap, HashMapExtensions, UdsQuery, UdsVariant,
     config::{ConfigSanity, ConfigSanityError},
     datatypes::{ComParams, FaultConfig},
     dlt_ctx,
@@ -754,6 +754,7 @@ pub fn create_uds_manager<S: SecurityPlugin>(
     gateway: DoipDiagGateway<EcuManager<S>>,
     databases: Arc<HashMap<String, RwLock<EcuManager<S>>>>,
     variant_detection_receiver: mpsc::Receiver<Vec<String>>,
+    state_coordinator: EcuStateCoordinator,
     functional_description_config: &FunctionalDescriptionConfig,
     fault_config: FaultConfig,
     update_in_progress: Arc<std::sync::atomic::AtomicBool>,
@@ -762,6 +763,7 @@ pub fn create_uds_manager<S: SecurityPlugin>(
         gateway,
         databases,
         variant_detection_receiver,
+        state_coordinator,
         functional_description_config,
         fault_config,
         update_in_progress,
@@ -795,10 +797,24 @@ pub async fn create_vehicle_components<
 
     let (variant_detection_tx, variant_detection_rx) = mpsc::channel(50);
     let databases = Arc::new(databases);
+
+    // Build runtime states for EcuStateCoordinator from all loaded ECU databases.
+    let runtime_states = {
+        let mut states = HashMap::new();
+        for (ecu_name, ecu_lock) in databases.as_ref() {
+            let state = ecu_lock.read().await.runtime_state();
+            states.insert(ecu_name.clone(), state);
+        }
+        states
+    };
+    let state_coordinator = EcuStateCoordinator::new(runtime_states);
+    let connectivity_handler: Arc<dyn EcuConnectivityHandler> = Arc::new(state_coordinator.clone());
+
     let diagnostic_gateway = create_diagnostic_gateway(
         Arc::clone(&databases),
         &config.doip,
         variant_detection_tx,
+        connectivity_handler,
         shutdown_signal,
         doip_provider,
         doip_socket,
@@ -809,6 +825,7 @@ pub async fn create_vehicle_components<
         diagnostic_gateway.clone(),
         Arc::clone(&databases),
         variant_detection_rx,
+        state_coordinator,
         &config.functional_description,
         config.faults.clone(),
         update_in_progress,
@@ -829,7 +846,7 @@ pub async fn create_vehicle_components<
 }
 
 #[tracing::instrument(
-    skip(databases, variant_detection, shutdown_signal, doip_health_provider, doip_socket),
+    skip(databases, variant_detection, connectivity_handler, shutdown_signal, doip_health_provider, doip_socket),
     fields(
         database_count = databases.len(),
         dlt_context = dlt_ctx!("MAIN"),
@@ -841,6 +858,7 @@ pub async fn create_diagnostic_gateway<S: SecurityPlugin>(
     databases: Arc<DatabaseMap<S>>,
     doip_config: &DoipConfig,
     variant_detection: mpsc::Sender<Vec<String>>,
+    connectivity_handler: Arc<dyn EcuConnectivityHandler>,
     shutdown_signal: impl Future<Output = ()> + Send + 'static,
     doip_health_provider: Option<&Arc<cda_health::StatusHealthProvider>>,
     doip_socket: Arc<Mutex<cda_comm_doip::socket::DoIPUdpSocket>>,
@@ -853,6 +871,7 @@ pub async fn create_diagnostic_gateway<S: SecurityPlugin>(
         doip_config,
         databases,
         variant_detection,
+        connectivity_handler,
         shutdown_signal,
         doip_socket,
     )

--- a/cda-sovd/src/sovd/apps/mod.rs
+++ b/cda-sovd/src/sovd/apps/mod.rs
@@ -89,16 +89,18 @@ impl IntoSovd for cda_interfaces::datatypes::Ecu {
     type SovdType = sovd_interfaces::apps::sovd2uds::data::network_structure::Ecu;
 
     fn into_sovd(self) -> Self::SovdType {
+        let state: super::sovd_ecu::State = self.variant.clone().into_sovd();
+        let variant_name = if let Some(n) = self.variant.name() {
+            n.to_owned()
+        } else if self.variant.is_base_variant() {
+            "BaseVariant".to_owned()
+        } else {
+            "Unknown".to_owned()
+        };
         Self::SovdType {
             qualifier: self.qualifier,
-            variant: if let Some(n) = self.variant.name {
-                n.clone()
-            } else if self.variant.is_base_variant {
-                "BaseVariant".to_owned()
-            } else {
-                "Unknown".to_owned()
-            },
-            state: self.variant.state.to_string(),
+            variant: variant_name,
+            state: format!("{state:?}"),
             logical_address: self.logical_address,
             logical_link: self.logical_link,
         }

--- a/cda-sovd/src/sovd/components/ecu/mod.rs
+++ b/cda-sovd/src/sovd/components/ecu/mod.rs
@@ -58,7 +58,7 @@ pub(crate) async fn get<T: UdsEcu + Clone, U: FileManager>(
 ) -> impl IntoApiResponse {
     let include_schema = query.include_schema;
     let base_path = format!("http://localhost:20002/vehicle/v15/components/{ecu_name}");
-    let status = match uds.get_ecu_status(&ecu_name).await {
+    let status = match uds.get_ecu_state(&ecu_name).await {
         Ok(v) => v,
         Err(e) => {
             return ErrorWrapper {

--- a/cda-sovd/src/sovd/components/ecu/mod.rs
+++ b/cda-sovd/src/sovd/components/ecu/mod.rs
@@ -58,7 +58,7 @@ pub(crate) async fn get<T: UdsEcu + Clone, U: FileManager>(
 ) -> impl IntoApiResponse {
     let include_schema = query.include_schema;
     let base_path = format!("http://localhost:20002/vehicle/v15/components/{ecu_name}");
-    let variant = match uds.get_variant(&ecu_name).await {
+    let status = match uds.get_ecu_status(&ecu_name).await {
         Ok(v) => v,
         Err(e) => {
             return ErrorWrapper {
@@ -67,6 +67,23 @@ pub(crate) async fn get<T: UdsEcu + Clone, U: FileManager>(
             }
             .into_response();
         }
+    };
+    let logical_address = match uds.get_logical_address(&ecu_name).await {
+        Ok(v) => v,
+        Err(e) => {
+            return ErrorWrapper {
+                error: e.into(),
+                include_schema,
+            }
+            .into_response();
+        }
+    };
+
+    let variant = sovd_interfaces::components::ecu::Variant {
+        name: status.name().unwrap_or("Unknown").to_owned(),
+        is_base_variant: status.is_base_variant(),
+        state: status.into_sovd(),
+        logical_address: format!("0x{logical_address:02x}"),
     };
 
     let sdgs = if query.include_sdgs {
@@ -101,7 +118,7 @@ pub(crate) async fn get<T: UdsEcu + Clone, U: FileManager>(
         Json(sovd_interfaces::components::ecu::get::Response {
             id: ecu_name.to_lowercase(),
             name: ecu_name.clone(),
-            variant: variant.into_sovd(),
+            variant,
             locks: format!("{base_path}/locks"),
             operations: format!("{base_path}/operations"),
             configurations: format!("{base_path}/configurations"),

--- a/cda-sovd/src/sovd/mod.rs
+++ b/cda-sovd/src/sovd/mod.rs
@@ -31,7 +31,8 @@ use axum::{
 };
 use axum_extra::extract::WithRejection;
 use cda_interfaces::{
-    FunctionalDescriptionConfig, HashMap, HashMapExtensions as _, SchemaProvider, UdsEcu,
+    Connectivity, FunctionalDescriptionConfig, HashMap, HashMapExtensions as _, SchemaProvider,
+    UdsEcu, VariantState,
     datatypes::ComponentsConfig,
     diagservices::{FieldParseError, UdsPayloadData},
     file_manager::FileManager,
@@ -80,30 +81,19 @@ trait IntoSovdWithSchema {
     fn into_sovd_with_schema(self, include_schema: bool) -> Result<Self::SovdType, ApiError>;
 }
 
-impl IntoSovd for cda_interfaces::EcuVariant {
-    type SovdType = sovd_ecu::Variant;
-
-    fn into_sovd(self) -> Self::SovdType {
-        sovd_ecu::Variant {
-            name: self.name.unwrap_or("Unknown".to_string()),
-            is_base_variant: self.is_base_variant,
-            state: self.state.into_sovd(),
-            logical_address: format!("0x{:02x}", self.logical_address),
-        }
-    }
-}
-
 impl IntoSovd for cda_interfaces::EcuState {
     type SovdType = sovd_ecu::State;
 
     fn into_sovd(self) -> Self::SovdType {
-        match self {
-            cda_interfaces::EcuState::Online => sovd_ecu::State::Online,
-            cda_interfaces::EcuState::Offline => sovd_ecu::State::Offline,
-            cda_interfaces::EcuState::NotTested => sovd_ecu::State::NotTested,
-            cda_interfaces::EcuState::Duplicate => sovd_ecu::State::Duplicate,
-            cda_interfaces::EcuState::Disconnected => sovd_ecu::State::Disconnected,
-            cda_interfaces::EcuState::NoVariantDetected => sovd_ecu::State::NoVariantDetected,
+        match (&self.connectivity, &self.variant_state) {
+            (_, VariantState::Duplicate) => sovd_ecu::State::Duplicate,
+            (Connectivity::Online, VariantState::Detected { .. }) => sovd_ecu::State::Online,
+            (Connectivity::Online, VariantState::NotDetected) => sovd_ecu::State::NoVariantDetected,
+            (Connectivity::Online, VariantState::NotTested) => sovd_ecu::State::NotTested,
+            (Connectivity::Offline, VariantState::NotTested) => sovd_ecu::State::Offline,
+            (Connectivity::Offline, VariantState::Detected { .. } | VariantState::NotDetected) => {
+                sovd_ecu::State::Disconnected
+            }
         }
     }
 }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -31,6 +31,7 @@ sovd-interfaces = { workspace = true }
 cda-tracing = { workspace = true }
 cda-plugin-security = { workspace = true }
 cda-comm-doip = { workspace = true }
+cda-comm-uds = { workspace = true }
 cda-health = { workspace = true }
 opensovd_cda_lib = { workspace = true, features = ["integration-tests"] }
 

--- a/integration-tests/tests/sovd/custom_routes.rs
+++ b/integration-tests/tests/sovd/custom_routes.rs
@@ -16,8 +16,9 @@ use std::sync::Arc;
 use aide::axum::{ApiRouter, routing};
 use axum::{Json, http::StatusCode};
 use cda_comm_doip::config::DoipConfig;
+use cda_comm_uds::state_coordinator::EcuStateCoordinator;
 use cda_interfaces::{
-    FunctionalDescriptionConfig, HashMap, HashMapExtensions, UdsQuery,
+    EcuConnectivityHandler, FunctionalDescriptionConfig, HashMap, HashMapExtensions, UdsQuery,
     datatypes::{ComponentsConfig, FaultConfig},
 };
 use cda_sovd::{Locks, dynamic_router::DynamicRouter};
@@ -140,10 +141,15 @@ async fn test_custom_demo_endpoint() {
     let doip_socket =
         cda_comm_doip::create_udp_vir_socket(&doip_config.tester_address, doip_config.gateway_port)
             .expect("Failed to create DoIP socket");
+
+    let state_coordinator = EcuStateCoordinator::new(HashMap::new());
+    let connectivity_handler: Arc<dyn EcuConnectivityHandler> = Arc::new(state_coordinator.clone());
+
     let gateway = opensovd_cda_lib::create_diagnostic_gateway(
         Arc::clone(&databases),
         &doip_config,
         variant_tx,
+        connectivity_handler,
         shutdown_signal.clone(),
         None,
         Arc::new(tokio::sync::Mutex::new(doip_socket)),
@@ -155,6 +161,7 @@ async fn test_custom_demo_endpoint() {
         gateway,
         databases,
         variant_rx,
+        state_coordinator,
         &cda_interfaces::FunctionalDescriptionConfig {
             description_database: "functional_groups".to_owned(),
             enabled_functional_groups: None,

--- a/integration-tests/tests/sovd/ecu.rs
+++ b/integration-tests/tests/sovd/ecu.rs
@@ -355,6 +355,9 @@ async fn test_variant_detection_duplicates() {
     ecusim::switch_variant(&runtime.ecu_sim, "FLXC1000", "APPLICATION")
         .await
         .unwrap();
+    force_variant_detection(&runtime.config, &auth, sovd::ECU_FLXC1000_ENDPOINT)
+        .await
+        .unwrap();
     let ecu = ecu_status(&runtime.config, &auth, sovd::ECU_FLXC1000_ENDPOINT)
         .await
         .unwrap();


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
This PR aims to improve the handling of EcuState and decouple it from the ecumanager itself.
The core changes are:
 
#### Single flat EcuState enum (Online, Offline, NotTested, Duplicate, Disconnected, NoVariantDetected) decoupled into 
- Connectivity — Online | Offline (transport reachability)
- VariantState — NotTested | Detected{name,is_base,is_fallback} | Duplicate | NotDetected

-> On disconnect, only Connectivity flips to Offline. Variant identity is preserved — enabling reconnect without re-running detection from scratch.

#### Variant Detection is now triggered when trying to send data to ECU that had no variant detection running yet
Before every UDS send, transport.rs checks if variant is NotDetected or ECU is Offline+Detected. If so, and ECU is reachable, triggers synchronous detect_variant first.

#### After a non-TesterPresent UDS send times out, handle_ecu_disconnected is called immediately, transitioning ECU to Offline

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)