### PR TITLE
ci(duplicate-code): add jscpd-based duplication check as informational stage

### DIFF
--- a/.github/scripts/analyze-duplication.py
+++ b/.github/scripts/analyze-duplication.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import os
+
+
+def normalize(p):
+    return p.lstrip("./")
+
+
+def analyze(report_path, changed_files):
+    if not os.path.exists(report_path):
+        return []
+
+    with open(report_path) as f:
+        report = json.load(f)
+
+    duplicates = report.get("duplicates", [])
+    changed_set = {normalize(f) for f in changed_files}
+    findings = []
+
+    for dup in duplicates:
+        first = dup.get("firstFile")
+        second = dup.get("secondFile")
+        if not first or not second:
+            continue
+
+        first_name = normalize(first.get("name", ""))
+        second_name = normalize(second.get("name", ""))
+        if first_name not in changed_set and second_name not in changed_set:
+            continue
+
+        findings.append(
+            {
+                "firstFile": first_name,
+                "firstStart": first.get("start"),
+                "firstEnd": first.get("end"),
+                "secondFile": second_name,
+                "secondStart": second.get("start"),
+                "secondEnd": second.get("end"),
+                "lines": dup.get("lines"),
+                "tokens": dup.get("tokens"),
+                "format": dup.get("format", ""),
+                "fragment": dup.get("fragment", ""),
+            }
+        )
+
+    return findings
+
+
+def format_comment_body(findings):
+    marker = "<!-- duplicate-code-check -->"
+    if not findings:
+        return f"{marker}\nDuplicate-code check passed - no duplication found in changed files."
+
+    lines = [
+        marker,
+        "**Duplicate code detected (informational)** - these clusters touch files "
+        "changed in this PR:",
+    ]
+    for i, f in enumerate(findings):
+        a, b = f["firstFile"], f["secondFile"]
+        lines.append("")
+        lines.append(
+            f"### {i + 1}. `{a}:{f['firstStart']}-{f['firstEnd']}` "
+            f"matches `{b}:{f['secondStart']}-{f['secondEnd']}` "
+            f"({f['lines']} lines, {f['tokens']} tokens)"
+        )
+        if f.get("fragment"):
+            lines.append("")
+            lines.append(f"```{f['format']}")
+            lines.append(f["fragment"])
+            lines.append("```")
+    return "\n".join(lines)
+
+
+def check_summary(findings):
+    if not findings:
+        return "No duplication touching this PR's changed files."
+    return "\n".join(
+        f"{f['firstFile']}:{f['firstStart']}-{f['firstEnd']} "
+        f"matches {f['secondFile']}:{f['secondStart']}-{f['secondEnd']}"
+        for f in findings
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("report", help="Path to jscpd JSON report")
+    parser.add_argument("changed_files", help="Path to newline-separated changed files list")
+    parser.add_argument("--outdir", default="/tmp", help="Output directory for generated files")
+    args = parser.parse_args()
+
+    with open(args.changed_files) as f:
+        changed_files = [line.strip() for line in f if line.strip()]
+
+    findings = analyze(args.report, changed_files)
+
+    os.makedirs(args.outdir, exist_ok=True)
+
+    body = format_comment_body(findings)
+    with open(os.path.join(args.outdir, "body.md"), "w") as f:
+        f.write(body)
+
+    ok = len(findings) == 0
+    with open(os.path.join(args.outdir, "check-title.txt"), "w") as f:
+        f.write("No duplicate code found" if ok else "Duplicate code found (informational)")
+
+    with open(os.path.join(args.outdir, "check-summary.txt"), "w") as f:
+        f.write(check_summary(findings))
+
+    msg = (
+        "No duplicate code found touching PR changed files."
+        if ok
+        else (
+            f"Found {len(findings)} duplicate code cluster(s) touching "
+            "PR changed files (informational)."
+        )
+    )
+    print(msg)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/analyze-duplication.py
+++ b/.github/scripts/analyze-duplication.py
@@ -14,15 +14,18 @@ import argparse
 import json
 import os
 
+MAX_FRAGMENT_LENGTH = 4_000
+
 
 def normalize(p):
     return p.lstrip("./")
 
 
-def analyze(report_path, changed_files):
-    if not os.path.exists(report_path):
-        return []
+def is_excluded(path):
+    return path.startswith((".github/", "docs/"))
 
+
+def analyze(report_path, changed_files):
     with open(report_path) as f:
         report = json.load(f)
 
@@ -38,6 +41,8 @@ def analyze(report_path, changed_files):
 
         first_name = normalize(first.get("name", ""))
         second_name = normalize(second.get("name", ""))
+        if is_excluded(first_name) or is_excluded(second_name):
+            continue
         if first_name not in changed_set and second_name not in changed_set:
             continue
 
@@ -52,7 +57,7 @@ def analyze(report_path, changed_files):
                 "lines": dup.get("lines"),
                 "tokens": dup.get("tokens"),
                 "format": dup.get("format", ""),
-                "fragment": dup.get("fragment", ""),
+                "fragment": dup.get("fragment", "")[:MAX_FRAGMENT_LENGTH],
             }
         )
 
@@ -102,26 +107,41 @@ def main():
     parser.add_argument("--outdir", default="/tmp", help="Output directory for generated files")
     args = parser.parse_args()
 
-    with open(args.changed_files) as f:
-        changed_files = [line.strip() for line in f if line.strip()]
-
-    findings = analyze(args.report, changed_files)
+    error = None
+    try:
+        with open(args.changed_files) as f:
+            changed_files = [line.strip() for line in f if line.strip()]
+        findings = analyze(args.report, changed_files)
+    except json.JSONDecodeError as exc:
+        findings = []
+        error = f"Could not parse the jscpd JSON report: {exc}"
 
     os.makedirs(args.outdir, exist_ok=True)
 
-    body = format_comment_body(findings)
+    body = f"<!-- duplicate-code-check -->\n{error}" if error else format_comment_body(findings)
     with open(os.path.join(args.outdir, "body.md"), "w") as f:
         f.write(body)
 
-    ok = len(findings) == 0
+    ok = not error and len(findings) == 0
     with open(os.path.join(args.outdir, "check-title.txt"), "w") as f:
-        f.write("No duplicate code found" if ok else "Duplicate code found (informational)")
+        f.write(
+            "Duplicate code check could not run"
+            if error
+            else "No duplicate code found"
+            if ok
+            else "Duplicate code found (informational)"
+        )
 
     with open(os.path.join(args.outdir, "check-summary.txt"), "w") as f:
-        f.write(check_summary(findings))
+        f.write(error or check_summary(findings))
+
+    with open(os.path.join(args.outdir, "check-conclusion.txt"), "w") as f:
+        f.write("success" if ok else "neutral")
 
     msg = (
-        "No duplicate code found touching PR changed files."
+        error
+        if error
+        else "No duplicate code found touching PR changed files."
         if ok
         else (
             f"Found {len(findings)} duplicate code cluster(s) touching "

--- a/.github/workflows/duplicate-code-check.yml
+++ b/.github/workflows/duplicate-code-check.yml
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Duplicate Code Check
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  duplication:
+    name: Detect duplicate code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run jscpd
+        continue-on-error: true
+        run: |
+          npx --yes jscpd@4 . \
+            --config .jscpd.json \
+            --reporters json \
+            --output ../jscpd-report \
+            --silent || true
+
+      - name: Get changed files
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const files = await github.paginate(
+              github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+              }
+            );
+            const fs = require('fs');
+            fs.writeFileSync(
+              'changed-files.txt',
+              files.map(f => f.filename).join('\n')
+            );
+
+      - name: Analyze duplication
+        run: |
+          python3 .github/scripts/analyze-duplication.py \
+            ../jscpd-report/jscpd-report.json \
+            changed-files.txt
+
+      - name: Post PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('/tmp/body.md', 'utf8');
+            const marker = '<!-- duplicate-code-check -->';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Create check run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const title = fs.readFileSync('/tmp/check-title.txt', 'utf8').trim();
+            const summary = fs.readFileSync('/tmp/check-summary.txt', 'utf8').trim();
+
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Duplicate Code Check',
+              head_sha: context.payload.pull_request.head.sha,
+              status: 'completed',
+              conclusion: 'success',
+              output: { title, summary },
+            });

--- a/.github/workflows/duplicate-code-check.yml
+++ b/.github/workflows/duplicate-code-check.yml
@@ -45,7 +45,7 @@ jobs:
             --config .jscpd.json \
             --reporters json \
             --output ../jscpd-report \
-            --silent || true
+            --silent
 
       - name: Get changed files
         uses: actions/github-script@v7
@@ -69,7 +69,8 @@ jobs:
         run: |
           python3 .github/scripts/analyze-duplication.py \
             ../jscpd-report/jscpd-report.json \
-            changed-files.txt
+            changed-files.txt \
+            --outdir /tmp
 
       - name: Post PR comment
         uses: actions/github-script@v7
@@ -108,6 +109,7 @@ jobs:
             const fs = require('fs');
             const title = fs.readFileSync('/tmp/check-title.txt', 'utf8').trim();
             const summary = fs.readFileSync('/tmp/check-summary.txt', 'utf8').trim();
+            const conclusion = fs.readFileSync('/tmp/check-conclusion.txt', 'utf8').trim();
 
             await github.rest.checks.create({
               owner: context.repo.owner,
@@ -115,6 +117,6 @@ jobs:
               name: 'Duplicate Code Check',
               head_sha: context.payload.pull_request.head.sha,
               status: 'completed',
-              conclusion: 'success',
+              conclusion,
               output: { title, summary },
             });

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,11 @@
+{
+  "ignore": [
+    "**/target/**",
+    "**/.git/**",
+    "**/*.lock",
+    "cda-database/src/flatbuf/**",
+    "cda-database/src/proto/**"
+  ],
+  "minLines": 10,
+  "minTokens": 70
+}

--- a/.jscpd.json.license
+++ b/.jscpd.json.license
@@ -1,0 +1,10 @@
+SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0
+
+SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Adds a duplicate code check using jscpd that runs on every PR. The check is purely informational — it always passes CI and never blocks merging. Results are posted as a PR comment and a check run for visibility.

The analysis script (Python) filters jscpd results to clusters that touch files changed in the PR, avoiding false positives from pre-existing duplication unrelated to the diff.

### Files
- `.jscpd.json` — jscpd configuration (minLines=10, minTokens=70)
- `.github/scripts/analyze-duplication.py` — pure analysis script (no external deps, no gh CLI)
- `.github/workflows/duplicate-code-check.yml` — GitHub Actions workflow using `actions/github-script` for API calls

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

## Notes for Reviewers

This follows the same pattern as the `coverage` and `crap` workflows in `cicd-workflows`: Python script generates output files, `actions/github-script` posts results via Octokit.

Example:

<img width="1085" height="1127" alt="Screenshot 2026-07-21 at 15 11 43" src="https://github.com/user-attachments/assets/a62740b3-bfee-477d-8f8a-ed5642cab173" />


---
Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)