### PR TITLE
ci: Fix GitHub Pages deployment breaking CI run in forks.

### DIFF
--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -101,7 +101,8 @@ jobs:
     needs:
       - build_documentation_and_trace_requirements
       - build_rustdoc_security_plugin
-    if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/gh-pages/')) && github.event_name == 'push'
+    # only run on `main` and `gh-pages` branches and do not run on forks
+    if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/gh-pages/')) && github.event_name == 'push' && github.repository_owner == 'eclipse-opensovd'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

In forks, the deployment to GitHub Pages would fail, when updating the `main` branch: https://github.com/mbfm/classic-diagnostic-adapter/actions/runs/29934584707/job/88973145865

It would require GitHub Pages to be enabled in the fork, which isn't usually sensible, so this PR disables the job when being run in a fork.

It then looks like this: https://github.com/mbfm/classic-diagnostic-adapter/actions/runs/29935452118

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
---

Frank Märkle [frank.maerkle@mercedes-benz.com](mailto:frank.maerkle@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)