### PR TITLE
Fix: Enforce SOVD lock ownership for diagnostic downloads

### DIFF
--- a/cda-comm-uds/src/data_transfer.rs
+++ b/cda-comm-uds/src/data_transfer.rs
@@ -197,6 +197,7 @@ impl<S: EcuGateway, T: EcuManager> UdsDataTransfer for UdsManager<S, T> {
             file_path,
             offset,
             length,
+            owner,
             transfer_meta_data,
         } = parameters;
 
@@ -273,6 +274,7 @@ impl<S: EcuGateway, T: EcuManager> UdsDataTransfer for UdsManager<S, T> {
             ecu_name_clone,
             EcuDataTransfer {
                 meta_data: transfer_meta_data,
+                owner,
                 status_receiver: receiver,
                 task: transfer_task,
             },
@@ -284,11 +286,18 @@ impl<S: EcuGateway, T: EcuManager> UdsDataTransfer for UdsManager<S, T> {
         &self,
         ecu_name: &str,
         id: &str,
+        owner: &str,
     ) -> Result<(), DiagServiceError> {
         let mut lock = self.data_transfers.lock().await;
         let transfer = lock.get(ecu_name).ok_or_else(|| {
             DiagServiceError::NotFound(format!("Data transfer for ECU {ecu_name} not found"))
         })?;
+
+        if transfer.meta_data.id != id || transfer.owner != owner {
+            return Err(DiagServiceError::NotFound(format!(
+                "Data transfer with id {id} not found for ECU {ecu_name}"
+            )));
+        }
 
         if !matches!(
             transfer.meta_data.status,
@@ -318,6 +327,12 @@ impl<S: EcuGateway, T: EcuManager> UdsDataTransfer for UdsManager<S, T> {
         })?;
 
         Ok(())
+    }
+
+    async fn ecu_flash_transfer_abort(&self, ecu_name: &str) {
+        if let Some(transfer) = self.data_transfers.lock().await.remove(ecu_name) {
+            transfer.task.abort();
+        }
     }
 
     async fn ecu_flash_transfer_status(

--- a/cda-comm-uds/src/data_transfer.rs
+++ b/cda-comm-uds/src/data_transfer.rs
@@ -292,22 +292,7 @@ impl<S: EcuGateway, T: EcuManager> UdsDataTransfer for UdsManager<S, T> {
         let transfer = lock.get(ecu_name).ok_or_else(|| {
             DiagServiceError::NotFound(format!("Data transfer for ECU {ecu_name} not found"))
         })?;
-
-        if transfer.meta_data.id != id || transfer.owner != owner {
-            return Err(DiagServiceError::NotFound(format!(
-                "Data transfer with id {id} not found for ECU {ecu_name}"
-            )));
-        }
-
-        if !matches!(
-            transfer.meta_data.status,
-            DataTransferStatus::Aborted | DataTransferStatus::Finished
-        ) {
-            return Err(DiagServiceError::InvalidRequest(format!(
-                "Data transfer with id {id} is currently in status {:?}, cannot exit",
-                transfer.meta_data.status,
-            )));
-        }
+        transfer.validate_exit(ecu_name, id, owner)?;
 
         // Now it is safe to remove the transfer from the map
         let mut transfer = lock.remove(ecu_name).ok_or_else(|| {

--- a/cda-comm-uds/src/types.rs
+++ b/cda-comm-uds/src/types.rs
@@ -43,6 +43,7 @@ pub(crate) struct UdsParameters {
 
 pub(crate) struct EcuDataTransfer {
     pub(crate) meta_data: DataTransferMetaData,
+    pub(crate) owner: String,
     pub(crate) status_receiver: watch::Receiver<bool>,
     pub(crate) task: JoinHandle<()>,
 }

--- a/cda-comm-uds/src/types.rs
+++ b/cda-comm-uds/src/types.rs
@@ -14,7 +14,7 @@
 use std::time::Duration;
 
 use cda_interfaces::{
-    HashMap, TransmissionParameters,
+    DiagServiceError, HashMap, TransmissionParameters,
     datatypes::{DataTransferMetaData, RetryPolicy},
 };
 use strum::Display;
@@ -48,6 +48,34 @@ pub(crate) struct EcuDataTransfer {
     pub(crate) task: JoinHandle<()>,
 }
 
+impl EcuDataTransfer {
+    pub(crate) fn validate_exit(
+        &self,
+        ecu_name: &str,
+        id: &str,
+        owner: &str,
+    ) -> Result<(), DiagServiceError> {
+        if self.meta_data.id != id || self.owner != owner {
+            return Err(DiagServiceError::NotFound(format!(
+                "Data transfer with id {id} not found for ECU {ecu_name}"
+            )));
+        }
+
+        if !matches!(
+            self.meta_data.status,
+            cda_interfaces::datatypes::DataTransferStatus::Aborted
+                | cda_interfaces::datatypes::DataTransferStatus::Finished
+        ) {
+            return Err(DiagServiceError::InvalidRequest(format!(
+                "Data transfer with id {id} is currently in status {:?}, cannot exit",
+                self.meta_data.status,
+            )));
+        }
+
+        Ok(())
+    }
+}
+
 pub struct TesterPresentTask {
     pub type_: cda_interfaces::TesterPresentType,
     pub task: JoinHandle<()>,
@@ -59,4 +87,71 @@ pub(crate) struct PerGatewayInfo {
     pub(crate) source_address: u16,
     pub(crate) functional_address: u16,
     pub(crate) ecus: HashMap<u16, String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use cda_interfaces::{
+        DiagServiceError,
+        datatypes::{DataTransferMetaData, DataTransferStatus},
+    };
+    use tokio::sync::watch;
+
+    use super::EcuDataTransfer;
+
+    fn transfer(status: DataTransferStatus) -> EcuDataTransfer {
+        let (_sender, receiver) = watch::channel(false);
+        EcuDataTransfer {
+            meta_data: DataTransferMetaData {
+                acknowledged_bytes: 0,
+                blocksize: 1,
+                next_block_sequence_counter: 1,
+                id: "transfer-id".to_owned(),
+                file_id: "file-id".to_owned(),
+                status,
+                error: None,
+            },
+            owner: "owner".to_owned(),
+            status_receiver: receiver,
+            task: tokio::spawn(async {}),
+        }
+    }
+
+    #[tokio::test]
+    async fn transfer_exit_rejects_wrong_id_or_owner() {
+        let transfer = transfer(DataTransferStatus::Finished);
+
+        assert!(matches!(
+            transfer.validate_exit("ecu", "wrong-id", "owner"),
+            Err(DiagServiceError::NotFound(_))
+        ));
+        assert!(matches!(
+            transfer.validate_exit("ecu", "transfer-id", "wrong-owner"),
+            Err(DiagServiceError::NotFound(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn transfer_exit_requires_terminal_status() {
+        let transfer = transfer(DataTransferStatus::Running);
+
+        assert!(matches!(
+            transfer.validate_exit("ecu", "transfer-id", "owner"),
+            Err(DiagServiceError::InvalidRequest(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn transfer_exit_accepts_terminal_statuses() {
+        assert!(
+            transfer(DataTransferStatus::Finished)
+                .validate_exit("ecu", "transfer-id", "owner")
+                .is_ok()
+        );
+        assert!(
+            transfer(DataTransferStatus::Aborted)
+                .validate_exit("ecu", "transfer-id", "owner")
+                .is_ok()
+        );
+    }
 }

--- a/cda-interfaces/src/ecuuds.rs
+++ b/cda-interfaces/src/ecuuds.rs
@@ -31,6 +31,7 @@ pub struct FlashTransferStartParams<'a> {
     pub file_path: &'a str,
     pub offset: u64,
     pub length: u64,
+    pub owner: String,
     pub transfer_meta_data: DataTransferMetaData,
 }
 
@@ -214,7 +215,10 @@ pub trait UdsDataTransfer {
         &self,
         ecu_name: &str,
         id: &str,
+        owner: &str,
     ) -> Result<(), DiagServiceError>;
+    /// Abort and remove any flash transfer for the given ECU.
+    async fn ecu_flash_transfer_abort(&self, ecu_name: &str);
     /// Fetch all flash transfers for the given ECU.
     /// # Errors
     /// * `DiagServiceError::NotFound`
@@ -764,7 +768,9 @@ pub mod mock {
                 &self,
                 ecu_name: &str,
                 id: &str,
+                owner: &str,
             ) -> Result<(), DiagServiceError>;
+            async fn ecu_flash_transfer_abort(&self, ecu_name: &str);
             async fn ecu_flash_transfer_status(
                 &self,
                 ecu_name: &str,

--- a/cda-sovd/src/sovd/components/ecu/faults.rs
+++ b/cda-sovd/src/sovd/components/ecu/faults.rs
@@ -179,7 +179,7 @@ pub(crate) fn docs_delete(op: TransformOperation) -> TransformOperation {
         res.description("On successfull call a 204 without content will be returned.")
     })
     .with(openapi::error_bad_request)
-    .with(openapi::error_forbidden)
+    .with(openapi::error_conflict)
     .with(openapi::error_not_found)
     .id("ecu_faults_delete")
 }
@@ -415,7 +415,7 @@ pub(crate) mod id {
                 res.description("Returns 204 without content if DTC could successfully be deleted.")
             })
             .with(openapi::error_bad_request)
-            .with(openapi::error_forbidden)
+            .with(openapi::error_conflict)
             .with(openapi::error_not_found)
             .id("ecu_faults_delete_by_id")
     }

--- a/cda-sovd/src/sovd/components/ecu/modes.rs
+++ b/cda-sovd/src/sovd/components/ecu/modes.rs
@@ -305,7 +305,7 @@ pub(crate) mod session {
                 },
             )
             .with(openapi::error_not_found)
-            .with(openapi::error_forbidden)
+            .with(openapi::error_conflict)
             .with(openapi::error_bad_request)
             .with(openapi::error_internal_server)
             .with(openapi::error_bad_gateway)
@@ -400,6 +400,7 @@ pub(crate) mod security {
                     })
             })
             .with(openapi::error_not_found)
+            .with(openapi::error_conflict)
     }
 
     fn is_request_seed_value(input: &str) -> bool {
@@ -577,7 +578,7 @@ pub(crate) mod security {
                 },
             )
             .with(openapi::error_not_found)
-            .with(openapi::error_forbidden)
+            .with(openapi::error_conflict)
             .with(openapi::error_bad_request)
             .with(openapi::error_internal_server)
             .with(openapi::error_bad_gateway)
@@ -684,7 +685,7 @@ pub(crate) mod commctrl {
                 )
             })
             .with(openapi::error_not_found)
-            .with(openapi::error_forbidden)
+            .with(openapi::error_conflict)
             .with(openapi::error_bad_request)
             .with(openapi::error_internal_server)
             .with(openapi::error_bad_gateway)
@@ -791,7 +792,7 @@ pub(crate) mod dtcsetting {
                 )
             })
             .with(openapi::error_not_found)
-            .with(openapi::error_forbidden)
+            .with(openapi::error_conflict)
             .with(openapi::error_bad_request)
             .with(openapi::error_internal_server)
             .with(openapi::error_bad_gateway)

--- a/cda-sovd/src/sovd/components/ecu/operations.rs
+++ b/cda-sovd/src/sovd/components/ecu/operations.rs
@@ -918,7 +918,6 @@ pub(crate) mod service {
                 })
                 .with(openapi::error_bad_request)
                 .with(openapi::error_not_found)
-                .with(openapi::error_forbidden)
                 .with(openapi::error_conflict)
                 .with(openapi::error_internal_server)
                 .with(openapi::error_bad_gateway)
@@ -1839,7 +1838,7 @@ pub(crate) mod service {
                 .with(openapi::error_not_found)
                 .with(openapi::error_bad_request)
                 .with(openapi::error_bad_gateway)
-                .with(openapi::error_forbidden)
+                .with(openapi::error_conflict)
             }
         }
     }

--- a/cda-sovd/src/sovd/components/ecu/x_sovd2uds_download.rs
+++ b/cda-sovd/src/sovd/components/ecu/x_sovd2uds_download.rs
@@ -118,6 +118,7 @@ pub(crate) mod request_download {
             WebserverEcuState, create_response_schema,
             error::{ApiError, ErrorWrapper, VendorErrorCode},
             field_parse_errors_to_json,
+            locks::validate_lock,
             x_sovd2uds_download::{
                 FLASH_DOWNLOAD_UPLOAD_FUNC_CLASS, sovd_to_func_class_service_exec,
             },
@@ -130,10 +131,19 @@ pub(crate) mod request_download {
             Query<sovd_interfaces::IncludeSchemaQuery>,
             ApiError,
         >,
-        State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<T, U>>,
+        State(WebserverEcuState {
+            ecu_name,
+            uds,
+            locks,
+            ..
+        }): State<WebserverEcuState<T, U>>,
         body: Json<sovd2uds::download::request_download::put::Request>,
     ) -> Response {
         let include_schema = query.include_schema;
+        let claims = security_plugin.as_auth_plugin().claims();
+        if let Some(response) = validate_lock(&claims, &ecu_name, &locks, include_schema).await {
+            return response;
+        }
         let schema = if include_schema {
             'schema: {
                 let Ok(service) = uds
@@ -236,6 +246,7 @@ pub(crate) mod request_download {
                 },
             )
             .with(openapi::error_bad_request)
+            .with(openapi::error_conflict)
             .with(openapi::error_not_found)
             .with(openapi::error_internal_server)
             .with(openapi::error_bad_gateway)
@@ -265,6 +276,7 @@ pub(crate) mod flash_transfer {
         sovd::{
             IntoSovd, WebserverEcuState, create_schema,
             error::{ApiError, ErrorWrapper},
+            locks::validate_lock,
             x_sovd2uds_download::FLASH_DOWNLOAD_UPLOAD_FUNC_CLASS,
         },
     };
@@ -279,11 +291,17 @@ pub(crate) mod flash_transfer {
             ecu_name,
             uds,
             flash_data,
+            locks,
             ..
         }): State<WebserverEcuState<T, U>>,
         body: Json<sovd2uds::download::flash_transfer::post::Request>,
     ) -> Response {
         let include_schema = query.include_schema;
+        let claims = security_plugin.as_auth_plugin().claims();
+        if let Some(response) = validate_lock(&claims, &ecu_name, &locks, include_schema).await {
+            return response;
+        }
+        let owner = claims.sub().to_owned();
         match flash_data
             .read()
             .await
@@ -326,6 +344,7 @@ pub(crate) mod flash_transfer {
                                 .to_string_lossy(),
                             offset: body.offset,
                             length: body.length,
+                            owner,
                             transfer_meta_data: transfer,
                         },
                     )
@@ -372,6 +391,7 @@ pub(crate) mod flash_transfer {
                 },
             )
             .with(openapi::error_bad_request)
+            .with(openapi::error_conflict)
             .with(openapi::error_not_found)
     }
 
@@ -485,11 +505,26 @@ pub(crate) mod flash_transfer {
         }
 
         pub(crate) async fn delete<T: UdsEcu + Clone, U: FileManager>(
-            UseApi(Secured(_security_plugin), _): UseApi<Secured, ()>,
+            UseApi(Secured(security_plugin), _): UseApi<Secured, ()>,
             Path(id): Path<IdPathParam>,
-            State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<T, U>>,
+            State(WebserverEcuState {
+                ecu_name,
+                uds,
+                locks,
+                ..
+            }): State<WebserverEcuState<T, U>>,
         ) -> Response {
-            match uds.ecu_flash_transfer_exit(&ecu_name, &id).await {
+            let claims = security_plugin.as_auth_plugin().claims();
+            if let Some(response) =
+                crate::sovd::locks::validate_lock(&claims, &ecu_name, &locks, false).await
+            {
+                return response;
+            }
+
+            match uds
+                .ecu_flash_transfer_exit(&ecu_name, &id, claims.sub())
+                .await
+            {
                 Ok(()) => StatusCode::NO_CONTENT.into_response(),
                 Err(e) => ErrorWrapper {
                     error: e.into(),
@@ -505,6 +540,7 @@ pub(crate) mod flash_transfer {
                  started.",
             )
             .response_with::<204, (), _>(|res| res)
+            .with(openapi::error_conflict)
             .with(openapi::error_not_found)
             .with(openapi::error_bad_request)
         }
@@ -579,6 +615,7 @@ pub(crate) mod transferexit {
         openapi,
         sovd::{
             WebserverEcuState,
+            locks::validate_lock,
             x_sovd2uds_download::{
                 FLASH_DOWNLOAD_UPLOAD_FUNC_CLASS, sovd_to_func_class_service_exec,
             },
@@ -587,8 +624,18 @@ pub(crate) mod transferexit {
 
     pub(crate) async fn put<T: UdsEcu + Clone, U: FileManager>(
         UseApi(Secured(security_plugin), _): UseApi<Secured, ()>,
-        State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<T, U>>,
+        State(WebserverEcuState {
+            ecu_name,
+            uds,
+            locks,
+            ..
+        }): State<WebserverEcuState<T, U>>,
     ) -> Response {
+        let claims = security_plugin.as_auth_plugin().claims();
+        if let Some(response) = validate_lock(&claims, &ecu_name, &locks, false).await {
+            return response;
+        }
+
         match sovd_to_func_class_service_exec::<T>(
             &uds,
             FLASH_DOWNLOAD_UPLOAD_FUNC_CLASS,
@@ -608,6 +655,7 @@ pub(crate) mod transferexit {
     pub(crate) fn docs_put(op: TransformOperation) -> TransformOperation {
         op.description("Exit a transfer session")
             .response_with::<204, (), _>(|res| res)
+            .with(openapi::error_conflict)
             .with(openapi::error_bad_request)
             .with(openapi::error_not_found)
             .with(openapi::error_bad_gateway)

--- a/cda-sovd/src/sovd/functions/functional_groups/locks.rs
+++ b/cda-sovd/src/sovd/functions/functional_groups/locks.rs
@@ -202,7 +202,7 @@ pub(crate) fn docs_post(op: TransformOperation) -> TransformOperation {
             })
             .description("Functional group lock created successfully.")
         })
-        .with(openapi::lock_not_owned)
+        .with(openapi::error_conflict)
 }
 
 pub(crate) async fn get<T: UdsEcu + Clone>(

--- a/cda-sovd/src/sovd/functions/functional_groups/modes.rs
+++ b/cda-sovd/src/sovd/functions/functional_groups/modes.rs
@@ -384,7 +384,7 @@ pub(crate) mod commctrl {
         >, _>(|res| {
             res.description("Response with results from all ECUs in the functional group")
         })
-        .with(openapi::error_forbidden)
+        .with(openapi::error_conflict)
         .with(openapi::error_not_found)
         .with(openapi::error_internal_server)
         .with(openapi::error_bad_request)
@@ -477,7 +477,7 @@ pub(crate) mod dtcsetting {
         >, _>(|res| {
             res.description("Response with results from all ECUs in the functional group")
         })
-        .with(openapi::error_forbidden)
+        .with(openapi::error_conflict)
         .with(openapi::error_not_found)
         .with(openapi::error_internal_server)
         .with(openapi::error_bad_request)
@@ -560,7 +560,7 @@ pub(crate) mod session {
                     res.description("Response with results from all ECUs in the functional group")
                 },
             )
-            .with(openapi::error_forbidden)
+            .with(openapi::error_conflict)
             .with(openapi::error_not_found)
             .with(openapi::error_internal_server)
             .with(openapi::error_bad_request)

--- a/cda-sovd/src/sovd/functions/functional_groups/operations.rs
+++ b/cda-sovd/src/sovd/functions/functional_groups/operations.rs
@@ -554,7 +554,6 @@ pub(crate) mod diag_service {
                  /operations/{operation}/executions/{id} to stop.",
             )
         })
-        .with(openapi::error_forbidden)
         .with(openapi::error_not_found)
         .with(openapi::error_conflict)
         .with(openapi::error_internal_server)
@@ -688,7 +687,6 @@ pub(crate) mod diag_service {
         })
         .with(openapi::error_not_found)
         .with(openapi::error_bad_request)
-        .with(openapi::error_forbidden)
         .with(openapi::error_conflict)
     }
 
@@ -1007,7 +1005,6 @@ pub(crate) mod diag_service {
             })
             .with(openapi::error_not_found)
             .with(openapi::error_bad_request)
-            .with(openapi::error_forbidden)
             .with(openapi::error_conflict)
             .with(openapi::error_bad_gateway)
         }
@@ -1539,7 +1536,7 @@ pub(crate) mod diag_service {
         }
 
         #[tokio::test]
-        async fn test_fg_delete_no_lock_returns_forbidden() {
+        async fn test_fg_delete_no_lock_returns_conflict() {
             let mock_uds = MockUdsEcu::new();
             // state has no lock set up
             let state = create_test_fg_state(mock_uds, "AllECUs".to_string());
@@ -1562,7 +1559,7 @@ pub(crate) mod diag_service {
             )
             .await;
 
-            assert_eq!(response.status(), StatusCode::FORBIDDEN);
+            assert_eq!(response.status(), StatusCode::CONFLICT);
         }
 
         #[tokio::test]

--- a/cda-sovd/src/sovd/locks.rs
+++ b/cda-sovd/src/sovd/locks.rs
@@ -579,7 +579,7 @@ pub(crate) mod vehicle {
 
         if let Err(e) = validate_claim(None, &claims, vehicle_lock.as_ref()) {
             return ErrorWrapper {
-                error: e,
+                error: ApiError::Conflict(e.to_string()),
                 include_schema: false,
             }
             .into_response();
@@ -588,7 +588,7 @@ pub(crate) mod vehicle {
         let ecu_locks = state.locks.ecu.lock_ro().await;
         if let Err(e) = all_locks_owned(&ecu_locks, &claims) {
             return ErrorWrapper {
-                error: e,
+                error: ApiError::Conflict(e.to_string()),
                 include_schema: false,
             }
             .into_response();
@@ -597,7 +597,7 @@ pub(crate) mod vehicle {
         let functional_locks = state.locks.functional_group.lock_ro().await;
         if let Err(e) = all_locks_owned(&functional_locks, &claims) {
             return ErrorWrapper {
-                error: e,
+                error: ApiError::Conflict(e.to_string()),
                 include_schema: false,
             }
             .into_response();
@@ -659,6 +659,8 @@ async fn reset_ecu_session_and_security<T: UdsEcu>(
     context: &str,
     security_plugin: &DynamicPlugin,
 ) {
+    uds.ecu_flash_transfer_abort(ecu_name).await;
+
     if let Err(e) = uds.reset_ecu_session(ecu_name, security_plugin).await {
         tracing::error!("Failed to reset ECU session for ECU {ecu_name} during {context}: {e}");
     } else {
@@ -887,53 +889,34 @@ pub(crate) async fn validate_lock(
     include_schema: bool,
 ) -> Option<Response> {
     let ecu_lock = locks.ecu.lock_ro().await;
-    let ecu_locks = get_locks(claims, &ecu_lock, Some(ecu_name));
-
     let vehicle_lock = locks.vehicle.lock_ro().await;
-    let vehicle_locks = get_locks(claims, &vehicle_lock, None);
+    let ecu_name = ecu_name.to_owned();
+    let ecu_lock = ecu_lock.get(Some(&ecu_name), None);
+    let vehicle_lock = vehicle_lock.get(None, None);
 
-    if ecu_locks.items.is_empty() && vehicle_locks.items.is_empty() {
+    if ecu_lock.is_none() && vehicle_lock.is_none() {
         return Some(
             ErrorWrapper {
-                error: ApiError::Forbidden(Some("Required ECU lock is missing".to_owned())),
+                error: ApiError::Conflict("Required ECU lock is missing".to_owned()),
                 include_schema,
             }
             .into_response(),
         );
     }
 
-    // Validate Vehicle lock is owned
-    if let Err(e) = all_locks_owned(&vehicle_lock, claims) {
-        return Some(
-            ErrorWrapper {
-                error: e,
-                include_schema,
-            }
-            .into_response(),
-        );
+    if ecu_lock.is_some_and(|lock| lock.is_owned_by(claims.sub()))
+        || vehicle_lock.is_some_and(|lock| lock.is_owned_by(claims.sub()))
+    {
+        return None;
     }
 
-    // Validate ECU lock is owned
-    if let Err(e) = all_locks_owned(&ecu_lock, claims) {
-        return Some(
-            ErrorWrapper {
-                error: e,
-                include_schema,
-            }
-            .into_response(),
-        );
-    }
-
-    if let Err(e) = all_locks_owned(&ecu_lock, claims) {
-        return Some(
-            ErrorWrapper {
-                error: e,
-                include_schema,
-            }
-            .into_response(),
-        );
-    }
-    None
+    Some(
+        ErrorWrapper {
+            error: ApiError::Conflict("Required ECU lock is owned by another subject".to_owned()),
+            include_schema,
+        }
+        .into_response(),
+    )
 }
 
 /// Validate that the caller holds a lock on the given **functional group** (or the vehicle lock).
@@ -948,46 +931,36 @@ pub(crate) async fn validate_fg_lock(
     include_schema: bool,
 ) -> Option<Response> {
     let fg_lock = locks.functional_group.lock_ro().await;
-    let fg_locks = get_locks(claims, &fg_lock, Some(functional_group_name));
-
     let vehicle_lock = locks.vehicle.lock_ro().await;
-    let vehicle_locks = get_locks(claims, &vehicle_lock, None);
+    let functional_group_name = functional_group_name.to_owned();
+    let fg_lock = fg_lock.get(Some(&functional_group_name), None);
+    let vehicle_lock = vehicle_lock.get(None, None);
 
-    if fg_locks.items.is_empty() && vehicle_locks.items.is_empty() {
+    if fg_lock.is_none() && vehicle_lock.is_none() {
         return Some(
             ErrorWrapper {
-                error: ApiError::Forbidden(Some(
-                    "Required functional group lock is missing".to_owned(),
-                )),
+                error: ApiError::Conflict("Required functional group lock is missing".to_owned()),
                 include_schema,
             }
             .into_response(),
         );
     }
 
-    // Validate vehicle lock is owned by the caller (if one exists)
-    if let Err(e) = all_locks_owned(&vehicle_lock, claims) {
-        return Some(
-            ErrorWrapper {
-                error: e,
-                include_schema,
-            }
-            .into_response(),
-        );
+    if fg_lock.is_some_and(|lock| lock.is_owned_by(claims.sub()))
+        || vehicle_lock.is_some_and(|lock| lock.is_owned_by(claims.sub()))
+    {
+        return None;
     }
 
-    // Validate functional group lock is owned by the caller
-    if let Err(e) = all_locks_owned(&fg_lock, claims) {
-        return Some(
-            ErrorWrapper {
-                error: e,
-                include_schema,
-            }
-            .into_response(),
-        );
-    }
-
-    None
+    Some(
+        ErrorWrapper {
+            error: ApiError::Conflict(
+                "Required functional group lock is owned by another subject".to_owned(),
+            ),
+            include_schema,
+        }
+        .into_response(),
+    )
 }
 
 pub(crate) async fn delete_lock(
@@ -1090,7 +1063,12 @@ pub(crate) async fn post_handler<T: UdsEcu + Clone>(
         ) {
             Ok(lock) => (StatusCode::CREATED, Json(lock)).into_response(),
             Err(e) => ErrorWrapper {
-                error: e,
+                error: match e {
+                    ApiError::Forbidden(_) => {
+                        ApiError::Conflict("Lock is already owned by another subject".to_owned())
+                    }
+                    other => other,
+                },
                 include_schema,
             }
             .into_response(),
@@ -1233,7 +1211,7 @@ pub(crate) async fn vehicle_read_lock<'a>(
     let vehicle_lock = vehicle_ro_lock.get(None, None);
     match validate_claim(None, claims, vehicle_lock) {
         Ok(()) => Ok(vehicle_ro_lock),
-        Err(e) => Err(e),
+        Err(e) => Err(ApiError::Conflict(e.to_string())),
     }
 }
 
@@ -1494,6 +1472,59 @@ mod tests {
         assert!(!locks.vehicle.lock_ro().await.is_any_locked());
     }
 
+    #[tokio::test]
+    async fn lock_validation_ignores_unrelated_foreign_locks() {
+        let locks = init_locks();
+        insert_test_ecu_lock(&locks, "flxc1000").await;
+        insert_test_fg_lock(&locks, "func_group").await;
+
+        let foreign_ecu_lock = test_lock("foreign-user", "foreign-ecu-lock");
+        let foreign_fg_lock = test_lock("foreign-user", "foreign-fg-lock");
+        match &locks.ecu {
+            LockType::Ecu(map) => {
+                map.write()
+                    .await
+                    .insert("unrelated_ecu".to_owned(), Some(foreign_ecu_lock));
+            }
+            _ => panic!("expected ECU lock type"),
+        }
+        match &locks.functional_group {
+            LockType::FunctionalGroup(map) => {
+                map.write()
+                    .await
+                    .insert("unrelated_fg".to_owned(), Some(foreign_fg_lock));
+            }
+            _ => panic!("expected functional group lock type"),
+        }
+
+        let claims = TestSecurityPlugin.claims();
+        assert!(
+            validate_lock(&claims, "flxc1000", &locks, false)
+                .await
+                .is_none()
+        );
+        assert!(
+            validate_fg_lock(&claims, "func_group", &locks, false)
+                .await
+                .is_none()
+        );
+    }
+
+    fn test_lock(owner: &str, id: &str) -> Lock {
+        Lock::new(
+            sovd_interfaces::locking::Lock {
+                id: id.to_owned(),
+                owned: None,
+            },
+            Utc::now()
+                .checked_add_signed(chrono::TimeDelta::seconds(3600))
+                .expect("test lock expiration must be valid"),
+            owner.to_owned(),
+            tokio::spawn(async {}),
+            LockCleanupFnHelper::new(|| async {}),
+        )
+    }
+
     pub fn init_locks() -> Arc<Locks> {
         // Initialize ecu_map with dummy data
         let mut ecu_map = LockHashMap::new();
@@ -1515,6 +1546,12 @@ mod tests {
     fn expect_ecu_lock_cleanup_multiple(uds_ecu: &mut MockUdsEcu, ecus: &Vec<String>) {
         // Expect reset methods to be called for each ECU during cleanup
         for ecu in ecus {
+            uds_ecu
+                .expect_ecu_flash_transfer_abort()
+                .with(eq(ecu.clone()))
+                .times(1)
+                .returning(|_| ());
+
             uds_ecu
                 .expect_reset_ecu_session()
                 .with(eq(ecu.clone()), always())
@@ -1560,6 +1597,12 @@ mod tests {
                 .returning(|_| Ok(()));
 
             // Expect reset methods to be called during cleanup
+            cloned
+                .expect_ecu_flash_transfer_abort()
+                .with(eq(ecu_name_clone.clone()))
+                .times(1)
+                .returning(|_| ());
+
             cloned
                 .expect_reset_ecu_session()
                 .with(eq(ecu_name_clone.clone()), always())

--- a/docs/03_architecture/02_sovd-api/images/generic_service.puml
+++ b/docs/03_architecture/02_sovd-api/images/generic_service.puml
@@ -19,21 +19,23 @@ participant "Diagnostic\nKernel" as DIAG
 participant "UDS / DoIP" as COMM
 participant ECU
 
-Client -> CDA : POST /components/{ecu}/genericservice\n{ "request": "22F190" }
+Client -> CDA : PUT /components/{ecu}/genericservice\nContent-Type: application/octet-stream\nAccept: application/octet-stream\nRaw bytes: 22 F1 90
 activate CDA
-
-CDA -> SEC : check permissions for\nraw UDS request (22 F1 90) on {ecu}
-activate SEC
-SEC -> SEC : evaluate authorization\n(client identity, target ECU,\nUDS SID + payload prefix)
-SEC -> CDA : authorized
-deactivate SEC
-
-CDA -> CDA : parse hex-encoded\nraw UDS request bytes
 
 CDA -> DIAG : send raw UDS (byte array)
 activate DIAG
 
-note over DIAG : no MDD service resolution\nor parameter encoding needed
+DIAG -> DIAG : read SID from first byte (22)\nresolve matching MDD service
+
+note over DIAG : Remaining request bytes are not\nparameter-decoded or validated
+
+DIAG -> DIAG : check service preconditions
+
+DIAG -> SEC : validate resolved diagnostic service
+activate SEC
+SEC -> SEC : evaluate authorization for service
+SEC --> DIAG : authorized
+deactivate SEC
 
 DIAG -> COMM : send raw UDS request
 activate COMM
@@ -47,9 +49,7 @@ deactivate COMM
 DIAG -> CDA : raw response bytes
 deactivate DIAG
 
-CDA -> CDA : hex-encode response
-
-CDA -> Client : HTTP 200 OK\n{ "response": "62F190..." }
+CDA -> Client : HTTP 200 OK\nContent-Type: application/octet-stream\nRaw bytes: 62 F1 90 {data}
 deactivate CDA
 
 @enduml

--- a/integration-tests/tests/sovd/ecu.rs
+++ b/integration-tests/tests/sovd/ecu.rs
@@ -130,7 +130,7 @@ async fn test_ecu_session_switching() {
         &runtime.config,
         &auth,
         ecu_endpoint,
-        StatusCode::FORBIDDEN,
+        StatusCode::CONFLICT,
     )
     .await
     .unwrap();
@@ -495,7 +495,7 @@ async fn test_communication_control() {
         &runtime.config,
         &auth,
         ecu_endpoint,
-        StatusCode::FORBIDDEN,
+        StatusCode::CONFLICT,
     )
     .await
     .unwrap();
@@ -736,7 +736,7 @@ async fn test_communication_control() {
         &runtime.config,
         &auth,
         ecu_endpoint,
-        StatusCode::FORBIDDEN,
+        StatusCode::CONFLICT,
     )
     .await
     .unwrap();

--- a/integration-tests/tests/sovd/faults.rs
+++ b/integration-tests/tests/sovd/faults.rs
@@ -50,7 +50,7 @@ async fn test_dtc_setting() {
         &runtime.config,
         &auth,
         ecu_endpoint,
-        StatusCode::FORBIDDEN,
+        StatusCode::CONFLICT,
     )
     .await
     .unwrap();
@@ -219,7 +219,7 @@ async fn test_dtc_setting() {
         &runtime.config,
         &auth,
         ecu_endpoint,
-        StatusCode::FORBIDDEN,
+        StatusCode::CONFLICT,
     )
     .await
     .unwrap();
@@ -409,10 +409,10 @@ async fn test_dtc_deletion() {
         &auth,
         ecu_endpoint,
         "999999",
-        StatusCode::FORBIDDEN,
+        StatusCode::CONFLICT,
     )
     .await
-    .expect("Request should be forbidden");
+    .expect("Request should conflict");
 
     // Verify the DTC was NOT deleted
     let dtcs_after_forbidden = ecusim::get_dtcs(&runtime.ecu_sim, ecu_name, fault_memory)

--- a/integration-tests/tests/sovd/flash_download.rs
+++ b/integration-tests/tests/sovd/flash_download.rs
@@ -49,6 +49,9 @@ use crate::{
 async fn test_flash_download_transfer_sequence() {
     let (runtime, _lock) = setup_integration_test(true).await.unwrap();
     let auth = auth_header(&runtime.config, None).await.unwrap();
+    let auth_non_owner = auth_header(&runtime.config, Some("flash-non-owner"))
+        .await
+        .unwrap();
     let ecu_endpoint = sovd::ECU_FLXC1000_ENDPOINT;
 
     // Create and acquire ECU lock
@@ -260,6 +263,18 @@ async fn test_flash_download_transfer_sequence() {
             )
         }
     });
+    send_cda_request(
+        &runtime.config,
+        &format!("{ecu_endpoint}/x-sovd2uds-download/requestdownload"),
+        StatusCode::CONFLICT,
+        Method::PUT,
+        Some(&request_download_body.to_string()),
+        Some(&auth_non_owner),
+        None,
+    )
+    .await
+    .unwrap();
+
     let request_download_response = send_cda_request(
         &runtime.config,
         &format!("{ecu_endpoint}/x-sovd2uds-download/requestdownload"),
@@ -292,6 +307,18 @@ async fn test_flash_download_transfer_sequence() {
         "length": file_size,
         "id": file_id
     });
+
+    send_cda_request(
+        &runtime.config,
+        &format!("{ecu_endpoint}/x-sovd2uds-download/flashtransfer"),
+        StatusCode::CONFLICT,
+        Method::POST,
+        Some(&flash_transfer_body.to_string()),
+        Some(&auth_non_owner),
+        None,
+    )
+    .await
+    .unwrap();
 
     let flash_transfer_response = send_cda_request(
         &runtime.config,
@@ -362,6 +389,18 @@ async fn test_flash_download_transfer_sequence() {
     send_cda_request(
         &runtime.config,
         &format!("{ecu_endpoint}/x-sovd2uds-download/flashtransfer/{transfer_id}"),
+        StatusCode::CONFLICT,
+        Method::DELETE,
+        None,
+        Some(&auth_non_owner),
+        None,
+    )
+    .await
+    .unwrap();
+
+    send_cda_request(
+        &runtime.config,
+        &format!("{ecu_endpoint}/x-sovd2uds-download/flashtransfer/{transfer_id}"),
         StatusCode::NO_CONTENT,
         Method::DELETE,
         None,
@@ -372,6 +411,18 @@ async fn test_flash_download_transfer_sequence() {
     .unwrap();
 
     // TransferExit
+    send_cda_request(
+        &runtime.config,
+        &format!("{ecu_endpoint}/x-sovd2uds-download/transferexit"),
+        StatusCode::CONFLICT,
+        Method::PUT,
+        None,
+        Some(&auth_non_owner),
+        None,
+    )
+    .await
+    .unwrap();
+
     send_cda_request(
         &runtime.config,
         &format!("{ecu_endpoint}/x-sovd2uds-download/transferexit"),

--- a/integration-tests/tests/sovd/locks.rs
+++ b/integration-tests/tests/sovd/locks.rs
@@ -297,6 +297,48 @@ async fn ownership() -> Result<(), TestingError> {
 }
 
 #[tokio::test]
+async fn lock_acquisition_collision_returns_conflict() -> Result<(), TestingError> {
+    let (runtime, _lock) = setup_integration_test(true).await?;
+    let auth_owner = auth_header(&runtime.config, None).await?;
+    let auth_other = auth_header(&runtime.config, Some("lock-contender")).await?;
+
+    for endpoint in ENDPOINTS {
+        let lock_id: String = response_to_json_to_field(
+            &create_lock(
+                default_timeout(),
+                endpoint,
+                StatusCode::CREATED,
+                &runtime.config,
+                &auth_owner,
+            )
+            .await,
+            "id",
+        )?;
+
+        create_lock(
+            default_timeout(),
+            endpoint,
+            StatusCode::CONFLICT,
+            &runtime.config,
+            &auth_other,
+        )
+        .await;
+
+        lock_operation(
+            endpoint,
+            Some(&lock_id),
+            &runtime.config,
+            &auth_owner,
+            StatusCode::NO_CONTENT,
+            Method::DELETE,
+        )
+        .await;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_vehicle_locking_blocked_by_other() -> Result<(), TestingError> {
     let (runtime, _lock) = setup_integration_test(true).await?;
     let auth_user1 = auth_header(&runtime.config, None).await?;
@@ -319,7 +361,7 @@ async fn test_vehicle_locking_blocked_by_other() -> Result<(), TestingError> {
     create_lock(
         default_timeout(),
         VEHICLE_ENDPOINT,
-        StatusCode::FORBIDDEN,
+        StatusCode::CONFLICT,
         &runtime.config,
         &auth_user2,
     )
@@ -538,7 +580,7 @@ async fn test_component_ownership_protection_with_vehicle_lock_only() -> Result<
         &runtime.config,
         &auth_non_owner,
         sovd::ECU_FLXC1000_ENDPOINT,
-        StatusCode::FORBIDDEN,
+        StatusCode::CONFLICT,
     )
     .await?;
 

--- a/integration-tests/tests/sovd/operations.rs
+++ b/integration-tests/tests/sovd/operations.rs
@@ -95,7 +95,7 @@ async fn test_sync_operation_no_lock() {
     send_cda_request(
         &runtime.config,
         &format!("{ecu_endpoint}/operations/selftest/executions"),
-        StatusCode::FORBIDDEN,
+        StatusCode::CONFLICT,
         Method::POST,
         Some("{}"),
         Some(&auth),
@@ -131,11 +131,11 @@ async fn test_async_operation_delete_no_lock() {
     // Release the lock before attempting DELETE
     release_ecu_lock(runtime, &auth, &lock_id).await;
 
-    // DELETE without a lock - should be 403
+    // DELETE without a lock - should be 409
     send_cda_request(
         &runtime.config,
         &format!("{ecu_endpoint}/operations/calibratesensors/executions/{execution_id}"),
-        StatusCode::FORBIDDEN,
+        StatusCode::CONFLICT,
         Method::DELETE,
         None,
         Some(&auth),
@@ -1037,7 +1037,7 @@ async fn test_functional_operation_list() {
 }
 
 /// Verify that `POST`ing a functional-group operation without holding the FG lock
-/// is rejected with 403 Forbidden.
+/// is rejected with 409 Conflict.
 #[tokio::test]
 async fn test_functional_operation_post_no_lock() {
     let (runtime, _lock) = setup_integration_test(true).await.unwrap();
@@ -1046,7 +1046,7 @@ async fn test_functional_operation_post_no_lock() {
     send_cda_request(
         &runtime.config,
         &format!("{FG_ENDPOINT}/operations/engage_safety_squints/executions"),
-        StatusCode::FORBIDDEN,
+        StatusCode::CONFLICT,
         Method::POST,
         Some(r#"{"parameters":{"SquintSlitWidth":2.5}}"#),
         Some(&auth),


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

Download mutations accepted requests from authenticated clients that did not own the active ECU lock. Lock validation also inspected unrelated locks, causing valid operations to fail, while acquisition collisions returned 403 instead of the SOVD-required 409.

This PR:
- Requires caller-owned ECU or vehicle locks for download mutations.
- Binds active transfers to initiating subject.
- Aborts transfers when locks expire, release, or change ownership.
- Limits validation to target ECU or functional group.
- Returns 409 for missing locks and acquisition collisions.
- Keeps 403 for unauthorized lock updates and deletion.
- Updates OpenAPI declarations and regression coverage.

Original security finding reported [here](https://gitlab.eclipse.org/security/vulnerability-reports/-/work_items/611). When fixing the issue it made sense to correct the Lock error codes to follow spec as well.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)