### PR TITLE
fix(diag-kernel): correct EndOfPdu max-items comparison

### DIFF
--- a/cda-core/src/diag_kernel/payload_encode.rs
+++ b/cda-core/src/diag_kernel/payload_encode.rs
@@ -275,7 +275,7 @@ impl<S: SecurityPlugin> EcuManager<S> {
                         )]
                         let value_len_u32 = value.len() as u32;
 
-                        value.len() > u32::MAX as usize || max > value_len_u32
+                        value.len() > u32::MAX as usize || value_len_u32 > max
                     })
                 {
                     return Err(DiagServiceError::InvalidRequest(
@@ -1927,6 +1927,67 @@ mod tests {
             &[sid, 0x01, 0xAA, 0x01, 0xBB][..],
             "Expected both RepeatedItem entries to be appended sequentially, but the second item \
              overwrote the first at the same absolute byte offset"
+        );
+    }
+
+    /// Regression test for the `EndOfPdu` item-count validation bug where the
+    /// comparison `max > value_len` was used instead of `value_len > max`.
+    ///
+    /// With `min_items = 1` and `max_items = Some(20)`, providing a single item is valid
+    /// (`1` is within `[1, 20]`), but the buggy comparison (`20 > 1` => `true`) incorrectly
+    /// rejected the request with "`EndOfPdu` expected different amount of items".
+    #[tokio::test]
+    async fn test_end_of_pdu_accepts_item_count_within_min_max_range() {
+        let (ecu_manager, service, sid) =
+            create_ecu_manager_with_end_pdu_request_service(1, Some(20));
+
+        let payload_data = UdsPayloadData::ParameterMap(
+            serde_json::from_value(json!({
+                "repeated_items": [
+                    { "leading_length_field": "AA" }
+                ]
+            }))
+            .unwrap(),
+        );
+
+        let result = ecu_manager
+            .create_uds_payload(&service, &skip_sec_plugin!(), Some(payload_data), None)
+            .await;
+
+        let service_payload = result.unwrap_or_else(|e| {
+            panic!(
+                "Encoding a single-item EndOfPdu request (within min/max range) should succeed, \
+                 but failed with: {e:?}"
+            )
+        });
+
+        assert_eq!(service_payload.data.as_slice(), &[sid, 0x01, 0xAA][..]);
+    }
+
+    /// Regression test ensuring that providing MORE items than `max_number_of_items`
+    /// is still correctly rejected after fixing the comparison direction.
+    #[tokio::test]
+    async fn test_end_of_pdu_rejects_item_count_above_max() {
+        let (ecu_manager, service, _sid) =
+            create_ecu_manager_with_end_pdu_request_service(1, Some(1));
+
+        let payload_data = UdsPayloadData::ParameterMap(
+            serde_json::from_value(json!({
+                "repeated_items": [
+                    { "leading_length_field": "AA" },
+                    { "leading_length_field": "BB" }
+                ]
+            }))
+            .unwrap(),
+        );
+
+        let result = ecu_manager
+            .create_uds_payload(&service, &skip_sec_plugin!(), Some(payload_data), None)
+            .await;
+
+        assert!(
+            result.is_err(),
+            "Expected an error when providing more items than max_number_of_items allows"
         );
     }
 }


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
The item-count validation for EndOfPdu array parameters compared max_number_of_items and the provided array length in the wrong direction (max > len instead of len > max). This caused valid requests providing fewer items than the maximum to be rejected with "EndOfPdu expected different amount of items", while requests providing more items than allowed were incorrectly accepted.

Swap the comparison so requests are only rejected when the array is longer than max_number_of_items (or shorter than min_number_of_items, which was already correct).

Add regression tests covering an item count within the valid min/max range (previously falsely rejected) and one exceeding the max (previously falsely accepted).


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
