### PR TITLE
fix(diag-kernel): type compu-method results by the declared type

### DIFF
--- a/cda-core/src/diag_kernel/diagservices.rs
+++ b/cda-core/src/diag_kernel/diagservices.rs
@@ -58,6 +58,10 @@ pub struct DiagDataTypeContainerRaw {
     pub data: Vec<u8>,
     pub bit_len: usize,
     pub data_type: DataType,
+    /// Base type of the DOP's PHYSICAL-TYPE, when one is declared. Types the
+    /// result of a compu-method conversion; `data_type` (the coded type)
+    /// would truncate e.g. a linear scale factor of 1/16 back to an integer.
+    pub physical_data_type: Option<DataType>,
     pub compu_method: Option<datatypes::CompuMethod>,
 }
 
@@ -100,6 +104,7 @@ impl DiagServiceResponse for DiagServiceResponseStruct {
                     let raw = u8::from_be(*nrc.data.first()?);
                     let message = match operations::uds_data_to_serializable(
                         nrc.data_type,
+                        nrc.physical_data_type,
                         nrc.compu_method.as_ref(),
                         true,
                         &nrc.data,
@@ -270,6 +275,7 @@ impl DiagServiceResponseStruct {
                     DiagDataTypeContainer::RawContainer(raw) => {
                         operations::uds_data_to_serializable(
                             raw.data_type,
+                            raw.physical_data_type,
                             raw.compu_method.as_ref(),
                             false,
                             &raw.data,
@@ -349,6 +355,7 @@ impl DiagServiceResponseStruct {
         match data {
             DiagDataTypeContainer::RawContainer(raw) => Ok(operations::uds_data_to_serializable(
                 raw.data_type,
+                raw.physical_data_type,
                 raw.compu_method.as_ref(),
                 false,
                 &raw.data,

--- a/cda-core/src/diag_kernel/ecumanager.rs
+++ b/cda-core/src/diag_kernel/ecumanager.rs
@@ -739,6 +739,7 @@ mod tests {
                         data: vec![value],
                         bit_len: 8,
                         data_type: DataType::UInt32,
+                        physical_data_type: None,
                         compu_method: None,
                     }),
                 )

--- a/cda-core/src/diag_kernel/operations.rs
+++ b/cda-core/src/diag_kernel/operations.rs
@@ -31,6 +31,7 @@ use crate::diag_kernel::{
 
 pub(in crate::diag_kernel) fn uds_data_to_serializable(
     diag_type: datatypes::DataType,
+    physical_type: Option<datatypes::DataType>,
     compu_method: Option<&datatypes::CompuMethod>,
     is_negative_response: bool,
     data: &[u8],
@@ -47,6 +48,7 @@ pub(in crate::diag_kernel) fn uds_data_to_serializable(
                 category => {
                     return compu_lookup(
                         diag_type,
+                        physical_type,
                         compu_method,
                         category,
                         is_negative_response,
@@ -131,6 +133,7 @@ fn apply_linear_conversion(
 
 fn compu_lookup(
     diag_type: DataType,
+    physical_type: Option<DataType>,
     compu_method: &datatypes::CompuMethod,
     category: datatypes::CompuCategory,
     is_negative_response: bool,
@@ -152,11 +155,14 @@ fn compu_lookup(
     }) {
         Some(scale) => match category {
             datatypes::CompuCategory::Identical => unreachable!("Already handled"),
-            datatypes::CompuCategory::Linear => {
-                compu_lookup_linear(diag_type, compu_method, lookup, scale)
-            }
+            datatypes::CompuCategory::Linear => compu_lookup_linear(
+                physical_type.unwrap_or(diag_type),
+                compu_method,
+                lookup,
+                scale,
+            ),
             datatypes::CompuCategory::ScaleLinear => {
-                compu_lookup_scale_linear(diag_type, lookup, scale)
+                compu_lookup_scale_linear(physical_type.unwrap_or(diag_type), lookup, scale)
             }
             datatypes::CompuCategory::TextTable => compu_lookup_text_table(scale),
             datatypes::CompuCategory::CompuCode => Err(DiagServiceError::RequestNotSupported(
@@ -663,6 +669,7 @@ pub(in crate::diag_kernel) fn extract_diag_data_container(
     param_bit_pos: usize,
     payload: &mut Payload,
     diag_type: &datatypes::DiagCodedType,
+    physical_type: Option<datatypes::PhysicalType>,
     compu_method: Option<datatypes::CompuMethod>,
 ) -> Result<DiagDataTypeContainer, DiagServiceError> {
     let uds_payload = payload.data()?;
@@ -702,6 +709,7 @@ pub(in crate::diag_kernel) fn extract_diag_data_container(
             data,
             bit_len,
             data_type,
+            physical_data_type: physical_type.map(|pt| pt.base_type),
             compu_method,
         },
     ))
@@ -1710,8 +1718,13 @@ mod tests {
         };
 
         let data = 3u32.to_be_bytes();
-        let result =
-            super::uds_data_to_serializable(DataType::UInt32, Some(&compu_method), false, &data);
+        let result = super::uds_data_to_serializable(
+            DataType::UInt32,
+            None,
+            Some(&compu_method),
+            false,
+            &data,
+        );
         // Should fail because LINEAR has 2 scales instead of 1
         assert!(result.is_err());
         if let Err(e) = result {
@@ -1729,10 +1742,69 @@ mod tests {
         };
 
         let data = 3u32.to_be_bytes();
-        let result =
-            super::uds_data_to_serializable(DataType::UInt32, Some(&compu_method), false, &data);
+        let result = super::uds_data_to_serializable(
+            DataType::UInt32,
+            None,
+            Some(&compu_method),
+            false,
+            &data,
+        );
         // Should fail because value doesn't match any scale (no scales exist)
         assert!(result.is_err());
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn test_compu_linear_result_typed_by_physical_type() {
+        // A fractional linear scale (factor 1/16, as used by e.g. battery SOC
+        // parameters) with a declared float PHYSICAL-TYPE must preserve the
+        // fraction. Typing the result with the coded type instead would
+        // truncate 57.375 to 57 and silently discard resolution.
+        let compu_method = CompuMethod {
+            category: CompuCategory::Linear,
+            internal_to_phys: CompuFunction {
+                scales: vec![CompuScale {
+                    rational_coefficients: Some(CompuRationalCoefficients {
+                        numerator: vec![0.0, 1.0],
+                        denominator: vec![16.0],
+                    }),
+                    consts: None,
+                    lower_limit: None,
+                    upper_limit: None,
+                    inverse_values: None,
+                }],
+            },
+        };
+
+        let data = 918u32.to_be_bytes();
+
+        // Physical type declared as float: full resolution.
+        let result = super::uds_data_to_serializable(
+            DataType::UInt32,
+            Some(DataType::Float64),
+            Some(&compu_method),
+            false,
+            &data,
+        )
+        .expect("linear conversion with float physical type");
+        match result {
+            crate::diag_kernel::DiagDataValue::Float64(v) => assert_eq!(v, 57.375),
+            other => panic!("expected Float64, got {other:?}"),
+        }
+
+        // No physical type declared: fall back to the coded type (integer).
+        let result = super::uds_data_to_serializable(
+            DataType::UInt32,
+            None,
+            Some(&compu_method),
+            false,
+            &data,
+        )
+        .expect("linear conversion without physical type");
+        match result {
+            crate::diag_kernel::DiagDataValue::UInt32(v) => assert_eq!(v, 57),
+            other => panic!("expected UInt32, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1803,8 +1875,13 @@ mod tests {
         // First interval: [0, 2) -> f(x) = 1 + 2x
         // Forward: x=0 -> y=1
         let data = 0u32.to_be_bytes();
-        let result =
-            super::uds_data_to_serializable(DataType::UInt32, Some(&compu_method), false, &data);
+        let result = super::uds_data_to_serializable(
+            DataType::UInt32,
+            None,
+            Some(&compu_method),
+            false,
+            &data,
+        );
         assert!(result.is_ok());
         let value: f64 = result.unwrap().try_into().unwrap();
         assert_eq!(value, 1.0);
@@ -1829,8 +1906,13 @@ mod tests {
 
         // Forward: x=1 -> y=3
         let data = 1u32.to_be_bytes();
-        let result =
-            super::uds_data_to_serializable(DataType::UInt32, Some(&compu_method), false, &data);
+        let result = super::uds_data_to_serializable(
+            DataType::UInt32,
+            None,
+            Some(&compu_method),
+            false,
+            &data,
+        );
         assert!(result.is_ok());
         let value: f64 = result.unwrap().try_into().unwrap();
         assert_eq!(value, 3.0);
@@ -1850,8 +1932,13 @@ mod tests {
 
         // Forward: x=1.5 -> y=4
         let data = 1.5f32.to_be_bytes();
-        let result =
-            super::uds_data_to_serializable(DataType::Float32, Some(&compu_method), false, &data);
+        let result = super::uds_data_to_serializable(
+            DataType::Float32,
+            None,
+            Some(&compu_method),
+            false,
+            &data,
+        );
         assert!(result.is_ok());
         let value: f64 = result.unwrap().try_into().unwrap();
         assert_eq!(value, 4.0);
@@ -1872,8 +1959,13 @@ mod tests {
         // Second interval: [2, 5) -> f(x) = 3 + x
         // Forward: x=2 -> y=5 (boundary, CLOSED at 2)
         let data = 2u32.to_be_bytes();
-        let result =
-            super::uds_data_to_serializable(DataType::UInt32, Some(&compu_method), false, &data);
+        let result = super::uds_data_to_serializable(
+            DataType::UInt32,
+            None,
+            Some(&compu_method),
+            false,
+            &data,
+        );
         assert!(result.is_ok());
         let value: f64 = result.unwrap().try_into().unwrap();
         assert_eq!(value, 5.0);
@@ -1893,8 +1985,13 @@ mod tests {
 
         // Forward: x=3 -> y=6
         let data = 3u32.to_be_bytes();
-        let result =
-            super::uds_data_to_serializable(DataType::UInt32, Some(&compu_method), false, &data);
+        let result = super::uds_data_to_serializable(
+            DataType::UInt32,
+            None,
+            Some(&compu_method),
+            false,
+            &data,
+        );
         assert!(result.is_ok());
         let value: f64 = result.unwrap().try_into().unwrap();
         assert_eq!(value, 6.0);
@@ -1914,8 +2011,13 @@ mod tests {
 
         // Forward: x=4 -> y=7
         let data = 4u32.to_be_bytes();
-        let result =
-            super::uds_data_to_serializable(DataType::UInt32, Some(&compu_method), false, &data);
+        let result = super::uds_data_to_serializable(
+            DataType::UInt32,
+            None,
+            Some(&compu_method),
+            false,
+            &data,
+        );
         assert!(result.is_ok());
         let value: f64 = result.unwrap().try_into().unwrap();
         assert_eq!(value, 7.0);
@@ -1936,24 +2038,39 @@ mod tests {
         // Third interval: [5, infinity) -> f(x) = 8 (constant)
         // Forward: x=5 -> y=8 (boundary)
         let data = 5u32.to_be_bytes();
-        let result =
-            super::uds_data_to_serializable(DataType::UInt32, Some(&compu_method), false, &data);
+        let result = super::uds_data_to_serializable(
+            DataType::UInt32,
+            None,
+            Some(&compu_method),
+            false,
+            &data,
+        );
         assert!(result.is_ok());
         let value: f64 = result.unwrap().try_into().unwrap();
         assert_eq!(value, 8.0);
 
         // Forward: x=10 -> y=8 (constant)
         let data = 10u32.to_be_bytes();
-        let result =
-            super::uds_data_to_serializable(DataType::UInt32, Some(&compu_method), false, &data);
+        let result = super::uds_data_to_serializable(
+            DataType::UInt32,
+            None,
+            Some(&compu_method),
+            false,
+            &data,
+        );
         assert!(result.is_ok());
         let value: f64 = result.unwrap().try_into().unwrap();
         assert_eq!(value, 8.0);
 
         // Forward: x=100 -> y=8 (constant)
         let data = 100u32.to_be_bytes();
-        let result =
-            super::uds_data_to_serializable(DataType::UInt32, Some(&compu_method), false, &data);
+        let result = super::uds_data_to_serializable(
+            DataType::UInt32,
+            None,
+            Some(&compu_method),
+            false,
+            &data,
+        );
         assert!(result.is_ok());
         let value: f64 = result.unwrap().try_into().unwrap();
         assert_eq!(value, 8.0);
@@ -2023,16 +2140,26 @@ mod tests {
 
         // First interval: x=2, f(2) = (2 + 4*2) / 2 = 10 / 2 = 5
         let data = 2u32.to_be_bytes();
-        let result =
-            super::uds_data_to_serializable(DataType::UInt32, Some(&compu_method), false, &data);
+        let result = super::uds_data_to_serializable(
+            DataType::UInt32,
+            None,
+            Some(&compu_method),
+            false,
+            &data,
+        );
         assert!(result.is_ok());
         let value: f64 = result.unwrap().try_into().unwrap();
         assert_eq!(value, 5.0);
 
         // Second interval: x=6, f(6) = (50 + 10*6) / 5 = 110 / 5 = 22
         let data = 6u32.to_be_bytes();
-        let result =
-            super::uds_data_to_serializable(DataType::UInt32, Some(&compu_method), false, &data);
+        let result = super::uds_data_to_serializable(
+            DataType::UInt32,
+            None,
+            Some(&compu_method),
+            false,
+            &data,
+        );
         assert!(result.is_ok());
         let value: f64 = result.unwrap().try_into().unwrap();
         assert_eq!(value, 22.0);
@@ -2065,15 +2192,25 @@ mod tests {
 
         // x=5 is outside [10, 20] -> falls back to raw value (parsing continues)
         let data = 5u32.to_be_bytes();
-        let result =
-            super::uds_data_to_serializable(DataType::UInt32, Some(&compu_method), false, &data);
+        let result = super::uds_data_to_serializable(
+            DataType::UInt32,
+            None,
+            Some(&compu_method),
+            false,
+            &data,
+        );
         let raw: u32 = result.unwrap().try_into().unwrap();
         assert_eq!(raw, 5);
 
         // x=25 is outside [10, 20] -> falls back to raw value (parsing continues)
         let data = 25u32.to_be_bytes();
-        let result =
-            super::uds_data_to_serializable(DataType::UInt32, Some(&compu_method), false, &data);
+        let result = super::uds_data_to_serializable(
+            DataType::UInt32,
+            None,
+            Some(&compu_method),
+            false,
+            &data,
+        );
         let raw: u32 = result.unwrap().try_into().unwrap();
         assert_eq!(raw, 25);
     }
@@ -2172,7 +2309,8 @@ mod tests {
 
         let data: [u8; 0] = [];
         let mut payload = Payload::new(&data);
-        let res = extract_diag_data_container(Some("test_param"), 0, 0, &mut payload, &dct, None);
+        let res =
+            extract_diag_data_container(Some("test_param"), 0, 0, &mut payload, &dct, None, None);
         assert!(
             res.is_ok(),
             "MinMaxLengthType with min_length 0 should be no error"
@@ -2182,7 +2320,15 @@ mod tests {
             create_diag_coded_type_minmax(DataType::ByteField, 1, Some(1), Termination::EndOfPdu);
         let mut payload = Payload::new(&data);
         let res: Result<crate::DiagDataTypeContainer, cda_interfaces::DiagServiceError> =
-            extract_diag_data_container(Some("test_param"), 0, 0, &mut payload, &dct_min1, None);
+            extract_diag_data_container(
+                Some("test_param"),
+                0,
+                0,
+                &mut payload,
+                &dct_min1,
+                None,
+                None,
+            );
         // the param is at or beyond the payload boundary, so it is treated as absent and optional
         // regardless of min_length.
         assert!(
@@ -2193,8 +2339,15 @@ mod tests {
         // But if there IS data and it's shorter than min_length, that should still error.
         let short_data: [u8; 0] = [];
         let mut payload = Payload::new(&short_data);
-        let res =
-            extract_diag_data_container(Some("test_param"), 0, 0, &mut payload, &dct_min1, None);
+        let res = extract_diag_data_container(
+            Some("test_param"),
+            0,
+            0,
+            &mut payload,
+            &dct_min1,
+            None,
+            None,
+        );
         assert!(res.is_ok(), "Boundary param is absent, not an error");
     }
 

--- a/cda-core/src/diag_kernel/payload_decode.rs
+++ b/cda-core/src/diag_kernel/payload_decode.rs
@@ -558,6 +558,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     param_ctx.parameter.bit_position() as usize,
                     uds_payload,
                     &diag_type,
+                    normal_dop.physical_type().map(Into::into),
                     None,
                 )?;
 
@@ -794,6 +795,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
             Some(DiagDataTypeContainer::RawContainer(raw)) => {
                 let phys_val = operations::uds_data_to_serializable(
                     raw.data_type,
+                    None,
                     raw.compu_method.as_ref(),
                     false,
                     &raw.data,
@@ -828,6 +830,9 @@ impl<S: SecurityPlugin> EcuManager<S> {
         let compu_method: Option<datatypes::CompuMethod> =
             normal_dop.compu_method().map(Into::into);
         let data_type = diag_coded_type.base_datatype();
+        let physical_data_type = normal_dop
+            .physical_type()
+            .map(|pt| datatypes::PhysicalType::from(pt).base_type);
 
         if byte_count == 0 {
             tracing::debug!(
@@ -840,6 +845,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     data: vec![],
                     bit_len: 0,
                     data_type,
+                    physical_data_type,
                     compu_method,
                 }),
             );
@@ -863,6 +869,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 data: decoded_bytes,
                 bit_len,
                 data_type,
+                physical_data_type,
                 compu_method,
             }),
         );
@@ -923,7 +930,8 @@ impl<S: SecurityPlugin> EcuManager<S> {
 
         let num_items_diag_val = operations::uds_data_to_serializable(
             datatypes::DataType::UInt32, // Using hard coded UInt32 as per ISO 22901-1:2008
-            None,                        // Also according per spec, no compu method defined.
+            None,
+            None, // Also according per spec, no compu method defined.
             false,
             &num_items_data,
         )?;
@@ -1131,6 +1139,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
             Some(DiagDataTypeContainer::RawContainer(raw)) => {
                 let val = operations::uds_data_to_serializable(
                     raw.data_type,
+                    None,
                     raw.compu_method.as_ref(),
                     false,
                     &raw.data,
@@ -1362,6 +1371,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 param_ctx.parameter.bit_position() as usize,
                 uds_payload,
                 &diag_coded_type,
+                normal_dop.physical_type().map(Into::into),
                 Some(compu_method),
             )?,
         );
@@ -1408,6 +1418,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
 
                 let switch_key_value = operations::uds_data_to_serializable(
                     switch_key_diag_type.base_datatype(),
+                    None,
                     normal_dop.compu_method().map(Into::into).as_ref(),
                     false,
                     &switch_key_data,
@@ -1420,6 +1431,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                         data: switch_key_data.clone(),
                         data_type: switch_key_diag_type.base_datatype(),
                         bit_len,
+                        physical_data_type: None,
                         compu_method: None,
                     }),
                 );
@@ -1516,6 +1528,7 @@ fn map_param_reserved_from_uds(
             data: param_data,
             bit_len,
             data_type: datatypes::DataType::UInt32,
+            physical_data_type: None,
             compu_method: None,
         }),
     );
@@ -1546,6 +1559,7 @@ fn map_param_coded_const_from_uds(
         param_ctx.parameter.bit_position() as usize,
         uds_payload,
         &diag_type,
+        None,
         None,
     )?;
 

--- a/cda-core/src/diag_kernel/payload_encode.rs
+++ b/cda-core/src/diag_kernel/payload_encode.rs
@@ -568,6 +568,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                         let selector = operations::uds_data_to_serializable(
                             switch_key_diag_type.base_datatype(),
                             None,
+                            None,
                             false,
                             &mux_payload,
                         )?;

--- a/cda-core/src/diag_kernel/schema.rs
+++ b/cda-core/src/diag_kernel/schema.rs
@@ -391,7 +391,15 @@ fn normal_dop_to_schema(
                     "Mapping {ctx}: Diag Coded Type not found in ECU database"
                 )));
             };
-            let type_ = ecu_datatype_to_jsontype(datatype.base_datatype());
+            // Values are exposed in their physical representation, so the
+            // schema type follows the declared PHYSICAL-TYPE where present
+            // (e.g. a linear scale of 1/16 turns an integer coded type into
+            // a float physical value); the coded type is the fallback.
+            let json_datatype = normal_dop.physical_type().map_or_else(
+                || datatype.base_datatype(),
+                |pt| datatypes::PhysicalType::from(pt).base_type,
+            );
+            let type_ = ecu_datatype_to_jsontype(json_datatype);
 
             let mut param_schema = schemars::json_schema!({
                 "default": default_value,


### PR DESCRIPTION
A DOP's DIAG-CODED-TYPE describes the raw bytes on the wire; the value produced by its compu method is described by the PHYSICAL-TYPE. The decode path dropped the physical type entirely and typed conversion results with the coded type, so every linear/scale-linear parameter with a fractional factor lost its fraction: a battery SOC coded as 16-bit unsigned with factor 1/16 and a float physical type decoded to 56 instead of 56.8125. The encode path already used the physical type; decode now carries it through DiagDataTypeContainerRaw and uses it to type linear and scale-linear results, falling back to the coded type when the MDD declares no physical type - databases that genuinely declare integer physical values keep integer results.

The JSON schema generation had the same flaw and reported such parameters as "integer"; it now derives the schema type from the physical type where declared.

Verified against a real BMS over CAN: SOC_Value now returns 56.8125 where a reference implementation reading the same DID computes 56.81 (raw 909 / 16); previously CDA returned 56.

## Summary

I was surprised to see the State of Charge returned by the CDA on my Smart EQ to truncate to integers while my handcrafted python script returned higher resolution. This is a change stemming from PR #323 but since it's not directly related to canbus, i've extracted it to here.

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated documentation (there isn't really any documentation as this is simply a bug)
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests
<-- this could been done, but it's also not smth that _has_ been tested before properly.

## Related
I don't think there is any open issue

## Notes for Reviewers
