### PR TITLE
fix(storage): resolve mixed-case filenames consistently across Collection ops & nextupdate behavior

### DIFF
--- a/cda-plugin-runtime-update/src/storage.rs
+++ b/cda-plugin-runtime-update/src/storage.rs
@@ -189,12 +189,15 @@ pub(crate) async fn list_backup_files(
 
 /// Remove a file from the next-update snapshot for the relevant collection.
 ///
-/// The `NextUpdate` collection must already be initialized (i.e. at least one file has been
-/// uploaded). If it is not initialized, [`RuntimeUpdateError::FileNotFound`] is returned.
-/// Returns [`RuntimeUpdateError::FileNotFound`]
-/// if the key does not exist in the `NextUpdate` collection.
+/// If the `NextUpdate` collection isn't initialized yet (i.e. no file has been uploaded for that
+/// category), it is lazily initialized from the corresponding current collection first, so that
+/// files which are only part of `runtimefiles-current` can still be deleted from the pending
+/// next-update state.
+///
+/// Returns [`RuntimeUpdateError::FileNotFound`] if the key does not exist in the `NextUpdate`
+/// collection (nor, when freshly initialized, in the current collection).
 pub(crate) async fn delete_nextupdate_file(
-    storage: &impl Storage,
+    storage: &(impl Storage + 'static),
     file_id: &str,
 ) -> Result<(), RuntimeUpdateError> {
     let key = file_id.to_lowercase();
@@ -204,21 +207,42 @@ pub(crate) async fn delete_nextupdate_file(
         .and_then(|e| e.to_str())
         .map(str::to_lowercase);
 
-    let next_collection_name = match ext.as_deref() {
-        Some("mdd") => CollectionName::DiagnosticDatabaseNextUpdate,
-        Some("toml") => CollectionName::ConfigurationNextUpdate,
+    let (next_collection_name, current_collection_name) = match ext.as_deref() {
+        Some("mdd") => (
+            CollectionName::DiagnosticDatabaseNextUpdate,
+            CollectionName::DiagnosticDatabase,
+        ),
+        Some("toml") => (
+            CollectionName::ConfigurationNextUpdate,
+            CollectionName::Configuration,
+        ),
         _ => return Err(RuntimeUpdateError::InvalidFileType(file_id.to_string())),
     };
 
+    let next_already_exists = match storage.get_collection(&next_collection_name).await {
+        Ok(_) => true,
+        Err(StorageError::CollectionNotFound(_)) => false,
+        Err(e) => return Err(RuntimeUpdateError::from(e)),
+    };
+
+    if !next_already_exists {
+        let mut tx = storage.begin_transaction()?;
+        let mut initialized = false;
+        init_collection_from_copy_if_missing(
+            storage,
+            &mut tx,
+            next_already_exists,
+            &mut initialized,
+            &current_collection_name,
+            &next_collection_name,
+        )
+        .await?;
+        tx.commit().await?;
+    }
+
     let next_col = storage
-        .get_collection(&next_collection_name)
-        .await
-        .map_err(|e| match e {
-            StorageError::CollectionNotFound(_) => {
-                RuntimeUpdateError::FileNotFound(file_id.to_string())
-            }
-            other => RuntimeUpdateError::from(other),
-        })?;
+        .get_or_create_collection(&next_collection_name)
+        .await?;
 
     let next_keys = next_col.list().await?;
     if !next_keys.iter().any(|k| k == &key) {
@@ -284,16 +308,19 @@ pub(crate) async fn delete_all_backup(storage: &impl Storage) -> Result<(), Runt
     Ok(())
 }
 
-/// Computes the "next update" state from the pending `NextUpdate` collections.
+/// Computes the "next update" state from the pending `NextUpdate` collections, falling back to
+/// the currently active collection when no update is pending yet.
 ///
 /// For each collection pair (MDD and Configuration), the logic is:
 /// - If the `NextUpdate` collection **exists** (even if empty), its contents represent the target
 ///   state for that category - an empty `NextUpdate` means "delete all" for that category.
-/// - If the `NextUpdate` collection **does not exist** (`CollectionNotFound`), an empty list is
-///   returned for that category - no update is pending.
+/// - If the `NextUpdate` collection **does not exist** (`CollectionNotFound`), the contents of the
+///   corresponding current collection (`DiagnosticDatabase` / `Configuration`) are returned
+///   instead - no update is pending yet, so the next update mirrors the currently active
+///   database, per spec.
 ///
-/// MDD and Configuration are handled **independently** - one may be initialized while the other
-/// returns empty.
+/// MDD and Configuration are handled **independently** - one may have a pending update while the
+/// other still mirrors current.
 ///
 /// This is a **read-only** operation - no writes or transactions are performed.
 ///
@@ -304,14 +331,20 @@ pub async fn compute_nextupdate_state(
     storage: &impl Storage,
     query: &RuntimeFilesQuery,
 ) -> Result<BulkDataList, RuntimeUpdateError> {
-    let mdd_items = get_collection_items(
+    let mdd_items = get_nextupdate_or_current_items(
         storage,
         &CollectionName::DiagnosticDatabaseNextUpdate,
+        &CollectionName::DiagnosticDatabase,
         query,
     )
     .await?;
-    let config_items =
-        get_collection_items(storage, &CollectionName::ConfigurationNextUpdate, query).await?;
+    let config_items = get_nextupdate_or_current_items(
+        storage,
+        &CollectionName::ConfigurationNextUpdate,
+        &CollectionName::Configuration,
+        query,
+    )
+    .await?;
 
     let mut items = mdd_items;
     items.extend(config_items);
@@ -321,6 +354,27 @@ pub async fn compute_nextupdate_state(
         items,
         schema: None,
     })
+}
+
+/// Returns the items of `next_collection` if it exists, otherwise falls back to the items of
+/// `current_collection`.
+///
+/// Used to compute the next-update state for a single category (MDD or Configuration): if no
+/// update has been staged yet (`next_collection` doesn't exist), the next update mirrors the
+/// currently active database.
+async fn get_nextupdate_or_current_items(
+    storage: &impl Storage,
+    next_collection: &CollectionName,
+    current_collection: &CollectionName,
+    query: &RuntimeFilesQuery,
+) -> Result<Vec<BulkDataDescriptor>, RuntimeUpdateError> {
+    match storage.get_collection(next_collection).await {
+        Ok(collection) => Ok(list_collection_files(&*collection, query).await?.items),
+        Err(StorageError::CollectionNotFound(_)) => {
+            get_collection_items(storage, current_collection, query).await
+        }
+        Err(e) => Err(RuntimeUpdateError::from(e)),
+    }
 }
 
 /// Upload files into the appropriate `NextUpdate` collections.
@@ -1038,7 +1092,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn two_files_in_current_no_nextupdate_returns_empty() {
+    async fn two_files_in_current_no_nextupdate_mirrors_current() {
         let (storage, _dir) = make_storage();
         let collection = storage
             .get_or_create_collection(&CollectionName::DiagnosticDatabase)
@@ -1051,9 +1105,12 @@ mod tests {
         let query = RuntimeFilesQuery::default();
         let result = compute_nextupdate_state(&storage, &query).await.unwrap();
 
-        assert!(
-            result.items.is_empty(),
-            "no NextUpdate collection = no pending changes = empty"
+        let mut ids: Vec<_> = result.items.iter().map(|i| i.id.clone()).collect();
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec!["alpha.mdd".to_string(), "beta.mdd".to_string()],
+            "no NextUpdate collection = no pending changes = mirrors current"
         );
     }
 
@@ -1145,7 +1202,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn compute_nextupdate_empty_when_config_not_initialized() {
+    async fn compute_nextupdate_mirrors_config_when_not_initialized() {
         let (storage, _dir) = make_storage();
         let cfg = storage
             .get_or_create_collection(&CollectionName::Configuration)
@@ -1155,9 +1212,10 @@ mod tests {
 
         let query = RuntimeFilesQuery::default();
         let result = compute_nextupdate_state(&storage, &query).await.unwrap();
+        let ids: Vec<&str> = result.items.iter().map(|i| i.id.as_str()).collect();
         assert!(
-            result.items.is_empty(),
-            "no ConfigurationNextUpdate = no pending changes = empty"
+            ids.contains(&"config.toml"),
+            "no ConfigurationNextUpdate = no pending changes = mirrors current config"
         );
     }
 
@@ -1239,14 +1297,14 @@ mod tests {
         let ids: Vec<&str> = result.items.iter().map(|i| i.id.as_str()).collect();
         assert!(ids.contains(&"ecu1.mdd"), "MDD from NextUpdate");
         assert!(
-            !ids.contains(&"config.toml"),
-            "Config has no NextUpdate = not shown"
+            ids.contains(&"config.toml"),
+            "Config has no NextUpdate = mirrors current config"
         );
-        assert_eq!(result.items.len(), 1);
+        assert_eq!(result.items.len(), 2);
     }
 
     #[tokio::test]
-    async fn delete_nextupdate_returns_not_found_when_not_initialized() {
+    async fn delete_nextupdate_initializes_from_current_when_not_initialized() {
         let (storage, _dir) = make_storage();
         let db = storage
             .get_or_create_collection(&CollectionName::DiagnosticDatabase)
@@ -1255,10 +1313,20 @@ mod tests {
         write_test_file_by_name(&storage, &*db, "ecu1.mdd", b"data1").await;
         write_test_file_by_name(&storage, &*db, "ecu2.mdd", b"data2").await;
 
-        let result = super::delete_nextupdate_file(&storage, "ecu1.mdd").await;
+        super::delete_nextupdate_file(&storage, "ecu1.mdd")
+            .await
+            .expect("delete should succeed by initializing NextUpdate from current first");
+
+        let query = RuntimeFilesQuery::default();
+        let result = compute_nextupdate_state(&storage, &query).await.unwrap();
+        let ids: Vec<&str> = result.items.iter().map(|i| i.id.as_str()).collect();
         assert!(
-            matches!(result, Err(RuntimeUpdateError::FileNotFound(_))),
-            "NextUpdate not initialized = FileNotFound, not init-from-current"
+            !ids.contains(&"ecu1.mdd"),
+            "deleted file must not appear in next-update state"
+        );
+        assert!(
+            ids.contains(&"ecu2.mdd"),
+            "sibling file from current must still appear in next-update state"
         );
     }
 
@@ -1303,7 +1371,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_all_nextupdate_then_compute_returns_empty() {
+    async fn delete_all_nextupdate_then_compute_mirrors_current() {
         let (storage, _dir) = make_storage();
         let db = storage
             .get_or_create_collection(&CollectionName::DiagnosticDatabase)
@@ -1330,12 +1398,17 @@ mod tests {
 
         super::delete_all_nextupdate(&storage).await.unwrap();
 
-        // After delete_all_nextupdate, collections are gone -> no pending changes = empty
+        // After delete_all_nextupdate, collections are gone -> no pending changes = mirrors current
         let query = RuntimeFilesQuery::default();
         let result = compute_nextupdate_state(&storage, &query).await.unwrap();
+        let ids: Vec<&str> = result.items.iter().map(|i| i.id.as_str()).collect();
         assert!(
-            result.items.is_empty(),
-            "no NextUpdate collections = empty nextupdate"
+            ids.contains(&"ecu1.mdd") && ids.contains(&"app.toml"),
+            "no NextUpdate collections = nextupdate mirrors current, got {ids:?}"
+        );
+        assert!(
+            !ids.contains(&"other.mdd") && !ids.contains(&"other.toml"),
+            "stale NextUpdate content must be gone after delete_all_nextupdate, got {ids:?}"
         );
     }
 

--- a/cda-storage/src/local_collection.rs
+++ b/cda-storage/src/local_collection.rs
@@ -62,17 +62,74 @@ impl LocalCollection {
         paths::sanitize_path_segment(key)?;
         Ok(self.dir.join(key))
     }
+
+    /// Ensures that a file matching `key` (already normalized to lowercase) exists on disk
+    /// under exactly that (lowercase) name.
+    ///
+    /// All keys are normalized to lowercase (see [`normalize_key`]), and [`list`](Collection::list)
+    /// returns keys in that same normalized form. However, a file can end up on disk with a
+    /// different case than its normalized key - for example when files are placed directly in
+    /// the collection directory outside of [`Collection::write`] (such as during initial
+    /// provisioning of OEM-supplied files, which often use mixed-case names). If left
+    /// unaddressed, such a file would be listed (via its normalized key) but every other
+    /// operation (`metadata`, `read`, `delete`, `file_path`) would fail with `KeyNotFound`,
+    /// since they resolve the path via the lowercase key directly.
+    ///
+    /// This self-heals that situation: if no file exists at the exact lowercase path but one
+    /// exists under a different case, it is renamed in place to the normalized name (a metadata-
+    /// only, same-filesystem operation) so that the on-disk state matches the key-normalization
+    /// invariant relied on everywhere else. No-op if the normalized path already exists or no
+    /// case-insensitive match is found.
+    ///
+    /// This is a best-effort, synchronous operation (no lock is taken): the rename is atomic
+    /// and idempotent, so a benign race with a concurrent caller doing the same self-heal (or
+    /// with a commit) simply results in a harmless `rename` failure that is ignored, since the
+    /// target either already exists in the desired state or will shortly.
+    fn ensure_normalized_on_disk(&self, key: &str) {
+        let target = self.dir.join(key);
+        if target.exists() {
+            return;
+        }
+
+        let Ok(entries) = std::fs::read_dir(&self.dir) else {
+            return;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            // For valid files which would be listed, check if the name deviates, and normalize
+            if is_valid_key(&path) && name != key && name.eq_ignore_ascii_case(key) {
+                // Best-effort: ignore errors (e.g. lost the race to another renamer, or the
+                // target now exists).
+                let _ = std::fs::rename(&path, &target);
+                break;
+            }
+        }
+    }
 }
 
 /// Normalize a key to lowercase for case-insensitive storage.
 fn normalize_key(key: &str) -> String {
-    key.to_lowercase()
+    key.to_ascii_lowercase()
+}
+
+/// Checks if a key should be listed in a collection
+fn is_valid_key(path: &Path) -> bool {
+    let bak_ext = std::ffi::OsStr::new(crate::recovery::BACKUP_EXTENSION);
+    let tmp_ext = std::ffi::OsStr::new(crate::recovery::STAGING_EXTENSION);
+
+    // Only files are valid, when they are not backup or staging files.
+    path.is_file() && path.extension() != Some(bak_ext) && path.extension() != Some(tmp_ext)
 }
 
 impl Collection for LocalCollection {
     async fn read(&self, key: &str) -> Result<Arc<impl RandomAccessData + 'static>, StorageError> {
         let key = normalize_key(key);
         let path = self.key_path(&key)?;
+        self.ensure_normalized_on_disk(&key);
 
         let guard = io::acquire_read_lock(&self.data_lock).await;
 
@@ -87,6 +144,7 @@ impl Collection for LocalCollection {
     async fn metadata(&self, key: &str) -> Result<Metadata, StorageError> {
         let key = normalize_key(key);
         let path = self.key_path(&key)?;
+        self.ensure_normalized_on_disk(&key);
 
         let _guard = io::acquire_read_lock(&self.data_lock).await;
 
@@ -160,6 +218,7 @@ impl Collection for LocalCollection {
 
     async fn delete(&self, tx: &mut Transaction, key: &str) -> Result<(), StorageError> {
         let key = normalize_key(key);
+        self.ensure_normalized_on_disk(&key);
 
         // Verify the key exists in committed state.
         let path = self.key_path(&key)?;
@@ -197,6 +256,7 @@ impl DirectFileAccess for LocalCollection {
 
     fn file_path(&self, key: &str) -> Result<PathBuf, StorageError> {
         let key = normalize_key(key);
+        self.ensure_normalized_on_disk(&key);
         let path = self.key_path(&key)?;
         if !path.exists() {
             return Err(StorageError::KeyNotFound(key));
@@ -206,6 +266,14 @@ impl DirectFileAccess for LocalCollection {
 }
 
 /// List all file names (keys) in a directory, excluding backup and staging files.
+///
+/// Returned keys are normalized to lowercase to match the invariant used by
+/// [`Collection::read`], [`Collection::metadata`], and [`DirectFileAccess::file_path`], all of
+/// which normalize the key before resolving it to a path. Without this normalization, a file
+/// that ended up on disk with a mixed-case name (e.g. placed there outside of
+/// [`Collection::write`], such as during initial provisioning) would be listed under its
+/// original case but then fail to resolve via `metadata`/`read`/`file_path`, which look up the
+/// lowercased path - causing spurious "key not found" errors on case-sensitive filesystems.
 fn list_keys_in_dir(dir: &Path) -> Result<Vec<String>, StorageError> {
     let mut keys = Vec::new();
 
@@ -213,20 +281,17 @@ fn list_keys_in_dir(dir: &Path) -> Result<Vec<String>, StorageError> {
         return Ok(keys);
     }
 
-    let bak_ext = std::ffi::OsStr::new(crate::recovery::BACKUP_EXTENSION);
-    let tmp_ext = std::ffi::OsStr::new(crate::recovery::STAGING_EXTENSION);
-
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
 
         // Skip directories, backup files, and staging files.
-        if path.is_dir() || path.extension() == Some(bak_ext) || path.extension() == Some(tmp_ext) {
+        if !is_valid_key(&path) {
             continue;
         }
 
         if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-            keys.push(name.to_string());
+            keys.push(normalize_key(name));
         }
     }
 

--- a/cda-storage/tests/local_storage_tests.rs
+++ b/cda-storage/tests/local_storage_tests.rs
@@ -830,3 +830,52 @@ async fn recovery_create_collection_with_write_removes_orphaned_dir() {
         "Orphaned empty collection directory was left behind after recovery"
     );
 }
+
+/// Regression test for a bug where `list()` returned a file's on-disk (possibly mixed-case)
+/// name verbatim, while `metadata()`/`read()`/`file_path()` normalize keys to lowercase before
+/// resolving them to a path. On a case-sensitive filesystem this mismatch caused every
+/// mixed-case file to appear in `list()` but then fail with `KeyNotFound` as soon as any
+/// per-key lookup (`metadata`, `read`, `file_path`) was attempted - exactly the "key vanished
+/// during iteration" symptom, even with no concurrent writer at all.
+///
+/// Simulates a file that ended up on disk with a mixed-case name outside of `Collection::write`
+/// (e.g. placed there during initial provisioning), then verifies that `list()`, `metadata()`,
+/// and `read()` are all consistent with each other.
+#[tokio::test]
+async fn list_normalizes_mixed_case_filenames_to_match_metadata_and_read() {
+    let (storage, dir) = create_test_storage();
+    let name = CollectionName::DiagnosticDatabase;
+
+    // Create the collection directory and place a mixed-case file directly on disk, bypassing
+    // `Collection::write` (which would have normalized the name to lowercase).
+    let collection_dir = dir.path().join("collections").join(name.as_str());
+    std::fs::create_dir_all(&collection_dir).unwrap();
+    std::fs::write(
+        collection_dir.join("FLXC1000_06.18.13.mdd"),
+        b"mixed case data",
+    )
+    .unwrap();
+
+    let collection = storage.get_or_create_collection(&name).await.unwrap();
+
+    // `list()` must return the normalized (lowercase) key, matching what `metadata`/`read`/
+    // `file_path` expect.
+    let keys = collection.list().await.unwrap();
+    assert_eq!(keys, vec!["flxc1000_06.18.13.mdd".to_string()]);
+
+    // Every key returned by `list()` must be resolvable via `metadata()` without a
+    // `KeyNotFound` error.
+    for key in &keys {
+        let meta = collection.metadata(key).await.unwrap();
+        assert_eq!(meta.data_size, "mixed case data".len() as u64);
+    }
+
+    // Every key returned by `list()` must also be resolvable via `read()`.
+    let Some(key) = keys.first() else {
+        panic!("expected one key");
+    };
+    let handle = collection.read(key).await.unwrap();
+    let mut buf = vec![0u8; "mixed case data".len()];
+    handle.read_at(0, &mut buf).unwrap();
+    assert_eq!(&buf, b"mixed case data");
+}

--- a/integration-tests/tests/sovd/runtimefiles.rs
+++ b/integration-tests/tests/sovd/runtimefiles.rs
@@ -20,6 +20,7 @@ use sovd_interfaces::{
     apps::sovd2uds::bulk_data::{BulkDataList, runtimefiles::ExecutionMode},
     common::operations::OperationIdItem,
     locking::post_put::Response as LockResponse,
+    sovd2uds::BulkDataDescriptor,
 };
 
 use crate::{
@@ -749,14 +750,26 @@ async fn runtimefiles_rollback_clears_nextupdate_with_new_pending() -> Result<()
     execute_mode(&runtime.config, &auth, ExecutionMode::Rollback).await?;
     cda_interfaces::util::tokio_ext::sleep_for(Duration::from_secs(3)).await;
 
-    // Step 4: Verify nextupdate is empty after rollback
+    // Step 4: Verify NEW_PENDING.mdd (the uploaded pending file) is gone, and nextupdate mirrors
+    // the restored current state.
     let nextupdate_items = get_file_list(&runtime.config, &auth, RUNTIMEFILES_NEXTUPDATE)
         .await?
         .items;
     assert!(
-        nextupdate_items.is_empty(),
-        "Expected nextupdate to be empty after Rollback, but found {} items",
-        nextupdate_items.len()
+        !nextupdate_items
+            .iter()
+            .any(|i| i.id.to_lowercase().contains("new_pending")),
+        "Expected NEW_PENDING.mdd to be gone from nextupdate after Rollback, got {:?}",
+        nextupdate_items.iter().map(|i| &i.id).collect::<Vec<_>>()
+    );
+
+    let current_items = get_file_list(&runtime.config, &auth, RUNTIMEFILES_CURRENT)
+        .await?
+        .items;
+    assert_eq!(
+        ids_of(&nextupdate_items),
+        ids_of(&current_items),
+        "Expected nextupdate to mirror current after Rollback (no pending changes)"
     );
 
     teardown_lock(&runtime.config, &auth, &lock_id).await;
@@ -1036,7 +1049,7 @@ async fn assert_nextupdate_contains_flxc1000(
 }
 
 /// Helper: verifies the post-Apply invariants:
-/// current non-empty, nextupdate empty, backup non-empty.
+/// current non-empty, nextupdate mirrors current (no pending changes), backup non-empty.
 async fn assert_state_after_apply(
     config: &Configuration,
     auth: &http::HeaderMap,
@@ -1052,9 +1065,10 @@ async fn assert_state_after_apply(
     let nextupdate = get_file_list(config, auth, RUNTIMEFILES_NEXTUPDATE)
         .await?
         .items;
-    assert!(
-        nextupdate.is_empty(),
-        "Expected empty nextupdate after apply"
+    assert_eq!(
+        ids_of(&nextupdate),
+        ids_of(&current),
+        "Expected nextupdate to mirror current after apply (no pending changes)"
     );
 
     let backup = get_file_list(config, auth, RUNTIMEFILES_BACKUP)
@@ -1069,7 +1083,7 @@ async fn assert_state_after_apply(
 }
 
 /// Helper: verifies the post-Rollback invariants:
-/// current count matches `expected_count`, nextupdate empty.
+/// current count matches `expected_count`, nextupdate mirrors current (no pending changes).
 async fn assert_state_after_rollback(
     config: &Configuration,
     auth: &http::HeaderMap,
@@ -1087,9 +1101,11 @@ async fn assert_state_after_rollback(
     let nextupdate = get_file_list(config, auth, RUNTIMEFILES_NEXTUPDATE)
         .await?
         .items;
-    assert!(
-        nextupdate.is_empty(),
-        "Expected empty nextupdate after rollback (spec: state of nextupdate must be reset)"
+    assert_eq!(
+        ids_of(&nextupdate),
+        ids_of(&current),
+        "Expected nextupdate to mirror current after rollback (spec: state of nextupdate must be \
+         reset)"
     );
 
     get_file_list(config, auth, RUNTIMEFILES_BACKUP).await?;
@@ -1098,7 +1114,7 @@ async fn assert_state_after_rollback(
 }
 
 /// Helper: verifies the post-Cleanup invariants:
-/// backup empty, nextupdate empty.
+/// backup empty, nextupdate mirrors current (no pending changes).
 async fn assert_state_after_cleanup(
     config: &Configuration,
     auth: &http::HeaderMap,
@@ -1108,15 +1124,27 @@ async fn assert_state_after_cleanup(
         .items;
     assert!(backup.is_empty(), "Expected empty backup after cleanup");
 
+    let current = get_file_list(config, auth, RUNTIMEFILES_CURRENT)
+        .await?
+        .items;
     let nextupdate = get_file_list(config, auth, RUNTIMEFILES_NEXTUPDATE)
         .await?
         .items;
-    assert!(
-        nextupdate.is_empty(),
-        "Expected empty nextupdate after cleanup (spec: reset all pending updates)"
+    assert_eq!(
+        ids_of(&nextupdate),
+        ids_of(&current),
+        "Expected nextupdate to mirror current after cleanup (spec: reset all pending updates)"
     );
 
     Ok(())
+}
+
+/// Helper: returns the sorted set of item ids from a bulk-data item list, for order-independent
+/// comparisons between `runtimefiles-current` and `runtimefiles-nextupdate`.
+fn ids_of(items: &[BulkDataDescriptor]) -> Vec<String> {
+    let mut ids: Vec<String> = items.iter().map(|i| i.id.to_lowercase()).collect();
+    ids.sort();
+    ids
 }
 
 /// Helper: finds the FLXC1000 entry id in nextupdate, failing the test if absent.
@@ -1186,7 +1214,7 @@ async fn assert_ecu_routes_after_apply(
 }
 
 /// Spec: DELETE on /runtimefiles-nextupdate removes all pending changes - nextupdate
-/// returns empty because there are no pending files.
+/// mirrors runtimefiles-current because there are no pending files anymore.
 #[tokio::test]
 async fn runtimefiles_delete_nextupdate_clears_pending() -> Result<(), TestingError> {
     let (runtime, _lock) = setup_integration_test(true).await?;
@@ -1218,9 +1246,13 @@ async fn runtimefiles_delete_nextupdate_clears_pending() -> Result<(), TestingEr
     let post_delete_items = get_file_list(&runtime.config, &auth, RUNTIMEFILES_NEXTUPDATE)
         .await?
         .items;
-    assert!(
-        post_delete_items.is_empty(),
-        "Expected empty nextupdate after DELETE (no pending files)"
+    let current_items = get_file_list(&runtime.config, &auth, RUNTIMEFILES_CURRENT)
+        .await?
+        .items;
+    assert_eq!(
+        ids_of(&post_delete_items),
+        ids_of(&current_items),
+        "Expected nextupdate to mirror current after DELETE (no pending files)"
     );
 
     teardown_lock(&runtime.config, &auth, &lock_id).await;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

fix(storage): resolve mixed-case filenames consistently across Collection ops

Collection::list() returned on-disk filenames verbatim, while metadata(), read(), delete(), and file_path() normalize the key to lowercase before resolving it to a path. Files placed on disk with mixed-case names (e.g. OEM-style MDD files provisioned outside of Collection::write) would appear in list() but then fail every subsequent per-key lookup with KeyNotFound, surfacing as spurious "key vanished during iteration" warnings when listing runtime files.

- list_keys_in_dir() now returns normalized (lowercase) keys, consistent with the rest of the Collection API.
- Added LocalCollection::ensure_normalized_on_disk(), called from read, metadata, delete, and file_path: if a case-insensitive match exists but the exact lowercase-named file doesn't, it is renamed in place so the on-disk state matches the key-normalization invariant.
- Added a regression test that places a mixed-case file directly on disk and verifies list()/metadata()/read() stay consistent.

---

fix(runtime-update): mirror runtimefiles-current in nextupdate when no update is pending

compute_nextupdate_state previously returned an empty list per category
(MDD/Configuration) whenever the corresponding NextUpdate collection did
not exist yet, instead of falling back to the currently active database.
This contradicted the documented spec, which states that
runtimefiles-nextupdate must initially mirror runtimefiles-current.

- compute_nextupdate_state now falls back to the current collection per
  category when its NextUpdate collection doesn't exist, while still
  treating an existing-but-empty NextUpdate collection as an explicit
  "delete all" target state.
- delete_nextupdate_file now lazily initializes NextUpdate from current
  before deleting, so files that only exist in current can be removed
  from the pending next-update state instead of returning FileNotFound.
- Updated unit tests to assert the mirrored-fallback behavior.
- Updated integration test assertions/helpers that previously expected
  nextupdate to be empty after apply/rollback/cleanup/delete-all to
  instead expect it to mirror runtimefiles-current.


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
