### PR TITLE
fix(plugin-runtime-update): reject apply synchronously when no update …

### DIFF
--- a/cda-plugin-runtime-update/src/lib.rs
+++ b/cda-plugin-runtime-update/src/lib.rs
@@ -226,6 +226,22 @@ pub(crate) mod test_utils {
             Ok(())
         }
     }
+
+    /// A [`RuntimeFileReloadHandler`] whose database reload always fails, useful for
+    /// exercising the async-failure path of an execution that has otherwise been
+    /// accepted (i.e. that got past all synchronous pre-checks in `start_execution`).
+    pub struct FailingReloadHandler;
+
+    #[async_trait]
+    impl RuntimeFileReloadHandler for FailingReloadHandler {
+        async fn reload_databases(&self, _mdd_paths: Vec<PathBuf>) -> Result<(), ReloadError> {
+            Err(ReloadError("simulated reload failure".to_string()))
+        }
+
+        async fn reload_configuration(&self, _config_path: PathBuf) -> Result<(), ReloadError> {
+            Ok(())
+        }
+    }
 }
 
 #[cfg(test)]

--- a/cda-plugin-runtime-update/src/operations/executions.rs
+++ b/cda-plugin-runtime-update/src/operations/executions.rs
@@ -117,6 +117,19 @@ where
         }
     }
 
+    // For Apply: verify there is at least one pending NextUpdate collection before
+    // accepting the request. This mirrors the Rollback check above, and must happen
+    // before spawning the task so that the 404 is returned synchronously instead of
+    // 202 being sent with a later Failed status (execute_apply's own check runs
+    // inside the spawned task and is too late to affect the HTTP response).
+    if mode == ExecutionMode::Apply
+        && collections.pending_mdd.is_none()
+        && collections.pending_config.is_none()
+    {
+        params.update_in_progress.store(false, Ordering::Release);
+        return Err(RuntimeUpdateError::NoPendingUpdate);
+    }
+
     let execution_id = uuid::Uuid::new_v4().to_string();
     {
         let mut execs = params.executions.write().await;
@@ -313,6 +326,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn start_execution_apply_with_no_pending_update_rejected_synchronously() {
+        let f = make_fixture();
+
+        // Nothing seeded into DiagnosticDatabaseNextUpdate or ConfigurationNextUpdate:
+        // Apply must be rejected synchronously (i.e. `start_execution` itself returns
+        // an error) rather than accepted (202-equivalent execution id) only to fail
+        // later inside the spawned task.
+        let result = super::start_execution(&f.params(), ExecutionMode::Apply).await;
+
+        assert!(
+            matches!(result, Err(RuntimeUpdateError::NoPendingUpdate)),
+            "expected NoPendingUpdate, got: {result:?}"
+        );
+        assert!(
+            f.executions.read().await.is_empty(),
+            "no execution should have been recorded for a synchronously-rejected apply"
+        );
+        assert!(
+            !f.update_in_progress
+                .load(std::sync::atomic::Ordering::Acquire),
+            "update_in_progress must be released after a synchronously-rejected apply"
+        );
+    }
+
+    #[tokio::test]
     async fn start_execution_cleanup_succeeds() {
         let f = make_fixture();
 
@@ -402,8 +440,28 @@ mod tests {
     #[tokio::test]
     async fn execution_transitions_to_failed_on_error() {
         let f = make_fixture();
+        // Seed a pending MDD so Apply passes the synchronous NoPendingUpdate
+        // pre-check in `start_execution`, and use a reload handler that fails so
+        // the execution fails asynchronously inside the spawned task instead.
+        write_test_file(
+            &f.storage,
+            &CollectionName::DiagnosticDatabaseNextUpdate,
+            "ecu.mdd",
+            b"mdd_data",
+        )
+        .await;
+        let failing_reload_handler = Arc::new(crate::test_utils::FailingReloadHandler);
+        let params = super::ExecutionParams {
+            storage: &f.storage,
+            security_handler: &f.security_handler,
+            reload_handler: &failing_reload_handler,
+            executions: &f.executions,
+            update_in_progress: &f.update_in_progress,
+            mdd_decompress: false,
+            lock_state_provider: &f.lock_provider,
+        };
 
-        let exec_id = super::start_execution(&f.params(), ExecutionMode::Apply)
+        let exec_id = super::start_execution(&params, ExecutionMode::Apply)
             .await
             .unwrap();
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
'start_execution' pre-checks Rollback's NoBackup condition synchronously (before spawning the async execution task) specifically so the caller gets an immediate 404-equivalent instead of a 202 followed later by an async Failed status. Apply had no equivalent pre-check: its NoPendingUpdate condition (mdd_next.is_none() && cfg_next.is_none()) was only checked deep inside execute_apply, which runs inside the spawned task. As a result, apply was always accepted (202) even when nothing was staged in NextUpdate, and NoPendingUpdate only ever surfaced later via the execution's Failed status.

Add the same synchronous pre-check for Apply, using the pending_mdd/pending_config collections already fetched earlier in start_execution, so NoPendingUpdate is returned synchronously and consistently with Rollback's NoBackup handling.

Also:
- Add FailingReloadHandler test helper (reload_databases always fails) to keep exercising the async-failure path of an execution, since the existing execution_transitions_to_failed_on_error test previously relied on Apply-with-nothing-pending to trigger an async failure -- that scenario is now caught synchronously instead.
- Add start_execution_apply_with_no_pending_update_rejected_synchronously regression test asserting the NoPendingUpdate error is returned directly from start_execution (not observed via polling an execution record), and that no execution is recorded and update_in_progress is released.


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
