### PR TITLE
fix(sovd): drain multipart body before early lock-rejection response

### DIFF
--- a/cda-sovd/src/sovd/apps/sovd2uds/bulk_data/runtimefiles.rs
+++ b/cda-sovd/src/sovd/apps/sovd2uds/bulk_data/runtimefiles.rs
@@ -259,6 +259,13 @@ pub(crate) mod nextupdate {
         )
         .await
         {
+            // The client may still be streaming the (potentially large) multipart
+            // body. If we respond and close/reset the connection before the body
+            // has been fully read, the client's in-flight write can fail with a
+            // transport-level error (e.g. a connection reset) instead of cleanly
+            // receiving this response. Drain the remaining body first so the
+            // connection can be closed/reused safely.
+            while let Ok(Some(_field)) = multipart.next_field().await {}
             return resp.into_response();
         }
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
nextupdate::post checked vehicle-lock ownership before reading the multipart upload body. Since axum's Multipart extractor is lazy, an early 403 response left the client's in-flight body write racing against the server tearing down the connection, surfacing as a transport-level disconnect error on the client (e.g. reqwest SendError { kind: Disconnected }) instead of a clean 403 response.

Drain any remaining multipart fields before returning the rejection so the connection can be closed/reused safely without a race.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)

