### PR TITLE
ci: add conventional-commits workflow

### DIFF
--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Conventional Commits
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-commits:
+    uses: eclipse-opensovd/cicd-workflows/.github/workflows/conventional-commits.yml@07140bdd84f20b66fd4aff58a83c5148deec388c


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Re-use reusable workflow from eclipse-opensovd/cicd-workflows#40 to validate PR titles and commit subjects on every pull request. The workflow delegates entirely to the shared `conventional-commits.yml` reusable workflow, keeping enforcement logic centralised.

Split from #334.

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

- Splits #334
- eclipse-opensovd/cicd-workflows#40

## Notes for Reviewers

This is a thin wrapper — the only project-specific choice is the `pull-requests: read` permission required by the reusable workflow.

---
Alexander Mohr <alexander.m.mohr@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)