### PR TITLE
Refactor: Code cleanup

### DIFF
--- a/cda-database/src/datatypes/mod.rs
+++ b/cda-database/src/datatypes/mod.rs
@@ -433,6 +433,12 @@ impl Parameter<'_> {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct LongName {
+    pub value: Option<String>,
+    pub ti: Option<String>,
+}
+
 impl From<dataformat::LongName<'_>> for LongName {
     fn from(val: dataformat::LongName<'_>) -> Self {
         LongName {
@@ -440,22 +446,6 @@ impl From<dataformat::LongName<'_>> for LongName {
             ti: val.ti().map(ToOwned::to_owned),
         }
     }
-}
-
-#[self_referencing]
-struct EcuData {
-    blob: bytes::Bytes,
-
-    #[borrows(blob)]
-    #[covariant]
-    pub data: dataformat::EcuData<'this>,
-}
-
-pub struct DiagnosticDatabase {
-    ecu_database_path: String,
-    ecu_data: Option<EcuData>,
-    flatbuf_config: FlatbBufConfig,
-    config: DatabaseConfig,
 }
 
 #[derive(Clone, Debug)]
@@ -473,10 +463,20 @@ pub enum LogicalAddressType {
     Functional(String),
 }
 
-#[derive(Debug, Clone)]
-pub struct LongName {
-    pub value: Option<String>,
-    pub ti: Option<String>,
+#[self_referencing]
+struct EcuData {
+    blob: bytes::Bytes,
+
+    #[borrows(blob)]
+    #[covariant]
+    pub data: dataformat::EcuData<'this>,
+}
+
+pub struct DiagnosticDatabase {
+    ecu_database_path: String,
+    ecu_data: Option<EcuData>,
+    flatbuf_config: FlatbBufConfig,
+    config: DatabaseConfig,
 }
 
 impl DiagnosticDatabase {

--- a/cda-main/src/config/mod.rs
+++ b/cda-main/src/config/mod.rs
@@ -78,11 +78,13 @@ pub fn require_config_source() -> Result<(), crate::AppError> {
         println!("No configuration found on disk or in storage. Using default values.");
         Ok(())
     } else {
-        Err(crate::AppError::ConfigurationError(
-            "No configuration found. Provide a configuration file, store one via runtime update, \
-             or build with the 'config-optional' feature to allow starting without one."
+        Err(crate::AppError::ConfigurationError {
+            message: "No configuration found. Provide a configuration file, store one via runtime \
+                      update, or build with the 'config-optional' feature to allow starting \
+                      without one."
                 .to_owned(),
-        ))
+            source: None,
+        })
     }
 }
 
@@ -163,9 +165,13 @@ pub async fn load_config_with_storage_override(
         }
     };
 
-    let keys = collection.list().await.map_err(|e| {
-        AppError::ConfigurationError(format!("Failed to list Configuration collection: {e}"))
-    })?;
+    let keys = collection
+        .list()
+        .await
+        .map_err(|source| AppError::ConfigurationError {
+            message: "Failed to list Configuration collection".to_string(),
+            source: Some(source.into()),
+        })?;
 
     let key = match keys.as_slice() {
         [] => {
@@ -173,29 +179,44 @@ pub async fn load_config_with_storage_override(
         }
         [single] => single,
         keys => {
-            return Err(AppError::ConfigurationError(format!(
-                "Expected at most one configuration in storage, found {}: {keys:?}",
-                keys.len()
-            )));
+            return Err(AppError::ConfigurationError {
+                message: format!(
+                    "Expected at most one configuration in storage, found {}: {keys:?}",
+                    keys.len()
+                ),
+                source: None,
+            });
         }
     };
 
-    let data_handle = collection.read(key).await.map_err(|e| {
-        AppError::ConfigurationError(format!("Failed to read stored config '{key}': {e}"))
-    })?;
+    let data_handle =
+        collection
+            .read(key)
+            .await
+            .map_err(|source| AppError::ConfigurationError {
+                message: format!("Failed to read stored config '{key}'"),
+                source: Some(source.into()),
+            })?;
 
-    let size = data_handle.data_size().map_err(|e| {
-        AppError::ConfigurationError(format!("Failed to get stored config size for '{key}': {e}"))
-    })?;
+    let size = data_handle
+        .data_size()
+        .map_err(|source| AppError::ConfigurationError {
+            message: format!("Failed to get stored config size for '{key}'"),
+            source: Some(source.into()),
+        })?;
 
     let mut buf = vec![0u8; usize::try_from(size).unwrap_or(usize::MAX)];
-    data_handle.read_at(0, &mut buf).map_err(|e| {
-        AppError::ConfigurationError(format!("Failed to read stored config data '{key}': {e}"))
-    })?;
+    data_handle
+        .read_at(0, &mut buf)
+        .map_err(|source| AppError::ConfigurationError {
+            message: format!("Failed to read stored config data '{key}'"),
+            source: Some(source.into()),
+        })?;
 
     let config = toml::from_str::<configfile::Configuration>(&String::from_utf8_lossy(&buf))
-        .map_err(|e| {
-            AppError::ConfigurationError(format!("Failed to parse stored config '{key}': {e}"))
+        .map_err(|source| AppError::ConfigurationError {
+            message: format!("Failed to parse stored config '{key}'"),
+            source: Some(source.into()),
         })?;
 
     tracing::info!(key, "Using configuration from storage (overrides disk)");

--- a/cda-main/src/error.rs
+++ b/cda-main/src/error.rs
@@ -1,0 +1,117 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use cda_interfaces::{DiagServiceError, DoipGatewaySetupError, config::ConfigSanityError};
+use cda_tracing::TracingSetupError;
+
+#[derive(thiserror::Error, Debug)]
+pub enum AppError {
+    #[error("Initialization failed `{0}`")]
+    InitializationFailed(String),
+    #[error("Resource error: `{0}`")]
+    ResourceError(String),
+    #[error("Connection error `{0}`")]
+    ConnectionError(String),
+    #[error("Configuration error `{0}`")]
+    ConfigurationError(String),
+    #[error("Data error `{0}`")]
+    DataError(String),
+    #[error("Error during execution `{0}`")]
+    RuntimeError(String),
+    #[error("Not found: `{0}`")]
+    NotFound(String),
+    #[error("Server error: `{0}`")]
+    ServerError(String),
+    #[error("Shutdown requested")]
+    ShutdownRequested,
+}
+
+impl From<DiagServiceError> for AppError {
+    fn from(value: DiagServiceError) -> Self {
+        match value {
+            DiagServiceError::RequestNotSupported(_)
+            | DiagServiceError::BadPayload(_)
+            | DiagServiceError::ConnectionClosed(_)
+            | DiagServiceError::UnexpectedResponse(_)
+            | DiagServiceError::EcuOffline(_)
+            | DiagServiceError::NoResponse(_)
+            | DiagServiceError::SendFailed(_)
+            | DiagServiceError::InvalidAddress(_)
+            | DiagServiceError::InvalidRequest(_)
+            | DiagServiceError::Timeout => Self::ConnectionError(value.to_string()),
+
+            DiagServiceError::ParameterConversionError(_)
+            | DiagServiceError::UnknownOperation
+            | DiagServiceError::UdsLookupError(_)
+            | DiagServiceError::VariantDetectionError(_)
+            | DiagServiceError::AccessDenied(_)
+            | DiagServiceError::InvalidState(_)
+            | DiagServiceError::Nack(_) => Self::RuntimeError(value.to_string()),
+
+            DiagServiceError::InvalidConfiguration(_) | DiagServiceError::InvalidSecurityPlugin => {
+                Self::ConfigurationError(value.to_string())
+            }
+
+            DiagServiceError::ResourceError(_) => Self::ResourceError(value.to_string()),
+
+            DiagServiceError::NotFound(_) => Self::NotFound(value.to_string()),
+
+            DiagServiceError::DataError(_)
+            | DiagServiceError::InvalidDatabase(_)
+            | DiagServiceError::AmbiguousParameters { .. }
+            | DiagServiceError::InvalidParameter { .. }
+            | DiagServiceError::NotEnoughData { .. } => Self::DataError(value.to_string()),
+        }
+    }
+}
+
+impl From<DoipGatewaySetupError> for AppError {
+    fn from(value: DoipGatewaySetupError) -> Self {
+        match value {
+            DoipGatewaySetupError::InvalidAddress(_) => Self::ConnectionError(value.to_string()),
+            DoipGatewaySetupError::SocketCreationFailed(_)
+            | DoipGatewaySetupError::PortBindFailed(_) => {
+                Self::InitializationFailed(value.to_string())
+            }
+            DoipGatewaySetupError::InvalidConfiguration(_) => {
+                Self::ConfigurationError(value.to_string())
+            }
+            DoipGatewaySetupError::ResourceError(_) => Self::ResourceError(value.to_string()),
+            DoipGatewaySetupError::ServerError(_) => Self::ServerError(value.to_string()),
+            DoipGatewaySetupError::UnknownECU {
+                logical_address,
+                protocol_version,
+            } => Self::ConfigurationError(format!(
+                "Unknown ECU with logical address {logical_address} and protocol version \
+                 {protocol_version}"
+            )),
+        }
+    }
+}
+
+impl From<TracingSetupError> for AppError {
+    fn from(value: TracingSetupError) -> Self {
+        match value {
+            TracingSetupError::ResourceCreationFailed(_) => Self::ResourceError(value.to_string()),
+            TracingSetupError::SubscriberInitializationFailed(_) => {
+                Self::InitializationFailed(value.to_string())
+            }
+        }
+    }
+}
+
+impl From<ConfigSanityError> for AppError {
+    fn from(value: ConfigSanityError) -> Self {
+        AppError::ConfigurationError(value.to_string())
+    }
+}

--- a/cda-main/src/error.rs
+++ b/cda-main/src/error.rs
@@ -11,10 +11,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use std::fmt;
+
 use cda_interfaces::{DiagServiceError, DoipGatewaySetupError, config::ConfigSanityError};
 use cda_tracing::TracingSetupError;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error)]
 pub enum AppError {
     #[error("Initialization failed `{0}`")]
     InitializationFailed(String),
@@ -22,8 +24,11 @@ pub enum AppError {
     ResourceError(String),
     #[error("Connection error `{0}`")]
     ConnectionError(String),
-    #[error("Configuration error `{0}`")]
-    ConfigurationError(String),
+    #[error("Configuration error `{message}`")]
+    ConfigurationError {
+        message: String,
+        source: Option<Box<dyn std::error::Error>>,
+    },
     #[error("Data error `{0}`")]
     DataError(String),
     #[error("Error during execution `{0}`")]
@@ -59,7 +64,10 @@ impl From<DiagServiceError> for AppError {
             | DiagServiceError::Nack(_) => Self::RuntimeError(value.to_string()),
 
             DiagServiceError::InvalidConfiguration(_) | DiagServiceError::InvalidSecurityPlugin => {
-                Self::ConfigurationError(value.to_string())
+                Self::ConfigurationError {
+                    message: value.to_string(),
+                    source: None,
+                }
             }
 
             DiagServiceError::ResourceError(_) => Self::ResourceError(value.to_string()),
@@ -83,18 +91,22 @@ impl From<DoipGatewaySetupError> for AppError {
             | DoipGatewaySetupError::PortBindFailed(_) => {
                 Self::InitializationFailed(value.to_string())
             }
-            DoipGatewaySetupError::InvalidConfiguration(_) => {
-                Self::ConfigurationError(value.to_string())
-            }
+            DoipGatewaySetupError::InvalidConfiguration(_) => Self::ConfigurationError {
+                message: value.to_string(),
+                source: None,
+            },
             DoipGatewaySetupError::ResourceError(_) => Self::ResourceError(value.to_string()),
             DoipGatewaySetupError::ServerError(_) => Self::ServerError(value.to_string()),
             DoipGatewaySetupError::UnknownECU {
                 logical_address,
                 protocol_version,
-            } => Self::ConfigurationError(format!(
-                "Unknown ECU with logical address {logical_address} and protocol version \
-                 {protocol_version}"
-            )),
+            } => Self::ConfigurationError {
+                message: format!(
+                    "Unknown ECU with logical address {logical_address} and protocol version \
+                     {protocol_version}"
+                ),
+                source: None,
+            },
         }
     }
 }
@@ -112,6 +124,54 @@ impl From<TracingSetupError> for AppError {
 
 impl From<ConfigSanityError> for AppError {
     fn from(value: ConfigSanityError) -> Self {
-        AppError::ConfigurationError(value.to_string())
+        AppError::ConfigurationError {
+            message: "Error while checking configuration sanity".to_string(),
+            source: Some(value.into()),
+        }
+    }
+}
+
+// Representation printed when returned from main().
+impl fmt::Debug for AppError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Error: {self}")?;
+
+        let mut error: &dyn std::error::Error = self;
+
+        while let Some(source) = error.source() {
+            writeln!(f, "    Caused by: {source}")?;
+            error = source;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_write_source_errors_in_debug_format() {
+        let source = "amet, consectetur".to_string();
+
+        let source = AppError::ConfigurationError {
+            message: "dolor sit".to_string(),
+            source: Some(source.into()),
+        };
+        let testee = AppError::ConfigurationError {
+            message: "Lorem ipsum".to_string(),
+            source: Some(source.into()),
+        };
+
+        let result = format!("{testee:?}");
+
+        assert_eq!(
+            result,
+            "Error: Configuration error `Lorem ipsum`
+    Caused by: Configuration error `dolor sit`
+    Caused by: amet, consectetur
+"
+        );
     }
 }

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -18,11 +18,8 @@ use cda_comm_uds::{UdsManager, state_coordinator::EcuStateCoordinator};
 use cda_core::EcuManager;
 use cda_database::FileManager;
 use cda_interfaces::{
-    DiagServiceError, DoipGatewaySetupError, EcuConnectivityHandler, FunctionalDescriptionConfig,
-    HashMap, HashMapExtensions, UdsQuery, UdsVariant,
-    config::{ConfigSanity, ConfigSanityError},
-    datatypes::FaultConfig,
-    dlt_ctx,
+    DoipGatewaySetupError, EcuConnectivityHandler, FunctionalDescriptionConfig, HashMap,
+    HashMapExtensions, UdsQuery, UdsVariant, config::ConfigSanity, datatypes::FaultConfig, dlt_ctx,
 };
 use cda_plugin_security::{
     DefaultSecurityPlugin, DefaultSecurityPluginData, SecurityPlugin, SecurityPluginLoader,
@@ -30,6 +27,7 @@ use cda_plugin_security::{
 use cda_sovd::Locks;
 use cda_tracing::{OtelGuard, TracingSetupError, TracingWorkerGuard};
 use clap::{Parser, Subcommand};
+pub use error::AppError;
 use futures::future::FutureExt;
 use tokio::sync::{Mutex, RwLock, mpsc};
 use tracing_subscriber::layer::SubscriberExt;
@@ -41,6 +39,7 @@ use crate::{
 };
 
 pub mod config;
+pub mod error;
 pub mod mdd;
 pub mod update;
 
@@ -141,108 +140,6 @@ pub struct VehicleComponents<S: SecurityPlugin> {
     pub databases: Arc<DatabaseMap<S>>,
     pub file_managers: FileManagerMap,
     pub variant_detection_handle: tokio::task::JoinHandle<()>,
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum AppError {
-    #[error("Initialization failed `{0}`")]
-    InitializationFailed(String),
-    #[error("Resource error: `{0}`")]
-    ResourceError(String),
-    #[error("Connection error `{0}`")]
-    ConnectionError(String),
-    #[error("Configuration error `{0}`")]
-    ConfigurationError(String),
-    #[error("Data error `{0}`")]
-    DataError(String),
-    #[error("Error during execution `{0}`")]
-    RuntimeError(String),
-    #[error("Not found: `{0}`")]
-    NotFound(String),
-    #[error("Server error: `{0}`")]
-    ServerError(String),
-    #[error("Shutdown requested")]
-    ShutdownRequested,
-}
-
-impl From<DiagServiceError> for AppError {
-    fn from(value: DiagServiceError) -> Self {
-        match value {
-            DiagServiceError::RequestNotSupported(_)
-            | DiagServiceError::BadPayload(_)
-            | DiagServiceError::ConnectionClosed(_)
-            | DiagServiceError::UnexpectedResponse(_)
-            | DiagServiceError::EcuOffline(_)
-            | DiagServiceError::NoResponse(_)
-            | DiagServiceError::SendFailed(_)
-            | DiagServiceError::InvalidAddress(_)
-            | DiagServiceError::InvalidRequest(_)
-            | DiagServiceError::Timeout => Self::ConnectionError(value.to_string()),
-
-            DiagServiceError::ParameterConversionError(_)
-            | DiagServiceError::UnknownOperation
-            | DiagServiceError::UdsLookupError(_)
-            | DiagServiceError::VariantDetectionError(_)
-            | DiagServiceError::AccessDenied(_)
-            | DiagServiceError::InvalidState(_)
-            | DiagServiceError::Nack(_) => Self::RuntimeError(value.to_string()),
-
-            DiagServiceError::InvalidConfiguration(_) | DiagServiceError::InvalidSecurityPlugin => {
-                Self::ConfigurationError(value.to_string())
-            }
-
-            DiagServiceError::ResourceError(_) => Self::ResourceError(value.to_string()),
-
-            DiagServiceError::NotFound(_) => Self::NotFound(value.to_string()),
-
-            DiagServiceError::DataError(_)
-            | DiagServiceError::InvalidDatabase(_)
-            | DiagServiceError::AmbiguousParameters { .. }
-            | DiagServiceError::InvalidParameter { .. }
-            | DiagServiceError::NotEnoughData { .. } => Self::DataError(value.to_string()),
-        }
-    }
-}
-
-impl From<DoipGatewaySetupError> for AppError {
-    fn from(value: DoipGatewaySetupError) -> Self {
-        match value {
-            DoipGatewaySetupError::InvalidAddress(_) => Self::ConnectionError(value.to_string()),
-            DoipGatewaySetupError::SocketCreationFailed(_)
-            | DoipGatewaySetupError::PortBindFailed(_) => {
-                Self::InitializationFailed(value.to_string())
-            }
-            DoipGatewaySetupError::InvalidConfiguration(_) => {
-                Self::ConfigurationError(value.to_string())
-            }
-            DoipGatewaySetupError::ResourceError(_) => Self::ResourceError(value.to_string()),
-            DoipGatewaySetupError::ServerError(_) => Self::ServerError(value.to_string()),
-            DoipGatewaySetupError::UnknownECU {
-                logical_address,
-                protocol_version,
-            } => Self::ConfigurationError(format!(
-                "Unknown ECU with logical address {logical_address} and protocol version \
-                 {protocol_version}"
-            )),
-        }
-    }
-}
-
-impl From<TracingSetupError> for AppError {
-    fn from(value: TracingSetupError) -> Self {
-        match value {
-            TracingSetupError::ResourceCreationFailed(_) => Self::ResourceError(value.to_string()),
-            TracingSetupError::SubscriberInitializationFailed(_) => {
-                Self::InitializationFailed(value.to_string())
-            }
-        }
-    }
-}
-
-impl From<ConfigSanityError> for AppError {
-    fn from(value: ConfigSanityError) -> Self {
-        AppError::ConfigurationError(value.to_string())
-    }
 }
 
 impl AppArgs {

--- a/cda-main/src/mdd.rs
+++ b/cda-main/src/mdd.rs
@@ -365,11 +365,14 @@ pub(crate) fn handle_ecu_config_keys<S: SecurityPlugin>(
         }
     }
     if strict && !unmatched.is_empty() {
-        return Err(AppError::ConfigurationError(format!(
-            "[strict] ecu_config is enabled and the following per-ECU config entries do not match \
-             any loaded database: {}",
-            unmatched.join(", ")
-        )));
+        return Err(AppError::ConfigurationError {
+            message: format!(
+                "[strict] ecu_config is enabled and the following per-ECU config entries do not \
+                 match any loaded database: {}",
+                unmatched.join(", ")
+            ),
+            source: None,
+        });
     }
     Ok(())
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

General code cleanups that came out of my work on moving the configuration into a separate crate.

In particular, the error handling rework makes a first step towards being able to see source errors, which were so far at best visible through logging.

This does not implement backtraces, which would be a separate step.


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Most of the Rust ecosystem seems to use `anyhow` to print the source errors. Since we don't currently have it as a dependency, I opted for implementing that printing manually.  
I believe, `anyhow` would also give backtraces for free within `cda-main`. Not sure, if that's worth the dependency then...


---

Frank Märkle [frank.maerkle@mercedes-benz.com](mailto:frank.maerkle@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)