### PR TITLE
fix(diag_kernel): invalidate stale service cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,7 @@ dependencies = [
 name = "cda-core"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "cda-database",
  "cda-interfaces",
  "cda-plugin-security",

--- a/cda-comm-uds/src/test_helpers.rs
+++ b/cda-comm-uds/src/test_helpers.rs
@@ -15,6 +15,7 @@
 
 use std::time::Duration;
 
+use async_trait::async_trait;
 use cda_interfaces::{
     DiagComm, DiagServiceError, DoipComParams, EcuAddresses, EcuState, EcuStateManager, HashMap,
     HashMapExtensions, UdsComParams, VariantDetection,
@@ -184,6 +185,7 @@ impl EcuStateManager for TestEcuDb {
     }
 }
 
+#[async_trait]
 impl VariantDetection for TestEcuDb {
     fn ecu_status(&self) -> EcuState {
         unimplemented!()

--- a/cda-comm-uds/src/test_helpers.rs
+++ b/cda-comm-uds/src/test_helpers.rs
@@ -200,11 +200,11 @@ impl VariantDetection for TestEcuDb {
         unimplemented!()
     }
 
-    fn mark_as_duplicate(&mut self) {
+    async fn mark_as_duplicate(&mut self) {
         unimplemented!()
     }
 
-    fn mark_as_no_variant_detected(&mut self) {
+    async fn mark_as_no_variant_detected(&mut self) {
         unimplemented!()
     }
 }

--- a/cda-comm-uds/src/variant.rs
+++ b/cda-comm-uds/src/variant.rs
@@ -239,7 +239,7 @@ impl<S: EcuGateway, T: EcuManager> UdsVariant for UdsManager<S, T> {
                         continue;
                     }
                     if let Some(ecu) = self.ecus.get(ecu_name) {
-                        ecu.write().await.mark_as_duplicate();
+                        ecu.write().await.mark_as_duplicate().await;
                     }
                 }
             }
@@ -248,7 +248,7 @@ impl<S: EcuGateway, T: EcuManager> UdsVariant for UdsManager<S, T> {
                 // Falling back to base variant is only allowed when there are no duplicates.
                 for ecu_name in &duplicated_ecus {
                     if let Some(ecu) = self.ecus.get(ecu_name) {
-                        ecu.write().await.mark_as_no_variant_detected();
+                        ecu.write().await.mark_as_no_variant_detected().await;
                     }
                 }
             }

--- a/cda-core/Cargo.toml
+++ b/cda-core/Cargo.toml
@@ -31,6 +31,7 @@ cda-database = { workspace = true }
 cda-plugin-security = { workspace = true }
 
 # external
+async-trait = { workspace = true }
 num-traits = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }

--- a/cda-core/src/diag_kernel/service_lookup.rs
+++ b/cda-core/src/diag_kernel/service_lookup.rs
@@ -28,26 +28,23 @@ use super::ecumanager::EcuManager;
 
 #[derive(Default)]
 pub(in crate::diag_kernel) struct DbCache {
-    diag_services: RwLock<HashMap<StringId, Option<CacheLocation>>>,
+    diag_services: RwLock<HashMap<StringId, CachedService>>,
 }
 
 impl DbCache {
     pub(in crate::diag_kernel) async fn reset(&self) {
         self.diag_services.write().await.clear();
     }
-
-    /// Synchronous cache reset. Used when the DB is unloaded (no async context needed
-    /// because no one should be concurrently reading the cache during unload).
-    pub(in crate::diag_kernel) fn reset_sync(&self) {
-        if let Ok(mut guard) = self.diag_services.try_write() {
-            guard.clear();
-        }
-    }
 }
 
 pub(in crate::diag_kernel) enum CacheLocation {
     Variant(usize),
     ParentRef(usize),
+}
+
+struct CachedService {
+    variant_index: Option<usize>,
+    location: Option<CacheLocation>,
 }
 
 fn diag_comm_short_name_starts_with(
@@ -115,8 +112,17 @@ impl<S: SecurityPlugin> EcuManager<S> {
             let cache_key = format!("{base_name}:sf{sf_id}:m{effective_mask:02X}");
             let lookup_id = STRINGS.get_or_insert(&cache_key);
 
-            if let Some(Some(location)) = self.db_cache.diag_services.read().await.get(&lookup_id) {
-                return match self.get_service_by_location(location) {
+            let variant_index = self.current_variant_index();
+            if let Some(cached) = self
+                .db_cache
+                .diag_services
+                .read()
+                .await
+                .get(&lookup_id)
+                .filter(|cached| cached.variant_index == variant_index)
+                .and_then(|cached| cached.location.as_ref())
+            {
+                return match self.get_service_by_location(cached) {
                     Some(service) => Ok(service),
                     None => Err(DiagServiceError::NotFound(format!(
                         "Cached diagnostic service '{base_name}' with subfunction {sf_id:#04X} \
@@ -129,11 +135,13 @@ impl<S: SecurityPlugin> EcuManager<S> {
                 return Ok(service);
             }
 
-            self.db_cache
-                .diag_services
-                .write()
-                .await
-                .insert(lookup_id, None);
+            self.db_cache.diag_services.write().await.insert(
+                lookup_id,
+                CachedService {
+                    variant_index,
+                    location: None,
+                },
+            );
 
             return Err(DiagServiceError::NotFound(format!(
                 "Diagnostic service '{base_name}' with subfunction {sf_id:#04X} not found in \
@@ -173,8 +181,17 @@ impl<S: SecurityPlugin> EcuManager<S> {
 
         let lookup_id = STRINGS.get_or_insert(&lookup_name);
 
-        if let Some(Some(location)) = self.db_cache.diag_services.read().await.get(&lookup_id) {
-            return match self.get_service_by_location(location) {
+        let variant_index = self.current_variant_index();
+        if let Some(cached) = self
+            .db_cache
+            .diag_services
+            .read()
+            .await
+            .get(&lookup_id)
+            .filter(|cached| cached.variant_index == variant_index)
+            .and_then(|cached| cached.location.as_ref())
+        {
+            return match self.get_service_by_location(cached) {
                 Some(service) => Ok(service),
                 None => Err(DiagServiceError::NotFound(format!(
                     "Cached diagnostic service '{lookup_name}' not found at stored location"
@@ -186,11 +203,13 @@ impl<S: SecurityPlugin> EcuManager<S> {
             return Ok(service);
         }
 
-        self.db_cache
-            .diag_services
-            .write()
-            .await
-            .insert(lookup_id, None);
+        self.db_cache.diag_services.write().await.insert(
+            lookup_id,
+            CachedService {
+                variant_index,
+                location: None,
+            },
+        );
 
         Err(DiagServiceError::NotFound(format!(
             "Diagnostic service '{lookup_name}' not found in variant, base variant, or ECU shared \
@@ -207,15 +226,22 @@ impl<S: SecurityPlugin> EcuManager<S> {
         F: Fn(&datatypes::DiagService<'_>) -> bool,
     {
         if let Some((service, location)) = self.search_with_location(predicate) {
-            self.db_cache
-                .diag_services
-                .write()
-                .await
-                .insert(lookup_id, Some(location));
+            let variant_index = self.current_variant_index();
+            self.db_cache.diag_services.write().await.insert(
+                lookup_id,
+                CachedService {
+                    variant_index,
+                    location: Some(location),
+                },
+            );
             Some(service)
         } else {
             None
         }
+    }
+
+    fn current_variant_index(&self) -> Option<usize> {
+        cda_interfaces::util::std_ext::lock_read(&self.runtime_state.ecu_state).variant_index
     }
 
     fn search_with_location<F>(
@@ -758,10 +784,52 @@ mod tests {
     use cda_database::datatypes::database_builder::{
         DataFormatParentRefType, DiagLayerParams, EcuDataBuilder, EcuDataParams,
     };
-    use cda_interfaces::{DiagComm, DiagCommLookup, DiagServiceError, subfunction_ids};
+    use cda_interfaces::{
+        DiagComm, DiagCommLookup, DiagServiceError, VariantDetection, subfunction_ids,
+        util::std_ext,
+    };
 
     use super::*;
-    use crate::diag_kernel::test_utils::ecu_manager_builder::create_ecu_manager_with_routine_control_service;
+    use crate::diag_kernel::test_utils::ecu_manager_builder::{
+        create_ecu_manager_variant_detection, create_ecu_manager_with_routine_control_service,
+    };
+
+    #[tokio::test]
+    async fn stale_variant_cache_is_ignored_after_variant_is_cleared() {
+        let ecu_manager = create_ecu_manager_variant_detection(true);
+        let service = ecu_manager
+            .get_variant_detection_requests()
+            .values()
+            .next()
+            .expect("Expected variant detection service")
+            .clone();
+        let lookup_name = service
+            .lookup_name
+            .clone()
+            .unwrap_or_else(|| {
+                ecu_manager
+                    .database_naming_convention
+                    .apply_action_affix(&service.name, &service.action())
+            })
+            .to_lowercase();
+        let lookup_id = STRINGS.get_or_insert(&lookup_name);
+
+        ecu_manager.db_cache.diag_services.write().await.insert(
+            lookup_id,
+            CachedService {
+                variant_index: Some(1),
+                location: Some(CacheLocation::Variant(usize::MAX)),
+            },
+        );
+        std_ext::lock_write(&ecu_manager.runtime_state.ecu_state).variant_index = None;
+
+        let result = ecu_manager.lookup_diag_service(&service, None, None).await;
+
+        assert!(
+            result.is_ok(),
+            "Expected lookup to ignore cache from previous variant, got: {result:?}"
+        );
+    }
 
     /// Tests that `get_parent_ref_diag_layers_with_refs_recursive` correctly resolves a
     /// mixed parent-ref hierarchy with the following structure:

--- a/cda-core/src/diag_kernel/variant.rs
+++ b/cda-core/src/diag_kernel/variant.rs
@@ -23,14 +23,21 @@ use super::ecumanager::{EcuManager, VariantData};
 use crate::diag_kernel::variant_detection;
 
 impl<S: SecurityPlugin> EcuManager<S> {
-    fn clear_variant(&self, variant_state: VariantState, connectivity: Option<Connectivity>) {
-        let mut ecu_state = std_ext::lock_write(&self.runtime_state.ecu_state);
-        ecu_state.variant_state = variant_state;
-        ecu_state.variant_index = None;
-        if let Some(connectivity) = connectivity {
-            ecu_state.connectivity = connectivity;
+    async fn clear_variant_and_unload(
+        &mut self,
+        variant_state: VariantState,
+        connectivity: Option<Connectivity>,
+    ) {
+        {
+            let mut ecu_state = std_ext::lock_write(&self.runtime_state.ecu_state);
+            ecu_state.variant_state = variant_state;
+            ecu_state.variant_index = None;
+            if let Some(connectivity) = connectivity {
+                ecu_state.connectivity = connectivity;
+            }
         }
-        drop(ecu_state);
+        self.db_cache.reset().await;
+        self.diag_database.unload();
     }
 }
 
@@ -72,9 +79,11 @@ impl<S: SecurityPlugin> VariantDetection for EcuManager<S> {
             Err(e) => {
                 if !self.fallback_to_base_variant {
                     // Connectivity is Online. We got responses but couldn't match a variant.
-                    self.clear_variant(VariantState::NotDetected, Some(Connectivity::Online));
-                    self.db_cache.reset().await;
-                    self.diag_database.unload();
+                    self.clear_variant_and_unload(
+                        VariantState::NotDetected,
+                        Some(Connectivity::Online),
+                    )
+                    .await;
                     tracing::debug!(
                         "No variant detected, fallback to base variant disabled, unloading DB"
                     );
@@ -84,9 +93,11 @@ impl<S: SecurityPlugin> VariantDetection for EcuManager<S> {
                 let base_variant = match self.diag_database.base_variant() {
                     Ok(base_variant) => base_variant,
                     Err(e) => {
-                        self.clear_variant(VariantState::NotDetected, Some(Connectivity::Online));
-                        self.db_cache.reset().await;
-                        self.diag_database.unload();
+                        self.clear_variant_and_unload(
+                            VariantState::NotDetected,
+                            Some(Connectivity::Online),
+                        )
+                        .await;
                         tracing::debug!(
                             "No variant detected, and no base variant found in DB, unloading DB"
                         );
@@ -105,14 +116,12 @@ impl<S: SecurityPlugin> VariantDetection for EcuManager<S> {
     }
 
     async fn mark_as_duplicate(&mut self) {
-        self.clear_variant(VariantState::Duplicate, None);
-        self.db_cache.reset().await;
-        self.diag_database.unload();
+        self.clear_variant_and_unload(VariantState::Duplicate, None)
+            .await;
     }
 
     async fn mark_as_no_variant_detected(&mut self) {
-        self.clear_variant(VariantState::NotDetected, None);
-        self.db_cache.reset().await;
-        self.diag_database.unload();
+        self.clear_variant_and_unload(VariantState::NotDetected, None)
+            .await;
     }
 }

--- a/cda-core/src/diag_kernel/variant.rs
+++ b/cda-core/src/diag_kernel/variant.rs
@@ -21,6 +21,18 @@ use cda_plugin_security::SecurityPlugin;
 use super::ecumanager::{EcuManager, VariantData};
 use crate::diag_kernel::variant_detection;
 
+impl<S: SecurityPlugin> EcuManager<S> {
+    fn clear_variant(&self, variant_state: VariantState, connectivity: Option<Connectivity>) {
+        let mut ecu_state = std_ext::lock_write(&self.runtime_state.ecu_state);
+        ecu_state.variant_state = variant_state;
+        ecu_state.variant_index = None;
+        if let Some(connectivity) = connectivity {
+            ecu_state.connectivity = connectivity;
+        }
+        drop(ecu_state);
+    }
+}
+
 impl<S: SecurityPlugin> VariantDetection for EcuManager<S> {
     fn ecu_status(&self) -> EcuState {
         self.runtime_state.status()
@@ -57,13 +69,9 @@ impl<S: SecurityPlugin> VariantDetection for EcuManager<S> {
             }
             Err(e) => {
                 if !self.fallback_to_base_variant {
-                    let mut ecu_state = std_ext::lock_write(&self.runtime_state.ecu_state);
-
-                    ecu_state.variant_state = VariantState::NotDetected;
-                    ecu_state.variant_index = None;
-                    // Connectivity is Online. We got responses but couldn't match a variant
-                    ecu_state.connectivity = Connectivity::Online;
-                    drop(ecu_state);
+                    // Connectivity is Online. We got responses but couldn't match a variant.
+                    self.clear_variant(VariantState::NotDetected, Some(Connectivity::Online));
+                    self.db_cache.reset().await;
                     self.diag_database.unload();
                     tracing::debug!(
                         "No variant detected, fallback to base variant disabled, unloading DB"
@@ -74,11 +82,8 @@ impl<S: SecurityPlugin> VariantDetection for EcuManager<S> {
                 let base_variant = match self.diag_database.base_variant() {
                     Ok(base_variant) => base_variant,
                     Err(e) => {
-                        let mut ecu_state = std_ext::lock_write(&self.runtime_state.ecu_state);
-                        ecu_state.variant_state = VariantState::NotDetected;
-                        ecu_state.variant_index = None;
-                        ecu_state.connectivity = Connectivity::Online;
-                        drop(ecu_state);
+                        self.clear_variant(VariantState::NotDetected, Some(Connectivity::Online));
+                        self.db_cache.reset().await;
                         self.diag_database.unload();
                         tracing::debug!(
                             "No variant detected, and no base variant found in DB, unloading DB"
@@ -97,21 +102,15 @@ impl<S: SecurityPlugin> VariantDetection for EcuManager<S> {
         &self.variant_detection.diag_service_requests
     }
 
-    fn mark_as_duplicate(&mut self) {
-        let mut ecu_state = std_ext::lock_write(&self.runtime_state.ecu_state);
-        ecu_state.variant_state = VariantState::Duplicate;
-        ecu_state.variant_index = None;
-        drop(ecu_state);
-        self.db_cache.reset_sync();
+    async fn mark_as_duplicate(&mut self) {
+        self.clear_variant(VariantState::Duplicate, None);
+        self.db_cache.reset().await;
         self.diag_database.unload();
     }
 
-    fn mark_as_no_variant_detected(&mut self) {
-        let mut ecu_state = std_ext::lock_write(&self.runtime_state.ecu_state);
-        ecu_state.variant_state = VariantState::NotDetected;
-        ecu_state.variant_index = None;
-        drop(ecu_state);
-        self.db_cache.reset_sync();
+    async fn mark_as_no_variant_detected(&mut self) {
+        self.clear_variant(VariantState::NotDetected, None);
+        self.db_cache.reset().await;
         self.diag_database.unload();
     }
 }

--- a/cda-core/src/diag_kernel/variant.rs
+++ b/cda-core/src/diag_kernel/variant.rs
@@ -11,6 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use async_trait::async_trait;
 // Needed so that `self.load()` is callable inside the EcuVariantProvider impl
 use cda_interfaces::{
     Connectivity, DiagComm, DiagServiceError, EcuManager as EcuManagerTrait, EcuState, HashMap,
@@ -33,6 +34,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
     }
 }
 
+#[async_trait]
 impl<S: SecurityPlugin> VariantDetection for EcuManager<S> {
     fn ecu_status(&self) -> EcuState {
         self.runtime_state.status()

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -748,6 +748,7 @@ pub trait Dtc: Send + Sync + 'static {
 }
 
 /// Provides variant detection and ECU variant identity.
+#[async_trait]
 pub trait VariantDetection: Send + Sync + 'static {
     /// Returns the current ECU status (connectivity + variant state).
     #[must_use]
@@ -756,10 +757,10 @@ pub trait VariantDetection: Send + Sync + 'static {
     /// Runs variant detection against the provided service responses.
     /// # Errors
     /// Returns `DiagServiceError` if no matching variant is found and fallback is disabled.
-    fn detect_variant<T: DiagServiceResponse + Sized>(
+    async fn detect_variant<T: DiagServiceResponse + Sized>(
         &mut self,
         service_responses: HashMap<String, T>,
-    ) -> impl Future<Output = Result<(), DiagServiceError>> + Send;
+    ) -> Result<(), DiagServiceError>;
 
     /// Returns the map of service requests used for variant detection.
     #[must_use]
@@ -767,11 +768,11 @@ pub trait VariantDetection: Send + Sync + 'static {
 
     /// Mark this ECU as duplicate. Sets the variant state to [`VariantState::Duplicate`] and
     /// unloads the database. Database will be reloaded before next variant detection.
-    fn mark_as_duplicate(&mut self) -> impl Future<Output = ()> + Send;
+    async fn mark_as_duplicate(&mut self);
 
     /// Mark this ECU as having no variant detected. Sets the variant state to
     /// [`VariantState::NotDetected`] and unloads the database.
-    fn mark_as_no_variant_detected(&mut self) -> impl Future<Output = ()> + Send;
+    async fn mark_as_no_variant_detected(&mut self);
 }
 
 /// Callback interface for connectivity changes for ECUs behind a `DoIP` gateway.

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -767,11 +767,11 @@ pub trait VariantDetection: Send + Sync + 'static {
 
     /// Mark this ECU as duplicate. Sets the variant state to [`VariantState::Duplicate`] and
     /// unloads the database. Database will be reloaded before next variant detection.
-    fn mark_as_duplicate(&mut self);
+    fn mark_as_duplicate(&mut self) -> impl Future<Output = ()> + Send;
 
     /// Mark this ECU as having no variant detected. Sets the variant state to
     /// [`VariantState::NotDetected`] and unloads the database.
-    fn mark_as_no_variant_detected(&mut self);
+    fn mark_as_no_variant_detected(&mut self) -> impl Future<Output = ()> + Send;
 }
 
 /// Callback interface for connectivity changes for ECUs behind a `DoIP` gateway.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

Observed following error when the ECU-State changed:
```
payload_encode.rs:75 msg: error=Not found: "Cached diagnostic service 'service_abc_redacted' not found at stored location"
    in create_uds_payload::create_uds_payload
    in cda_comm_uds::variant::detect_variant
    in cda_comm_uds::transport::send_with_optional_timeout
    in cda_sovd::request
```

This PR changes the logic so it:
- Associates cached service locations with their ECU variant so lookups ignore stale entries after variant changes or reconnects. This ensures that we don't hit a stale cache if the variant index changed but the db-cache was not reset.
- Clears db-cache when variant is cleared (NotTested / Duplicate)

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)