### PR TITLE
fix(diag_kernel): use basevariant for service info as fallback

### DIFF
--- a/cda-core/src/diag_kernel/component_info.rs
+++ b/cda-core/src/diag_kernel/component_info.rs
@@ -678,7 +678,9 @@ mod tests {
         DataType,
         database_builder::{DiagClassType, DiagCommParams, DiagLayerParams, EcuDataBuilder},
     };
-    use cda_interfaces::{DiagComm, DiagCommType, Protocol};
+    use cda_interfaces::{
+        Connectivity, DiagComm, DiagCommType, Protocol, VariantState, util::std_ext,
+    };
     use cda_plugin_security::DefaultSecurityPluginData;
 
     use super::*;
@@ -1267,6 +1269,39 @@ mod tests {
         assert!(
             result.is_empty(),
             "Expected no operations for non-routine-control DB"
+        );
+    }
+
+    /// Verify that `get_components_operations_info` returns the base-variant services even when
+    /// no specific variant has been detected yet (i.e. `variant_index` is `None`).
+    #[test]
+    fn test_get_components_operations_info_falls_back_to_base_variant_when_not_tested() {
+        let ecu_manager = build_ecu_manager_with_routine_subfunctions(
+            "MyRoutine",
+            &[subfunction_ids::routine::START],
+        );
+
+        // Simulate the ECU state immediately after startup: variant detection has never run.
+        {
+            let mut ecu_state = std_ext::lock_write(&ecu_manager.runtime_state.ecu_state);
+            ecu_state.connectivity = Connectivity::Offline;
+            ecu_state.variant_state = VariantState::NotTested;
+            ecu_state.variant_index = None;
+        }
+
+        let result = ecu_manager.get_components_operations_info(&skip_sec_plugin!());
+
+        assert_eq!(
+            result.len(),
+            1,
+            "Expected one operation from base variant even though variant is not yet detected"
+        );
+        let op = result.first().expect("Expected at least one operation");
+        assert_eq!(op.id, "MyRoutine");
+        assert!(!op.has_stop, "Expected has_stop = false");
+        assert!(
+            !op.has_request_results,
+            "Expected has_request_results = false"
         );
     }
 

--- a/cda-core/src/diag_kernel/service_lookup.rs
+++ b/cda-core/src/diag_kernel/service_lookup.rs
@@ -314,8 +314,10 @@ impl<S: SecurityPlugin> EcuManager<S> {
     }
 
     /// Retrieves diagnostic services from the current variants `DiagLayer` and its parent
-    /// references, filtered by the provided predicate. Returns an empty vector if no variant
-    /// is set.
+    /// references, filtered by the provided predicate. Falls back to the base variant when no
+    /// specific variant has been detected yet (e.g. before first UDS contact with the ECU or
+    /// while the ECU is offline), so that info-listing endpoints return meaningful data
+    /// regardless of the current connectivity or detection state.
     ///
     /// # Example
     ///
@@ -337,6 +339,9 @@ impl<S: SecurityPlugin> EcuManager<S> {
         F: Fn(&datatypes::DiagService) -> bool,
     {
         self.variant()
+            // This is necessary, so we are able to lookup services
+            // _before_ a variant has been found i.e. for variant detection.
+            .or_else(|| self.diag_database.base_variant().ok())
             .and_then(|v| v.diag_layer().map(|dl| (dl, v.parent_refs())))
             .map_or(<_>::default(), |(diag_layer, parent_refs)| {
                 Self::get_services_from_diag_layer_and_parent_refs(
@@ -408,8 +413,10 @@ impl<S: SecurityPlugin> EcuManager<S> {
     }
 
     /// Retrieves single ECU jobs from the current variants `DiagLayer` and its parent
-    /// references, filtered by the provided predicate. Returns an empty vector if no variant
-    /// is set.
+    /// references, filtered by the provided predicate. Falls back to the base variant when no
+    /// specific variant has been detected yet (e.g. before first UDS contact with the ECU or
+    /// while the ECU is offline), so that info-listing endpoints return meaningful data
+    /// regardless of the current connectivity or detection state.
     ///
     /// # Example
     ///
@@ -426,6 +433,9 @@ impl<S: SecurityPlugin> EcuManager<S> {
         F: Fn(&datatypes::SingleEcuJob) -> bool,
     {
         self.variant()
+            // This is necessary, so we are able to lookup services
+            // _before_ a variant has been found i.e. for variant detection.
+            .or_else(|| self.diag_database.base_variant().ok())
             .and_then(|v| v.diag_layer().map(|dl| (dl, v.parent_refs())))
             .map_or(<_>::default(), |(diag_layer, parent_refs)| {
                 Self::get_single_ecu_jobs_from_diag_layer_and_parent_refs(
@@ -583,7 +593,10 @@ impl<S: SecurityPlugin> EcuManager<S> {
     /// Collects all `DiagLayers` from the current variant and its parent references.
     /// The variants own `DiagLayer` is placed first to give it higher priority in
     /// subsequent operations, followed by layers resolved recursively from parent references.
-    /// Returns an empty vector if no variant is set.
+    /// Falls back to the base variant when no specific variant has been detected yet
+    /// (e.g. before first UDS contact with the ECU or while the ECU is offline), so that
+    /// info-listing endpoints return meaningful data regardless of the current connectivity
+    /// or detection state.
     ///
     /// # Example
     ///
@@ -598,7 +611,12 @@ impl<S: SecurityPlugin> EcuManager<S> {
     pub(in crate::diag_kernel) fn get_diag_layers_from_variant_and_parent_refs(
         &self,
     ) -> Vec<datatypes::DiagLayer<'_>> {
-        let Some(variant) = self.variant() else {
+        let Some(variant) = self
+            .variant()
+            // This is necessary, so we are able to lookup services
+            // _before_ a variant has been found i.e. for variant detection.
+            .or_else(|| self.diag_database.base_variant().ok())
+        else {
             return Vec::new();
         };
 

--- a/integration-tests/tests/sovd/operations.rs
+++ b/integration-tests/tests/sovd/operations.rs
@@ -785,3 +785,54 @@ async fn test_functional_operation_lifecycle_no_request_results() {
 
     release_fg_lock(runtime, &auth, &lock_id).await;
 }
+
+/// Verify that GET `{ecu}/operations/{op}` returns 200 OK with the correct operation info even
+/// when the ECU has never been contacted (variant is in the initial `NotTested` state).
+#[tokio::test]
+async fn test_get_operation_info_before_variant_detection() {
+    let (runtime, _lock) = setup_integration_test(true).await.unwrap();
+    let auth = auth_header(&runtime.config, None).await.unwrap();
+    let ecu_endpoint = sovd::ECU_FLXC1000_ENDPOINT;
+
+    // Use ecusim recording to prove no UDS frame is sent for a pure info GET.
+    ecusim::start_recording(&runtime.ecu_sim, "flxc1000")
+        .await
+        .unwrap();
+
+    let response = send_cda_request(
+        &runtime.config,
+        &format!("{ecu_endpoint}/operations/selftest"),
+        StatusCode::OK,
+        Method::GET,
+        None,
+        Some(&auth),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let frames = ecusim::stop_and_clear_recording(&runtime.ecu_sim, "flxc1000")
+        .await
+        .unwrap();
+    assert!(
+        frames.is_empty(),
+        "Expected no UDS frames for a pure info GET, but got: {frames:?}"
+    );
+
+    let list: Items<OperationCollectionItem> = response_to_t(&response).unwrap();
+    assert_eq!(list.items.len(), 1, "Expected exactly one item in response");
+    let op = list.items.first().expect("Expected one operation item");
+    assert!(
+        op.id.eq_ignore_ascii_case("selftest"),
+        "Expected id 'selftest', got: {}",
+        op.id
+    );
+    assert!(
+        !op.asynchronous_execution,
+        "selftest should not be asynchronous (no Stop or RequestResults)"
+    );
+    assert!(
+        !op.proximity_proof_required,
+        "selftest should not require proximity proof"
+    );
+}


### PR DESCRIPTION
Service-lookup functions returned empty results when the ECU's diagnostic variant hadn't been detected yet (e.g. before any UDS traffic), causing SOVD info endpoints (operations/data/configurations/single-ecu-jobs) to 404 even though default routine/data info should be available.

Add base-variant fallback (self.diag_database.base_variant()) to get_services_from_variant_and_parent_refs, get_single_ecu_jobs_from_variant_and_parent_refs, and get_diag_layers_from_variant_and_parent_refs, matching the pattern already used by search_with_location, get_service_by_location, and get_variant_parent_ref_services.

Add unit test covering the not-tested variant case and an integration test verifying GET /operations/{op} returns 200 with correct info before any UDS communication occurs.

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)