### PR TITLE
fix (ci): set lcov-merged.info as input for crap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,6 +258,7 @@ jobs:
       rust-version: "1.88.0"
       cargo-crap-git-url: "https://github.com/theswiftfox/cargo-crap.git"
       cargo-crap-git-rev: "27bab7d86c0ff9c4f8f681d6538be24572ca1a8d"
+      lcov-file: "lcov-merged.info"
       post-pr-comment: true
       fail-regressions: false
     permissions:

--- a/.github/workflows/crap-baseline.yml
+++ b/.github/workflows/crap-baseline.yml
@@ -28,6 +28,7 @@ jobs:
       rust-version: "1.88.0"
       cargo-crap-git-url: "https://github.com/theswiftfox/cargo-crap.git"
       cargo-crap-git-rev: "27bab7d86c0ff9c4f8f681d6538be24572ca1a8d"
+      lcov-file: "lcov-merged.info"
     permissions:
       contents: write
       actions: read


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

Fixes the failing crap jobs by setting the new name for the created lcov file.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
