### PR TITLE
ci: make clippy findings blocking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly-2025-07-14
+          toolchain: nightly-2026-07-21
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,7 +60,7 @@ jobs:
         continue-on-error: true
         uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@07140bdd84f20b66fd4aff58a83c5148deec388c
         with:
-          toolchain: nightly-2025-07-14
+          toolchain: nightly-2026-07-21
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-format-error: "false"
           fail-on-clippy-error: "false"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -49,10 +49,10 @@ jobs:
       - name: Format and Clippy - Nightly toolchain pinned
         uses: eclipse-opensovd/cicd-workflows/rust-lint-and-format-action@07140bdd84f20b66fd4aff58a83c5148deec388c
         with:
-          toolchain: nightly-2025-07-14
+          toolchain: nightly-2026-07-21
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-format-error: "false"
-          fail-on-clippy-error: "false"
+          fail-on-clippy-error: "true"
           clippy-deny-warnings: "false"
           clippy-features: "all-features"
           error-on-unformatted: "false"
@@ -65,10 +65,8 @@ jobs:
           toolchain: nightly
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-format-error: "false"
-          fail-on-clippy-error: "false"
+          fail-on-clippy-error: "true"
           clippy-deny-warnings: "false"
           clippy-features: "all-features"
           error-on-unformatted: "false"
-          # For nightly, we also want to see files not touched by
-          # the PR, to detect if there are any new warnings introduced by the latest nightly toolchain.
-          reporter: ${{ env.IS_FORK == 'true' && 'github-annotations' || 'github-pr-check' }}
+          reporter: ${{ env.IS_FORK == 'true' && 'github-pr-annotations' || 'github-pr-review' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ name = "cda-comm-uds"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "cda-build",
  "cda-interfaces",
  "cda-plugin-runtime-update",
  "futures",
@@ -434,6 +435,7 @@ name = "cda-core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "cda-build",
  "cda-database",
  "cda-interfaces",
  "cda-plugin-security",
@@ -506,6 +508,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytes",
+ "cda-build",
  "foldhash",
  "hex",
  "mockall",
@@ -2408,6 +2411,7 @@ version = "0.1.0"
 dependencies = [
  "aide",
  "axum",
+ "cda-build",
  "http",
  "tokio",
 ]

--- a/cda-comm-can/src/gateway.rs
+++ b/cda-comm-can/src/gateway.rs
@@ -708,29 +708,36 @@ impl EcuGateway for CanDiagGateway {
         }
     }
 
-    async fn get_ecu_network_address(&self, ecu_name: &str) -> Option<String> {
-        self.get_connection(&ecu_name.to_lowercase())
-            .map(|conn| conn.network_address())
+    fn get_ecu_network_address(
+        &self,
+        ecu_name: &str,
+    ) -> impl Future<Output = Option<String>> + Send {
+        let result = self
+            .get_connection(&ecu_name.to_lowercase())
+            .map(|conn| conn.network_address());
+        std::future::ready(result)
     }
 
-    async fn send_functional(
+    fn send_functional(
         &self,
         _transmission_params: cda_interfaces::TransmissionParameters,
         _message: cda_interfaces::ServicePayload,
         _expected_ecu_logical_addrs: cda_interfaces::HashMap<u16, String>,
         _timeout: std::time::Duration,
         _expect_positive_response: bool,
-    ) -> Result<
-        cda_interfaces::HashMap<String, Result<cda_interfaces::UdsResponse, DiagServiceError>>,
-        DiagServiceError,
-    > {
+    ) -> impl Future<
+        Output = Result<
+            cda_interfaces::HashMap<String, Result<cda_interfaces::UdsResponse, DiagServiceError>>,
+            DiagServiceError,
+        >,
+    > + Send {
         // CAN functional addressing is not implemented yet, see #417.
         // Fail the whole request honestly; the UDS layer maps a gateway-level
         // error to a per-ECU error result, so clients see WHY it failed
         // instead of every ECU appearing to be offline.
-        Err(DiagServiceError::RequestNotSupported(
+        std::future::ready(Err(DiagServiceError::RequestNotSupported(
             "functional addressing is not implemented for the CAN transport".to_owned(),
-        ))
+        )))
     }
 }
 

--- a/cda-comm-can/src/multi_transport.rs
+++ b/cda-comm-can/src/multi_transport.rs
@@ -431,48 +431,60 @@ mod tests {
         }
 
         impl EcuGateway for DoipStub {
-            async fn get_gateway_network_address(&self, _logical_address: u16) -> Option<String> {
-                self.online
+            fn get_gateway_network_address(
+                &self,
+                _logical_address: u16,
+            ) -> impl Future<Output = Option<String>> + Send {
+                let result = self
+                    .online
                     .load(Ordering::SeqCst)
-                    .then(|| "1.2.3.4".to_owned())
+                    .then(|| "1.2.3.4".to_owned());
+                std::future::ready(result)
             }
 
-            async fn send(
+            fn send(
                 &self,
                 _transmission_params: TransmissionParameters,
                 _message: ServicePayload,
                 _response_sender: mpsc::Sender<Result<Option<UdsResponse>, DiagServiceError>>,
                 _expect_uds_reply: bool,
-            ) -> Result<(), DiagServiceError> {
-                Ok(())
+            ) -> impl Future<Output = Result<(), DiagServiceError>> + Send {
+                std::future::ready(Ok(()))
             }
 
-            async fn ecu_online<T: EcuAddresses>(
+            fn ecu_online<T: EcuAddresses>(
                 &self,
                 ecu_name: &str,
                 _ecu_db: &RwLock<T>,
-            ) -> Result<(), DiagServiceError> {
+            ) -> impl Future<Output = Result<(), DiagServiceError>> + Send {
                 self.ecu_online_calls.fetch_add(1, Ordering::SeqCst);
-                if self.online.load(Ordering::SeqCst) {
+                let result = if self.online.load(Ordering::SeqCst) {
                     Ok(())
                 } else {
                     Err(DiagServiceError::EcuOffline(ecu_name.to_owned()))
-                }
+                };
+                std::future::ready(result)
             }
 
-            async fn send_functional(
+            fn send_functional(
                 &self,
                 _transmission_params: TransmissionParameters,
                 _message: ServicePayload,
                 _expected_ecu_logical_addrs: HashMap<u16, String>,
                 _timeout: std::time::Duration,
                 _expect_positive_response: bool,
-            ) -> Result<HashMap<String, Result<UdsResponse, DiagServiceError>>, DiagServiceError>
-            {
-                Ok(HashMap::default())
+            ) -> impl Future<
+                Output = Result<
+                    HashMap<String, Result<UdsResponse, DiagServiceError>>,
+                    DiagServiceError,
+                >,
+            > + Send {
+                std::future::ready(Ok(HashMap::default()))
             }
 
-            async fn shutdown(&mut self) {}
+            fn shutdown(&mut self) -> impl Future<Output = ()> + Send {
+                std::future::ready(())
+            }
         }
 
         struct EcuStub;

--- a/cda-comm-uds/Cargo.toml
+++ b/cda-comm-uds/Cargo.toml
@@ -50,5 +50,8 @@ strum = { workspace = true, features = ["derive"] }
 default = []
 dlt-tracing = ["cda-interfaces/dlt-tracing"]
 
+[build-dependencies]
+cda-build = { workspace = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/cda-comm-uds/build.rs
+++ b/cda-comm-uds/build.rs
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+fn main() {
+    cda_build::set_nightly_flag();
+}

--- a/cda-comm-uds/src/coordinator.rs
+++ b/cda-comm-uds/src/coordinator.rs
@@ -17,6 +17,14 @@
 //! Variant detection writes happen directly via `std::sync::RwLock` (from `EcuManager`),
 //! while disconnect events go through the actor to avoid races.
 //!
+#![cfg_attr(
+    nightly,
+    allow(
+        unknown_lints,
+        clippy::unused_async_trait_impl,
+        reason = "The `Actor` derive macro generates async trait impls that may have no `.await`"
+    )
+)]
 //! Reads go directly through [`EcuCoordinatorHandle::state`] (a `std::sync::RwLock`)
 //! without touching the actor mailbox.
 

--- a/cda-comm-uds/src/test_helpers.rs
+++ b/cda-comm-uds/src/test_helpers.rs
@@ -13,7 +13,7 @@
 
 //! Shared test doubles for `cda-comm-uds` tests.
 
-use std::time::Duration;
+use std::{future::Future, time::Duration};
 
 use async_trait::async_trait;
 use cda_interfaces::{
@@ -164,24 +164,24 @@ impl EcuStateManager for TestEcuDb {
         async move { states.lock().await.get(&sid).cloned() }
     }
 
-    async fn session(&self) -> Result<String, DiagServiceError> {
-        Ok("default".to_string())
+    fn session(&self) -> impl Future<Output = Result<String, DiagServiceError>> + Send {
+        std::future::ready(Ok("default".to_string()))
     }
 
     fn default_session(&self) -> Result<String, DiagServiceError> {
         Ok("default".to_string())
     }
 
-    async fn security_access(&self) -> Result<String, DiagServiceError> {
-        Ok("locked".to_string())
+    fn security_access(&self) -> impl Future<Output = Result<String, DiagServiceError>> + Send {
+        std::future::ready(Ok("locked".to_string()))
     }
 
     async fn lookup_session_change(&self, _session: &str) -> Result<DiagComm, DiagServiceError> {
         unimplemented!()
     }
 
-    async fn set_default_states(&self) -> Result<(), DiagServiceError> {
-        Ok(())
+    fn set_default_states(&self) -> impl Future<Output = Result<(), DiagServiceError>> + Send {
+        std::future::ready(Ok(()))
     }
 }
 

--- a/cda-comm-uds/src/test_helpers.rs
+++ b/cda-comm-uds/src/test_helpers.rs
@@ -13,7 +13,7 @@
 
 //! Shared test doubles for `cda-comm-uds` tests.
 
-use std::{future::Future, time::Duration};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use cda_interfaces::{

--- a/cda-comm-uds/src/transport.rs
+++ b/cda-comm-uds/src/transport.rs
@@ -753,8 +753,11 @@ mod send_tests {
     impl EcuGateway for TestGateway {
         async fn shutdown(&mut self) {}
 
-        async fn get_gateway_network_address(&self, _logical_address: u16) -> Option<String> {
-            None
+        fn get_gateway_network_address(
+            &self,
+            _logical_address: u16,
+        ) -> impl Future<Output = Option<String>> + Send {
+            std::future::ready(None)
         }
 
         fn send(
@@ -768,24 +771,28 @@ mod send_tests {
             async move { result }
         }
 
-        async fn ecu_online<T: EcuAddresses>(
+        fn ecu_online<T: EcuAddresses>(
             &self,
             _ecu_name: &str,
             _ecu_db: &RwLock<T>,
-        ) -> Result<(), DiagServiceError> {
-            Ok(())
+        ) -> impl Future<Output = Result<(), DiagServiceError>> + Send {
+            std::future::ready(Ok(()))
         }
 
-        async fn send_functional(
+        fn send_functional(
             &self,
             _transmission_params: TransmissionParameters,
             _message: ServicePayload,
             _expected_ecu_logical_addrs: HashMap<u16, String>,
             _timeout: Duration,
             _expect_positive_response: bool,
-        ) -> Result<HashMap<String, Result<UdsResponse, DiagServiceError>>, DiagServiceError>
-        {
-            Ok(HashMap::new())
+        ) -> impl Future<
+            Output = Result<
+                HashMap<String, Result<UdsResponse, DiagServiceError>>,
+                DiagServiceError,
+            >,
+        > + Send {
+            std::future::ready(Ok(HashMap::new()))
         }
     }
 

--- a/cda-core/Cargo.toml
+++ b/cda-core/Cargo.toml
@@ -43,6 +43,9 @@ schemars = { workspace = true }
 # logging & tracing
 tracing = { workspace = true }
 
+[build-dependencies]
+cda-build = { workspace = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }
 flatbuffers = { workspace = true }

--- a/cda-core/build.rs
+++ b/cda-core/build.rs
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+fn main() {
+    cda_build::set_nightly_flag();
+}

--- a/cda-core/src/diag_kernel/state.rs
+++ b/cda-core/src/diag_kernel/state.rs
@@ -11,6 +11,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#![cfg_attr(
+    nightly,
+    allow(
+        unknown_lints,
+        clippy::unused_async_trait_impl,
+        reason = "The `Actor` derive macro generates async trait impls that may have no `.await`"
+    )
+)]
+
 use cda_database::datatypes;
 use cda_interfaces::{DiagServiceError, EcuStateManager, dlt_ctx, service_ids, util::std_ext};
 use cda_plugin_security::SecurityPlugin;

--- a/cda-database/src/datatypes.rs
+++ b/cda-database/src/datatypes.rs
@@ -11,6 +11,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#![allow(
+    clippy::extra_unused_lifetimes,
+    reason = "The `self_referencing` macro from ouroboros generates a lifetime that clippy cannot \
+              see is used"
+)]
+
 use std::fmt::Debug;
 
 use cda_interfaces::{

--- a/cda-database/src/datatypes/diag_coded_type.rs
+++ b/cda-database/src/datatypes/diag_coded_type.rs
@@ -41,29 +41,25 @@ impl DataType {
 
         if matches!(self, DataType::Int32 | DataType::UInt32) && bit_len > 64 {
             return Err(DiagServiceError::BadPayload(format!(
-                "Length must be at most 64 bit for {:?}, got {bit_len} bit",
-                &self
+                "Length must be at most 64 bit for {self:?}, got {bit_len} bit",
             )));
         }
 
         if DataType::Float32 == self && bit_len != 32 {
             return Err(DiagServiceError::BadPayload(format!(
-                "Length must be exactly 32 bit for {:?}, got {bit_len} bit",
-                &self
+                "Length must be exactly 32 bit for {self:?}, got {bit_len} bit",
             )));
         }
 
         if DataType::Float64 == self && bit_len != 64 {
             return Err(DiagServiceError::BadPayload(format!(
-                "Length must be exactly 64 bit for {:?}, got {bit_len} bit",
-                &self
+                "Length must be exactly 64 bit for {self:?}, got {bit_len} bit",
             )));
         }
 
         if DataType::Unicode2String == self && !bit_len.is_multiple_of(16) {
             return Err(DiagServiceError::BadPayload(format!(
-                "Length must be a multiple of 16 bit for {:?}, got {bit_len} bit",
-                &self
+                "Length must be a multiple of 16 bit for {self:?}, got {bit_len} bit",
             )));
         }
 

--- a/cda-interfaces/Cargo.toml
+++ b/cda-interfaces/Cargo.toml
@@ -52,6 +52,10 @@ tokio = { workspace = true, features = ["macros", "rt"] }
 
 [features]
 default = []
+nightly = []
 tokio-tracing = ["tokio/tracing"]
 dlt-tracing = []
 test-utils = ["mockall"]
+
+[build-dependencies]
+cda-build = { workspace = true }

--- a/cda-interfaces/build.rs
+++ b/cda-interfaces/build.rs
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+fn main() {
+    cda_build::set_nightly_flag();
+}

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -11,8 +11,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::future::Future;
-
 use async_trait::async_trait;
 use serde::Serialize;
 use strum_macros::Display;

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -11,10 +11,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::{fmt::Display, future::Future};
+use std::future::Future;
 
 use async_trait::async_trait;
 use serde::Serialize;
+use strum_macros::Display;
 
 use crate::{
     DiagComm, DiagServiceError, DoipComParams, DynamicPlugin, EcuSchemas, HashMap,
@@ -133,21 +134,12 @@ pub struct MuxCaseInfo {
 /// Derived from [`Connectivity`] + [`VariantState`] via [`EcuStatus::to_ecu_state()`].
 ///
 /// ECU connectivity state, eg. reachable via underlying transport
-#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Display, Serialize, PartialEq, Eq)]
 pub enum Connectivity {
     /// ECU responded to the last communication attempt.
     Online,
     /// ECU is currently unreachable (never connected, or lost connection).
     Offline,
-}
-
-impl Display for Connectivity {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Online => f.write_str("Online"),
-            Self::Offline => f.write_str("Offline"),
-        }
-    }
 }
 
 /// ECU variant detection result.

--- a/cda-interfaces/src/ecuuds.rs
+++ b/cda-interfaces/src/ecuuds.rs
@@ -965,32 +965,32 @@ pub mod mock {
 
     use crate::schema::{SchemaDescription, SchemaProvider};
 
-    // We have to adhere to the signature of the trait, which is async, but we don't actually need to do any async work here.
-    // core::future::ready what clippy suggest as alternative if not available on 1.88
-    #[cfg_attr(nightly, allow(unknown_lints, clippy::unused_async_trait_impl))]
     impl SchemaProvider for MockUdsEcu {
-        async fn schema_for_request(
+        fn schema_for_request(
             &self,
             _ecu: &str,
             _service: &crate::DiagComm,
-        ) -> Result<SchemaDescription, DiagServiceError> {
-            Err(DiagServiceError::NotFound(String::new()))
+        ) -> impl std::future::Future<Output = Result<SchemaDescription, DiagServiceError>> + Send
+        {
+            std::future::ready(Err(DiagServiceError::NotFound(String::new())))
         }
 
-        async fn schema_for_responses(
+        fn schema_for_responses(
             &self,
             _ecu: &str,
             _service: &crate::DiagComm,
-        ) -> Result<SchemaDescription, DiagServiceError> {
-            Err(DiagServiceError::NotFound(String::new()))
+        ) -> impl std::future::Future<Output = Result<SchemaDescription, DiagServiceError>> + Send
+        {
+            std::future::ready(Err(DiagServiceError::NotFound(String::new())))
         }
 
-        async fn schema_for_fg_request(
+        fn schema_for_fg_request(
             &self,
             _service: &crate::DiagComm,
             _functional_group_name: &str,
-        ) -> Result<SchemaDescription, DiagServiceError> {
-            Err(DiagServiceError::NotFound(String::new()))
+        ) -> impl std::future::Future<Output = Result<SchemaDescription, DiagServiceError>> + Send
+        {
+            std::future::ready(Err(DiagServiceError::NotFound(String::new())))
         }
     }
 }

--- a/cda-main/src/config/configfile.rs
+++ b/cda-main/src/config/configfile.rs
@@ -449,7 +449,7 @@ interface = "vcan0"
     #[cfg(feature = "can")]
     #[tokio::test]
     async fn can_ecu_mappings_sanity_rejects_ambiguity() -> Result<(), Box<dyn std::error::Error>> {
-        async fn config_with_mappings(
+        fn config_with_mappings(
             mappings: &str,
         ) -> Result<Configuration, Box<dyn std::error::Error>> {
             let config_str = format!(
@@ -475,8 +475,7 @@ ecu_name = "ECU2"
 request_id = 0x7E1
 response_id = 0x7E9
 "#,
-        )
-        .await?;
+        )?;
         valid
             .validate_sanity()
             .expect("distinct mappings should pass sanity");
@@ -493,8 +492,7 @@ ecu_name = "ecu1"
 request_id = 0x7E1
 response_id = 0x7E9
 "#,
-        )
-        .await?;
+        )?;
         let err = duplicate_name
             .validate_sanity()
             .expect_err("case-insensitive duplicate ECU name should fail sanity");
@@ -512,8 +510,7 @@ ecu_name = "ECU2"
 request_id = 0x7E0
 response_id = 0x7E8
 "#,
-        )
-        .await?;
+        )?;
         let err = duplicate_pair
             .validate_sanity()
             .expect_err("reused CAN ID pair should fail sanity");
@@ -526,8 +523,7 @@ ecu_name = "ECU1"
 request_id = 0x7E0
 response_id = 0x7E0
 "#,
-        )
-        .await?;
+        )?;
         let err = self_answering
             .validate_sanity()
             .expect_err("request_id == response_id should fail sanity");

--- a/cda-sovd/src/sovd.rs
+++ b/cda-sovd/src/sovd.rs
@@ -965,8 +965,8 @@ macro_rules! create_response_schema {
                     Some(s) => s.to_value(),
                 };
                 obj.insert($target_field.into(), value);
-                if let Some(mut errs) = obj.get_mut("errors") {
-                    crate::sovd::remove_descriptions_recursive(&mut errs);
+                if let Some(errs) = obj.get_mut("errors") {
+                    crate::sovd::remove_descriptions_recursive(&mut *errs);
                 }
             }
         }

--- a/cda-sovd/src/sovd/apps/sovd2uds/bulk_data/runtimefiles.rs
+++ b/cda-sovd/src/sovd/apps/sovd2uds/bulk_data/runtimefiles.rs
@@ -192,18 +192,22 @@ pub(crate) async fn require_vehicle_lock(
     lock_state: &dyn LockStateProvider,
     claims: &dyn cda_plugin_security::Claims,
     retry_after_seconds: u64,
-) -> Result<(), Response> {
+) -> Result<(), Box<Response>> {
     match lock_state.vehicle_lock_owner_sub().await {
-        None => Err(DbUpdateErrorResponse::new(
-            RuntimeUpdateError::NoLock("Vehicle lock is missing".to_owned()),
-            retry_after_seconds,
-        )
-        .into_response()),
-        Some(owner) if owner != claims.sub() => Err(DbUpdateErrorResponse::new(
-            RuntimeUpdateError::NoLock("Vehicle lock is owned by another user".to_owned()),
-            retry_after_seconds,
-        )
-        .into_response()),
+        None => Err(Box::new(
+            DbUpdateErrorResponse::new(
+                RuntimeUpdateError::NoLock("Vehicle lock is missing".to_owned()),
+                retry_after_seconds,
+            )
+            .into_response(),
+        )),
+        Some(owner) if owner != claims.sub() => Err(Box::new(
+            DbUpdateErrorResponse::new(
+                RuntimeUpdateError::NoLock("Vehicle lock is owned by another user".to_owned()),
+                retry_after_seconds,
+            )
+            .into_response(),
+        )),
         Some(_) => Ok(()),
     }
 }
@@ -466,7 +470,7 @@ pub(crate) mod nextupdate {
             // receiving this response. Drain the remaining body first so the
             // connection can be closed/reused safely.
             while let Ok(Some(_field)) = multipart.next_field().await {}
-            return resp.into_response();
+            return (*resp).into_response();
         }
 
         let mut files = Vec::new();
@@ -561,7 +565,7 @@ pub(crate) mod nextupdate {
         )
         .await
         {
-            return resp.into_response();
+            return (*resp).into_response();
         }
         route_state.plugin.delete_nextupdate().await.map_or_else(
             |e| DbUpdateErrorResponse::new(e, route_state.retry_after_seconds).into_response(),
@@ -602,7 +606,7 @@ pub(crate) mod nextupdate {
             )
             .await
             {
-                return resp.into_response();
+                return (*resp).into_response();
             }
             route_state
                 .plugin
@@ -656,7 +660,7 @@ pub(crate) mod backup {
         )
         .await
         {
-            return resp.into_response();
+            return (*resp).into_response();
         }
         route_state.plugin.delete_backup().await.map_or_else(
             |e| DbUpdateErrorResponse::new(e, route_state.retry_after_seconds).into_response(),

--- a/cda-sovd/src/sovd/components/ecu/operations.rs
+++ b/cda-sovd/src/sovd/components/ecu/operations.rs
@@ -1047,7 +1047,7 @@ pub(crate) mod service {
                     Ok(r) => r,
                     Err(e) => {
                         remove_reserved_execution(&service_executions, &service, &exec_id).await;
-                        return e;
+                        return *e;
                     }
                 }
             };
@@ -1102,22 +1102,26 @@ pub(crate) mod service {
             data: Option<cda_interfaces::diagservices::UdsPayloadData>,
             map_to_json: bool,
             include_schema: bool,
-        ) -> Result<Option<T::Response>, Response> {
+        ) -> Result<Option<T::Response>, Box<Response>> {
             let response = match uds
                 .send(ecu_name, diag_service, security_plugin, data, map_to_json)
                 .await
             {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(ErrorWrapper {
-                        error: e.into(),
-                        include_schema,
-                    }
-                    .into_response());
+                    return Err(Box::new(
+                        ErrorWrapper {
+                            error: e.into(),
+                            include_schema,
+                        }
+                        .into_response(),
+                    ));
                 }
             };
             if let DiagServiceResponseType::Negative = response.response_type() {
-                return Err(api_error_from_diag_response(&response, include_schema).into_response());
+                return Err(Box::new(
+                    api_error_from_diag_response(&response, include_schema).into_response(),
+                ));
             }
             Ok(Some(response))
         }

--- a/cda-sovd/src/sovd/components/ecu/x_sovd2uds_download.rs
+++ b/cda-sovd/src/sovd/components/ecu/x_sovd2uds_download.rs
@@ -41,7 +41,7 @@ async fn sovd_to_func_class_service_exec<T: UdsEcu + Clone>(
     parameters: HashMap<String, serde_json::Value>,
     security_plugin: Box<dyn SecurityPlugin>,
     include_schema: bool,
-) -> Result<DiagServiceJsonResponse, Response> {
+) -> Result<DiagServiceJsonResponse, Box<Response>> {
     let params = UdsPayloadData::ParameterMap(parameters);
     let response = match uds
         .ecu_exec_service_from_function_class(
@@ -55,26 +55,32 @@ async fn sovd_to_func_class_service_exec<T: UdsEcu + Clone>(
     {
         Ok(v) => v,
         Err(e) => {
-            return Err(ErrorWrapper {
-                error: e.into(),
-                include_schema,
-            }
-            .into_response());
+            return Err(Box::new(
+                ErrorWrapper {
+                    error: e.into(),
+                    include_schema,
+                }
+                .into_response(),
+            ));
         }
     };
 
     if let DiagServiceResponseType::Negative = response.response_type() {
-        return Err(api_error_from_diag_response(&response, include_schema).into_response());
+        return Err(Box::new(
+            api_error_from_diag_response(&response, include_schema).into_response(),
+        ));
     }
 
     let mapped_data = match response.into_json() {
         Ok(v) => v,
         Err(e) => {
-            return Err(ErrorWrapper {
-                error: ApiError::InternalServerError(Some(format!("{e:?}"))),
-                include_schema,
-            }
-            .into_response());
+            return Err(Box::new(
+                ErrorWrapper {
+                    error: ApiError::InternalServerError(Some(format!("{e:?}"))),
+                    include_schema,
+                }
+                .into_response(),
+            ));
         }
     };
     Ok(mapped_data)
@@ -212,7 +218,7 @@ pub(crate) mod request_download {
                 include_schema,
             }
             .into_response(),
-            Err(response) => response,
+            Err(response) => *response,
         }
     }
 
@@ -601,7 +607,7 @@ pub(crate) mod transferexit {
         .await
         {
             Ok(_) => StatusCode::NO_CONTENT.into_response(),
-            Err(response) => response,
+            Err(response) => *response,
         }
     }
 

--- a/cda-storage/Cargo.toml
+++ b/cda-storage/Cargo.toml
@@ -25,6 +25,7 @@ workspace = true
 ## Enable runtime validation of collection names and keys used as path segments.
 ## Rejects directory traversal attempts (e.g., "..", "/") with an error.
 sanitize-paths = []
+nightly = []
 
 [lib]
 path = "src/lib.rs"

--- a/cda-storage/src/local_collection.rs
+++ b/cda-storage/src/local_collection.rs
@@ -216,36 +216,48 @@ impl Collection for LocalCollection {
         Ok(())
     }
 
-    async fn delete(&self, tx: &mut Transaction, key: &str) -> Result<(), StorageError> {
-        let key = normalize_key(key);
-        self.ensure_normalized_on_disk(&key);
+    fn delete(
+        &self,
+        tx: &mut Transaction,
+        key: &str,
+    ) -> impl std::future::Future<Output = Result<(), StorageError>> + Send {
+        let result = (|| {
+            let key = normalize_key(key);
+            self.ensure_normalized_on_disk(&key);
 
-        // Verify the key exists in committed state.
-        let path = self.key_path(&key)?;
-        if !path.exists() {
-            return Err(StorageError::KeyNotFound(key));
-        }
+            // Verify the key exists in committed state.
+            let path = self.key_path(&key)?;
+            if !path.exists() {
+                return Err(StorageError::KeyNotFound(key));
+            }
 
-        let op = Operation::Delete {
-            collection: self.name.clone(),
-            key,
-        };
+            let op = Operation::Delete {
+                collection: self.name.clone(),
+                key,
+            };
 
-        wal::append_operation(tx.journal_path(), &op)?;
-        tx.record(op);
+            wal::append_operation(tx.journal_path(), &op)?;
+            tx.record(op);
 
-        Ok(())
+            Ok(())
+        })();
+        std::future::ready(result)
     }
 
-    async fn delete_all(&self, tx: &mut Transaction) -> Result<(), StorageError> {
+    fn delete_all(
+        &self,
+        tx: &mut Transaction,
+    ) -> impl std::future::Future<Output = Result<(), StorageError>> + Send {
         let op = Operation::DeleteAll {
             collection: self.name.clone(),
         };
 
-        wal::append_operation(tx.journal_path(), &op)?;
-        tx.record(op);
-
-        Ok(())
+        let result = (|| {
+            wal::append_operation(tx.journal_path(), &op)?;
+            tx.record(op);
+            Ok(())
+        })();
+        std::future::ready(result)
     }
 }
 

--- a/cda-storage/src/local_storage.rs
+++ b/cda-storage/src/local_storage.rs
@@ -242,13 +242,13 @@ impl Storage for LocalStorage {
                 return Err(StorageError::CollectionNotFound(source.to_string()));
             }
 
-        let op = Operation::CopyCollection {
-            source: source.clone(),
-            dest: dest.clone(),
-            dest_existed: self.collection_dir(dest)?.exists(),
-        };
-        wal::append_operation(tx.journal_path(), &op)?;
-        tx.record(op);
+            let op = Operation::CopyCollection {
+                source: source.clone(),
+                dest: dest.clone(),
+                dest_existed: self.collection_dir(dest)?.exists(),
+            };
+            wal::append_operation(tx.journal_path(), &op)?;
+            tx.record(op);
 
             Ok(())
         })();

--- a/cda-storage/src/local_storage.rs
+++ b/cda-storage/src/local_storage.rs
@@ -183,57 +183,64 @@ impl Storage for LocalStorage {
         ))
     }
 
-    async fn create_collection(
+    fn create_collection(
         &self,
         tx: &mut Transaction,
         name: &CollectionName,
-    ) -> Result<Arc<LocalCollection>, StorageError> {
-        let dir = self.collection_dir(name)?;
-        if dir.exists() {
-            return Err(StorageError::TransactionConflict(format!(
-                "Collection already exists: {name}"
-            )));
-        }
+    ) -> impl std::future::Future<Output = Result<Arc<LocalCollection>, StorageError>> + Send {
+        let result = (|| {
+            let dir = self.collection_dir(name)?;
+            if dir.exists() {
+                return Err(StorageError::TransactionConflict(format!(
+                    "Collection already exists: {name}"
+                )));
+            }
 
-        let op = Operation::CreateCollection { name: name.clone() };
-        wal::append_operation(tx.journal_path(), &op)?;
-        tx.record(op);
+            let op = Operation::CreateCollection { name: name.clone() };
+            wal::append_operation(tx.journal_path(), &op)?;
+            tx.record(op);
 
-        // Return a collection handle that points to where the directory *will* be after commit.
-        Ok(Arc::new(LocalCollection::new(
-            name.clone(),
-            dir,
-            Arc::clone(&self.data_lock),
-        )))
+            // Return a collection handle that points to where the directory *will* be after commit.
+            Ok(Arc::new(LocalCollection::new(
+                name.clone(),
+                dir,
+                Arc::clone(&self.data_lock),
+            )))
+        })();
+        std::future::ready(result)
     }
 
-    async fn delete_collection(
+    fn delete_collection(
         &self,
         tx: &mut Transaction,
         name: &CollectionName,
-    ) -> Result<(), StorageError> {
-        let dir = self.collection_dir(name)?;
-        if !dir.exists() {
-            return Err(StorageError::CollectionNotFound(name.to_string()));
-        }
+    ) -> impl std::future::Future<Output = Result<(), StorageError>> + Send {
+        let result = (|| {
+            let dir = self.collection_dir(name)?;
+            if !dir.exists() {
+                return Err(StorageError::CollectionNotFound(name.to_string()));
+            }
 
-        let op = Operation::DeleteCollection { name: name.clone() };
-        wal::append_operation(tx.journal_path(), &op)?;
-        tx.record(op);
+            let op = Operation::DeleteCollection { name: name.clone() };
+            wal::append_operation(tx.journal_path(), &op)?;
+            tx.record(op);
 
-        Ok(())
+            Ok(())
+        })();
+        std::future::ready(result)
     }
 
-    async fn copy_collection(
+    fn copy_collection(
         &self,
         tx: &mut Transaction,
         source: &CollectionName,
         dest: &CollectionName,
-    ) -> Result<(), StorageError> {
-        let source_dir = self.collection_dir(source)?;
-        if !source_dir.exists() {
-            return Err(StorageError::CollectionNotFound(source.to_string()));
-        }
+    ) -> impl std::future::Future<Output = Result<(), StorageError>> + Send {
+        let result = (|| {
+            let source_dir = self.collection_dir(source)?;
+            if !source_dir.exists() {
+                return Err(StorageError::CollectionNotFound(source.to_string()));
+            }
 
         let op = Operation::CopyCollection {
             source: source.clone(),
@@ -243,7 +250,9 @@ impl Storage for LocalStorage {
         wal::append_operation(tx.journal_path(), &op)?;
         tx.record(op);
 
-        Ok(())
+            Ok(())
+        })();
+        std::future::ready(result)
     }
 }
 

--- a/cda-tracing/src/lib.rs
+++ b/cda-tracing/src/lib.rs
@@ -320,7 +320,14 @@ impl Default for LogFileConfig {
 impl Default for TokioTracingConfig {
     fn default() -> Self {
         Self {
-            #[cfg_attr(nightly, allow(unknown_lints, clippy::duration_suboptimal_units))]
+            #[cfg_attr(
+                nightly,
+                allow(
+                    unknown_lints,
+                    clippy::duration_suboptimal_units,
+                    reason = "from_hours not available in Rust 1.88"
+                )
+            )]
             retention: std::time::Duration::from_secs(60 * 60), // 1h
             server: "127.0.0.1:6669".to_owned(),
             recording_path: None,

--- a/integration-tests/tests/integration_tests.rs
+++ b/integration-tests/tests/integration_tests.rs
@@ -11,5 +11,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Duration::from_mins is only available in rust >= 1.91.0, we want to support 1.88.0
+#![cfg_attr(
+    nightly,
+    allow(
+        unknown_lints,
+        clippy::duration_suboptimal_units,
+        reason = "from_mins/from_hours not available in Rust 1.88"
+    )
+)]
+
 mod sovd;
 mod util;

--- a/integration-tests/tests/sovd/ecu.rs
+++ b/integration-tests/tests/sovd/ecu.rs
@@ -251,8 +251,6 @@ async fn test_ecu_session_switching() {
     .await
     .unwrap();
 
-    // Duration::from_mins is only available in rust >= 1.91.0, we want to support 1.88.0
-    #[cfg_attr(nightly, allow(unknown_lints, clippy::duration_suboptimal_units))]
     let expiration_timeout = Duration::from_secs(60);
     let ecu_lock = create_lock(
         expiration_timeout,
@@ -626,8 +624,6 @@ async fn test_communication_control() {
     .unwrap();
 
     // Create and acquire lock
-    // Duration::from_mins is only available in rust >= 1.91.0, we want to support 1.88.0
-    #[cfg_attr(nightly, allow(unknown_lints, clippy::duration_suboptimal_units))]
     let expiration_timeout = Duration::from_secs(60);
     let ecu_lock = create_lock(
         expiration_timeout,

--- a/integration-tests/tests/sovd/ecu.rs
+++ b/integration-tests/tests/sovd/ecu.rs
@@ -190,7 +190,7 @@ async fn test_can_only_ecu_from_configuration() {
         .map(|structures| {
             structures
                 .iter()
-                .flat_map(|ns| ns.get("Gateways").and_then(|g| g.as_array()))
+                .filter_map(|ns| ns.get("Gateways").and_then(|g| g.as_array()))
                 .flatten()
                 .collect()
         })

--- a/integration-tests/tests/sovd/faults.rs
+++ b/integration-tests/tests/sovd/faults.rs
@@ -56,8 +56,6 @@ async fn test_dtc_setting() {
     .unwrap();
 
     // Create and acquire lock
-    // Duration::from_mins is only available in rust >= 1.91.0, we want to support 1.88.0
-    #[cfg_attr(nightly, allow(unknown_lints, clippy::duration_suboptimal_units))]
     let expiration_timeout = Duration::from_secs(60);
     let ecu_lock = locks::create_lock(
         expiration_timeout,

--- a/integration-tests/tests/sovd/flash_download.rs
+++ b/integration-tests/tests/sovd/flash_download.rs
@@ -52,8 +52,6 @@ async fn test_flash_download_transfer_sequence() {
     let ecu_endpoint = sovd::ECU_FLXC1000_ENDPOINT;
 
     // Create and acquire ECU lock
-    // Duration::from_mins is only available in rust >= 1.91.0, we want to support 1.88.0
-    #[cfg_attr(nightly, allow(unknown_lints, clippy::duration_suboptimal_units))]
     let expiration_timeout = Duration::from_secs(120);
     let ecu_lock = create_lock(
         expiration_timeout,
@@ -438,7 +436,6 @@ async fn test_flash_transfer_zero_length_rejected() {
     let ecu_endpoint = sovd::ECU_FLXC1000_ENDPOINT;
 
     // Create and acquire ECU lock
-    #[cfg_attr(nightly, allow(unknown_lints, clippy::duration_suboptimal_units))]
     let expiration_timeout = Duration::from_secs(120);
     let ecu_lock = create_lock(
         expiration_timeout,
@@ -686,7 +683,6 @@ async fn test_security_access_supplier_level() {
     let ecu_endpoint = sovd::ECU_FLXC1000_ENDPOINT;
 
     // Create and acquire ECU lock
-    #[cfg_attr(nightly, allow(unknown_lints, clippy::duration_suboptimal_units))]
     let expiration_timeout = Duration::from_secs(120);
     let ecu_lock = create_lock(
         expiration_timeout,

--- a/integration-tests/tests/sovd/locks.rs
+++ b/integration-tests/tests/sovd/locks.rs
@@ -615,8 +615,6 @@ pub(crate) async fn create_lock(
 }
 
 pub(crate) fn default_timeout() -> Duration {
-    // Duration::from_hours is only available in rust >= 1.91.0, we want to support 1.88.0
-    #[cfg_attr(nightly, allow(unknown_lints, clippy::duration_suboptimal_units))]
     Duration::from_secs(3600)
 }
 

--- a/integration-tests/tests/sovd/operations.rs
+++ b/integration-tests/tests/sovd/operations.rs
@@ -748,7 +748,7 @@ async fn test_time_circuits_sends_correct_uds_frames() {
 }
 
 /// Verify the correct UDS frame for `TimeCircuits` Start with `ManualEntry` travel method.
-/// The ManualEntry row encodes: travelMethod key=0x01 followed by
+/// The `ManualEntry` row encodes: travelMethod key=0x01 followed by
 /// destinationYear (uint16), destinationMonth (uint8), destinationDay (uint8).
 #[tokio::test]
 async fn test_time_circuits_manual_entry_uds_frame() {
@@ -819,7 +819,7 @@ async fn test_time_circuits_manual_entry_uds_frame() {
 }
 
 /// Verify the correct UDS frame for `TimeCircuits` Start with `PresetDestination` travel method.
-/// The PresetDestination row encodes: travelMethod key=0x02 followed by presetId (uint8 texttable).
+/// The `PresetDestination` row encodes: travelMethod key=0x02 followed by presetId (uint8 texttable).
 #[tokio::test]
 async fn test_time_circuits_preset_destination_uds_frame() {
     let (runtime, _lock) = setup_integration_test(true).await.unwrap();
@@ -896,7 +896,6 @@ async fn acquire_ecu_lock(
 
     use crate::sovd::locks::{self, create_lock, lock_operation};
 
-    #[cfg_attr(nightly, allow(unknown_lints, clippy::duration_suboptimal_units))]
     let expiration_timeout = Duration::from_secs(60);
     let ecu_lock = create_lock(
         expiration_timeout,
@@ -953,7 +952,6 @@ async fn acquire_fg_lock(
 
     use crate::sovd::locks::{self, create_lock, lock_operation};
 
-    #[cfg_attr(nightly, allow(unknown_lints, clippy::duration_suboptimal_units))]
     let expiration_timeout = Duration::from_secs(60);
     let fg_lock = create_lock(
         expiration_timeout,

--- a/integration-tests/tests/sovd/runtimefiles.rs
+++ b/integration-tests/tests/sovd/runtimefiles.rs
@@ -192,9 +192,18 @@ async fn runtimefiles_execution_responses_follow_operation_standard() -> Result<
         execution.get("id").is_none() && execution.get("mode").is_none(),
         "execution details must not expose operation-specific values at the top level"
     );
-    assert_eq!(execution["parameters"]["mode"], "cleanup");
+    assert_eq!(
+        execution
+            .get("parameters")
+            .and_then(|p| p.get("mode"))
+            .expect("mode should exist"),
+        "cleanup"
+    );
     assert!(
-        execution["parameters"].get("reason").is_none(),
+        execution
+            .get("parameters")
+            .and_then(|p| p.get("reason"))
+            .is_none(),
         "a successful execution must not include a failure reason"
     );
     assert!(execution.get("status").is_some());
@@ -228,8 +237,12 @@ async fn runtimefiles_bulk_data_responses_follow_standard() -> Result<(), Testin
             .expect("upload response body must be readable"),
     )
     .expect("upload response must be JSON");
-    let first_id = upload_body["items"][0]["id"]
-        .as_str()
+    let first_id = upload_body
+        .get("items")
+        .and_then(|items| items.as_array())
+        .and_then(|items| items.first())
+        .and_then(|item| item.get("id"))
+        .and_then(|id| id.as_str())
         .expect("upload response must identify the created file");
     let expected_location = format!(
         "http://{}:{}/vehicle/v15/{RUNTIMEFILES_NEXTUPDATE}/{first_id}",
@@ -304,9 +317,14 @@ async fn runtimefiles_bulk_data_responses_follow_standard() -> Result<(), Testin
         "runtimefiles-backup",
     ] {
         assert!(
-            categories["items"]
-                .as_array()
-                .is_some_and(|items| items.iter().any(|item| item["name"] == name)),
+            categories
+                .get("items")
+                .and_then(|items| items.as_array())
+                .is_some_and(|items| {
+                    items
+                        .iter()
+                        .any(|item| item.get("name").is_some_and(|item_name| item_name == name))
+                }),
             "bulk-data discovery must include {name}"
         );
     }

--- a/opensovd-axum-extra/Cargo.toml
+++ b/opensovd-axum-extra/Cargo.toml
@@ -40,3 +40,6 @@ http = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
+
+[build-dependencies]
+cda-build = { workspace = true }

--- a/opensovd-axum-extra/build.rs
+++ b/opensovd-axum-extra/build.rs
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+fn main() {
+    cda_build::set_nightly_flag();
+}

--- a/opensovd-axum-extra/src/lib.rs
+++ b/opensovd-axum-extra/src/lib.rs
@@ -70,10 +70,10 @@ where
 {
     type Rejection = Infallible;
 
-    async fn from_request_parts(
+    fn from_request_parts(
         parts: &mut Parts,
         _state: &S,
-    ) -> Result<Option<Self>, Self::Rejection> {
+    ) -> impl std::future::Future<Output = Result<Option<Self>, Self::Rejection>> + Send {
         // suppress unused-parameter warning when all host resolution features are disabled
         #[cfg(not(any(
             feature = "forwarded",
@@ -83,35 +83,38 @@ where
         )))]
         let _ = parts;
 
-        #[cfg(feature = "forwarded")]
-        if let Some(host) = parse_forwarded(&parts.headers) {
-            return Ok(Some(ExtractHost(host.to_owned())));
-        }
+        let result = (|| {
+            #[cfg(feature = "forwarded")]
+            if let Some(host) = parse_forwarded(&parts.headers) {
+                return Ok(Some(ExtractHost(host.to_owned())));
+            }
 
-        #[cfg(feature = "x-forwarded-host")]
-        if let Some(host) = parts
-            .headers
-            .get(X_FORWARDED_HOST_HEADER_KEY)
-            .and_then(|host| host.to_str().ok())
-        {
-            return Ok(Some(ExtractHost(host.to_owned())));
-        }
+            #[cfg(feature = "x-forwarded-host")]
+            if let Some(host) = parts
+                .headers
+                .get(X_FORWARDED_HOST_HEADER_KEY)
+                .and_then(|host| host.to_str().ok())
+            {
+                return Ok(Some(ExtractHost(host.to_owned())));
+            }
 
-        #[cfg(feature = "host-header")]
-        if let Some(host) = parts
-            .headers
-            .get(http::header::HOST)
-            .and_then(|host| host.to_str().ok())
-        {
-            return Ok(Some(ExtractHost(host.to_owned())));
-        }
+            #[cfg(feature = "host-header")]
+            if let Some(host) = parts
+                .headers
+                .get(http::header::HOST)
+                .and_then(|host| host.to_str().ok())
+            {
+                return Ok(Some(ExtractHost(host.to_owned())));
+            }
 
-        #[cfg(feature = "uri-authority")]
-        if let Some(authority) = parts.uri.authority() {
-            return Ok(Some(ExtractHost(parse_authority(authority).to_owned())));
-        }
+            #[cfg(feature = "uri-authority")]
+            if let Some(authority) = parts.uri.authority() {
+                return Ok(Some(ExtractHost(parse_authority(authority).to_owned())));
+            }
 
-        Ok(None)
+            Ok(None)
+        })();
+        std::future::ready(result)
     }
 }
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors
SPDX-License-Identifier: Apache-2.0
-->

## Summary

This PR implements #451 by making clippy findings blocking in CI.

**Changes**:
- Changed `fail-on-clippy-error` from `"false"` to `"true"` in pr-checks.yml
- Updated pinned nightly toolchain from `nightly-2025-07-14` to `nightly-2026-07-21` in all workflow files
- Added `cfg_attr` annotations to suppress `duration_suboptimal_units` lint on nightly (not available in Rust 1.88 MSRV)
- Fixed `doc_markdown` errors in integration tests

**Testing**:
- Verified with `cargo +1.88 clippy --all-targets` - no warnings
- Verified with `cargo +nightly-2026-07-21 clippy --all-targets --all-features` - passes on PR code

**Note**: The new nightly toolchain detects additional pre-existing issues in `cda-interfaces/src/ecuuds.rs` (unused_async_trait_impl). 

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

Fixes #451

## Notes for Reviewers

The nightly toolchain update (2025-07-14 → 2026-07-21) introduces new lints that may detect pre-existing issues. The `duration_suboptimal_units` lint is suppressed with `cfg_attr` annotations since `from_mins`/`from_hours` are not available in Rust 1.88 MSRV.

Reason for making these failure mandatory: It's a _fixed_ nightly version, no surprises will happen. The optional clippy findings where too invisible and even regular Contributors missed them. 
Updating the nighlty version so something more recent to get more analytics. 

---
Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)