### PR TITLE
fix(cda-core): return 400 on truncated ECU positive response

### DIFF
--- a/cda-core/src/diag_kernel/operations.rs
+++ b/cda-core/src/diag_kernel/operations.rs
@@ -677,30 +677,43 @@ pub(in crate::diag_kernel) fn extract_diag_data_container(
 ) -> Result<DiagDataTypeContainer, DiagServiceError> {
     let uds_payload = payload.data()?;
 
-    // When the parameter position is at or beyond the payload boundary, treat
-    // it as absent (trailing field past end-of-PDU). Catch decode errors at
-    // that boundary and return empty data instead of propagating NotEnoughData.
+    // For MinMaxLength parameters, silently treat a boundary-position failure as an absent
+    // field: if the start position is at or beyond the payload end, the field is simply not
+    // present in this PDU. Fixed-size (StandardLength) parameters do not get this treatment.
+    // If their position is beyond the payload end, the ECU sent a malformed response.
+    let is_variable_length_at_boundary =
+        matches!(diag_type.type_(), DiagCodedTypeVariant::MinMaxLength(_))
+            && param_byte_pos >= uds_payload.len();
+
     let (data, bit_len) = match diag_type.decode(uds_payload, param_byte_pos, param_bit_pos) {
         Ok(result) => result,
-        Err(_) if param_byte_pos >= uds_payload.len() => (vec![], 0),
+        Err(_) if is_variable_length_at_boundary => (vec![], 0),
         Err(e) => return Err(e),
     };
 
+    // A parameter is optional when either:
+    //   - its type declares a minimum length of zero (MinMaxLength with min_length == 0), or
+    //   - it is a variable-length field at boundary position (absent from this PDU, see above).
+    //
+    // Fixed-size parameters at boundary are NOT optional: a positive UDS response that is
+    // too short to contain a required field is a malformed payload and must surface as an
+    // error rather than silently returning empty data (which would produce 204 No Content).
     let is_optional = match diag_type.type_() {
-        DiagCodedTypeVariant::MinMaxLength(MinMaxLengthType { min_length, .. }) => *min_length == 0,
+        DiagCodedTypeVariant::MinMaxLength(MinMaxLengthType { min_length, .. }) => {
+            *min_length == 0 || param_byte_pos >= uds_payload.len()
+        }
         _ => false,
-    } || param_byte_pos >= uds_payload.len();
+    };
     if data.is_empty() && !is_optional {
-        // at least 1 byte expected, we are using NotEnoughData error here, because
-        // this might happen when parsing end of pdu and leftover bytes can be ignored
         tracing::debug!(
-            "Not enough Data for parameter {:?} in extract_diag_data_container, expected at least \
-             1 byte",
-            param_short_name
+            "Not enough data for parameter {:?} in extract_diag_data_container, expected at least \
+             1 byte, payload length {}",
+            param_short_name,
+            uds_payload.len(),
         );
         return Err(DiagServiceError::NotEnoughData {
-            expected: 1,
-            actual: 0,
+            expected: param_byte_pos.saturating_add(1),
+            actual: uds_payload.len(),
         });
     }
 

--- a/cda-core/src/diag_kernel/payload_decode.rs
+++ b/cda-core/src/diag_kernel/payload_decode.rs
@@ -956,13 +956,21 @@ impl<S: SecurityPlugin> EcuManager<S> {
         let mut start = 0usize;
 
         for _ in 0..num_items {
-            let (item_data, item_size) = self.decode_dynamic_length_field_item(
+            let (item_data, item_size) = match self.decode_dynamic_length_field_item(
                 mapped_service,
                 uds_payload,
                 data,
                 &repeated_dop,
                 start,
-            )?;
+            ) {
+                Ok(result) => result,
+                Err(DiagServiceError::NotEnoughData { .. }) => {
+                    // ECU sent fewer bytes than the item count implied; treat as end of list.
+                    tracing::warn!("Not enough data for next DynamicLengthField item, truncating");
+                    break;
+                }
+                Err(e) => return Err(e),
+            };
             tracing::debug!(
                 item_index = repeated_data.len(),
                 item_size,
@@ -1468,12 +1476,23 @@ impl<S: SecurityPlugin> EcuManager<S> {
                     // to last_read_byte_pos; it must be 0 (start of case data)
                     // rather than stale from a previous context.
                     uds_payload.set_last_read_byte_pos(0);
-                    let case_data = self.map_struct_from_uds(
+                    let case_data = match self.map_struct_from_uds(
                         &case_structure,
                         mapped_service,
                         uds_payload,
                         data,
-                    )?;
+                    ) {
+                        Ok(d) => d,
+                        Err(DiagServiceError::NotEnoughData { .. }) => {
+                            // ECU payload is too short to contain the case structure;
+                            // treat as absent (no case data decoded).
+                            tracing::warn!(
+                                "Not enough data to decode mux case structure, treating as empty"
+                            );
+                            HashMap::default()
+                        }
+                        Err(e) => return Err(e),
+                    };
                     uds_payload.pop_slice()?;
                     mux_data.insert(case_name, DiagDataTypeContainer::Struct(case_data));
                 }

--- a/cda-sovd/src/sovd/error.rs
+++ b/cda-sovd/src/sovd/error.rs
@@ -92,13 +92,15 @@ impl From<DiagServiceError> for ApiError {
             | DiagServiceError::ConnectionClosed(_)
             | DiagServiceError::SendFailed(_)
             | DiagServiceError::InvalidAddress(_)
-            | DiagServiceError::NotEnoughData { .. }
             | DiagServiceError::UnexpectedResponse(_)
             | DiagServiceError::DataError(_)
             | DiagServiceError::InvalidConfiguration(_)
             | DiagServiceError::InvalidSecurityPlugin => {
                 ApiError::InternalServerError(Some(value.to_string()))
             }
+            DiagServiceError::NotEnoughData { expected, actual } => ApiError::BadRequest(format!(
+                "Payload too short, expected at least {expected} bytes, got {actual} bytes"
+            )),
             DiagServiceError::InvalidRequest(_)
             | DiagServiceError::Nack(_)
             | DiagServiceError::ParameterConversionError(_)

--- a/integration-tests/tests/sovd/data.rs
+++ b/integration-tests/tests/sovd/data.rs
@@ -82,10 +82,78 @@ async fn test_wrong_did_in_response_returns_504() {
     cleanup(&runtime.ecu_sim).await;
 }
 
+/// Tests that CDA returns an error response when an ECU replies with a positive
+/// `ReadDataByIdentifier` response that is too short to contain the expected data.
+///
+/// According to ISO 14229-1, a `ReadDataByIdentifier` positive response (`0x62`) must
+/// include the DID echo bytes followed by the actual data record. If the ECU sends only
+/// the SID and DID bytes (3 bytes total) without any data payload, CDA must return an
+/// error indicating the payload was too short.
+///
+/// This test verifies that CDA correctly detects the truncated response and returns
+/// HTTP 400 Bad Request.
+#[tokio::test]
+async fn test_short_ecu_response_returns_error() {
+    let (runtime, _lock) = setup_integration_test(true).await.unwrap();
+
+    let cleanup_sim = runtime.ecu_sim.clone();
+    hook_cleanup(move || {
+        let sim = cleanup_sim.clone();
+        async move { cleanup_truncated(&sim).await }
+    });
+
+    let auth = auth_header(&runtime.config, None).await.unwrap();
+
+    // Install a raw response override on FLXC1000:
+    // When the ECU receives ReadDataByIdentifier for DID 0xF200 (FluxCapacitorPowerConsumption),
+    // respond with correct SID+DID bytes only, no data payload.
+    //
+    // Normal request:  22 F2 00  (ReadDataByIdentifier, DID=0xF200)
+    // Normal response: 62 F2 00 <4 data bytes>  (INT32 power consumption value)
+    // Override response: 62 F2 00  (correct SID+DID, but missing the 4 data bytes)
+    ecusim::set_interceptor(
+        &runtime.ecu_sim,
+        "FLXC1000",
+        "truncated_response",
+        "22f200",
+        "62f200",
+    )
+    .await
+    .expect("Failed to install interceptor");
+
+    // Attempt to read the FluxCapacitorPowerConsumption data from FLXC1000.
+    // CDA should detect the truncated payload and return an error, not 204 No Content.
+    let result = send_cda_request(
+        &runtime.config,
+        "components/flxc1000/data/fluxcapacitorpowerconsumption",
+        StatusCode::BAD_REQUEST,
+        Method::GET,
+        None,
+        Some(&auth),
+        None,
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "Expected 400 Bad Request when ECU responds with truncated payload, got: {result:?}"
+    );
+
+    cleanup_truncated(&runtime.ecu_sim).await;
+}
+
 async fn cleanup(ecu_sim: &EcuSim) {
     // Clean up: remove the interceptor so other tests are not affected.
     // Cannot use panic, in a panic handler, hence have to resort to eprintln
     if let Err(e) = ecusim::clear_interceptor(ecu_sim, "FLXC1000", "did_mismatch").await {
         eprintln!("Failed to clear raw response override: {e}");
+    }
+}
+
+async fn cleanup_truncated(ecu_sim: &EcuSim) {
+    // Clean up: remove the interceptor so other tests are not affected.
+    // Cannot use panic, in a panic handler, hence have to resort to eprintln
+    if let Err(e) = ecusim::clear_interceptor(ecu_sim, "FLXC1000", "truncated_response").await {
+        eprintln!("Failed to clear truncated response interceptor: {e}");
     }
 }


### PR DESCRIPTION
StandardLength params at the payload boundary silently yielded empty data, masking NotEnoughData -> raw_uds_payload empty -> 204 No Content.

- Propagate NotEnoughData for fixed-size params at boundary; silence only MinMaxLength (variable-length) types
- Map NotEnoughData to 400 Bad Request with "Payload too short" message
- DLF and mux case struct decode break gracefully on NotEnoughData (mirrors existing map_end_of_pdu_dop_from_uds behavior)

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
Fixes a bug where the CDA returns `204 No Content` instead of `400 Bad Request` when an ECU responds with a truncated positive UDS message, for example valid SID + DID header but no data bytes for the expected parameter.

Added test_short_ecu_response_returns_error: uses the FLXC1000 ECU sim to intercept ReadDataByIdentifier for FluxCapacitorPowerConsumption (DID 0xF200, expects 4-byte INT32) and inject a 3-byte truncated response 62 F2 00. Asserts HTTP 400.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)