### PR TITLE
ci(labels): add ready to merge label when PR is approved

### DIFF
--- a/.github/workflows/pr-label-review-state.yml
+++ b/.github/workflows/pr-label-review-state.yml
@@ -41,6 +41,7 @@ jobs:
 
             const NEEDS_REVIEW = 'needs review';
             const CHANGES_REQUESTED = 'changes requested';
+            const READY_TO_MERGE = 'ready to merge';
 
             async function addLabel(label) {
               try {
@@ -80,14 +81,14 @@ jobs:
 
             const latestByReviewer = {};
             for (const review of reviews) {
-              if (review.state === 'COMMENTED') continue;
+              if (review.state === 'COMMENTED' || review.state === 'DISMISSED') continue;
               latestByReviewer[review.user.login] = review.state;
             }
 
             const states = Object.values(latestByReviewer);
             const hasChangesRequested = states.includes('CHANGES_REQUESTED');
             const allApproved = states.length > 0
-              && states.every(s => s === 'APPROVED' || s === 'DISMISSED');
+              && states.every(s => s === 'APPROVED');
 
             const { repository } = await github.graphql(`
               query($owner: String!, $repo: String!, $pr: Int!) {
@@ -134,6 +135,7 @@ jobs:
               core.info('PR is a draft, removing review labels.');
               await removeLabel(NEEDS_REVIEW);
               await removeLabel(CHANGES_REQUESTED);
+              await removeLabel(READY_TO_MERGE);
               return;
             }
 
@@ -144,25 +146,31 @@ jobs:
                 && context.payload.review.state === 'changes_requested') {
               await addLabel(CHANGES_REQUESTED);
               await removeLabel(NEEDS_REVIEW);
+              await removeLabel(READY_TO_MERGE);
 
             } else if (allApproved && !hasUnresolvedThreads) {
+              await addLabel(READY_TO_MERGE);
               await removeLabel(NEEDS_REVIEW);
               await removeLabel(CHANGES_REQUESTED);
 
             } else if (eventName === 'pull_request_target' && action === 'synchronize') {
               await addLabel(NEEDS_REVIEW);
               await removeLabel(CHANGES_REQUESTED);
+              await removeLabel(READY_TO_MERGE);
 
             } else if (hasUnresolvedThreads && authorRepliedToAll) {
               // Author replied to every reviewer thread - ready for re-review
               await addLabel(NEEDS_REVIEW);
               await removeLabel(CHANGES_REQUESTED);
+              await removeLabel(READY_TO_MERGE);
 
             } else if (hasUnresolvedThreads) {
               await addLabel(CHANGES_REQUESTED);
               await removeLabel(NEEDS_REVIEW);
+              await removeLabel(READY_TO_MERGE);
 
             } else {
               await addLabel(NEEDS_REVIEW);
               await removeLabel(CHANGES_REQUESTED);
+              await removeLabel(READY_TO_MERGE);
             }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Adds `ready to merge` label handling to the PR review state label workflow:

- Adds `ready to merge` label when all reviewers approve and all review threads are resolved
- Removes `ready to merge` on any regression (new commits, changes requested, unresolved threads, draft conversion)
- Excludes DISMISSED reviews from the approval tally (dismissed approvals no longer count toward all-approved state)

## Checklist

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

## Notes for Reviewers

---
Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)