### PR TITLE
fix(update): make the update plugin actually pluggable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,7 @@ dependencies = [
 name = "cda-comm-can"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "cda-interfaces",
  "hex",
  "schemars",
@@ -396,6 +397,7 @@ dependencies = [
 name = "cda-comm-doip"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "cda-interfaces",
  "doip-codec",
  "doip-definitions",
@@ -510,6 +512,7 @@ dependencies = [
  "bytes",
  "cda-build",
  "foldhash",
+ "futures",
  "hex",
  "mockall",
  "parking_lot",
@@ -532,15 +535,17 @@ dependencies = [
  "bytes",
  "cda-database",
  "cda-interfaces",
+ "cda-plugin-security",
+ "cda-sovd",
  "cda-storage",
  "schemars",
  "serde",
  "serde_json",
  "sha2",
- "sovd-interfaces",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
+ "toml 0.9.8",
  "tracing",
  "uuid",
 ]
@@ -577,9 +582,7 @@ dependencies = [
  "bytes",
  "cda-build",
  "cda-interfaces",
- "cda-plugin-runtime-update",
  "cda-plugin-security",
- "cda-tracing",
  "chrono",
  "http",
  "indexmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
- "toml 0.9.8",
  "tracing",
  "uuid",
 ]

--- a/cda-comm-can/Cargo.toml
+++ b/cda-comm-can/Cargo.toml
@@ -28,6 +28,7 @@ path = "src/lib.rs"
 # internal dependencies
 cda-interfaces = { workspace = true }
 # external
+async-trait = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 # tokio

--- a/cda-comm-can/src/gateway.rs
+++ b/cda-comm-can/src/gateway.rs
@@ -26,6 +26,7 @@ mod rediscovery;
 
 use std::{sync::Arc, time::Duration};
 
+use async_trait::async_trait;
 use cda_interfaces::{
     CanComParamProvider, CanId, DiagServiceError, EcuAddresses, EcuGateway, HashMap,
     ServicePayload, TransmissionParameters, UdsResponse, dlt_ctx,
@@ -477,19 +478,6 @@ impl CanDiagGateway {
 }
 
 impl EcuGateway for CanDiagGateway {
-    async fn shutdown(&mut self) {
-        // CAN uses per-transaction ISO-TP sockets (no long-lived connection
-        // tasks); only the broadcast keep-alive and the rediscovery loop run
-        // in the background. Rediscovery first: it holds a gateway clone, so
-        // awaiting it here also breaks that reference cycle.
-        if let Some(rediscovery) = self.rediscovery_handle.get() {
-            rediscovery.shutdown().await;
-        }
-        if let Some(ref keepalive) = self.keepalive_handle {
-            keepalive.shutdown().await;
-        }
-    }
-
     async fn get_gateway_network_address(&self, logical_address: u16) -> Option<String> {
         let ecu_name = self.logical_address_to_ecu.get(&logical_address)?;
         if !self.is_ecu_discovered_by_name(ecu_name).await {
@@ -738,6 +726,22 @@ impl EcuGateway for CanDiagGateway {
         std::future::ready(Err(DiagServiceError::RequestNotSupported(
             "functional addressing is not implemented for the CAN transport".to_owned(),
         )))
+    }
+}
+
+#[async_trait]
+impl cda_interfaces::Shutdown for CanDiagGateway {
+    async fn shutdown(&self) {
+        // CAN uses per-transaction ISO-TP sockets (no long-lived connection
+        // tasks); only the broadcast keep-alive and the rediscovery loop run
+        // in the background. Rediscovery first: it holds a gateway clone, so
+        // awaiting it here also breaks that reference cycle.
+        if let Some(rediscovery) = self.rediscovery_handle.get() {
+            rediscovery.shutdown().await;
+        }
+        if let Some(ref keepalive) = self.keepalive_handle {
+            keepalive.shutdown().await;
+        }
     }
 }
 

--- a/cda-comm-can/src/gateway/background.rs
+++ b/cda-comm-can/src/gateway/background.rs
@@ -14,6 +14,8 @@
 //! Handle for the gateway's cancellable background tasks (keep-alive
 //! broadcast, rediscovery).
 
+use async_trait::async_trait;
+use cda_interfaces::Shutdown;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -35,9 +37,11 @@ impl BackgroundTask {
             task: std::sync::Mutex::new(Some(task)),
         }
     }
+}
 
-    /// Stops the task and waits until it has terminated. Idempotent.
-    pub(crate) async fn shutdown(&self) {
+#[async_trait]
+impl Shutdown for BackgroundTask {
+    async fn shutdown(&self) {
         self.cancel.cancel();
         let task = self.task.lock().map_or(None, |mut guard| guard.take());
         if let Some(task) = task {

--- a/cda-comm-can/src/lib.rs
+++ b/cda-comm-can/src/lib.rs
@@ -40,6 +40,17 @@ mod gateway;
 #[cfg(feature = "can")]
 pub use gateway::{CanDiagGateway, error};
 
+#[cfg(feature = "can")]
+impl cda_interfaces::ReusableTransportResource for CanDiagGateway {
+    type TransportResource = ();
+
+    fn reusable_transport_resource(
+        &self,
+    ) -> Option<std::sync::Arc<tokio::sync::Mutex<Self::TransportResource>>> {
+        None
+    }
+}
+
 /// Stub `CanDiagGateway` when the `can` feature is disabled.
 ///
 /// This type exists only to satisfy the `Option<CanDiagGateway>` field in
@@ -54,8 +65,6 @@ pub struct CanDiagGateway {
 
 #[cfg(not(feature = "can"))]
 impl cda_interfaces::EcuGateway for CanDiagGateway {
-    async fn shutdown(&mut self) {}
-
     async fn get_gateway_network_address(&self, _logical_address: u16) -> Option<String> {
         None
     }
@@ -109,5 +118,22 @@ impl cda_interfaces::EcuGateway for CanDiagGateway {
                 )
             })
             .collect())
+    }
+}
+
+#[cfg(not(feature = "can"))]
+#[async_trait::async_trait]
+impl cda_interfaces::Shutdown for CanDiagGateway {
+    async fn shutdown(&self) {}
+}
+
+#[cfg(not(feature = "can"))]
+impl cda_interfaces::ReusableTransportResource for CanDiagGateway {
+    type TransportResource = ();
+
+    fn reusable_transport_resource(
+        &self,
+    ) -> Option<std::sync::Arc<tokio::sync::Mutex<Self::TransportResource>>> {
+        None
     }
 }

--- a/cda-comm-can/src/multi_transport.rs
+++ b/cda-comm-can/src/multi_transport.rs
@@ -41,9 +41,10 @@
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use cda_interfaces::{
-    DiagServiceError, EcuAddresses, EcuGateway, HashMap, ServicePayload, TransmissionParameters,
-    UdsResponse,
+    DiagServiceError, EcuAddresses, EcuGateway, HashMap, ReusableTransportResource, ServicePayload,
+    Shutdown, TransmissionParameters, UdsResponse,
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::{RwLock, mpsc};
@@ -195,15 +196,6 @@ impl<D: EcuGateway> MultiTransportGateway<D> {
 }
 
 impl<D: EcuGateway> EcuGateway for MultiTransportGateway<D> {
-    async fn shutdown(&mut self) {
-        if let Some(ref mut doip) = self.doip_gateway {
-            doip.shutdown().await;
-        }
-        if let Some(ref mut can) = self.can_gateway {
-            can.shutdown().await;
-        }
-    }
-
     async fn get_gateway_network_address(&self, logical_address: u16) -> Option<String> {
         // DoIP addresses are returned verbatim (bare IP) to keep the SOVD
         // network-structure API compatible with pre-multi-transport releases.
@@ -352,15 +344,12 @@ impl<D: EcuGateway> EcuGateway for MultiTransportGateway<D> {
 
     async fn send_functional(
         &self,
-        transmission_params: cda_interfaces::TransmissionParameters,
-        message: cda_interfaces::ServicePayload,
-        expected_ecu_logical_addrs: cda_interfaces::HashMap<u16, String>,
+        transmission_params: TransmissionParameters,
+        message: ServicePayload,
+        expected_ecu_logical_addrs: HashMap<u16, String>,
         timeout: std::time::Duration,
         expect_positive_response: bool,
-    ) -> Result<
-        cda_interfaces::HashMap<String, Result<cda_interfaces::UdsResponse, DiagServiceError>>,
-        DiagServiceError,
-    > {
+    ) -> Result<HashMap<String, Result<UdsResponse, DiagServiceError>>, DiagServiceError> {
         if let Some(ref doip) = self.doip_gateway {
             return doip
                 .send_functional(
@@ -396,6 +385,32 @@ impl<D: EcuGateway> Clone for MultiTransportGateway<D> {
             can_gateway: self.can_gateway.clone(),
             transport_overrides: Arc::clone(&self.transport_overrides),
             ecu_bindings: Arc::clone(&self.ecu_bindings),
+        }
+    }
+}
+
+impl<D: EcuGateway + ReusableTransportResource> ReusableTransportResource
+    for MultiTransportGateway<D>
+{
+    type TransportResource = D::TransportResource;
+
+    fn reusable_transport_resource(
+        &self,
+    ) -> Option<Arc<tokio::sync::Mutex<Self::TransportResource>>> {
+        self.doip_gateway
+            .as_ref()
+            .and_then(ReusableTransportResource::reusable_transport_resource)
+    }
+}
+
+#[async_trait]
+impl<D: EcuGateway + Shutdown> Shutdown for MultiTransportGateway<D> {
+    async fn shutdown(&self) {
+        if let Some(ref doip) = self.doip_gateway {
+            doip.shutdown().await;
+        }
+        if let Some(ref can) = self.can_gateway {
+            can.shutdown().await;
         }
     }
 }
@@ -480,10 +495,6 @@ mod tests {
                 >,
             > + Send {
                 std::future::ready(Ok(HashMap::default()))
-            }
-
-            fn shutdown(&mut self) -> impl Future<Output = ()> + Send {
-                std::future::ready(())
             }
         }
 

--- a/cda-comm-doip/Cargo.toml
+++ b/cda-comm-doip/Cargo.toml
@@ -28,6 +28,7 @@ path = "src/lib.rs"
 # internal dependencies
 cda-interfaces = { workspace = true }
 # external
+async-trait = { workspace = true }
 thiserror = { workspace = true }
 # DoIP
 doip-definitions = { workspace = true }

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -17,10 +17,11 @@ use std::{
     time::{Duration, Instant},
 };
 
+use async_trait::async_trait;
 use cda_interfaces::{
     DiagServiceError, DoipComParams, DoipGatewaySetupError, EcuAddresses, EcuConnectivityHandler,
-    EcuGateway, HashMap, HashMapExtensions, ServicePayload, TransmissionParameters, UdsResponse,
-    dlt_ctx,
+    EcuGateway, HashMap, HashMapExtensions, ReusableTransportResource, ServicePayload,
+    TransmissionParameters, UdsResponse, dlt_ctx,
     util::{self, tokio_ext},
 };
 use doip_definitions::{
@@ -483,27 +484,6 @@ impl<T: EcuAddresses + DoipComParams> DoipDiagGateway<T> {
 }
 
 impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
-    async fn shutdown(&mut self) {
-        self.cancel_token.cancel();
-
-        if let Some(vam_listener_handle) = self.vam_listener_handle.lock().await.take() {
-            // Abort and await the VAM listener task so it stops reading from the
-            // shared UDP socket before a new gateway reuses it.
-            vam_listener_handle.abort();
-            let _ = vam_listener_handle.await;
-        }
-
-        // Abort all background tasks (sender, receiver, connection-reset) for each
-        // gateway connection. This immediately drops their TCP socket halves.
-        let connections = self.state.doip_connections.write().await;
-        let mut tasks = self.state.connection_tasks.lock().await;
-        tasks.abort_all();
-        while tasks.join_next().await.is_some() {}
-        drop(tasks);
-        drop(connections);
-        self.state.doip_connections.write().await.clear();
-    }
-
     async fn get_gateway_network_address(&self, logical_address: u16) -> Option<String> {
         self.state
             .doip_connections
@@ -1122,6 +1102,38 @@ impl<T: EcuAddresses + DoipComParams> Clone for DoipDiagGateway<T> {
             cancel_token: self.cancel_token.clone(),
             vam_listener_handle: Arc::clone(&self.vam_listener_handle),
         }
+    }
+}
+
+#[async_trait]
+impl<T: EcuAddresses + DoipComParams> cda_interfaces::Shutdown for DoipDiagGateway<T> {
+    async fn shutdown(&self) {
+        self.cancel_token.cancel();
+
+        if let Some(vam_listener_handle) = self.vam_listener_handle.lock().await.take() {
+            // Abort and await the VAM listener task so it stops reading from the
+            // shared UDP socket before a new gateway reuses it.
+            vam_listener_handle.abort();
+            let _ = vam_listener_handle.await;
+        }
+
+        // Abort all background tasks (sender, receiver, connection-reset) for each
+        // gateway connection. This immediately drops their TCP socket halves.
+        let connections = self.state.doip_connections.write().await;
+        let mut tasks = self.state.connection_tasks.lock().await;
+        tasks.abort_all();
+        while tasks.join_next().await.is_some() {}
+        drop(tasks);
+        drop(connections);
+        self.state.doip_connections.write().await.clear();
+    }
+}
+
+impl<T: EcuAddresses + DoipComParams> ReusableTransportResource for DoipDiagGateway<T> {
+    type TransportResource = DoIPUdpSocket;
+
+    fn reusable_transport_resource(&self) -> Option<Arc<Mutex<Self::TransportResource>>> {
+        Some(Arc::clone(&self.state.socket))
     }
 }
 

--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -161,21 +161,6 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
         self.state_coordinator.clone()
     }
 
-    /// Abort all background tasks owned by this instance. Idempotent.
-    pub async fn shutdown(&self) {
-        let mut tester_present_tasks = self.tester_present_tasks.write().await;
-        let mut session_reset_tasks = self.session_reset_tasks.write().await;
-        let mut security_reset_tasks = self.security_reset_tasks.write().await;
-        let mut data_transfers = self.data_transfers.lock().await;
-        tester_present_tasks
-            .drain()
-            .map(|(_, tp)| tp.task)
-            .chain(session_reset_tasks.drain().map(|(_, h)| h))
-            .chain(security_reset_tasks.drain().map(|(_, h)| h))
-            .chain(data_transfers.drain().map(|(_, t)| t.task))
-            .for_each(|h| h.abort());
-    }
-
     /// Send a diagnostic service by its request prefix, looking up the service definition
     /// in the MDD database and encoding JSON parameters according to the
     /// service's parameter definitions.
@@ -306,6 +291,23 @@ impl<S: Clone + EcuGateway, T: UdsEcuDb> Clone for UdsManager<S, T> {
             fault_config: self.fault_config.clone(),
             update_in_progress: Arc::clone(&self.update_in_progress),
         }
+    }
+}
+
+#[async_trait::async_trait]
+impl<S: EcuGateway, T: EcuManager> cda_interfaces::Shutdown for UdsManager<S, T> {
+    async fn shutdown(&self) {
+        let mut tester_present_tasks = self.tester_present_tasks.write().await;
+        let mut session_reset_tasks = self.session_reset_tasks.write().await;
+        let mut security_reset_tasks = self.security_reset_tasks.write().await;
+        let mut data_transfers = self.data_transfers.lock().await;
+        tester_present_tasks
+            .drain()
+            .map(|(_, tp)| tp.task)
+            .chain(session_reset_tasks.drain().map(|(_, h)| h))
+            .chain(security_reset_tasks.drain().map(|(_, h)| h))
+            .chain(data_transfers.drain().map(|(_, t)| t.task))
+            .for_each(|h| h.abort());
     }
 }
 

--- a/cda-comm-uds/src/transport.rs
+++ b/cda-comm-uds/src/transport.rs
@@ -751,8 +751,6 @@ mod send_tests {
         + Sync;
 
     impl EcuGateway for TestGateway {
-        async fn shutdown(&mut self) {}
-
         fn get_gateway_network_address(
             &self,
             _logical_address: u16,

--- a/cda-health/src/lib.rs
+++ b/cda-health/src/lib.rs
@@ -15,9 +15,7 @@ use std::sync::Arc;
 
 use aide::axum::{ApiRouter as Router, routing};
 use cda_interfaces::HashMap;
-use cda_sovd::dynamic_router::DynamicRouter;
 use futures::future;
-use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
 pub mod config;
@@ -28,21 +26,8 @@ pub enum HealthError {
     ProviderAlreadyExists(String),
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, schemars::JsonSchema, Eq, PartialEq)]
-pub enum Status {
-    Up,
-    Starting,
-    Pending,
-    Failed,
-}
-
-/// Trait for health providers that are queried on-demand when a health check request comes in.
-/// Implementors should return the current health status when `check_health` is called.
-#[async_trait::async_trait]
-pub trait HealthProvider: Send + Sync {
-    /// Returns the current health status of the component.
-    async fn check_health(&self) -> Status;
-}
+pub use cda_interfaces::health::{HealthProvider, Status};
+use cda_sovd::dynamic_router::DynamicRouter;
 
 /// A simple health provider implementation that stores the last status.
 /// Useful for components that run through an initialization once and their health
@@ -69,8 +54,12 @@ impl StatusHealthProvider {
 
 #[async_trait::async_trait]
 impl HealthProvider for StatusHealthProvider {
-    async fn check_health(&self) -> Status {
+    async fn status(&self) -> Status {
         *self.status.read().await
+    }
+
+    async fn set_status(&self, status: Status) {
+        *self.status.write().await = status;
     }
 }
 
@@ -107,7 +96,7 @@ impl HealthState {
         let providers = self.providers.read().await;
 
         let futures = providers.iter().map(|(name, provider)| async move {
-            let status = provider.check_health().await;
+            let status = provider.status().await;
             (name.clone(), status)
         });
 

--- a/cda-interfaces/Cargo.toml
+++ b/cda-interfaces/Cargo.toml
@@ -38,6 +38,7 @@ thiserror = { workspace = true }
 async-trait = { workspace = true }
 #tokio
 tokio = { workspace = true, features = ["sync", "time"] }
+futures = { workspace = true }
 # runtime size info
 hex = { workspace = true }
 strum = { workspace = true }

--- a/cda-interfaces/src/ecugateway.rs
+++ b/cda-interfaces/src/ecugateway.rs
@@ -11,9 +11,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::{Mutex, RwLock, mpsc};
 
 use crate::{DiagServiceError, EcuAddresses, HashMap, ServicePayload};
 
@@ -127,12 +127,6 @@ pub trait EcuGateway: Clone + Send + Sync + 'static {
         Output = Result<HashMap<String, Result<UdsResponse, DiagServiceError>>, DiagServiceError>,
     > + Send;
 
-    /// Stops the gateway, aborting its background tasks and releasing its
-    /// transport resources. Completes only after the owned tasks have
-    /// terminated, so callers (e.g. the runtime database reload, which reuses
-    /// the `DoIP` UDP socket) can rely on the transport being quiescent.
-    fn shutdown(&mut self) -> impl Future<Output = ()> + Send;
-
     /// Network address of a specific ECU, looked up by name.
     ///
     /// Fallback for ECUs whose logical addresses are unresolved com-param
@@ -146,4 +140,20 @@ pub trait EcuGateway: Clone + Send + Sync + 'static {
     ) -> impl Future<Output = Option<String>> + Send {
         std::future::ready(None)
     }
+}
+
+/// An [`EcuGateway`] that may own a reusable transport resource.
+///
+/// Implementing this trait allows a reload handler to retrieve and hand back an existing
+/// transport resource to the factory during a database reload. Gateways without a reusable
+/// resource, such as CAN-only gateways, return `None`.
+///
+/// The associated resource type is deliberately opaque in `cda-interfaces` so that this crate
+/// stays free of dependencies on concrete transport implementations.
+pub trait ReusableTransportResource {
+    /// Opaque reusable transport resource type (e.g. `cda_comm_doip::socket::DoIPUdpSocket`).
+    type TransportResource: Send + Sync + 'static;
+
+    /// Returns a shared, cloneable handle to the reusable transport resource when present.
+    fn reusable_transport_resource(&self) -> Option<Arc<Mutex<Self::TransportResource>>>;
 }

--- a/cda-interfaces/src/health.rs
+++ b/cda-interfaces/src/health.rs
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// Health status of a component.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, schemars::JsonSchema, Eq, PartialEq)]
+pub enum Status {
+    Up,
+    Starting,
+    Pending,
+    Failed,
+}
+
+/// Trait for health providers that are queried on-demand when a health check request comes in,
+/// and updated as components transition between states.
+#[async_trait]
+pub trait HealthProvider: Send + Sync + 'static {
+    /// Returns the current health status of the component.
+    async fn status(&self) -> Status;
+
+    /// Updates the health status of the component.
+    async fn set_status(&self, status: Status);
+}

--- a/cda-interfaces/src/lib.rs
+++ b/cda-interfaces/src/lib.rs
@@ -16,6 +16,8 @@ use std::{
     time::Duration,
 };
 
+use async_trait::async_trait;
+use futures::{FutureExt, future::BoxFuture};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -32,6 +34,7 @@ pub use ecumanager::*;
 mod ecuuds;
 pub use ecuuds::*;
 pub mod file_manager;
+pub mod health;
 mod schema;
 pub use schema::*;
 pub mod config;
@@ -435,4 +438,24 @@ impl Display for DiagCommAction {
             DiagCommAction::Stop => write!(f, "Stop"),
         }
     }
+}
+
+/// Type alias for the boxed shared shutdown signal.
+/// This provides a concrete named type for use in generic bounds.
+pub type ShutdownSignal = futures::future::Shared<BoxFuture<'static, ()>>;
+
+pub fn shutdown_signal<F>(future: F) -> ShutdownSignal
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    future.boxed().shared()
+}
+
+/// Capability for gracefully shutting down background tasks/connections, e.g. before a
+/// hot-reload replaces the underlying component with a freshly constructed one.
+#[async_trait]
+pub trait Shutdown: Send + Sync + 'static {
+    /// Aborts background tasks and releases connections/resources owned by this instance.
+    /// Implementations should be idempotent where practical.
+    async fn shutdown(&self);
 }

--- a/cda-interfaces/src/runtime_update_api.rs
+++ b/cda-interfaces/src/runtime_update_api.rs
@@ -22,8 +22,8 @@
 
 //! Runtime Update Plugin API
 //!
-//! Provides the interface definitions for runtime file management (MDD databases and
-//! configuration), including security handler traits, reload handler traits, and error types.
+//! Provides the interface definitions for runtime MDD database management, including security
+//! handler traits, reload handler traits, and error types.
 //!
 //! The concrete plugin implementation lives in `cda-plugin-runtime-update`.
 
@@ -47,7 +47,7 @@ use crate::{
 };
 
 mod error;
-pub use error::{ConfigValidationError, ReloadError, RuntimeUpdateError, VerificationError};
+pub use error::{ReloadError, RuntimeUpdateError, VerificationError};
 
 /// Guards against activity during a runtime update.
 pub trait ActivityGuard: Send + Sync + 'static {
@@ -123,39 +123,15 @@ pub struct UploadFile {
 pub struct UpdateCollections<C: Collection + DirectFileAccess> {
     /// Staged MDD collection (`DiagnosticDatabaseNextUpdate`), or `None` if no update is pending.
     pub pending_mdd: Option<Arc<C>>,
-    /// Staged configuration collection (`ConfigurationNextUpdate`), or `None` if not pending.
-    pub pending_config: Option<Arc<C>>,
     /// Currently active MDD collection (`DiagnosticDatabase`), or `None` if not yet initialized.
     pub current_mdd: Option<Arc<C>>,
-    /// Currently active configuration collection (`Configuration`), or `None` if uninitialised.
-    pub current_config: Option<Arc<C>>,
 }
 
 impl<C: Collection + DirectFileAccess> Default for UpdateCollections<C> {
     fn default() -> Self {
         Self {
             pending_mdd: None,
-            pending_config: None,
             current_mdd: None,
-            current_config: None,
-        }
-    }
-}
-
-/// Determines the kind of file being applied in a runtime update.
-#[derive(Clone)]
-pub enum UpdateFileType<'a> {
-    /// A diagnostic database file (`.mdd`).
-    Mdd,
-    /// A CDA configuration file (`.toml`), with an associated config validator.
-    Config(&'a dyn ConfigValidator),
-}
-
-impl std::fmt::Debug for UpdateFileType<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Mdd => write!(f, "Mdd"),
-            Self::Config(_) => write!(f, "Config"),
         }
     }
 }
@@ -177,45 +153,13 @@ pub trait LockStateProvider: Send + Sync + 'static {
 /// Handler for reloading diagnostic runtime data after file operations (apply/rollback).
 ///
 /// Implementors bridge the runtime-files plugin to the application's live diagnostic state,
-/// ensuring that newly applied MDD databases and configuration are picked up without a restart.
+/// ensuring that newly applied MDD databases are picked up without a restart.
 #[async_trait]
 pub trait RuntimeReloaderPlugin: Send + Sync + 'static {
     /// Loads (or re-loads) the MDD databases at the given paths into the running system.
     ///
     /// Called after a successful apply operation with the paths of all newly active MDD files.
     async fn reload_databases(&self, mdd_paths: Vec<PathBuf>) -> Result<(), ReloadError>;
-
-    /// Reloads the application configuration from the file at the given path.
-    ///
-    /// Called when a configuration file is part of the applied update.
-    /// The default implementation is a no-op (returns `Ok(())`).
-    async fn reload_configuration(&self, config_path: PathBuf) -> Result<(), ReloadError>;
-}
-
-/// Validates configuration file content during runtime updates.
-///
-/// Implementors parse and validate TOML (or other format) configuration files
-/// to ensure they are syntactically valid and semantically acceptable before
-/// being applied.
-pub trait ConfigValidator: Send + Sync + 'static {
-    /// Validates configuration file content.
-    ///
-    /// # Arguments
-    /// * `content` - Raw file content as string
-    ///
-    /// # Returns
-    /// * `Ok(())` if configuration is valid
-    /// * `Err(ConfigValidationError)` if invalid
-    /// # Errors
-    /// Returns `ConfigValidationError` on failure during validation.
-    fn validate(&self, content: &str) -> Result<(), ConfigValidationError>;
-}
-
-/// No-Op configuration validator, which can be used to skip configuration validation.
-impl ConfigValidator for () {
-    fn validate(&self, _content: &str) -> Result<(), ConfigValidationError> {
-        Ok(())
-    }
 }
 
 /// Security and file integrity handler for the diagnostic database update process.
@@ -251,23 +195,16 @@ pub trait RuntimeUpdateSecurityPlugin<
 
     /// Checks the integrity of all pending files before they are applied.
     ///
-    /// Called during the apply operation with all pending MDD and configuration files.
+    /// Called during the apply operation with all pending MDD files.
     /// Implementations may perform signature verification, hash checks, version
     /// compatibility validation, or any other file-level security checks.
     ///
-    /// The config validator, if needed, is embedded in the [`UpdateFileType::Config`] variant.
-    ///
     /// # Arguments
-    /// * `type_` - The type of file being validated (MDD or Config)
     /// * `path` - Path to the file to validate
     ///
     /// # Errors
     /// Return [`VerificationError`] to abort the apply operation.
-    async fn check_file_integrity(
-        &self,
-        type_: UpdateFileType<'_>,
-        path: &std::path::Path,
-    ) -> Result<(), VerificationError>;
+    async fn check_file_integrity(&self, path: &std::path::Path) -> Result<(), VerificationError>;
 }
 
 /// Status of an in-progress or completed database update execution.
@@ -408,7 +345,7 @@ pub struct UpdateExecution {
 
 // RuntimeFilesUpdatePlugin trait + ExclusiveRuntimePlugin wrapper
 
-/// The main plugin trait for managing diagnostic runtime files (MDD databases and configuration).
+/// The main plugin trait for managing diagnostic runtime files (MDD databases).
 ///
 /// Provides the full lifecycle for runtime file management: listing, uploading, deleting,
 /// and executing apply/rollback/cleanup operations on the diagnostic database.

--- a/cda-interfaces/src/runtime_update_api.rs
+++ b/cda-interfaces/src/runtime_update_api.rs
@@ -27,17 +27,27 @@
 //!
 //! The concrete plugin implementation lives in `cda-plugin-runtime-update`.
 
-use std::{path::PathBuf, str::FromStr, sync::Arc};
+use std::{
+    path::PathBuf,
+    str::FromStr,
+    sync::{Arc, atomic::AtomicBool},
+};
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use serde::{Deserialize, Deserializer, Serialize};
 use strum_macros::EnumString;
+use tokio::{sync::Mutex, task::JoinHandle};
 
-use crate::storage_api::{Collection, DirectFileAccess};
+use crate::{
+    FunctionalDescriptionConfig, HashMap, Shutdown, UdsQuery,
+    ecugateway::ReusableTransportResource,
+    file_manager::FileManager,
+    storage_api::{Collection, DirectFileAccess},
+};
 
 mod error;
-pub use error::{ReloadError, RuntimeUpdateError, VerificationError};
+pub use error::{ConfigValidationError, ReloadError, RuntimeUpdateError, VerificationError};
 
 /// Guards against activity during a runtime update.
 pub trait ActivityGuard: Send + Sync + 'static {
@@ -50,6 +60,52 @@ impl ActivityGuard for Vec<Box<dyn ActivityGuard>> {
     }
 }
 
+/// The result of creating a fresh set of vehicle components inside
+/// [`VehicleComponentFactory::create`].
+pub struct VehicleComponents<UdsManager, Gateway, File>
+where
+    UdsManager: UdsQuery + Shutdown,
+    Gateway: ReusableTransportResource + Shutdown,
+    File: FileManager,
+{
+    pub uds_manager: UdsManager,
+    pub file_managers: HashMap<String, File>,
+    pub diagnostic_gateway: Gateway,
+    pub variant_detection_handle: JoinHandle<()>,
+    pub functional_group_config: FunctionalDescriptionConfig,
+}
+
+/// Async factory that recreates vehicle components (UDS manager, diagnostic gateway,
+/// file managers, variant-detection task) from a configuration snapshot and new MDD paths.
+///
+///
+/// # Type parameters
+/// - `C`: opaque application configuration
+/// - `Q`: UDS manager type - must implement [`UdsQuery`] + [`Shutdown`]
+/// - `G`: diagnostic gateway type - must implement [`ReusableTransportResource`] + [`Shutdown`]
+#[async_trait]
+pub trait VehicleComponentFactory<Config, Uds, Gateway>: Send + Sync + 'static
+where
+    Config: Send + Sync + 'static,
+    Uds: UdsQuery + Shutdown,
+    Gateway: ReusableTransportResource + Shutdown,
+{
+    /// Concrete file-manager type produced by this factory.
+    type FileManager: FileManager;
+
+    /// Creates a fresh set of vehicle components.
+    ///
+    /// `reusable_transport_resource` is the optional transport resource owned by the gateway being
+    /// replaced. Implementations reuse it when their configured transport requires it.
+    async fn create(
+        &self,
+        config: &Config,
+        mdd_paths: &[PathBuf],
+        update_in_progress: Arc<AtomicBool>,
+        reusable_transport_resource: Option<Arc<Mutex<Gateway::TransportResource>>>,
+    ) -> Result<VehicleComponents<Uds, Gateway, Self::FileManager>, ReloadError>;
+}
+
 /// A file to be uploaded to the CDA during a runtime update.
 #[derive(Debug)]
 pub struct UploadFile {
@@ -59,7 +115,7 @@ pub struct UploadFile {
     pub data: Bytes,
 }
 
-/// Collections passed to [`RuntimeFilesUpdateSecurityHandler::check_apply_allowed`].
+/// Collections passed to [`RuntimeUpdateSecurityPlugin::check_apply_allowed`].
 ///
 /// Provides direct access to the staged (`*NextUpdate`) and currently active collections
 /// so implementations can inspect file lists, read metadata, or verify file content
@@ -87,12 +143,21 @@ impl<C: Collection + DirectFileAccess> Default for UpdateCollections<C> {
 }
 
 /// Determines the kind of file being applied in a runtime update.
-#[derive(Debug, Clone)]
-pub enum UpdateFileType {
+#[derive(Clone)]
+pub enum UpdateFileType<'a> {
     /// A diagnostic database file (`.mdd`).
     Mdd,
-    /// A CDA configuration file (`.toml`).
-    Config,
+    /// A CDA configuration file (`.toml`), with an associated config validator.
+    Config(&'a dyn ConfigValidator),
+}
+
+impl std::fmt::Debug for UpdateFileType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Mdd => write!(f, "Mdd"),
+            Self::Config(_) => write!(f, "Config"),
+        }
+    }
 }
 
 /// Provides read-only access to vehicle lock state for security validation.
@@ -114,7 +179,7 @@ pub trait LockStateProvider: Send + Sync + 'static {
 /// Implementors bridge the runtime-files plugin to the application's live diagnostic state,
 /// ensuring that newly applied MDD databases and configuration are picked up without a restart.
 #[async_trait]
-pub trait RuntimeFileReloadHandler: Send + Sync + 'static {
+pub trait RuntimeReloaderPlugin: Send + Sync + 'static {
     /// Loads (or re-loads) the MDD databases at the given paths into the running system.
     ///
     /// Called after a successful apply operation with the paths of all newly active MDD files.
@@ -124,7 +189,33 @@ pub trait RuntimeFileReloadHandler: Send + Sync + 'static {
     ///
     /// Called when a configuration file is part of the applied update.
     /// The default implementation is a no-op (returns `Ok(())`).
-    async fn reload_configuration(&self, _config_path: PathBuf) -> Result<(), ReloadError>;
+    async fn reload_configuration(&self, config_path: PathBuf) -> Result<(), ReloadError>;
+}
+
+/// Validates configuration file content during runtime updates.
+///
+/// Implementors parse and validate TOML (or other format) configuration files
+/// to ensure they are syntactically valid and semantically acceptable before
+/// being applied.
+pub trait ConfigValidator: Send + Sync + 'static {
+    /// Validates configuration file content.
+    ///
+    /// # Arguments
+    /// * `content` - Raw file content as string
+    ///
+    /// # Returns
+    /// * `Ok(())` if configuration is valid
+    /// * `Err(ConfigValidationError)` if invalid
+    /// # Errors
+    /// Returns `ConfigValidationError` on failure during validation.
+    fn validate(&self, content: &str) -> Result<(), ConfigValidationError>;
+}
+
+/// No-Op configuration validator, which can be used to skip configuration validation.
+impl ConfigValidator for () {
+    fn validate(&self, _content: &str) -> Result<(), ConfigValidationError> {
+        Ok(())
+    }
 }
 
 /// Security and file integrity handler for the diagnostic database update process.
@@ -137,7 +228,7 @@ pub trait RuntimeFileReloadHandler: Send + Sync + 'static {
 /// Vehicle lock ownership for modifying operations (upload, delete) is enforced at
 /// the HTTP handler layer in cda-sovd, not through this trait.
 #[async_trait]
-pub trait RuntimeFilesUpdateSecurityHandler<
+pub trait RuntimeUpdateSecurityPlugin<
     L: LockStateProvider,
     C: Collection + DirectFileAccess + Send + Sync + 'static,
 >: Send + Sync + 'static
@@ -164,11 +255,17 @@ pub trait RuntimeFilesUpdateSecurityHandler<
     /// Implementations may perform signature verification, hash checks, version
     /// compatibility validation, or any other file-level security checks.
     ///
+    /// The config validator, if needed, is embedded in the [`UpdateFileType::Config`] variant.
+    ///
+    /// # Arguments
+    /// * `type_` - The type of file being validated (MDD or Config)
+    /// * `path` - Path to the file to validate
+    ///
     /// # Errors
     /// Return [`VerificationError`] to abort the apply operation.
     async fn check_file_integrity(
         &self,
-        type_: UpdateFileType,
+        type_: UpdateFileType<'_>,
         path: &std::path::Path,
     ) -> Result<(), VerificationError>;
 }
@@ -317,7 +414,7 @@ pub struct UpdateExecution {
 /// and executing apply/rollback/cleanup operations on the diagnostic database.
 ///
 /// Security validation for mutating operations is delegated to the associated
-/// [`RuntimeFilesUpdateSecurityHandler`].
+/// [`RuntimeUpdateSecurityPlugin`].
 #[async_trait]
 pub trait RuntimeFilesUpdatePlugin: Send + Sync + 'static {
     /// Lists the currently active diagnostic runtime files.

--- a/cda-interfaces/src/runtime_update_api/error.rs
+++ b/cda-interfaces/src/runtime_update_api/error.rs
@@ -77,3 +77,8 @@ pub struct VerificationError(pub String);
 #[derive(Debug, thiserror::Error)]
 #[error("Reload error: {0}")]
 pub struct ReloadError(pub String);
+
+/// Error type for configuration validation failures.
+#[derive(Debug, thiserror::Error)]
+#[error("Config validation error: {0}")]
+pub struct ConfigValidationError(pub String);

--- a/cda-interfaces/src/runtime_update_api/error.rs
+++ b/cda-interfaces/src/runtime_update_api/error.rs
@@ -28,8 +28,6 @@ pub enum RuntimeUpdateError {
     StorageError(CdaStorageError),
     #[error("Invalid MDD file: {0}")]
     InvalidMddFile(String),
-    #[error("Invalid config file: {0}")]
-    InvalidConfig(String),
     #[error("Invalid file type: {0}")]
     InvalidFileType(String),
     #[error("Validation failed: {0}")]
@@ -77,8 +75,3 @@ pub struct VerificationError(pub String);
 #[derive(Debug, thiserror::Error)]
 #[error("Reload error: {0}")]
 pub struct ReloadError(pub String);
-
-/// Error type for configuration validation failures.
-#[derive(Debug, thiserror::Error)]
-#[error("Config validation error: {0}")]
-pub struct ConfigValidationError(pub String);

--- a/cda-interfaces/src/storage_api/collection.rs
+++ b/cda-interfaces/src/storage_api/collection.rs
@@ -34,12 +34,6 @@ pub enum CollectionName {
     DiagnosticDatabaseNextUpdate,
     /// Backup of the diagnostic database before an update.
     DiagnosticDatabaseBackup,
-    /// Configuration collection for CDA settings.
-    Configuration,
-    /// Staging area for a pending configuration update.
-    ConfigurationNextUpdate,
-    /// Backup of the configuration before an update.
-    ConfigurationBackup,
     /// A user-defined collection with an arbitrary name.
     Custom(String),
 }
@@ -52,9 +46,6 @@ impl CollectionName {
             Self::DiagnosticDatabase => "diagnostic_database",
             Self::DiagnosticDatabaseNextUpdate => "diagnostic_database_next_update",
             Self::DiagnosticDatabaseBackup => "diagnostic_database_backup",
-            Self::Configuration => "configuration",
-            Self::ConfigurationNextUpdate => "configuration_next_update",
-            Self::ConfigurationBackup => "configuration_backup",
             Self::Custom(name) => name.as_str(),
         }
     }

--- a/cda-main/src/cda_factory.rs
+++ b/cda-main/src/cda_factory.rs
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+use std::{path::PathBuf, sync::Arc};
+
+use async_trait::async_trait;
+use cda_comm_can::MultiTransportGateway;
+use cda_comm_doip::DoipDiagGateway;
+use cda_core::EcuManager;
+use cda_interfaces::{
+    HashMap, ShutdownSignal,
+    health::HealthProvider,
+    runtime_update_api::{ReloadError, VehicleComponentFactory, VehicleComponents},
+};
+use cda_plugin_security::SecurityPlugin;
+use tokio::sync::Mutex;
+
+use crate::{UdsManagerType, config::configfile::Configuration};
+
+/// Concrete [`VehicleComponentFactory`] that delegates to
+/// [`crate::create_vehicle_components`].
+///
+/// Used by [`cda_plugin_runtime_update::default_runtime_reloader_plugin::DefaultRuntimeReloaderPlugin`]
+/// and called every time the diagnostic databases are reloaded.
+pub struct CdaMainVehicleFactory<SP>
+where
+    SP: SecurityPlugin,
+{
+    shutdown_signal: ShutdownSignal,
+    health_providers: Option<HashMap<String, Arc<dyn HealthProvider>>>,
+    _phantom: std::marker::PhantomData<SP>,
+}
+
+impl<SP> CdaMainVehicleFactory<SP>
+where
+    SP: SecurityPlugin,
+{
+    #[must_use]
+    pub fn new(
+        shutdown_signal: ShutdownSignal,
+        health_providers: Option<HashMap<String, Arc<dyn HealthProvider>>>,
+    ) -> Self {
+        Self {
+            shutdown_signal,
+            health_providers,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+#[async_trait]
+impl<SP>
+    VehicleComponentFactory<
+        Configuration,
+        UdsManagerType<SP>,
+        MultiTransportGateway<DoipDiagGateway<EcuManager<SP>>>,
+    > for CdaMainVehicleFactory<SP>
+where
+    SP: SecurityPlugin,
+{
+    type FileManager = cda_database::FileManager;
+
+    async fn create(
+        &self,
+        config: &Configuration,
+        mdd_paths: &[PathBuf],
+        update_in_progress: Arc<std::sync::atomic::AtomicBool>,
+        reusable_transport_resource: Option<Arc<Mutex<cda_comm_doip::socket::DoIPUdpSocket>>>,
+    ) -> Result<
+        VehicleComponents<
+            UdsManagerType<SP>,
+            MultiTransportGateway<DoipDiagGateway<EcuManager<SP>>>,
+            Self::FileManager,
+        >,
+        ReloadError,
+    > {
+        let crate_components = crate::create_vehicle_components::<SP>(
+            config,
+            mdd_paths,
+            self.shutdown_signal.clone(),
+            self.health_providers.as_ref(),
+            update_in_progress,
+            reusable_transport_resource,
+        )
+        .await
+        .map_err(|e| ReloadError(format!("Failed to create vehicle components: {e}")))?;
+
+        Ok(VehicleComponents {
+            uds_manager: crate_components.uds_manager,
+            diagnostic_gateway: crate_components.diagnostic_gateway,
+            file_managers: crate_components.file_managers,
+            variant_detection_handle: crate_components.variant_detection_handle,
+            functional_group_config: config.functional_description.clone(),
+        })
+    }
+}

--- a/cda-main/src/config.rs
+++ b/cda-main/src/config.rs
@@ -12,13 +12,10 @@
  */
 use std::path::Path;
 
-use cda_interfaces::storage_api::{Collection, RandomAccessData, Storage};
 use figment::{
     Figment,
     providers::{Env, Format as _, Serialized, Toml},
 };
-
-use crate::AppError;
 
 pub mod com_params;
 pub mod configfile;
@@ -66,259 +63,21 @@ pub fn load_config_with_fallback(config_path: &Path) -> (configfile::Configurati
 /// (only when the `config-optional` feature is disabled).
 pub fn require_config_source() -> Result<(), crate::AppError> {
     if cfg!(feature = "config-optional") {
-        println!("No configuration found on disk or in storage. Using default values.");
+        println!("No configuration found on disk. Using default values.");
         Ok(())
     } else {
         Err(crate::AppError::ConfigurationError {
-            message: "No configuration found. Provide a configuration file, store one via runtime \
-                      update, or build with the 'config-optional' feature to allow starting \
-                      without one."
+            message: "No configuration found. Provide a configuration file or build with the \
+                      'config-optional' feature to allow starting without one."
                 .to_owned(),
             source: None,
         })
     }
 }
 
-/// Seeds the `Configuration` storage collection from `config_file_path` when the collection
-/// is empty. This copies the configuration file into storage so that the runtime update plugin
-/// has a populated baseline to work with.
-///
-/// # Errors
-/// Returns [`AppError`](crate::AppError) when no configuration file
-/// is accessible.
-pub async fn seed_storage_from_config_file(
-    storage: &cda_storage::LocalStorage,
-    config_file: &Path,
-) -> Result<(), crate::AppError> {
-    let data = tokio::fs::read(config_file).await.map_err(|source| {
-        crate::AppError::ConfigurationError {
-            message: format!(
-                "Cannot read config file from {} for seeding",
-                config_file.display()
-            ),
-            source: Some(source.into()),
-        }
-    })?;
-
-    let key = config_file
-        .file_name()
-        .ok_or_else(|| crate::AppError::ConfigurationError {
-            message: format!(
-                "Provided configuration file path does not have a file name: {}",
-                config_file.display()
-            ),
-            source: None,
-        })?
-        .to_string_lossy()
-        .to_string();
-
-    let count = cda_storage::storage_seed::seed_storage_collection(
-        storage,
-        &cda_interfaces::storage_api::CollectionName::Configuration,
-        std::iter::once((key.clone(), data)),
-    )
-    .await;
-
-    if let Some(count) = count
-        && count > 0
-    {
-        let config_file = config_file.display().to_string();
-        tracing::info!(
-            key,
-            config_file,
-            "Seeded Configuration collection from config file"
-        );
-    }
-    Ok(())
-}
-
-/// Attempts to load configuration from the storage Configuration collection.
-///
-/// Scans the collection for configuration files. The filename is not prescribed - any
-/// single entry in the collection is accepted.
-///
-/// # Errors
-/// - `Err(AppError::ConfigurationError)` - more than one entry exists (ambiguous) or
-///   reading/parsing the stored configuration failed.
-///
-/// # Returns
-/// - `Ok(None)` - storage is unavailable or the collection is empty (no override).
-/// - `Ok(Some(config))` - exactly one configuration was found and parsed successfully.
-pub async fn load_config_with_storage_override(
-    storage: &cda_storage::LocalStorage,
-) -> Result<Option<configfile::Configuration>, AppError> {
-    let collection = match storage
-        .get_or_create_collection(&cda_interfaces::storage_api::CollectionName::Configuration)
-        .await
-    {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::debug!(error = %e, "Cannot access Configuration collection, no config override");
-            return Ok(None);
-        }
-    };
-
-    let keys = collection
-        .list()
-        .await
-        .map_err(|source| AppError::ConfigurationError {
-            message: "Failed to list Configuration collection".to_string(),
-            source: Some(source.into()),
-        })?;
-
-    let key = match keys.as_slice() {
-        [] => {
-            return Ok(None);
-        }
-        [single] => single,
-        keys => {
-            return Err(AppError::ConfigurationError {
-                message: format!(
-                    "Expected at most one configuration in storage, found {}: {keys:?}",
-                    keys.len()
-                ),
-                source: None,
-            });
-        }
-    };
-
-    let data_handle =
-        collection
-            .read(key)
-            .await
-            .map_err(|source| AppError::ConfigurationError {
-                message: format!("Failed to read stored config '{key}'"),
-                source: Some(source.into()),
-            })?;
-
-    let size = data_handle
-        .data_size()
-        .map_err(|source| AppError::ConfigurationError {
-            message: format!("Failed to get stored config size for '{key}'"),
-            source: Some(source.into()),
-        })?;
-
-    let mut buf = vec![0u8; usize::try_from(size).unwrap_or(usize::MAX)];
-    data_handle
-        .read_at(0, &mut buf)
-        .map_err(|source| AppError::ConfigurationError {
-            message: format!("Failed to read stored config data '{key}'"),
-            source: Some(source.into()),
-        })?;
-
-    let config = toml::from_str::<configfile::Configuration>(&String::from_utf8_lossy(&buf))
-        .map_err(|source| AppError::ConfigurationError {
-            message: format!("Failed to parse stored config '{key}'"),
-            source: Some(source.into()),
-        })?;
-
-    tracing::info!(key, "Using configuration from storage (overrides disk)");
-    Ok(Some(config))
-}
-
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
-
-    use cda_interfaces::storage_api::{CollectionName, RandomAccessData, Storage};
-    use cda_storage::LocalStorage;
-
     use super::*;
-
-    #[tokio::test]
-    async fn seed_copies_config_file_into_empty_storage() {
-        let fixture = StorageFixture::new();
-        let config_dir = tempfile::tempdir().expect("config dir");
-        let config_file = config_dir.path().join("opensovd-cda.toml");
-        std::fs::write(&config_file, b"[database]\npath = \".\"").expect("write config");
-
-        seed_storage_from_config_file(&fixture.storage, &config_file)
-            .await
-            .unwrap();
-
-        let collection = fixture
-            .storage
-            .get_or_create_collection(&CollectionName::Configuration)
-            .await
-            .unwrap();
-        let keys = collection.list().await.unwrap();
-        assert_eq!(keys, vec!["opensovd-cda.toml"]);
-    }
-
-    #[tokio::test]
-    async fn seed_skips_when_collection_already_populated() {
-        let fixture = StorageFixture::new();
-        let config_dir = tempfile::tempdir().expect("config dir");
-        let config_file = config_dir.path().join("new.toml");
-        std::fs::write(&config_file, b"[database]\npath = \".\"").expect("write config");
-
-        // Pre-populate storage with an existing entry.
-        let collection = fixture
-            .storage
-            .get_or_create_collection(&CollectionName::Configuration)
-            .await
-            .unwrap();
-        let mut tx = fixture.storage.begin_transaction().unwrap();
-        let mut data: &[u8] = b"EXISTING";
-        collection
-            .write(&mut tx, "existing.toml", &mut data)
-            .await
-            .unwrap();
-        tx.commit().await.unwrap();
-
-        seed_storage_from_config_file(&fixture.storage, &config_file)
-            .await
-            .unwrap();
-
-        // Verify collection was NOT modified.
-        let collection = fixture
-            .storage
-            .get_or_create_collection(&CollectionName::Configuration)
-            .await
-            .unwrap();
-        let keys = collection.list().await.unwrap();
-        assert_eq!(keys, vec!["existing.toml"]);
-    }
-
-    #[tokio::test]
-    async fn seed_errors_on_nonexistent_config_file() {
-        let fixture = StorageFixture::new();
-
-        let result = seed_storage_from_config_file(
-            &fixture.storage,
-            Path::new("/tmp/nonexistent_cda_config_test_12345.toml"),
-        )
-        .await;
-
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn seed_preserves_config_content_through_storage_roundtrip() {
-        let fixture = StorageFixture::new();
-        let config_dir = tempfile::tempdir().expect("config dir");
-        let original_data = b"[database]\npath = \"/app/database\"\n";
-        let config_file = config_dir.path().join("opensovd-cda.toml");
-        std::fs::write(&config_file, original_data).expect("write config");
-
-        seed_storage_from_config_file(&fixture.storage, &config_file)
-            .await
-            .unwrap();
-
-        let collection = fixture
-            .storage
-            .get_or_create_collection(&CollectionName::Configuration)
-            .await
-            .unwrap();
-        let data_handle = collection.read("opensovd-cda.toml").await.unwrap();
-        let size = data_handle.data_size().unwrap();
-        let mut buf = vec![0u8; usize::try_from(size).expect("size fits in usize")];
-        data_handle.read_at(0, &mut buf).unwrap();
-        assert_eq!(
-            buf, original_data,
-            "Storage must preserve config content byte-for-byte"
-        );
-    }
 
     #[tokio::test]
     async fn load_configuration_fails_on_invalid_toml() {
@@ -332,21 +91,5 @@ mod tests {
             err.contains("Failed to build configuration"),
             "unexpected error: {err:?}"
         );
-    }
-
-    struct StorageFixture {
-        storage: LocalStorage,
-        /// Carried along, so that it gets dropped at the end of the test
-        _temp_dir: tempfile::TempDir,
-    }
-    impl StorageFixture {
-        fn new() -> Self {
-            let temp_dir = tempfile::tempdir().expect("storage dir");
-            let storage = LocalStorage::new(temp_dir.path()).unwrap();
-            Self {
-                storage,
-                _temp_dir: temp_dir,
-            }
-        }
     }
 }

--- a/cda-main/src/config/configfile.rs
+++ b/cda-main/src/config/configfile.rs
@@ -304,32 +304,6 @@ impl ConfigSanity for Configuration {
     }
 }
 
-/// Validates TOML configuration files against the `Configuration` schema.
-///
-/// This validator is used by the runtime update security handler to ensure
-/// configuration files are valid before they are applied.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct ConfigurationValidator;
-
-impl ConfigurationValidator {
-    /// Creates a new configuration validator.
-    #[must_use]
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl cda_interfaces::runtime_update_api::ConfigValidator for ConfigurationValidator {
-    fn validate(
-        &self,
-        content: &str,
-    ) -> Result<(), cda_interfaces::runtime_update_api::ConfigValidationError> {
-        toml::from_str::<Configuration>(content)
-            .map(|_| ())
-            .map_err(|e| cda_interfaces::runtime_update_api::ConfigValidationError(e.to_string()))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use cda_interfaces::datatypes::DiagnosticServiceAffixPosition;

--- a/cda-main/src/config/configfile.rs
+++ b/cda-main/src/config/configfile.rs
@@ -304,6 +304,32 @@ impl ConfigSanity for Configuration {
     }
 }
 
+/// Validates TOML configuration files against the `Configuration` schema.
+///
+/// This validator is used by the runtime update security handler to ensure
+/// configuration files are valid before they are applied.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ConfigurationValidator;
+
+impl ConfigurationValidator {
+    /// Creates a new configuration validator.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl cda_interfaces::runtime_update_api::ConfigValidator for ConfigurationValidator {
+    fn validate(
+        &self,
+        content: &str,
+    ) -> Result<(), cda_interfaces::runtime_update_api::ConfigValidationError> {
+        toml::from_str::<Configuration>(content)
+            .map(|_| ())
+            .map_err(|e| cda_interfaces::runtime_update_api::ConfigValidationError(e.to_string()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use cda_interfaces::datatypes::DiagnosticServiceAffixPosition;

--- a/cda-main/src/config/generate.rs
+++ b/cda-main/src/config/generate.rs
@@ -14,14 +14,41 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Write,
+    path::PathBuf,
 };
 
 use cda_interfaces::{FunctionalDescriptionConfig, datatypes::FaultConfig};
 
-use crate::config::{
-    com_params::EcuComParams,
-    configfile::{Configuration, EcuConfig},
+use crate::{
+    AppError,
+    config::{
+        com_params::EcuComParams,
+        configfile::{Configuration, EcuConfig},
+    },
 };
+
+/// Generate a reference CDA configuration and write it to the requested output.
+///
+/// # Errors
+/// Returns [`AppError`] if generating the reference configuration or writing it fails.
+pub fn generate_config_cmd(output: Option<&PathBuf>) -> Result<(), AppError> {
+    let content = generate_reference_config()
+        .map_err(|e| AppError::RuntimeError(format!("Failed to generate config: {e}")))?;
+
+    match output.map(|p| p.as_os_str()) {
+        Some(p) if p == "-" => {
+            use std::io::Write;
+            std::io::stdout()
+                .write_all(content.as_bytes())
+                .map_err(|e| AppError::RuntimeError(format!("Failed to write stdout: {e}")))?;
+            Ok(())
+        }
+        Some(path) => std::fs::write(path, &content)
+            .map_err(|e| AppError::RuntimeError(format!("Failed to write config: {e}"))),
+        None => std::fs::write("opensovd-cda.toml", &content)
+            .map_err(|e| AppError::RuntimeError(format!("Failed to write config: {e}"))),
+    }
+}
 
 /// Create a Configuration instance with example values for fields that default to `None`.
 /// This ensures they appear in the generated reference config output.

--- a/cda-main/src/error.rs
+++ b/cda-main/src/error.rs
@@ -13,7 +13,10 @@
 
 use std::fmt;
 
-use cda_interfaces::{DiagServiceError, DoipGatewaySetupError, config::ConfigSanityError};
+use cda_interfaces::{
+    DiagServiceError, DoipGatewaySetupError, config::ConfigSanityError,
+    runtime_update_api::RuntimeUpdateError,
+};
 use cda_tracing::TracingSetupError;
 
 #[derive(thiserror::Error)]
@@ -146,6 +149,12 @@ impl From<ConfigSanityError> for AppError {
             message: "Error while checking configuration sanity".to_string(),
             source: Some(value.into()),
         }
+    }
+}
+
+impl From<RuntimeUpdateError> for AppError {
+    fn from(value: RuntimeUpdateError) -> Self {
+        AppError::InitializationFailed(value.to_string())
     }
 }
 

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -266,28 +266,11 @@ where
     };
 
     let (mut config, disk_loaded) = config::load_config_with_fallback(config_file);
-
-    match cda_storage::LocalStorage::new(&config.runtime_update_config.storage_dir) {
-        Ok(storage) => {
-            if config.runtime_update_config.init_storage_from_config_file {
-                config::seed_storage_from_config_file(&storage, config_file).await?;
-            }
-
-            if let Some(storage_config) =
-                config::load_config_with_storage_override(&storage).await?
-            {
-                config = storage_config;
-            } else if !disk_loaded {
-                config::require_config_source()?;
-            }
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, "Storage not available, skipping seed and config override");
-            return Ok(());
-        }
+    if !disk_loaded {
+        config::require_config_source()?;
     }
 
-    // Command line arguments always take precedence over stored configuration
+    // Command line arguments always take precedence over file configuration.
     args.update_config(&mut config);
 
     config.validate_sanity().map_err(AppError::from)?;

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -31,7 +31,7 @@ use cda_core::EcuManager;
 use cda_database::FileManager;
 use cda_interfaces::{
     EcuConnectivityHandler, FunctionalDescriptionConfig, HashMap, HashMapExtensions, UdsQuery,
-    UdsVariant, config::ConfigSanity, datatypes::FaultConfig, dlt_ctx,
+    UdsVariant, config::ConfigSanity, datatypes::FaultConfig, dlt_ctx, health::HealthProvider,
 };
 use cda_plugin_security::{
     DefaultSecurityPlugin, DefaultSecurityPluginData, SecurityPlugin, SecurityPluginLoader,
@@ -39,21 +39,25 @@ use cda_plugin_security::{
 use cda_sovd::Locks;
 use cda_tracing::{OtelGuard, TracingSetupError, TracingWorkerGuard};
 use clap::{Parser, Subcommand};
-pub use error::AppError;
-use futures::future::FutureExt;
 use tokio::sync::{Mutex, RwLock, mpsc};
 use tracing_subscriber::layer::SubscriberExt;
 
 use crate::{
-    config::configfile::Configuration,
+    config::{configfile::Configuration, generate::generate_config_cmd},
     mdd::{load_databases, resolve_mdd_paths},
-    update::{RuntimeUpdateContext, security::UpdateSecurityHandler},
+    setup::PreLoadHook,
+    update::{UpdatePluginBuilder, create_default_update_plugin, update_plugin_fn},
 };
 
+pub mod cda_factory;
 pub mod config;
 pub mod error;
 pub mod mdd;
+pub mod setup;
 pub mod update;
+
+pub use error::AppError;
+pub use setup::Setup;
 
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
@@ -143,7 +147,7 @@ pub struct VehicleData<S: SecurityPlugin> {
     pub update_guard: cda_sovd::UpdateGuardState,
     pub databases: Arc<DatabaseMap<S>>,
     pub variant_detection_handle: tokio::task::JoinHandle<()>,
-    pub health_providers: Option<HealthProviders>,
+    pub health_providers: Option<HashMap<String, Arc<dyn HealthProvider>>>,
 }
 
 pub struct VehicleComponents<S: SecurityPlugin> {
@@ -206,33 +210,6 @@ impl AppArgs {
     }
 }
 
-/// Generate a reference CDA configuration and write it to the requested output.
-///
-/// # Errors
-/// Returns [`AppError`] if generating the reference configuration or writing it fails.
-pub fn generate_config_cmd(output: Option<&PathBuf>) -> Result<(), AppError> {
-    let content = config::generate::generate_reference_config()
-        .map_err(|e| AppError::RuntimeError(format!("Failed to generate config: {e}")))?;
-
-    match output.map(|p| p.as_os_str()) {
-        Some(p) if p == "-" => {
-            use std::io::Write;
-            std::io::stdout()
-                .write_all(content.as_bytes())
-                .map_err(|e| AppError::RuntimeError(format!("Failed to write stdout: {e}")))?;
-        }
-        Some(path) => {
-            std::fs::write(path, &content)
-                .map_err(|e| AppError::RuntimeError(format!("Failed to write config: {e}")))?;
-        }
-        None => {
-            std::fs::write("opensovd-cda.toml", &content)
-                .map_err(|e| AppError::RuntimeError(format!("Failed to write config: {e}")))?;
-        }
-    }
-    Ok(())
-}
-
 /// Parse CLI arguments and start the CDA with the default startup flow.
 ///
 /// # Errors
@@ -243,26 +220,27 @@ pub async fn run_from_cli() -> Result<(), AppError> {
 }
 
 #[tracing::instrument(
-    skip(args, extra_health_providers, pre_load_hook),
+    skip(args, setup),
     fields(
         dlt_context = dlt_ctx!("MAIN"),
     )
 )]
-/// Run the CDA from parsed CLI arguments, with optional extra health providers and a
-/// pre-vehicle-load hook. See [`run_with_config_ext`] for parameter documentation.
+/// Run the CDA from parsed CLI arguments with a custom [`Setup`].
+///
+/// This is the primary setup-aware entry point. Pass a [`Setup`] created with
+/// [`Setup::new`] and optionally configured with
+/// [`Setup::with_preload`] / [`Setup::with_update_plugin`].
 ///
 /// # Errors
 /// Returns [`AppError`] if configuration loading, validation, or startup fails.
-pub async fn run_with_ext<SP, SL, H, Fut>(
+pub async fn run_with_ext<SP, SL, UPB>(
     args: AppArgs,
-    extra_health_providers: Vec<(&'static str, Arc<dyn cda_health::HealthProvider>)>,
-    pre_load_hook: H,
+    setup: Setup<SP, SL, UPB>,
 ) -> Result<(), AppError>
 where
     SP: SecurityPlugin,
     SL: SecurityPluginLoader,
-    H: FnOnce(cda_sovd::dynamic_router::DynamicRouter) -> Fut + Send,
-    Fut: Future<Output = Result<(), AppError>> + Send,
+    UPB: UpdatePluginBuilder<SP>,
 {
     if let Some(Command::GenerateConfig { output }) = args.command.as_ref() {
         // Exiting after generating config is on purpose.
@@ -314,10 +292,89 @@ where
 
     config.validate_sanity().map_err(AppError::from)?;
 
-    run_with_config_ext::<SP, SL, _, _>(config, extra_health_providers, pre_load_hook).await
+    run_with_ext_from_config(config, setup).await
+}
+
+/// Start the CDA runtime from a prepared configuration with a custom [`Setup`].
+///
+/// This is the setup-aware version of [`run_with_config`]. Supply a [`Setup`] to
+/// configure a custom update plugin and/or a preload hook:
+///
+/// ```rust,ignore
+/// use opensovd_cda_lib::{Setup, run_with_ext_from_config, update::update_plugin_fn};
+/// use opensovd_cda_lib::config::configfile::Configuration;
+///
+/// let config: Configuration = // ... load or construct ...
+/// # todo!();
+///
+/// run_with_ext_from_config::<MySecurityPlugin, MySecurityLoader, _>(
+///     config,
+///     Setup::new().with_update_plugin(update_plugin_fn(|infra| async move {
+///         Ok(MyPlugin::new(infra))
+///     })),
+/// ).await?;
+/// ```
+///
+/// # Errors
+/// Returns [`AppError`] if tracing setup, webserver startup, data loading, or route setup fails.
+pub async fn run_with_ext_from_config<SP, SL, UPB>(
+    config: Configuration,
+    setup: Setup<SP, SL, UPB>,
+) -> Result<(), AppError>
+where
+    SP: SecurityPlugin,
+    SL: SecurityPluginLoader,
+    UPB: UpdatePluginBuilder<SP>,
+{
+    let webserver_state = init_webserver(&config, setup.pre_load).await?;
+
+    tracing::debug!("Webserver is running. Loading sovd routes...");
+    let vehicle_data = match load_vehicle_data::<SP>(
+        &config,
+        webserver_state.shutdown_signal.clone(),
+        webserver_state.health_state.as_ref(),
+    )
+    .await
+    {
+        Ok(data) => data,
+        Err(AppError::ShutdownRequested) => {
+            tracing::info!("Shutdown requested during database load, exiting cleanly");
+            return Ok(());
+        }
+        Err(e) => return Err(e),
+    };
+
+    if vehicle_data.databases.is_empty() && config.database.exit_no_database_loaded {
+        return Err(AppError::ResourceError(
+            "No database loaded, exiting as configured".to_string(),
+        ));
+    }
+
+    setup::setup_runtime_routes::<SP, SL, UPB>(
+        config,
+        vehicle_data,
+        &webserver_state,
+        setup.build_update_plugin,
+    )
+    .await?;
+
+    tracing::info!("CDA fully initialized and ready to serve requests");
+    if let Some(provider) = &webserver_state.main_health_provider {
+        provider.update_status(cda_health::Status::Up).await;
+    }
+
+    // Wait for shutdown signal
+    webserver_state.shutdown_signal.clone().await;
+    tracing::info!("Shutting down...");
+    webserver_state.join().await?;
+
+    Ok(())
 }
 
 /// Run the CDA from parsed CLI arguments.
+///
+/// Uses the default security plugin and the default runtime update plugin.
+/// To customize startup behavior, use [`run_with_ext`] instead.
 ///
 /// # Errors
 /// Returns [`AppError`] if configuration loading, validation, or startup fails.
@@ -326,39 +383,47 @@ pub async fn run(args: AppArgs) -> Result<(), AppError> {
         DefaultSecurityPluginData,
         DefaultSecurityPlugin,
         _,
-        _,
-    >(args, vec![], |_| async { Ok(()) }))
+    >(
+        args,
+        Setup::new().with_update_plugin(update_plugin_fn(|infra| async move {
+            create_default_update_plugin::<DefaultSecurityPluginData, DefaultSecurityPlugin>(infra)
+                .await
+        })),
+    ))
     .await
 }
 
-/// Start the CDA runtime from a prepared configuration, with optional extra health providers
-/// and a pre-vehicle-load hook.
+/// Start the CDA runtime from a prepared configuration.
 ///
-/// - `extra_health_providers`: additional `(key, provider)` pairs registered into the health
-///   state alongside the built-in `main` provider. Ignored when the `health` feature is
-///   disabled or `config.health.enabled` is `false`.
-/// - `pre_load_hook`: called after the webserver, health state, and sd-notify are set up but
-///   **before** vehicle data is loaded. Use it to register extra routes or endpoints that
-///   should be available during (and benefit from parallelism with) the database load.
-///   Must return `Ok(())` to continue startup; an `Err` aborts immediately.
-/// - `SP` / `SL`: security plugin data and loader types. Use [`DefaultSecurityPluginData`] and
-///   [`DefaultSecurityPlugin`] for the default behaviour.
+/// Uses the default security plugin and the default runtime update plugin.
+/// To customize startup behavior, use [`run_with_ext_from_config`] instead.
 ///
 /// # Errors
-/// Returns [`AppError`] if tracing setup, webserver startup, hook execution, data loading, or
-/// route setup fails.
-pub async fn run_with_config_ext<SP, SL, H, Fut>(
-    config: Configuration,
-    extra_health_providers: Vec<(&'static str, Arc<dyn cda_health::HealthProvider>)>,
-    pre_load_hook: H,
-) -> Result<(), AppError>
-where
-    SP: SecurityPlugin,
-    SL: SecurityPluginLoader,
-    H: FnOnce(cda_sovd::dynamic_router::DynamicRouter) -> Fut + Send,
-    Fut: Future<Output = Result<(), AppError>> + Send,
-{
-    let _tracing_guards = setup_tracing(&config)?;
+/// Returns [`AppError`] if tracing setup, webserver startup, data loading, or route setup fails.
+pub async fn run_with_config(config: Configuration) -> Result<(), AppError> {
+    Box::pin(run_with_ext_from_config::<
+        DefaultSecurityPluginData,
+        DefaultSecurityPlugin,
+        _,
+    >(
+        config,
+        Setup::new().with_update_plugin(update_plugin_fn(
+            |infra: setup::CdaRuntime<DefaultSecurityPluginData>| async move {
+                create_default_update_plugin::<DefaultSecurityPluginData, DefaultSecurityPlugin>(
+                    infra,
+                )
+                .await
+            },
+        )),
+    ))
+    .await
+}
+
+async fn init_webserver(
+    config: &Configuration,
+    pre_load: Option<PreLoadHook>,
+) -> Result<ApplicationState, AppError> {
+    let tracing_guards = setup_tracing(config)?;
     tracing::info!("Starting CDA - version {}", cda_version());
 
     let webserver_config = cda_sovd::WebServerConfig {
@@ -366,33 +431,39 @@ where
         port: config.server.port,
     };
 
-    let clonable_shutdown_signal = shutdown_signal().shared();
+    let clonable_shutdown_signal = cda_interfaces::shutdown_signal(shutdown_signal());
 
     let (dynamic_router, webserver_task) =
         cda_sovd::launch_webserver(webserver_config.clone(), clonable_shutdown_signal.clone())
             .await?;
 
+    let mut webserver_state = ApplicationState {
+        _tracing_guards: tracing_guards,
+        dynamic_router,
+        webserver_task: Some(webserver_task),
+        shutdown_signal: clonable_shutdown_signal,
+        health_state: None,
+        main_health_provider: None,
+    };
+
     #[cfg(feature = "health")]
     let (health_state, main_health_provider) = if config.health.enabled {
-        let health_state =
-            cda_health::add_health_routes(&dynamic_router, cda_version().to_owned()).await;
+        let health_state = cda_health::add_health_routes(
+            &webserver_state.dynamic_router,
+            cda_version().to_owned(),
+        )
+        .await;
         let main_health_provider = Arc::new(cda_health::StatusHealthProvider::new(
             cda_health::Status::Starting,
         ));
-
-        health_state
+        let registration = health_state
             .register_provider(
                 MAIN_HEALTH_COMPONENT_KEY,
                 Arc::clone(&main_health_provider) as Arc<dyn cda_health::HealthProvider>,
             )
             .await
-            .map_err(|e| AppError::InitializationFailed(e.to_string()))?;
-        for (key, provider) in extra_health_providers {
-            health_state
-                .register_provider(key, provider)
-                .await
-                .map_err(|e| AppError::InitializationFailed(e.to_string()))?;
-        }
+            .map_err(|e| AppError::InitializationFailed(e.to_string()));
+        registration?;
         (Some(health_state), Some(main_health_provider))
     } else {
         (None, None)
@@ -402,175 +473,24 @@ where
     let (health_state, main_health_provider): (
         Option<cda_health::HealthState>,
         Option<Arc<cda_health::StatusHealthProvider>>,
-    ) = {
-        // Prevents compiler warning for unused variable when health feature is disabled
-        let _ = extra_health_providers;
-        (None, None)
-    };
+    ) = (None, None);
+
+    webserver_state.health_state = health_state;
+    webserver_state.main_health_provider = main_health_provider;
 
     #[cfg(feature = "systemd-notify")]
-    let _sd_notify_task =
-        cda_extra::create_sd_notify_task(health_state.clone(), clonable_shutdown_signal.clone());
-
-    register_version_endpoints(&dynamic_router).await;
-    pre_load_hook(dynamic_router.clone()).await?;
-
-    let display_address = if config.server.address == "0.0.0.0" {
-        "127.0.0.1"
-    } else {
-        &config.server.address
-    };
-    let swagger_ui_url = format!(
-        "http://{}:{}{}",
-        display_address,
-        config.server.port,
-        cda_sovd::SWAGGER_UI_ROUTE
+    let _sd_notify_task = cda_extra::create_sd_notify_task(
+        webserver_state.health_state.clone(),
+        webserver_state.shutdown_signal.clone(),
     );
 
-    setup_vehicle_and_routes::<SP, SL>(
-        config,
-        &dynamic_router,
-        health_state.as_ref(),
-        clonable_shutdown_signal.clone(),
-    )
-    .await?;
+    register_version_endpoints(&webserver_state.dynamic_router).await;
 
-    tracing::info!(
-        "CDA fully initialized and ready to serve requests.\nYou can access the REST API \
-         documentation at: {swagger_ui_url}"
-    );
-    if let Some(provider) = main_health_provider {
-        provider.update_status(cda_health::Status::Up).await;
+    if let Some(hook) = pre_load {
+        hook(webserver_state.dynamic_router.clone()).await?;
     }
 
-    // Wait for shutdown signal
-    clonable_shutdown_signal.await;
-    tracing::info!("Shutting down...");
-    webserver_task
-        .await
-        .map_err(|e| AppError::RuntimeError(format!("Webserver task join error: {e}")))?;
-
-    Ok(())
-}
-
-/// Start the CDA runtime from a prepared configuration.
-///
-/// # Errors
-/// Returns [`AppError`] if tracing setup, webserver startup, data loading, or route setup fails.
-pub async fn run_with_config(config: Configuration) -> Result<(), AppError> {
-    // Boxed: the composed runtime future exceeds clippy::large_futures'
-    // threshold, and this once-per-process startup future is not worth
-    // keeping on the caller's stack.
-    Box::pin(run_with_config_ext::<
-        DefaultSecurityPluginData,
-        DefaultSecurityPlugin,
-        _,
-        _,
-    >(config, vec![], |_| async { Ok(()) }))
-    .await
-}
-
-/// Loads vehicle data, registers all SOVD routes, runtime-update routes, `OpenAPI` routes,
-/// and installs the update guard. Extracted from `run_with_config` to keep it under the line limit.
-///
-/// The type parameters `SP` and `SL` select the security plugin data and loader implementations.
-/// Use [`DefaultSecurityPluginData`] and [`DefaultSecurityPlugin`] for the default behaviour.
-///
-/// # Errors
-/// Returns [`AppError`] if vehicle data loading, route registration, or update plugin setup fails.
-pub async fn setup_vehicle_and_routes<SP: SecurityPlugin, SL: SecurityPluginLoader>(
-    config: Configuration,
-    dynamic_router: &cda_sovd::dynamic_router::DynamicRouter,
-    health_state: Option<&cda_health::HealthState>,
-    clonable_shutdown_signal: futures::future::Shared<
-        impl std::future::Future<Output = ()> + Send + 'static,
-    >,
-) -> Result<(), AppError> {
-    tracing::debug!("Webserver is running. Loading sovd routes...");
-
-    let vehicle_data =
-        match load_vehicle_data::<_, SP>(&config, clonable_shutdown_signal.clone(), health_state)
-            .await
-        {
-            Ok(data) => data,
-            Err(AppError::ShutdownRequested) => {
-                tracing::info!("Shutdown requested during database load, exiting cleanly");
-                return Ok(());
-            }
-            Err(e) => return Err(e),
-        };
-
-    if vehicle_data.databases.is_empty() && config.database.exit_no_database_loaded {
-        return Err(AppError::ResourceError(
-            "No database loaded, exiting as configured".to_string(),
-        ));
-    }
-
-    let flash_files_path = config.flash_files_path.clone();
-    let components_config = config.components.clone();
-    let runtime_update_config = config.runtime_update_config.clone();
-
-    let (ecu_execution_registry, vehicle_route_handle) = cda_sovd::add_vehicle_routes::<_, _, SL>(
-        dynamic_router,
-        cda_sovd::VehicleConfig {
-            flash_files_path: config.flash_files_path.clone(),
-            functional_group_config: config.functional_description.clone(),
-            components_config: config.components.clone(),
-        },
-        cda_sovd::VehicleResources {
-            ecu_uds: vehicle_data.uds_manager.clone(),
-            file_manager: vehicle_data.file_managers,
-            locks: Arc::clone(&vehicle_data.locks),
-            update_in_progress: vehicle_data.update_guard.busy_handle(),
-        },
-    )
-    .await?;
-
-    let lock_provider: Arc<cda_sovd::SovdLockStateProvider> = Arc::new(
-        cda_sovd::SovdLockStateProvider::new(Arc::clone(&vehicle_data.locks)),
-    );
-
-    let flash_transfer_guard = vehicle_data.uds_manager.flash_transfer_guard();
-    let runtime_update_plugin =
-        update::init_default_runtime_update_plugin::<SP, _, SL>(Box::new(RuntimeUpdateContext {
-            dynamic_router: dynamic_router.clone(),
-            vehicle_route_handle,
-            config,
-            flash_files_path,
-            components_config,
-            lock_provider: Arc::clone(&lock_provider),
-            update_guard: vehicle_data.update_guard.clone(),
-            shutdown_signal: clonable_shutdown_signal,
-            runtime_update_config: runtime_update_config.clone(),
-            ecu_execution_registry: ecu_execution_registry.clone(),
-            uds_manager: vehicle_data.uds_manager,
-            doip_gateway: vehicle_data.diagnostic_gateway,
-            health: vehicle_data.health_providers,
-            variant_detection_handle: Some(vehicle_data.variant_detection_handle),
-            security_handler: Arc::new(UpdateSecurityHandler::new(
-                Arc::clone(&lock_provider),
-                vec![
-                    Box::new(flash_transfer_guard),
-                    Box::new(ecu_execution_registry),
-                ],
-            )),
-        }))
-        .await?;
-    update::add_runtime_update_routes::<SL, _>(
-        dynamic_router,
-        runtime_update_plugin,
-        lock_provider,
-        &vehicle_data.update_guard,
-        runtime_update_config.upload_body_limit_bytes,
-        runtime_update_config.retry_after_seconds,
-    )
-    .await;
-
-    cda_sovd::add_openapi_routes(dynamic_router, &vehicle_data.update_guard).await;
-
-    cda_sovd::install_update_guard(dynamic_router, vehicle_data.update_guard.clone()).await;
-
-    Ok(())
+    Ok(webserver_state)
 }
 
 async fn register_version_endpoints(dynamic_router: &cda_sovd::dynamic_router::DynamicRouter) {
@@ -606,12 +526,9 @@ async fn register_version_endpoints(dynamic_router: &cda_sovd::dynamic_router::D
 ///
 /// # Errors
 /// Returns [`AppError`] if MDD path resolution, database loading, or component creation fails.
-pub async fn load_vehicle_data<
-    F: Future<Output = ()> + Clone + Send + 'static,
-    S: SecurityPlugin,
->(
+pub async fn load_vehicle_data<S: SecurityPlugin>(
     config: &Configuration,
-    clonable_shutdown_signal: F,
+    clonable_shutdown_signal: cda_interfaces::ShutdownSignal,
     health: Option<&cda_health::HealthState>,
 ) -> Result<VehicleData<S>, AppError> {
     let mdd_paths: Vec<PathBuf> = {
@@ -646,34 +563,28 @@ pub async fn load_vehicle_data<
             )
             .await
             .map_err(|e| AppError::InitializationFailed(e.to_string()))?;
-        Some(HealthProviders { doip, database })
+        let mut providers: HashMap<String, Arc<dyn HealthProvider>> = HashMap::default();
+        providers.insert(
+            DOIP_HEALTH_COMPONENT_KEY.to_owned(),
+            doip as Arc<dyn HealthProvider>,
+        );
+        providers.insert(
+            mdd::DB_HEALTH_COMPONENT_KEY.to_owned(),
+            database as Arc<dyn HealthProvider>,
+        );
+        Some(providers)
     } else {
         None
     };
 
     let update_guard = cda_sovd::UpdateGuardState::new();
-    // In CAN-only operation (doip.enabled = false) no DoIP socket is bound at
-    // all: binding one anyway could collide with another DoIP stack on the
-    // host for no benefit.
-    let doip_socket = if config.doip.enabled {
-        let socket = cda_comm_doip::create_udp_vir_socket(
-            &config.doip.tester_address,
-            config.doip.gateway_port,
-        )
-        .map_err(|e| {
-            AppError::InitializationFailed(format!("Failed to create DoIP socket: {e}"))
-        })?;
-        Some(Arc::new(Mutex::new(socket)))
-    } else {
-        None
-    };
-    let components = create_vehicle_components::<F, S>(
+    let components = create_vehicle_components::<S>(
         config,
         &mdd_paths,
         clonable_shutdown_signal,
         health_providers.as_ref(),
         update_guard.busy_handle(),
-        doip_socket,
+        None,
     )
     .await?;
 
@@ -684,7 +595,7 @@ pub async fn load_vehicle_data<
         file_managers: components.file_managers,
         locks: Arc::new(Locks::new(ecu_names)),
         update_guard,
-        databases: components.databases,
+        databases: Arc::clone(&components.databases),
         variant_detection_handle: components.variant_detection_handle,
         health_providers,
     })
@@ -732,28 +643,61 @@ pub fn create_uds_manager<S: SecurityPlugin>(
     )
 }
 
-pub struct HealthProviders {
-    pub doip: Arc<cda_health::StatusHealthProvider>,
-    pub database: Arc<cda_health::StatusHealthProvider>,
+/// Collected webserver state produced by [`init_webserver`].
+///
+/// Passed to [`setup::setup_runtime_routes`] and [`run_with_ext_from_config`] so that
+/// the shutdown signal and health provider are accessible after the webserver is started.
+///
+/// Dropping this value aborts the webserver task, so all error paths are covered
+/// automatically without any explicit cleanup calls.
+pub(crate) struct ApplicationState {
+    _tracing_guards: TracingGuards,
+    pub dynamic_router: cda_sovd::dynamic_router::DynamicRouter,
+    webserver_task: Option<tokio::task::JoinHandle<()>>,
+    pub shutdown_signal: cda_interfaces::ShutdownSignal,
+    health_state: Option<cda_health::HealthState>,
+    main_health_provider: Option<Arc<cda_health::StatusHealthProvider>>,
+}
+
+impl Drop for ApplicationState {
+    fn drop(&mut self) {
+        if let Some(task) = self.webserver_task.take() {
+            task.abort();
+        }
+    }
+}
+
+impl ApplicationState {
+    /// Waits for the normally signaled webserver task to finish.
+    async fn join(mut self) -> Result<(), AppError> {
+        if let Some(task) = self.webserver_task.take() {
+            task.await
+                .map_err(|e| AppError::RuntimeError(format!("Webserver task join error: {e}")))?;
+        }
+        Ok(())
+    }
 }
 
 /// Creates vehicle components (databases, `DoIP` gateway, UDS manager) from configuration.
 ///
 /// # Errors
 /// Returns [`AppError`] if database loading or diagnostic gateway creation fails.
-pub async fn create_vehicle_components<
-    F: Future<Output = ()> + Clone + Send + 'static,
-    S: SecurityPlugin,
->(
+#[allow(
+    clippy::implicit_hasher,
+    reason = "Type alias doesn't allow specifying hasher"
+)]
+pub async fn create_vehicle_components<S: SecurityPlugin>(
     config: &Configuration,
     mdd_paths: &[PathBuf],
-    shutdown_signal: F,
-    health_providers: Option<&HealthProviders>,
+    shutdown_signal: cda_interfaces::ShutdownSignal,
+    health_providers: Option<&HashMap<String, Arc<dyn HealthProvider>>>,
     update_in_progress: Arc<std::sync::atomic::AtomicBool>,
-    doip_socket: Option<Arc<tokio::sync::Mutex<cda_comm_doip::socket::DoIPUdpSocket>>>,
+    reusable_doip_socket: Option<Arc<Mutex<cda_comm_doip::socket::DoIPUdpSocket>>>,
 ) -> Result<VehicleComponents<S>, AppError> {
-    let db_provider = health_providers.map(|h| &h.database);
-    let doip_provider = health_providers.map(|h| &h.doip);
+    let db_provider: Option<&Arc<dyn HealthProvider>> =
+        health_providers.and_then(|h| h.get(mdd::DB_HEALTH_COMPONENT_KEY));
+    let doip_provider: Option<&Arc<dyn HealthProvider>> =
+        health_providers.and_then(|h| h.get(DOIP_HEALTH_COMPONENT_KEY));
 
     let (databases, file_managers) = load_databases::<S>(config, mdd_paths, db_provider).await?;
 
@@ -782,7 +726,7 @@ pub async fn create_vehicle_components<
         connectivity_handler,
         shutdown_signal,
         doip_provider,
-        doip_socket,
+        reusable_doip_socket,
     )
     .await?;
 
@@ -811,7 +755,7 @@ pub async fn create_vehicle_components<
 }
 
 #[tracing::instrument(
-    skip(databases, transports, variant_detection, connectivity_handler, shutdown_signal, doip_health_provider, doip_socket),
+    skip(databases, transports, variant_detection, connectivity_handler, shutdown_signal, doip_health_provider, reusable_doip_socket),
     fields(
         database_count = databases.len(),
         dlt_context = dlt_ctx!("MAIN"),
@@ -828,12 +772,11 @@ pub async fn create_diagnostic_gateway<S: SecurityPlugin>(
     variant_detection: mpsc::Sender<Vec<String>>,
     connectivity_handler: Arc<dyn EcuConnectivityHandler>,
     shutdown_signal: impl Future<Output = ()> + Send + 'static,
-    doip_health_provider: Option<&Arc<cda_health::StatusHealthProvider>>,
-    // `None` is only valid in CAN-only operation (doip.enabled = false); when
-    // DoIP is enabled the caller owns socket creation so the runtime-update
-    // reload path can hand the existing socket over (never two sockets bound
-    // to the same DoIP port).
-    doip_socket: Option<Arc<Mutex<cda_comm_doip::socket::DoIPUdpSocket>>>,
+    doip_health_provider: Option<&Arc<dyn HealthProvider>>,
+    // `None` on initial startup - `init_doip_gateway` creates the socket.
+    // `None` in CAN-only operation - DoIP is skipped entirely.
+    // `Some(socket)` on reload - reused to avoid rebinding the DoIP port.
+    reusable_doip_socket: Option<Arc<Mutex<cda_comm_doip::socket::DoIPUdpSocket>>>,
 ) -> Result<MultiTransportGateway<DoipDiagGateway<EcuManager<S>>>, AppError> {
     let TransportConfigs {
         doip: doip_config,
@@ -874,7 +817,7 @@ pub async fn create_diagnostic_gateway<S: SecurityPlugin>(
         connectivity_handler,
         shutdown_signal,
         doip_health_provider,
-        doip_socket,
+        reusable_doip_socket,
     )
     .await?
     {
@@ -901,24 +844,25 @@ async fn init_doip_gateway<S: SecurityPlugin>(
     variant_detection: mpsc::Sender<Vec<String>>,
     connectivity_handler: Arc<dyn EcuConnectivityHandler>,
     shutdown_signal: impl Future<Output = ()> + Send + 'static,
-    doip_health_provider: Option<&Arc<cda_health::StatusHealthProvider>>,
-    doip_socket: Option<Arc<Mutex<cda_comm_doip::socket::DoIPUdpSocket>>>,
+    doip_health_provider: Option<&Arc<dyn HealthProvider>>,
+    reusable_doip_socket: Option<Arc<Mutex<cda_comm_doip::socket::DoIPUdpSocket>>>,
 ) -> Result<Option<DoipDiagGateway<EcuManager<S>>>, AppError> {
     if !doip_config.enabled {
         tracing::info!("DoIP transport disabled by config (doip.enabled = false)");
         if let Some(provider) = doip_health_provider {
-            provider.update_status(cda_health::Status::Up).await;
+            provider.set_status(cda_health::Status::Up).await;
         }
         return Ok(None);
     }
 
-    let doip_socket = doip_socket.ok_or_else(|| {
-        AppError::InitializationFailed(
-            "doip.enabled = true but no DoIP socket was provided".to_owned(),
-        )
+    let doip_socket = reuse_or_create_transport_resource(reusable_doip_socket, || {
+        cda_comm_doip::create_udp_vir_socket(&doip_config.tester_address, doip_config.gateway_port)
+            .map_err(|e| {
+                AppError::InitializationFailed(format!("Failed to create DoIP socket: {e}"))
+            })
     })?;
     if let Some(provider) = doip_health_provider {
-        provider.update_status(cda_health::Status::Starting).await;
+        provider.set_status(cda_health::Status::Starting).await;
     }
     let result = DoipDiagGateway::new(
         doip_config,
@@ -935,7 +879,7 @@ async fn init_doip_gateway<S: SecurityPlugin>(
         cda_health::Status::Failed
     };
     if let Some(provider) = doip_health_provider {
-        provider.update_status(status).await;
+        provider.set_status(status).await;
     }
     match result {
         Ok(d) => {
@@ -944,6 +888,17 @@ async fn init_doip_gateway<S: SecurityPlugin>(
         }
         // Fatal; main reports the error on exit.
         Err(e) => Err(e.into()),
+    }
+}
+
+/// Reuses the transport resource supplied by a previous runtime or creates the initial resource.
+fn reuse_or_create_transport_resource<T, E>(
+    reusable_resource: Option<Arc<Mutex<T>>>,
+    create: impl FnOnce() -> Result<T, E>,
+) -> Result<Arc<Mutex<T>>, E> {
+    match reusable_resource {
+        Some(resource) => Ok(resource),
+        None => create().map(|resource| Arc::new(Mutex::new(resource))),
     }
 }
 
@@ -1046,4 +1001,33 @@ pub fn setup_tracing(config: &Configuration) -> Result<TracingGuards, TracingSet
 #[must_use]
 pub fn cda_version() -> &'static str {
     option_env!("CDA_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))
+}
+
+#[cfg(test)]
+mod webserver_lifecycle_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn drop_aborts_webserver_task() {
+        let task = tokio::spawn(std::future::pending::<()>());
+        let abort_handle = task.abort_handle();
+
+        let state = ApplicationState {
+            _tracing_guards: TracingGuards {
+                _file: None,
+                _otel: None,
+            },
+            dynamic_router: cda_sovd::dynamic_router::DynamicRouter::new(),
+            webserver_task: Some(task),
+            shutdown_signal: cda_interfaces::shutdown_signal(std::future::pending()),
+            health_state: None,
+            main_health_provider: None,
+        };
+
+        drop(state);
+
+        // abort() is asynchronous; yield to let the cancellation propagate.
+        tokio::task::yield_now().await;
+        assert!(abort_handle.is_finished());
+    }
 }

--- a/cda-main/src/main.rs
+++ b/cda-main/src/main.rs
@@ -12,6 +12,6 @@
  */
 
 #[tokio::main]
-async fn main() -> Result<(), opensovd_cda_lib::AppError> {
+async fn main() -> Result<(), opensovd_cda_lib::error::AppError> {
     opensovd_cda_lib::run_from_cli().await
 }

--- a/cda-main/src/mdd.rs
+++ b/cda-main/src/mdd.rs
@@ -19,12 +19,12 @@ use std::{
 
 use cda_core::{EcuManager, EcuManagerConfig};
 use cda_database::{FileManager, ProtoLoadConfig, update_mdd_uncompressed};
-use cda_health::StatusHealthProvider;
 use cda_interfaces::{
     EcuAddresses, EcuManager as EcuManagerTrait, EcuManagerType, FunctionalDescriptionConfig,
     HashMap, HashMapEntry, HashMapExtensions, HashSet, Protocol,
     datatypes::{ComParams, DatabaseNamingConvention, FlatbBufConfig},
     file_manager::{Chunk, ChunkType},
+    health::HealthProvider,
     storage_api::{Collection, CollectionName, DirectFileAccess, Storage},
 };
 use cda_plugin_security::SecurityPlugin;
@@ -128,10 +128,10 @@ fn get_mdd_files_and_size(files: ReadDir) -> Vec<(PathBuf, u64)> {
 pub async fn load_databases<S: SecurityPlugin>(
     config: &Configuration,
     mdd_paths: &[PathBuf],
-    db_health_provider: Option<&Arc<StatusHealthProvider>>,
+    db_health_provider: Option<&Arc<dyn HealthProvider>>,
 ) -> Result<(DatabaseMap<S>, FileManagerMap), AppError> {
     if let Some(provider) = db_health_provider {
-        provider.update_status(cda_health::Status::Starting).await;
+        provider.set_status(cda_health::Status::Starting).await;
     }
     let start = std::time::Instant::now();
 
@@ -156,7 +156,7 @@ pub async fn load_databases<S: SecurityPlugin>(
                 }
                 Err(e) => {
                     if let Some(provider) = db_health_provider {
-                        provider.update_status(cda_health::Status::Failed).await;
+                        provider.set_status(cda_health::Status::Failed).await;
                     }
                     return Err(AppError::DataError(e.to_string()));
                 }
@@ -212,7 +212,7 @@ pub async fn load_databases<S: SecurityPlugin>(
         cda_health::Status::Up
     };
     if let Some(provider) = db_health_provider {
-        provider.update_status(status).await;
+        provider.set_status(status).await;
     }
 
     Ok((databases, file_managers))

--- a/cda-main/src/setup.rs
+++ b/cda-main/src/setup.rs
@@ -1,0 +1,425 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! CDA startup builder.
+//!
+//! [`Setup`] is the public entry-point for applications that need to customize how the CDA
+//! boots. The default startup path uses [`Setup::new`] with the standard update plugin; a
+//! custom path calls [`Setup::with_update_plugin`] to inject any [`RuntimeFilesUpdatePlugin`]
+//! implementation before handing the `Setup` to one of the `run_*` functions.
+//!
+//! [`RuntimeFilesUpdatePlugin`]: cda_interfaces::runtime_update_api::RuntimeFilesUpdatePlugin
+
+use std::{future::Future, sync::Arc};
+
+use cda_comm_can::MultiTransportGateway;
+use cda_comm_doip::DoipDiagGateway;
+use cda_comm_uds::FlashTransferObserver;
+use cda_core::EcuManager;
+use cda_interfaces::{HashMap, ShutdownSignal, health::HealthProvider};
+use cda_plugin_security::{SecurityPlugin, SecurityPluginLoader};
+use futures::future::BoxFuture;
+use tokio::sync::{Mutex, RwLock};
+
+use crate::{
+    ApplicationState, UdsManagerType, VehicleData,
+    config::configfile::Configuration,
+    error::AppError,
+    update::{UpdatePluginBuilder, add_runtime_update_routes},
+};
+
+// Type alias
+
+/// Boxed async callback executed after the webserver starts but **before** vehicle data is
+/// loaded. Receives the dynamic router so it can register early routes.
+pub(crate) type PreLoadHook = Box<
+    dyn FnOnce(cda_sovd::dynamic_router::DynamicRouter) -> BoxFuture<'static, Result<(), AppError>>
+        + Send,
+>;
+
+/// Runtime context produced during CDA initialization and provided to update-plugin builders.
+pub struct CdaRuntime<SP: SecurityPlugin> {
+    pub config: Arc<RwLock<Configuration>>,
+    pub uds_manager: Arc<RwLock<UdsManagerType<SP>>>,
+    pub gateway: Arc<RwLock<MultiTransportGateway<DoipDiagGateway<EcuManager<SP>>>>>,
+    pub dynamic_router: cda_sovd::dynamic_router::DynamicRouter,
+    pub vehicle_route_handle: cda_sovd::RouteHandle,
+    pub lock_provider: Arc<cda_sovd::SovdLockStateProvider>,
+    pub ecu_execution_registry: cda_sovd::EcuExecutionRegistry,
+    pub update_guard: cda_sovd::UpdateGuardState,
+    pub update_in_progress: Arc<std::sync::atomic::AtomicBool>,
+    pub flash_files_path: String,
+    pub components_config: cda_interfaces::datatypes::ComponentsConfig,
+    pub variant_detection_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    pub health: Option<HashMap<String, Arc<dyn HealthProvider>>>,
+    pub flash_transfer_guard: FlashTransferObserver,
+    pub storage_dir: String,
+    pub mdd_decompress: bool,
+    pub shutdown_signal: ShutdownSignal,
+}
+
+// Setup
+
+/// Builder for customising the CDA startup sequence.
+///
+/// Use [`Setup::new`] to start with the defaults and then chain optional
+/// configuration methods:
+///
+/// ```rust,ignore
+/// use opensovd_cda_lib::{
+///     setup::Setup,
+///     update::update_plugin_fn,
+/// };
+///
+/// let setup = Setup::<MySecurityPlugin, MySecurityLoader>::new()
+///     .with_preload(|router| async move {
+///         // register additional routes before databases load
+///         Ok(())
+///     })
+///     .with_update_plugin(update_plugin_fn(|infra| async move {
+///         Ok(MyCustomUpdatePlugin::new(infra))
+///     }));
+///
+/// opensovd_cda_lib::run_with_ext_from_config(config, setup).await?;
+/// ```
+///
+/// When no update plugin is configured (`UpdatePluginBuilder = ()`) the runtime-update routes
+/// are **not** mounted. Pass a builder, typically via [`update_plugin_fn`] or by implementing
+/// [`UpdatePluginBuilder`], to enable them.
+///
+/// [`update_plugin_fn`]: crate::update::update_plugin_fn
+/// [`UpdatePluginBuilder`]: crate::update::UpdatePluginBuilder
+pub struct Setup<SP: SecurityPlugin, SL: SecurityPluginLoader, UPB = ()> {
+    pub(crate) _phantom: std::marker::PhantomData<(SP, SL)>,
+
+    /// Optional callback run after the webserver starts but before vehicle data is loaded.
+    pub(crate) pre_load: Option<PreLoadHook>,
+
+    /// Optional update-plugin builder. When `None` (or `UPB = ()`) the runtime-update
+    /// routes are not registered.
+    pub(crate) build_update_plugin: Option<UPB>,
+}
+
+impl<SP: SecurityPlugin, SL: SecurityPluginLoader> Default for Setup<SP, SL> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<SP: SecurityPlugin, SL: SecurityPluginLoader> Setup<SP, SL> {
+    /// Creates a new `Setup` with no preload hook and no custom update plugin.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            _phantom: std::marker::PhantomData,
+            pre_load: None,
+            build_update_plugin: None,
+        }
+    }
+}
+
+impl<SP: SecurityPlugin, SL: SecurityPluginLoader, UPB> Setup<SP, SL, UPB> {
+    /// Registers a preload hook.
+    ///
+    /// The hook is called after the webserver starts, health state and sd-notify are
+    /// configured, but **before** vehicle data (MDD databases) are loaded.  Use it to
+    /// mount additional routes that should be reachable during the (potentially slow)
+    /// database load.
+    ///
+    /// The hook must return `Ok(())` to allow startup to continue; returning `Err` aborts
+    /// the entire startup.
+    #[must_use]
+    pub fn with_preload<F, Fut>(mut self, f: F) -> Self
+    where
+        F: FnOnce(cda_sovd::dynamic_router::DynamicRouter) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<(), AppError>> + Send + 'static,
+    {
+        self.pre_load = Some(Box::new(|router| Box::pin(f(router))));
+        self
+    }
+
+    /// Configures a custom runtime update plugin.
+    ///
+    /// `builder` will be called after vehicle data is loaded and routes are registered. It
+    /// receives the complete [`CdaRuntime`] context so it can access the UDS manager, `DoIP`
+    /// gateway, storage directory, lock provider, and every other piece of infrastructure it
+    /// needs.
+    ///
+    /// The returned plugin is wrapped in [`ExclusiveRuntimePlugin`] (read/write mutual
+    /// exclusion) and mounted on the standard runtime-update HTTP endpoints automatically.
+    ///
+    /// Use [`update_plugin_fn`] to wrap a plain async closure without implementing the trait
+    /// manually:
+    ///
+    /// ```rust,ignore
+    /// setup.with_update_plugin(update_plugin_fn(|infra| async move {
+    ///     Ok(MyPlugin::new(infra))
+    /// }))
+    /// ```
+    ///
+    /// [`ExclusiveRuntimePlugin`]: cda_interfaces::runtime_update_api::ExclusiveRuntimePlugin
+    /// [`update_plugin_fn`]: crate::update::update_plugin_fn
+    pub fn with_update_plugin<UPB2: UpdatePluginBuilder<SP>>(
+        self,
+        builder: UPB2,
+    ) -> Setup<SP, SL, UPB2> {
+        Setup {
+            _phantom: self._phantom,
+            pre_load: self.pre_load,
+            build_update_plugin: Some(builder),
+        }
+    }
+}
+
+// Route setup
+
+/// Registers all SOVD routes, the runtime-update plugin, `OpenAPI` routes, and the update guard.
+///
+/// This is called after vehicle data has been loaded. The `build_update_plugin` optional
+/// builder is consumed here; when `None` the runtime-update endpoints are simply not mounted.
+pub(crate) async fn setup_runtime_routes<SP, SL, UPB>(
+    config: Configuration,
+    vehicle_data: VehicleData<SP>,
+    ws: &ApplicationState,
+    build_update_plugin: Option<UPB>,
+) -> Result<(), AppError>
+where
+    SP: SecurityPlugin,
+    SL: SecurityPluginLoader,
+    UPB: UpdatePluginBuilder<SP>,
+{
+    let flash_files_path = config.flash_files_path.clone();
+    let components_config = config.components.clone();
+    let runtime_update_config = config.runtime_update_config.clone();
+    let mdd_decompress = config.flat_buf.mdd_decompress;
+
+    let (ecu_execution_registry, vehicle_route_handle) = cda_sovd::add_vehicle_routes::<_, _, SL>(
+        &ws.dynamic_router,
+        cda_sovd::VehicleConfig {
+            flash_files_path: config.flash_files_path.clone(),
+            functional_group_config: config.functional_description.clone(),
+            components_config: config.components.clone(),
+        },
+        cda_sovd::VehicleResources {
+            ecu_uds: vehicle_data.uds_manager.clone(),
+            file_manager: vehicle_data.file_managers,
+            locks: Arc::clone(&vehicle_data.locks),
+            update_in_progress: vehicle_data.update_guard.busy_handle(),
+        },
+    )
+    .await?;
+
+    let lock_provider: Arc<cda_sovd::SovdLockStateProvider> = Arc::new(
+        cda_sovd::SovdLockStateProvider::new(Arc::clone(&vehicle_data.locks)),
+    );
+
+    let flash_transfer_guard = vehicle_data.uds_manager.flash_transfer_guard();
+    let update_in_progress = vehicle_data.update_guard.busy_handle();
+
+    let shutdown_signal = cda_interfaces::shutdown_signal(ws.shutdown_signal.clone());
+
+    // Build the CdaRuntime context for the update plugin builder.
+    let infra = CdaRuntime {
+        config: Arc::new(RwLock::new(config)),
+        dynamic_router: ws.dynamic_router.clone(),
+        vehicle_route_handle,
+        flash_files_path,
+        components_config,
+        lock_provider: Arc::clone(&lock_provider),
+        update_guard: vehicle_data.update_guard.clone(),
+        shutdown_signal,
+        uds_manager: Arc::new(RwLock::new(vehicle_data.uds_manager)),
+        gateway: Arc::new(RwLock::new(vehicle_data.diagnostic_gateway)),
+        ecu_execution_registry: ecu_execution_registry.clone(),
+        health: vehicle_data.health_providers,
+        variant_detection_handle: Mutex::new(Some(vehicle_data.variant_detection_handle)),
+        storage_dir: runtime_update_config.storage_dir.clone(),
+        mdd_decompress,
+        flash_transfer_guard,
+        update_in_progress,
+    };
+
+    // Invoke the builder (if any) and mount the update plugin.
+    if let Some(builder) = build_update_plugin {
+        let plugin = builder.build(infra).await?;
+        add_runtime_update_routes::<SL, _>(
+            &ws.dynamic_router,
+            plugin,
+            lock_provider,
+            &vehicle_data.update_guard,
+            runtime_update_config.upload_body_limit_bytes,
+            runtime_update_config.retry_after_seconds,
+        )
+        .await;
+    }
+
+    cda_sovd::add_openapi_routes(&ws.dynamic_router, &vehicle_data.update_guard).await;
+    cda_sovd::install_update_guard(&ws.dynamic_router, vehicle_data.update_guard.clone()).await;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use cda_interfaces::runtime_update_api::{
+        BulkDataCreatedList, BulkDataList, ExecutionMode, RuntimeFilesQuery,
+        RuntimeFilesUpdatePlugin, RuntimeUpdateError, UpdateExecution,
+    };
+    use cda_plugin_security::{DefaultSecurityPlugin, DefaultSecurityPluginData};
+
+    use super::*;
+    use crate::update::{UpdatePluginFn, update_plugin_fn};
+
+    // Minimal no-op plugin for type-checking.
+    struct NoOpPlugin;
+
+    #[async_trait::async_trait]
+    impl RuntimeFilesUpdatePlugin for NoOpPlugin {
+        async fn list_current(
+            &self,
+            _q: &RuntimeFilesQuery,
+        ) -> Result<BulkDataList, RuntimeUpdateError> {
+            Ok(BulkDataList::default())
+        }
+
+        async fn list_nextupdate(
+            &self,
+            _q: &RuntimeFilesQuery,
+        ) -> Result<BulkDataList, RuntimeUpdateError> {
+            Ok(BulkDataList::default())
+        }
+
+        async fn list_backup(
+            &self,
+            _q: &RuntimeFilesQuery,
+        ) -> Result<BulkDataList, RuntimeUpdateError> {
+            Ok(BulkDataList::default())
+        }
+
+        async fn upload(
+            &self,
+            _files: Vec<cda_interfaces::runtime_update_api::UploadFile>,
+        ) -> Result<BulkDataCreatedList, RuntimeUpdateError> {
+            Ok(BulkDataCreatedList::default())
+        }
+
+        async fn delete_nextupdate(&self) -> Result<Vec<String>, RuntimeUpdateError> {
+            Ok(vec![])
+        }
+
+        async fn delete_nextupdate_by_id(&self, _id: &str) -> Result<(), RuntimeUpdateError> {
+            Ok(())
+        }
+
+        async fn delete_backup(&self) -> Result<Vec<String>, RuntimeUpdateError> {
+            Ok(vec![])
+        }
+
+        async fn start_execution(
+            &self,
+            _mode: ExecutionMode,
+        ) -> Result<String, RuntimeUpdateError> {
+            Ok(String::new())
+        }
+
+        async fn list_executions(&self) -> Vec<UpdateExecution> {
+            vec![]
+        }
+
+        async fn get_execution_status(&self, _id: &str) -> Option<UpdateExecution> {
+            None
+        }
+    }
+
+    type TestSetup = Setup<DefaultSecurityPluginData, DefaultSecurityPlugin>;
+
+    #[test]
+    fn documented_public_api_type_checks() {
+        let _: Option<CdaRuntime<DefaultSecurityPluginData>> = None;
+    }
+
+    #[test]
+    fn new_has_no_preload_and_no_plugin() {
+        let s = TestSetup::new();
+        assert!(
+            s.pre_load.is_none(),
+            "fresh Setup must have no preload hook"
+        );
+        assert!(
+            s.build_update_plugin.is_none(),
+            "fresh Setup must have no update plugin"
+        );
+    }
+
+    #[test]
+    fn with_preload_stores_hook() {
+        let s = TestSetup::new().with_preload(|_router| async { Ok(()) });
+        assert!(
+            s.pre_load.is_some(),
+            "with_preload must store the provided hook"
+        );
+    }
+
+    #[test]
+    fn with_update_plugin_stores_builder() {
+        // Use `update_plugin_fn` as a convenient closure adapter.
+        let builder: UpdatePluginFn<_> =
+            update_plugin_fn(|_infra: CdaRuntime<DefaultSecurityPluginData>| async {
+                Ok(NoOpPlugin)
+            });
+
+        let s: Setup<DefaultSecurityPluginData, DefaultSecurityPlugin, _> =
+            TestSetup::new().with_update_plugin(builder);
+
+        assert!(
+            s.build_update_plugin.is_some(),
+            "with_update_plugin must store the provided builder"
+        );
+    }
+
+    #[test]
+    fn chaining_preload_then_plugin_retains_both() {
+        let builder: UpdatePluginFn<_> =
+            update_plugin_fn(|_infra: CdaRuntime<DefaultSecurityPluginData>| async {
+                Ok(NoOpPlugin)
+            });
+
+        let s = TestSetup::new()
+            .with_preload(|_| async { Ok(()) })
+            .with_update_plugin(builder);
+
+        assert!(s.pre_load.is_some(), "preload hook must survive chaining");
+        assert!(
+            s.build_update_plugin.is_some(),
+            "plugin builder must be stored after chaining"
+        );
+    }
+
+    #[test]
+    fn chaining_plugin_then_preload_retains_both() {
+        let builder: UpdatePluginFn<_> =
+            update_plugin_fn(|_infra: CdaRuntime<DefaultSecurityPluginData>| async {
+                Ok(NoOpPlugin)
+            });
+
+        let s = TestSetup::new()
+            .with_update_plugin(builder)
+            .with_preload(|_| async { Ok(()) });
+
+        assert!(s.pre_load.is_some(), "preload hook must survive chaining");
+        assert!(
+            s.build_update_plugin.is_some(),
+            "plugin builder must survive chaining"
+        );
+    }
+}

--- a/cda-main/src/update.rs
+++ b/cda-main/src/update.rs
@@ -28,10 +28,8 @@ use cda_storage::LocalStorage;
 use tokio::sync::Mutex;
 
 use crate::{
-    AppError, UdsManagerType,
-    cda_factory::CdaMainVehicleFactory,
-    config::configfile::{Configuration, ConfigurationValidator},
-    setup::CdaRuntime,
+    AppError, UdsManagerType, cda_factory::CdaMainVehicleFactory,
+    config::configfile::Configuration, setup::CdaRuntime,
 };
 
 /// Trait for async plugin builders that produce a [`RuntimeFilesUpdatePlugin`].
@@ -191,6 +189,5 @@ where
         Arc::clone(&infra.lock_provider),
         infra.mdd_decompress,
         Arc::clone(&infra.update_in_progress),
-        ConfigurationValidator::new(),
     ))
 }

--- a/cda-main/src/update.rs
+++ b/cda-main/src/update.rs
@@ -10,240 +10,104 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+use std::sync::Arc;
 
-use std::{future::Future, path::PathBuf, sync::Arc};
-
-use async_trait::async_trait;
 use cda_comm_can::MultiTransportGateway;
 use cda_comm_doip::DoipDiagGateway;
 use cda_core::EcuManager;
-use cda_interfaces::{
-    EcuGateway, UdsQuery,
-    datatypes::ComponentsConfig,
-    runtime_update_api::{ReloadError, RuntimeFilesUpdateSecurityHandler},
+use cda_interfaces::runtime_update_api::RuntimeFilesUpdatePlugin;
+use cda_plugin_runtime_update::{
+    DefaultRuntimeUpdatePlugin, DefaultUpdateSecurityHandler,
+    default_runtime_reloader_plugin::{
+        DefaultReloadContext as ReloaderContext, DefaultRuntimeReloaderPlugin,
+    },
 };
 use cda_plugin_security::{SecurityPlugin, SecurityPluginLoader};
-use tokio::sync::{Mutex, RwLock};
+use cda_sovd::{SovdLockStateProvider, UpdateGuardState};
+use cda_storage::LocalStorage;
+use tokio::sync::Mutex;
 
-use crate::{AppError, UdsManagerType};
+use crate::{
+    AppError, UdsManagerType,
+    cda_factory::CdaMainVehicleFactory,
+    config::configfile::{Configuration, ConfigurationValidator},
+    setup::CdaRuntime,
+};
 
-pub mod security;
-
-pub struct ReloadHandlerDeps<S, F>
-where
-    S: SecurityPlugin,
-    F: Future<Output = ()> + Clone + Send + Sync + 'static,
-{
-    pub config: Arc<RwLock<crate::config::configfile::Configuration>>,
-    pub dynamic_router: cda_sovd::dynamic_router::DynamicRouter,
-    pub vehicle_route_handle: cda_sovd::RouteHandle,
-    pub flash_files_path: String,
-    pub components_config: ComponentsConfig,
-    pub lock_provider: Arc<cda_sovd::SovdLockStateProvider>,
-    pub shutdown_signal: F,
-    pub uds_manager: RwLock<UdsManagerType<S>>,
-    pub doip_gateway: RwLock<MultiTransportGateway<DoipDiagGateway<EcuManager<S>>>>,
-    pub ecu_execution_registry: cda_sovd::EcuExecutionRegistry,
-    pub update_guard: cda_sovd::UpdateGuardState,
-    pub health: Option<crate::HealthProviders>,
-    pub variant_detection_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
-}
-
-pub struct DefaultRuntimeFileReloadHandler<S, F, P>
-where
-    S: SecurityPlugin,
-    F: Future<Output = ()> + Clone + Send + Sync + 'static,
-    P: SecurityPluginLoader,
-{
-    config: Arc<RwLock<crate::config::configfile::Configuration>>,
-    dynamic_router: cda_sovd::dynamic_router::DynamicRouter,
-    vehicle_route_handle: cda_sovd::RouteHandle,
-    flash_files_path: String,
-    components_config: ComponentsConfig,
-    lock_provider: Arc<cda_sovd::SovdLockStateProvider>,
-    shutdown_signal: F,
-    uds_manager: RwLock<UdsManagerType<S>>,
-    doip_gateway: RwLock<MultiTransportGateway<DoipDiagGateway<EcuManager<S>>>>,
-    update_guard: cda_sovd::UpdateGuardState,
-    ecu_execution_registry: cda_sovd::EcuExecutionRegistry,
-    health: Option<crate::HealthProviders>,
-    variant_detection_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
-    _phantom: std::marker::PhantomData<P>,
-}
-
-impl<S, F, P> DefaultRuntimeFileReloadHandler<S, F, P>
-where
-    S: SecurityPlugin,
-    F: Future<Output = ()> + Clone + Send + Sync + 'static,
-    P: SecurityPluginLoader,
-{
-    #[must_use]
-    pub fn new(deps: ReloadHandlerDeps<S, F>) -> Self {
-        Self {
-            config: deps.config,
-            dynamic_router: deps.dynamic_router,
-            vehicle_route_handle: deps.vehicle_route_handle,
-            flash_files_path: deps.flash_files_path,
-            components_config: deps.components_config,
-            lock_provider: deps.lock_provider,
-            shutdown_signal: deps.shutdown_signal,
-            uds_manager: deps.uds_manager,
-            doip_gateway: deps.doip_gateway,
-            update_guard: deps.update_guard,
-            ecu_execution_registry: deps.ecu_execution_registry,
-            health: deps.health,
-            variant_detection_handle: deps.variant_detection_handle,
-            _phantom: std::marker::PhantomData,
-        }
-    }
-}
-
-#[async_trait]
-impl<S, F, P> cda_interfaces::runtime_update_api::RuntimeFileReloadHandler
-    for DefaultRuntimeFileReloadHandler<S, F, P>
-where
-    S: SecurityPlugin,
-    F: Future<Output = ()> + Clone + Send + Sync + 'static,
-    P: SecurityPluginLoader,
-{
-    async fn reload_databases(&self, mdd_paths: Vec<PathBuf>) -> Result<(), ReloadError> {
-        let cfg = self.config.read().await.clone();
-
-        // Shut down old components BEFORE creating new ones to avoid port/socket
-        // conflicts. Reuse the existing UDP socket so that there is never a second
-        // socket bound to the same DoIP port (which would cause non-deterministic
-        // VAM delivery between old and new listeners).
-        if let Some(variant_detection_handle) = self.variant_detection_handle.lock().await.take() {
-            variant_detection_handle.abort();
-            let _ = variant_detection_handle.await;
-        }
-
-        self.uds_manager.write().await.shutdown().await;
-        let doip_socket = {
-            let mut gw = self.doip_gateway.write().await;
-            // `None` in CAN-only operation (no DoIP transport configured);
-            // `create_vehicle_components` only needs the socket when DoIP is
-            // enabled.
-            let socket = gw.doip().map(DoipDiagGateway::udp_socket);
-            // Shut down all transports and await their task termination, so
-            // the VAM listener has stopped reading from the shared UDP socket
-            // before the replacement gateway reuses it.
-            gw.shutdown().await;
-            socket
-        };
-
-        let new_components = crate::create_vehicle_components::<F, S>(
-            &cfg,
-            &mdd_paths,
-            self.shutdown_signal.clone(),
-            self.health.as_ref(),
-            self.update_guard.busy_handle(),
-            doip_socket,
-        )
-        .await
-        .map_err(|e| ReloadError(format!("Failed to create vehicle components: {e}")))?;
-
-        // Replace with new components
-        *self.variant_detection_handle.lock().await = Some(new_components.variant_detection_handle);
-        *self.uds_manager.write().await = new_components.uds_manager.clone();
-        *self.doip_gateway.write().await = new_components.diagnostic_gateway;
-
-        // Update lock entries, to make sure new ECUs or removed ECUs are updated.
-        let ecu_names = new_components.uds_manager.get_physical_ecus().await;
-        self.lock_provider
-            .update_entries(ecu_names)
-            .await
-            .map_err(|e| ReloadError(e.to_string()))?;
-        let current_locks = self.lock_provider.current_locks().await;
-
-        // Build and replace vehicle routes
-        let (vehicle_router, new_registry) = cda_sovd::build_vehicle_routes::<_, _, P>(
-            cda_sovd::VehicleConfig {
-                flash_files_path: self.flash_files_path.clone(),
-                functional_group_config: cfg.functional_description.clone(),
-                components_config: self.components_config.clone(),
-            },
-            cda_sovd::VehicleResources {
-                ecu_uds: new_components.uds_manager,
-                file_manager: new_components.file_managers,
-                locks: current_locks,
-                update_in_progress: self.update_guard.busy_handle(),
-            },
-        )
-        .await;
-        self.ecu_execution_registry.replace(&new_registry).await;
-        self.dynamic_router
-            .replace_routes(&self.vehicle_route_handle, vehicle_router)
-            .await
-            .map_err(|e| ReloadError(format!("Failed to replace vehicle routes: {e}")))?;
-
-        Ok(())
-    }
-
-    async fn reload_configuration(&self, config_path: PathBuf) -> Result<(), ReloadError> {
-        reload_configuration_from_path(&self.config, config_path).await
-    }
-}
-
-/// Reads, parses, and applies a TOML [`Configuration`] from `config_path` into `config`.
+/// Trait for async plugin builders that produce a [`RuntimeFilesUpdatePlugin`].
 ///
-/// Extracted as a free function so that it can be unit-tested without constructing
-/// the full [`DefaultRuntimeFileReloadHandler`].
-async fn reload_configuration_from_path(
-    config: &Arc<RwLock<crate::config::configfile::Configuration>>,
-    config_path: PathBuf,
-) -> Result<(), ReloadError> {
-    let parsed = crate::config::load_config(&config_path)
-        .map_err(|e| ReloadError(format!("Failed to load config: {e}")))?;
+/// Implement this trait (or use a closure via [`update_plugin_fn`]) to provide a
+/// custom update plugin to [`crate::Setup::with_update_plugin`].
+pub trait UpdatePluginBuilder<SP: SecurityPlugin>: Send {
+    /// The concrete plugin type this builder produces.
+    type Plugin: RuntimeFilesUpdatePlugin;
 
-    *config.write().await = parsed;
-    Ok(())
+    /// Build the plugin from the given runtime context.
+    fn build(
+        self,
+        infra: CdaRuntime<SP>,
+    ) -> impl Future<Output = Result<Self::Plugin, AppError>> + Send;
 }
 
-pub struct RuntimeUpdateContext<
-    S: SecurityPlugin,
-    F,
-    T: RuntimeFilesUpdateSecurityHandler<
-            cda_sovd::SovdLockStateProvider,
-            cda_storage::LocalCollection,
-        >,
-> {
-    pub dynamic_router: cda_sovd::dynamic_router::DynamicRouter,
-    pub vehicle_route_handle: cda_sovd::RouteHandle,
-    pub config: crate::config::configfile::Configuration,
-    pub flash_files_path: String,
-    pub components_config: ComponentsConfig,
-    pub lock_provider: Arc<cda_sovd::SovdLockStateProvider>,
-    pub update_guard: cda_sovd::UpdateGuardState,
-    pub shutdown_signal: F,
-    pub runtime_update_config: cda_plugin_runtime_update::config::RuntimeUpdateConfig,
-    pub security_handler: Arc<T>,
-    pub ecu_execution_registry: cda_sovd::EcuExecutionRegistry,
-    pub uds_manager: UdsManagerType<S>,
-    pub doip_gateway: MultiTransportGateway<DoipDiagGateway<EcuManager<S>>>,
-    pub health: Option<crate::HealthProviders>,
-    pub variant_detection_handle: Option<tokio::task::JoinHandle<()>>,
+/// Wrapper that adapts an async closure into an [`UpdatePluginBuilder`].
+///
+/// Created via [`update_plugin_fn`].
+pub struct UpdatePluginFn<F>(F);
+
+/// Wrap an async closure as an [`UpdatePluginBuilder`].
+///
+/// # Example
+/// ```rust,ignore
+/// use opensovd_cda_lib::{Setup, update::update_plugin_fn};
+///
+/// let setup = Setup::new().with_update_plugin(update_plugin_fn(|infra| async move {
+///     Ok(MyPlugin::new(infra))
+/// }));
+/// ```
+pub fn update_plugin_fn<SP, F, Fut, P>(f: F) -> UpdatePluginFn<F>
+where
+    SP: SecurityPlugin,
+    F: FnOnce(CdaRuntime<SP>) -> Fut + Send,
+    Fut: Future<Output = Result<P, AppError>> + Send,
+    P: RuntimeFilesUpdatePlugin,
+{
+    UpdatePluginFn(f)
+}
+
+impl<SP, F, Fut, P> UpdatePluginBuilder<SP> for UpdatePluginFn<F>
+where
+    SP: SecurityPlugin,
+    F: FnOnce(CdaRuntime<SP>) -> Fut + Send,
+    Fut: Future<Output = Result<P, AppError>> + Send,
+    P: RuntimeFilesUpdatePlugin,
+{
+    type Plugin = P;
+
+    async fn build(self, infra: CdaRuntime<SP>) -> Result<P, AppError> {
+        self.0(infra).await
+    }
 }
 
 /// Registers the runtime update routes on the dynamic router using the provided plugin.
 ///
-/// Wraps the plugin in [`ExclusiveRuntimePlugin`] for read/write mutual exclusion and
+/// Wraps the plugin in
+/// [`ExclusiveRuntimePlugin`](cda_interfaces::runtime_update_api::ExclusiveRuntimePlugin) for
+/// read/write mutual exclusion and
 /// mounts the HTTP endpoints by delegating to [`cda_sovd::add_runtime_update_routes`].
-/// The caller is responsible for constructing the plugin (e.g. via
-/// [`init_default_runtime_update_plugin`]) before calling this function.
+/// The caller is responsible for constructing the plugin before calling this function.
 pub async fn add_runtime_update_routes<S, P>(
     dynamic_router: &cda_sovd::dynamic_router::DynamicRouter,
     plugin: P,
-    lock_provider: Arc<cda_sovd::SovdLockStateProvider>,
-    update_guard: &cda_sovd::UpdateGuardState,
+    lock_provider: Arc<SovdLockStateProvider>,
+    update_guard: &UpdateGuardState,
     upload_body_limit_bytes: usize,
     retry_after_seconds: u64,
 ) where
     S: SecurityPluginLoader,
-    P: cda_interfaces::runtime_update_api::RuntimeFilesUpdatePlugin,
+    P: RuntimeFilesUpdatePlugin,
 {
     let service = Arc::new(plugin.with_exclusive_access());
-    cda_sovd::add_runtime_update_routes::<S, _, cda_sovd::SovdLockStateProvider>(
+    cda_sovd::add_runtime_update_routes::<S, _, SovdLockStateProvider>(
         dynamic_router,
         service,
         lock_provider,
@@ -254,127 +118,79 @@ pub async fn add_runtime_update_routes<S, P>(
     .await;
 }
 
-/// Initializes the default runtime update plugin.
+/// Creates the default runtime update plugin using the standard CDA components.
 ///
-/// Creates the reload handler, storage backend, and returns a configured
-/// [`cda_plugin_runtime_update::DefaultRuntimeFilesUpdatePlugin`] instance.
-/// The returned plugin is not wrapped in Arc; the caller should apply Arc wrapping
-/// if needed.
+/// This helper function eliminates code duplication between `run()` and `run_with_config()`.
+/// It builds a fully configured `DefaultRuntimeUpdatePlugin` with all the standard
+/// CDA infrastructure components.
+///
+/// # Arguments
+/// - `infra`: The runtime infrastructure containing all CDA components
 ///
 /// # Errors
-/// Returns [`AppError`] if storage initialization fails.
-pub async fn init_default_runtime_update_plugin<S, F, P>(
-    // Boxed to keep the async future size within Clippy's `large_futures` limit;
-    // the context is heap-allocated so its fields don't bloat the state machine.
-    ctx: Box<
-        RuntimeUpdateContext<
-            S,
-            F,
-            impl RuntimeFilesUpdateSecurityHandler<
-                cda_sovd::SovdLockStateProvider,
-                cda_storage::LocalCollection,
-            >,
-        >,
-    >,
-) -> Result<
-    cda_plugin_runtime_update::DefaultRuntimeFilesUpdatePlugin<
-        cda_storage::LocalStorage,
-        DefaultRuntimeFileReloadHandler<S, F, P>,
-        impl RuntimeFilesUpdateSecurityHandler<
-            cda_sovd::SovdLockStateProvider,
-            cda_storage::LocalCollection,
-        >,
-        cda_sovd::SovdLockStateProvider,
-    >,
-    AppError,
->
+/// Returns [`AppError::RuntimeUpdateError`] if plugin initialization fails.
+pub(crate) async fn create_default_update_plugin<SP, SL>(
+    infra: CdaRuntime<SP>,
+) -> Result<impl RuntimeFilesUpdatePlugin, AppError>
 where
-    S: SecurityPlugin,
-    F: Future<Output = ()> + Clone + Send + Sync + 'static,
-    P: SecurityPluginLoader,
+    SP: SecurityPlugin,
+    SL: SecurityPluginLoader,
 {
-    // Move out of the box so the large context fields are consumed into
-    // heap-backed Arcs before the first await, keeping the future small.
-    let ctx = *ctx;
-    let config = Arc::new(RwLock::new(ctx.config));
-    let reload_handler = Arc::new(DefaultRuntimeFileReloadHandler::<S, F, P>::new(
-        ReloadHandlerDeps {
-            config: Arc::clone(&config),
-            dynamic_router: ctx.dynamic_router.clone(),
-            vehicle_route_handle: ctx.vehicle_route_handle,
-            flash_files_path: ctx.flash_files_path,
-            components_config: ctx.components_config,
-            lock_provider: Arc::clone(&ctx.lock_provider),
-            shutdown_signal: ctx.shutdown_signal,
-            uds_manager: RwLock::new(ctx.uds_manager),
-            doip_gateway: RwLock::new(ctx.doip_gateway),
-            update_guard: ctx.update_guard.clone(),
-            ecu_execution_registry: ctx.ecu_execution_registry,
-            health: ctx.health,
-            variant_detection_handle: Mutex::new(ctx.variant_detection_handle),
-        },
+    let health_for_factory = infra.health.clone();
+    let shutdown_signal = infra.shutdown_signal.clone();
+    let factory = Arc::new(CdaMainVehicleFactory::<SP>::new(
+        shutdown_signal,
+        health_for_factory,
     ));
-    let storage = Arc::new(
-        cda_storage::LocalStorage::new(&ctx.runtime_update_config.storage_dir)
-            .map_err(|e| AppError::InitializationFailed(format!("DbUpdate storage: {e}")))?,
-    );
-    let mdd_decompress = config.read().await.flat_buf.mdd_decompress;
 
-    let update_plugin = cda_plugin_runtime_update::DefaultRuntimeFilesUpdatePlugin::new(
+    let storage = Arc::new(LocalStorage::new(&infra.storage_dir).map_err(|e| {
+        AppError::InitializationFailed(format!("Failed to init storage, error={e:?}"))
+    })?);
+
+    let reloader_infra = ReloaderContext {
+        config: infra.config,
+        dynamic_router: infra.dynamic_router,
+        vehicle_route_handle: infra.vehicle_route_handle,
+        flash_files_path: infra.flash_files_path,
+        components_config: infra.components_config,
+        lock_provider: Arc::clone(&infra.lock_provider),
+        shutdown_signal: infra.shutdown_signal,
+        uds_manager: infra.uds_manager,
+        diagnostic_gateway: infra.gateway,
+        update_guard: infra.update_guard,
+        ecu_execution_registry: infra.ecu_execution_registry.clone(),
+        health: infra.health,
+        variant_detection_handle: Mutex::new(infra.variant_detection_handle.lock().await.take()),
+        storage_dir: infra.storage_dir.clone(),
+        mdd_decompress: infra.mdd_decompress,
+        storage: Arc::clone(&storage),
+    };
+
+    let reloader_config =
+        cda_plugin_runtime_update::RuntimeReloaderConfig::new(reloader_infra, factory);
+
+    let reloader_plugin = Arc::new(DefaultRuntimeReloaderPlugin::<
+        UdsManagerType<SP>,
+        MultiTransportGateway<DoipDiagGateway<EcuManager<SP>>>,
+        Configuration,
+        SL,
+        _,
+        LocalStorage,
+    >::new(reloader_config));
+
+    Ok(DefaultRuntimeUpdatePlugin::new(
         storage,
-        reload_handler,
-        ctx.security_handler,
-        ctx.lock_provider,
-        mdd_decompress,
-        ctx.update_guard.busy_handle(),
-    );
-    Ok(update_plugin)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-
-    use tokio::sync::RwLock;
-
-    use super::reload_configuration_from_path;
-    use crate::config::configfile::Configuration;
-
-    fn default_config() -> Arc<RwLock<Configuration>> {
-        Arc::new(RwLock::new(Configuration::default()))
-    }
-
-    #[tokio::test]
-    async fn reload_configuration_updates_config_on_valid_file() {
-        let original = Configuration::default();
-        let config = Arc::new(RwLock::new(original));
-
-        let new_cfg = Configuration::default();
-        let toml_str = toml::to_string(&new_cfg).expect("default config must serialize");
-
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("valid.toml");
-        std::fs::write(&path, &toml_str).unwrap();
-
-        let result = reload_configuration_from_path(&config, path).await;
-        assert!(result.is_ok(), "expected Ok, got {result:?}");
-    }
-
-    #[tokio::test]
-    async fn reload_configuration_does_not_mutate_config_on_parse_error() {
-        let config = default_config();
-        let original_flash_path = config.read().await.flash_files_path.clone();
-
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("bad.toml");
-        std::fs::write(&path, "not = {{{ toml").unwrap();
-
-        let _ = reload_configuration_from_path(&config, path).await;
-
-        assert_eq!(
-            config.read().await.flash_files_path,
-            original_flash_path,
-            "config must not be mutated when TOML parsing fails"
-        );
-    }
+        reloader_plugin,
+        Arc::new(DefaultUpdateSecurityHandler::new(
+            Arc::clone(&infra.lock_provider),
+            vec![
+                Box::new(infra.flash_transfer_guard),
+                Box::new(infra.ecu_execution_registry.clone()),
+            ],
+        )),
+        Arc::clone(&infra.lock_provider),
+        infra.mdd_decompress,
+        Arc::clone(&infra.update_in_progress),
+        ConfigurationValidator::new(),
+    ))
 }

--- a/cda-plugin-runtime-update/Cargo.toml
+++ b/cda-plugin-runtime-update/Cargo.toml
@@ -26,7 +26,9 @@ path = "src/lib.rs"
 [dependencies]
 cda-interfaces = { workspace = true }
 cda-database = { workspace = true }
-sovd-interfaces = { workspace = true }
+cda-plugin-security = { workspace = true }
+cda-sovd = { workspace = true }
+cda-storage = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 serde_json = { workspace = true }
@@ -34,11 +36,11 @@ serde = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync", "macros", "fs"] }
+toml = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 schemars = { workspace = true }
 
 [dev-dependencies]
 cda-database = { workspace = true, features = ["database-builder"] }
-cda-storage = { workspace = true }
 tempfile = { workspace = true }

--- a/cda-plugin-runtime-update/Cargo.toml
+++ b/cda-plugin-runtime-update/Cargo.toml
@@ -36,7 +36,6 @@ serde = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync", "macros", "fs"] }
-toml = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 schemars = { workspace = true }

--- a/cda-plugin-runtime-update/src/config.rs
+++ b/cda-plugin-runtime-update/src/config.rs
@@ -18,7 +18,7 @@ pub struct RuntimeUpdateConfig {
     /// Maximum upload body size in bytes for multipart file uploads.
     /// Default: 50MB. Axum's built-in limit is 2MB which is too low for MDD files.
     pub upload_body_limit_bytes: usize,
-    /// Directory where the updatable configuration and database are stored.
+    /// Directory where the updatable database is stored.
     pub storage_dir: String,
     /// Value of the Retry-After header (in seconds) sent when the service is
     /// temporarily unavailable due to a busy transaction.
@@ -30,11 +30,6 @@ pub struct RuntimeUpdateConfig {
     /// Default: `false`.
     #[serde(default)]
     pub init_storage_from_database_path: bool,
-    /// When `true` and the `Configuration` storage collection is empty,
-    /// seed it from the configuration file loaded from disk on first startup.
-    /// Default: `false`.
-    #[serde(default)]
-    pub init_storage_from_config_file: bool,
 }
 
 fn default_retry_after_seconds() -> u64 {
@@ -48,7 +43,6 @@ impl Default for RuntimeUpdateConfig {
             storage_dir: ".".to_owned(),
             retry_after_seconds: default_retry_after_seconds(),
             init_storage_from_database_path: false,
-            init_storage_from_config_file: false,
         }
     }
 }

--- a/cda-plugin-runtime-update/src/default_runtime_reloader_plugin.rs
+++ b/cda-plugin-runtime-update/src/default_runtime_reloader_plugin.rs
@@ -180,7 +180,7 @@ where
     }
 }
 
-/// Default reload handler for runtime database and configuration updates.
+/// Default reload handler for runtime database updates.
 ///
 /// Implements [`RuntimeReloaderPlugin`] by:
 /// - Shutting down existing UDS and `DoIP` components
@@ -346,10 +346,6 @@ where
 
         result
     }
-
-    async fn reload_configuration(&self, config_path: PathBuf) -> Result<(), ReloadError> {
-        reload_configuration_from_path(&self.config, config_path).await
-    }
 }
 
 impl<Uds, Gateway, Config, SecurityLoader, VehicleFactory, S>
@@ -436,155 +432,5 @@ where
         self.route_state
             .install_routes::<_, SecurityLoader>(components)
             .await
-    }
-
-    async fn reload_configuration(&self, config_path: PathBuf) -> Result<(), ReloadError> {
-        reload_configuration_from_path(&self.config, config_path).await
-    }
-}
-
-/// Reads, parses, and applies a TOML configuration from `config_path` into `config`.
-///
-/// Extracted as a free function so that it can be unit-tested without constructing
-/// the full [`DefaultRuntimeReloaderPlugin`].
-pub(crate) async fn reload_configuration_from_path<C>(
-    config: &Arc<RwLock<C>>,
-    config_path: PathBuf,
-) -> Result<(), ReloadError>
-where
-    C: serde::de::DeserializeOwned + Send + Sync + 'static,
-{
-    let content = tokio::fs::read_to_string(&config_path)
-        .await
-        .map_err(|e| ReloadError(format!("Failed to read config: {e}")))?;
-    let parsed = toml::from_str(&content)
-        .map_err(|e| ReloadError(format!("Failed to parse config: {e}")))?;
-    *config.write().await = parsed;
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use std::{path::PathBuf, sync::Arc};
-
-    use serde::{Deserialize, Serialize};
-    use tokio::sync::RwLock;
-
-    use super::reload_configuration_from_path;
-
-    /// Minimal config stub for testing `reload_configuration_from_path`.
-    #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
-    struct StubConfig {
-        marker: Option<String>,
-    }
-
-    fn default_config() -> Arc<RwLock<StubConfig>> {
-        Arc::new(RwLock::new(StubConfig::default()))
-    }
-
-    #[tokio::test]
-    async fn reload_configuration_fails_when_file_does_not_exist() {
-        let config = default_config();
-        let result =
-            reload_configuration_from_path(&config, PathBuf::from("/nonexistent/path/config.toml"))
-                .await;
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(
-            err.0.contains("Failed to read config"),
-            "unexpected error: {err:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn reload_configuration_fails_on_invalid_toml() {
-        let config = default_config();
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("bad.toml");
-        std::fs::write(&path, "this is {{ not valid toml").unwrap();
-
-        let result = reload_configuration_from_path(&config, path).await;
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(
-            err.0.contains("Failed to parse config"),
-            "unexpected error: {err:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn reload_configuration_fails_on_valid_toml_with_wrong_schema() {
-        #[derive(Deserialize)]
-        #[serde(deny_unknown_fields)]
-        struct Strict {
-            #[allow(dead_code, reason = "field used only in deserialization")]
-            known: String,
-        }
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("wrong_schema.toml");
-        // StubConfig only has `marker: Option<String>` - deny_unknown_fields would
-        // reject this, but our stub doesn't use it; use a strict type to force failure.
-        let strict_config: Arc<RwLock<Strict>> = Arc::new(RwLock::new(Strict {
-            known: String::new(),
-        }));
-        std::fs::write(&path, "[unknown_section]\nfoo = 42\n").unwrap();
-
-        let result = reload_configuration_from_path(&strict_config, path).await;
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(
-            err.0.contains("Failed to parse config"),
-            "unexpected error: {err:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn reload_configuration_updates_config_on_valid_file() {
-        let config = default_config();
-        let new_cfg = StubConfig {
-            marker: Some("hello".to_string()),
-        };
-        let toml_str = toml::to_string(&new_cfg).expect("StubConfig must serialize");
-
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("valid.toml");
-        std::fs::write(&path, &toml_str).unwrap();
-
-        let result = reload_configuration_from_path(&config, path).await;
-        assert!(result.is_ok(), "expected Ok, got {result:?}");
-        assert_eq!(config.read().await.marker, Some("hello".to_string()));
-    }
-
-    #[tokio::test]
-    async fn reload_configuration_does_not_mutate_config_on_read_error() {
-        let config = default_config();
-        let original = config.read().await.clone();
-
-        let _ = reload_configuration_from_path(&config, PathBuf::from("/nonexistent/config.toml"))
-            .await;
-
-        assert_eq!(
-            *config.read().await,
-            original,
-            "config must not be mutated when file read fails"
-        );
-    }
-
-    #[tokio::test]
-    async fn reload_configuration_does_not_mutate_config_on_parse_error() {
-        let config = default_config();
-        let original = config.read().await.clone();
-
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("bad.toml");
-        std::fs::write(&path, "not = {{{ toml").unwrap();
-
-        let _ = reload_configuration_from_path(&config, path).await;
-
-        assert_eq!(
-            *config.read().await,
-            original,
-            "config must not be mutated when TOML parsing fails"
-        );
     }
 }

--- a/cda-plugin-runtime-update/src/default_runtime_reloader_plugin.rs
+++ b/cda-plugin-runtime-update/src/default_runtime_reloader_plugin.rs
@@ -1,0 +1,590 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+use std::{path::PathBuf, sync::Arc};
+
+use async_trait::async_trait;
+use cda_interfaces::{
+    EcuGateway, HashMap, ReusableTransportResource, SchemaProvider, Shutdown, ShutdownSignal,
+    UdsEcu,
+    datatypes::ComponentsConfig,
+    health::HealthProvider,
+    runtime_update_api::{
+        ReloadError, RuntimeReloaderPlugin, VehicleComponentFactory, VehicleComponents,
+    },
+    storage_api::Storage,
+};
+use cda_plugin_security::SecurityPluginLoader;
+use cda_sovd::{SovdLockStateProvider, UpdateGuardState, dynamic_router::DynamicRouter};
+use tokio::sync::{Mutex, RwLock};
+
+/// Context for the runtime reload operation.
+///
+/// This struct contains all the components needed to reload runtime databases
+/// and configuration. It bundles the infrastructure required by the reloader plugin.
+pub struct DefaultReloadContext<Uds, Gateway, Config, S>
+where
+    Uds: UdsEcu + SchemaProvider + Clone + Shutdown + Send + Sync + 'static,
+    Gateway: ReusableTransportResource + Shutdown,
+    Config: Clone + serde::de::DeserializeOwned + Send + Sync + 'static,
+    S: Storage + Send + Sync + 'static,
+{
+    /// Application configuration
+    pub config: Arc<RwLock<Config>>,
+
+    /// Vehicle diagnostic manager
+    pub uds_manager: Arc<RwLock<Uds>>,
+
+    /// Diagnostic gateway across all configured transports
+    pub diagnostic_gateway: Arc<RwLock<Gateway>>,
+
+    /// Dynamic router for hot-swapping routes
+    pub dynamic_router: DynamicRouter,
+
+    /// Handle for vehicle route registration/replacement
+    pub vehicle_route_handle: cda_sovd::RouteHandle,
+
+    /// Lock state provider for SOVD locks
+    pub lock_provider: Arc<SovdLockStateProvider>,
+
+    /// ECU execution registry for tracking in-flight operations
+    pub ecu_execution_registry: cda_sovd::EcuExecutionRegistry,
+
+    /// Update guard state
+    pub update_guard: UpdateGuardState,
+
+    /// Path for flash files
+    pub flash_files_path: String,
+
+    /// Component configuration
+    pub components_config: ComponentsConfig,
+
+    /// Handle for variant detection background task
+    pub variant_detection_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+
+    /// Health providers for monitoring
+    pub health: Option<HashMap<String, Arc<dyn HealthProvider>>>,
+
+    /// Storage directory for runtime update files
+    pub storage_dir: String,
+
+    /// Whether to decompress MDD files after apply
+    pub mdd_decompress: bool,
+
+    /// Shutdown signal for graceful termination
+    pub shutdown_signal: ShutdownSignal,
+
+    /// Persistent storage used to execute automatic rollback when component installation
+    /// fails after the previous runtime has already been torn down.
+    pub storage: Arc<S>,
+}
+
+/// Shared state for installing vehicle routes.
+///
+/// Contains exactly the fields needed for route installation, allowing both
+/// [`DefaultRuntimeReloaderPlugin`] and rollback handlers to share a single
+/// implementation of `install_routes` without duplicating logic or fields.
+pub struct RouteInstallState<Uds, Gateway>
+where
+    Uds: UdsEcu + SchemaProvider + Clone + Shutdown + Send + Sync + 'static,
+    Gateway: EcuGateway + ReusableTransportResource + Shutdown,
+{
+    lock_provider: Arc<SovdLockStateProvider>,
+    dynamic_router: DynamicRouter,
+    vehicle_route_handle: cda_sovd::RouteHandle,
+    flash_files_path: String,
+    components_config: ComponentsConfig,
+    update_guard: UpdateGuardState,
+    ecu_execution_registry: cda_sovd::EcuExecutionRegistry,
+    variant_detection_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
+    uds_manager: Arc<RwLock<Uds>>,
+    diagnostic_gateway: Arc<RwLock<Gateway>>,
+}
+
+impl<Uds, Gateway> RouteInstallState<Uds, Gateway>
+where
+    Uds: UdsEcu + SchemaProvider + Clone + Shutdown + Send + Sync + 'static,
+    Gateway: EcuGateway + ReusableTransportResource + Shutdown,
+{
+    async fn install_routes<M, SecurityLoader>(
+        &self,
+        components: VehicleComponents<Uds, Gateway, M>,
+    ) -> Result<(), ReloadError>
+    where
+        M: cda_interfaces::file_manager::FileManager,
+        SecurityLoader: SecurityPluginLoader,
+    {
+        let VehicleComponents {
+            uds_manager: new_uds,
+            diagnostic_gateway: new_gateway,
+            file_managers: file_manager,
+            variant_detection_handle: new_vd_handle,
+            functional_group_config,
+        } = components;
+
+        let ecu_names = new_uds.get_physical_ecus().await;
+        if let Err(e) = self.lock_provider.update_entries(ecu_names).await {
+            new_vd_handle.abort();
+            let _ = new_vd_handle.await;
+            new_gateway.shutdown().await;
+            new_uds.shutdown().await;
+            return Err(ReloadError(format!("Failed to update runtime locks: {e}")));
+        }
+        let current_locks = self.lock_provider.current_locks().await;
+
+        let (vehicle_router, new_registry) =
+            cda_sovd::build_vehicle_routes::<_, _, SecurityLoader>(
+                cda_sovd::VehicleConfig {
+                    flash_files_path: self.flash_files_path.clone(),
+                    functional_group_config,
+                    components_config: self.components_config.clone(),
+                },
+                cda_sovd::VehicleResources {
+                    ecu_uds: new_uds.clone(),
+                    file_manager,
+                    locks: current_locks,
+                    update_in_progress: self.update_guard.busy_handle(),
+                },
+            )
+            .await;
+
+        if let Err(e) = self
+            .dynamic_router
+            .replace_routes(&self.vehicle_route_handle, vehicle_router)
+            .await
+        {
+            new_vd_handle.abort();
+            let _ = new_vd_handle.await;
+            new_gateway.shutdown().await;
+            new_uds.shutdown().await;
+            return Err(ReloadError(format!(
+                "Failed to replace vehicle routes: {e}"
+            )));
+        }
+
+        self.ecu_execution_registry.replace(&new_registry).await;
+        *self.variant_detection_handle.lock().await = Some(new_vd_handle);
+        *self.uds_manager.write().await = new_uds;
+        *self.diagnostic_gateway.write().await = new_gateway;
+
+        Ok(())
+    }
+}
+
+/// Default reload handler for runtime database and configuration updates.
+///
+/// Implements [`RuntimeReloaderPlugin`] by:
+/// - Shutting down existing UDS and `DoIP` components
+/// - Delegating component creation to a [`VehicleComponentFactory`]
+/// - Replacing running routes via the [`DynamicRouter`]
+pub struct DefaultRuntimeReloaderPlugin<Uds, Gateway, Config, SecurityLoader, VehicleFactory, S>
+where
+    Uds: UdsEcu + SchemaProvider + Clone + Shutdown + Send + Sync + 'static,
+    Gateway: EcuGateway + ReusableTransportResource + Shutdown,
+    Config: Clone + serde::de::DeserializeOwned + Send + Sync + 'static,
+    SecurityLoader: SecurityPluginLoader,
+    VehicleFactory: VehicleComponentFactory<Config, Uds, Gateway>,
+    S: Storage + Send + Sync + 'static,
+{
+    config: Arc<RwLock<Config>>,
+    route_state: Arc<RouteInstallState<Uds, Gateway>>,
+    factory: Arc<VehicleFactory>,
+    storage: Arc<S>,
+    _phantom: std::marker::PhantomData<SecurityLoader>,
+}
+
+/// Configuration for creating a [`DefaultRuntimeReloaderPlugin`].
+///
+/// This bundles the [`ReloadContext`] with a [`VehicleComponentFactory`]
+/// to simplify plugin construction.
+pub struct RuntimeReloaderConfig<Uds, Gateway, Config, VehicleFactory, S>
+where
+    Uds: UdsEcu + SchemaProvider + Clone + Shutdown + Send + Sync + 'static,
+    Gateway: ReusableTransportResource + Shutdown,
+    Config: Clone + serde::de::DeserializeOwned + Send + Sync + 'static,
+    VehicleFactory: VehicleComponentFactory<Config, Uds, Gateway>,
+    S: Storage + Send + Sync + 'static,
+{
+    /// Runtime context containing all CDA components.
+    pub infrastructure: DefaultReloadContext<Uds, Gateway, Config, S>,
+    /// Factory for creating vehicle components on reload.
+    pub factory: Arc<VehicleFactory>,
+}
+
+impl<Uds, Gateway, Config, VehicleFactory, S>
+    RuntimeReloaderConfig<Uds, Gateway, Config, VehicleFactory, S>
+where
+    Uds: UdsEcu + SchemaProvider + Clone + Shutdown + Send + Sync + 'static,
+    Gateway: ReusableTransportResource + Shutdown,
+    Config: Clone + serde::de::DeserializeOwned + Send + Sync + 'static,
+    VehicleFactory: VehicleComponentFactory<Config, Uds, Gateway>,
+    S: Storage + Send + Sync + 'static,
+{
+    /// Creates a new [`RuntimeReloaderConfig`] from context and a factory.
+    #[must_use]
+    pub fn new(
+        infrastructure: DefaultReloadContext<Uds, Gateway, Config, S>,
+        factory: Arc<VehicleFactory>,
+    ) -> Self {
+        Self {
+            infrastructure,
+            factory,
+        }
+    }
+}
+
+impl<Uds, Gateway, Config, SecurityLoader, VehicleFactory, S>
+    DefaultRuntimeReloaderPlugin<Uds, Gateway, Config, SecurityLoader, VehicleFactory, S>
+where
+    Uds: UdsEcu + SchemaProvider + Clone + Shutdown + Send + Sync + 'static,
+    Gateway: EcuGateway + ReusableTransportResource + Shutdown,
+    Config: Clone + serde::de::DeserializeOwned + Send + Sync + 'static,
+    SecurityLoader: SecurityPluginLoader,
+    VehicleFactory: VehicleComponentFactory<Config, Uds, Gateway>,
+    S: Storage + Send + Sync + 'static,
+{
+    /// Creates a new [`DefaultRuntimeReloaderPlugin`] from a [`RuntimeReloaderConfig`].
+    #[must_use]
+    pub fn new(config: RuntimeReloaderConfig<Uds, Gateway, Config, VehicleFactory, S>) -> Self {
+        let route_state = Arc::new(RouteInstallState {
+            lock_provider: config.infrastructure.lock_provider,
+            dynamic_router: config.infrastructure.dynamic_router,
+            vehicle_route_handle: config.infrastructure.vehicle_route_handle,
+            flash_files_path: config.infrastructure.flash_files_path,
+            components_config: config.infrastructure.components_config,
+            update_guard: config.infrastructure.update_guard,
+            ecu_execution_registry: config.infrastructure.ecu_execution_registry,
+            variant_detection_handle: Arc::new(config.infrastructure.variant_detection_handle),
+            uds_manager: config.infrastructure.uds_manager,
+            diagnostic_gateway: config.infrastructure.diagnostic_gateway,
+        });
+
+        Self {
+            config: config.infrastructure.config,
+            route_state,
+            factory: config.factory,
+            storage: config.infrastructure.storage,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+#[async_trait]
+impl<Uds, Gateway, Config, SecurityLoader, VehicleFactory, S> RuntimeReloaderPlugin
+    for DefaultRuntimeReloaderPlugin<Uds, Gateway, Config, SecurityLoader, VehicleFactory, S>
+where
+    Uds: UdsEcu + SchemaProvider + Clone + Shutdown + Send + Sync + 'static,
+    Gateway: EcuGateway + ReusableTransportResource + Shutdown,
+    Config: Clone + serde::de::DeserializeOwned + Send + Sync + 'static,
+    SecurityLoader: SecurityPluginLoader,
+    VehicleFactory: VehicleComponentFactory<Config, Uds, Gateway>,
+    S: Storage + Send + Sync + 'static,
+{
+    async fn reload_databases(&self, mdd_paths: Vec<PathBuf>) -> Result<(), ReloadError> {
+        let cfg = self.config.read().await.clone();
+
+        // Shut down old components BEFORE creating new ones to avoid port/socket
+        // conflicts. Reuse the existing UDP socket so that there is never a second
+        // socket bound to the same DoIP port (which would cause non-deterministic
+        // VAM delivery between old and new listeners).
+        if let Some(handle) = self
+            .route_state
+            .variant_detection_handle
+            .lock()
+            .await
+            .take()
+        {
+            handle.abort();
+            let _ = handle.await;
+        }
+
+        self.route_state.uds_manager.write().await.shutdown().await;
+        let reusable_transport_resource = {
+            let gw = self.route_state.diagnostic_gateway.write().await;
+            let resource = gw.reusable_transport_resource();
+            gw.shutdown().await;
+            resource
+        };
+
+        // From this point the old runtime is gone. Every failure must roll back.
+        let result = self
+            .install_new_runtime(cfg, &mdd_paths, reusable_transport_resource)
+            .await;
+
+        if let Err(ref install_err) = result {
+            tracing::error!(
+                error = %install_err.0,
+                "Runtime installation failed after old runtime was torn down; \
+                 rolling back from persistent backup"
+            );
+
+            let rollback_handler = RollbackHandler {
+                config: Arc::clone(&self.config),
+                factory: Arc::clone(&self.factory),
+                route_state: Arc::clone(&self.route_state),
+                _phantom: std::marker::PhantomData::<SecurityLoader>,
+            };
+            match crate::operations::rollback::execute_rollback(&*self.storage, &rollback_handler)
+                .await
+            {
+                Ok(()) => tracing::info!("Automatic rollback completed successfully"),
+                Err(rollback_err) => tracing::error!(
+                    rollback_error = %rollback_err,
+                    "Automatic rollback also failed; CDA is degraded and requires a restart"
+                ),
+            }
+        }
+
+        result
+    }
+
+    async fn reload_configuration(&self, config_path: PathBuf) -> Result<(), ReloadError> {
+        reload_configuration_from_path(&self.config, config_path).await
+    }
+}
+
+impl<Uds, Gateway, Config, SecurityLoader, VehicleFactory, S>
+    DefaultRuntimeReloaderPlugin<Uds, Gateway, Config, SecurityLoader, VehicleFactory, S>
+where
+    Uds: UdsEcu + SchemaProvider + Clone + Shutdown + Send + Sync + 'static,
+    Gateway: EcuGateway + ReusableTransportResource + Shutdown,
+    Config: Clone + serde::de::DeserializeOwned + Send + Sync + 'static,
+    SecurityLoader: SecurityPluginLoader,
+    VehicleFactory: VehicleComponentFactory<Config, Uds, Gateway>,
+    S: Storage + Send + Sync + 'static,
+{
+    /// Creates new vehicle components, installs them, and makes them live.
+    ///
+    /// Called only after the old runtime has already been torn down. Any error here
+    /// leaves the CDA without an active runtime; the caller is responsible for rolling back.
+    async fn install_new_runtime(
+        &self,
+        cfg: Config,
+        mdd_paths: &[PathBuf],
+        reusable_transport_resource: Option<
+            Arc<Mutex<<Gateway as ReusableTransportResource>::TransportResource>>,
+        >,
+    ) -> Result<(), ReloadError> {
+        let components = self
+            .factory
+            .create(
+                &cfg,
+                mdd_paths,
+                self.route_state.update_guard.busy_handle(),
+                reusable_transport_resource,
+            )
+            .await
+            .map_err(|e| ReloadError(format!("Failed to create replacement runtime: {e}")))?;
+
+        self.route_state
+            .install_routes::<_, SecurityLoader>(components)
+            .await
+    }
+}
+///
+/// Unlike the full [`DefaultRuntimeReloaderPlugin`], this handler does not
+/// tear down existing components - it assumes the old runtime is already gone.
+/// This prevents infinite recursion during rollback.
+struct RollbackHandler<Uds, Gateway, Config, SecurityLoader, VehicleFactory>
+where
+    Uds: UdsEcu + SchemaProvider + Clone + Shutdown + Send + Sync + 'static,
+    Gateway: EcuGateway + ReusableTransportResource + Shutdown,
+    Config: Clone + serde::de::DeserializeOwned + Send + Sync + 'static,
+    SecurityLoader: SecurityPluginLoader,
+    VehicleFactory: VehicleComponentFactory<Config, Uds, Gateway>,
+{
+    config: Arc<RwLock<Config>>,
+    factory: Arc<VehicleFactory>,
+    route_state: Arc<RouteInstallState<Uds, Gateway>>,
+    _phantom: std::marker::PhantomData<SecurityLoader>,
+}
+
+#[async_trait]
+impl<Uds, Gateway, Config, SecurityLoader, VehicleFactory> RuntimeReloaderPlugin
+    for RollbackHandler<Uds, Gateway, Config, SecurityLoader, VehicleFactory>
+where
+    Uds: UdsEcu + SchemaProvider + Clone + Shutdown + Send + Sync + 'static,
+    Gateway: EcuGateway + ReusableTransportResource + Shutdown,
+    Config: Clone + serde::de::DeserializeOwned + Send + Sync + 'static,
+    SecurityLoader: SecurityPluginLoader,
+    VehicleFactory: VehicleComponentFactory<Config, Uds, Gateway>,
+{
+    async fn reload_databases(&self, mdd_paths: Vec<PathBuf>) -> Result<(), ReloadError> {
+        let cfg = self.config.read().await.clone();
+        // The old components are already torn down; pass None so the factory creates a
+        // fresh transport resource rather than trying to reuse one that no longer exists.
+        let components = self
+            .factory
+            .create(
+                &cfg,
+                &mdd_paths,
+                self.route_state.update_guard.busy_handle(),
+                None,
+            )
+            .await
+            .map_err(|e| ReloadError(format!("Failed to create runtime during rollback: {e}")))?;
+
+        self.route_state
+            .install_routes::<_, SecurityLoader>(components)
+            .await
+    }
+
+    async fn reload_configuration(&self, config_path: PathBuf) -> Result<(), ReloadError> {
+        reload_configuration_from_path(&self.config, config_path).await
+    }
+}
+
+/// Reads, parses, and applies a TOML configuration from `config_path` into `config`.
+///
+/// Extracted as a free function so that it can be unit-tested without constructing
+/// the full [`DefaultRuntimeReloaderPlugin`].
+pub(crate) async fn reload_configuration_from_path<C>(
+    config: &Arc<RwLock<C>>,
+    config_path: PathBuf,
+) -> Result<(), ReloadError>
+where
+    C: serde::de::DeserializeOwned + Send + Sync + 'static,
+{
+    let content = tokio::fs::read_to_string(&config_path)
+        .await
+        .map_err(|e| ReloadError(format!("Failed to read config: {e}")))?;
+    let parsed = toml::from_str(&content)
+        .map_err(|e| ReloadError(format!("Failed to parse config: {e}")))?;
+    *config.write().await = parsed;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{path::PathBuf, sync::Arc};
+
+    use serde::{Deserialize, Serialize};
+    use tokio::sync::RwLock;
+
+    use super::reload_configuration_from_path;
+
+    /// Minimal config stub for testing `reload_configuration_from_path`.
+    #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+    struct StubConfig {
+        marker: Option<String>,
+    }
+
+    fn default_config() -> Arc<RwLock<StubConfig>> {
+        Arc::new(RwLock::new(StubConfig::default()))
+    }
+
+    #[tokio::test]
+    async fn reload_configuration_fails_when_file_does_not_exist() {
+        let config = default_config();
+        let result =
+            reload_configuration_from_path(&config, PathBuf::from("/nonexistent/path/config.toml"))
+                .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.0.contains("Failed to read config"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_configuration_fails_on_invalid_toml() {
+        let config = default_config();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.toml");
+        std::fs::write(&path, "this is {{ not valid toml").unwrap();
+
+        let result = reload_configuration_from_path(&config, path).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.0.contains("Failed to parse config"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_configuration_fails_on_valid_toml_with_wrong_schema() {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Strict {
+            #[allow(dead_code, reason = "field used only in deserialization")]
+            known: String,
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wrong_schema.toml");
+        // StubConfig only has `marker: Option<String>` - deny_unknown_fields would
+        // reject this, but our stub doesn't use it; use a strict type to force failure.
+        let strict_config: Arc<RwLock<Strict>> = Arc::new(RwLock::new(Strict {
+            known: String::new(),
+        }));
+        std::fs::write(&path, "[unknown_section]\nfoo = 42\n").unwrap();
+
+        let result = reload_configuration_from_path(&strict_config, path).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.0.contains("Failed to parse config"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_configuration_updates_config_on_valid_file() {
+        let config = default_config();
+        let new_cfg = StubConfig {
+            marker: Some("hello".to_string()),
+        };
+        let toml_str = toml::to_string(&new_cfg).expect("StubConfig must serialize");
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("valid.toml");
+        std::fs::write(&path, &toml_str).unwrap();
+
+        let result = reload_configuration_from_path(&config, path).await;
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+        assert_eq!(config.read().await.marker, Some("hello".to_string()));
+    }
+
+    #[tokio::test]
+    async fn reload_configuration_does_not_mutate_config_on_read_error() {
+        let config = default_config();
+        let original = config.read().await.clone();
+
+        let _ = reload_configuration_from_path(&config, PathBuf::from("/nonexistent/config.toml"))
+            .await;
+
+        assert_eq!(
+            *config.read().await,
+            original,
+            "config must not be mutated when file read fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_configuration_does_not_mutate_config_on_parse_error() {
+        let config = default_config();
+        let original = config.read().await.clone();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.toml");
+        std::fs::write(&path, "not = {{{ toml").unwrap();
+
+        let _ = reload_configuration_from_path(&config, path).await;
+
+        assert_eq!(
+            *config.read().await,
+            original,
+            "config must not be mutated when TOML parsing fails"
+        );
+    }
+}

--- a/cda-plugin-runtime-update/src/default_runtime_update_plugin.rs
+++ b/cda-plugin-runtime-update/src/default_runtime_update_plugin.rs
@@ -26,8 +26,8 @@ use async_trait::async_trait;
 use cda_interfaces::{
     HashMap,
     runtime_update_api::{
-        BulkDataCreatedList, BulkDataList, ConfigValidator, ExecutionMode, LockStateProvider,
-        RuntimeFilesQuery, RuntimeFilesUpdatePlugin, RuntimeReloaderPlugin, RuntimeUpdateError,
+        BulkDataCreatedList, BulkDataList, ExecutionMode, LockStateProvider, RuntimeFilesQuery,
+        RuntimeFilesUpdatePlugin, RuntimeReloaderPlugin, RuntimeUpdateError,
         RuntimeUpdateSecurityPlugin, UpdateExecution, UploadFile,
     },
     storage_api::Storage,
@@ -40,7 +40,6 @@ pub struct DefaultRuntimeUpdatePlugin<
     Store: Storage,
     UpdateSecurityPlugin: RuntimeUpdateSecurityPlugin<Lock, Store::CollectionHandle>,
     Lock: LockStateProvider,
-    Validator: ConfigValidator,
 > {
     /// Access to the persistent storage layer (all mutations go through this)
     storage: Arc<Store>,
@@ -50,8 +49,6 @@ pub struct DefaultRuntimeUpdatePlugin<
     security_handler: Arc<UpdateSecurityPlugin>,
     /// Lock state provider passed to security checks
     lock_provider: Arc<Lock>,
-    /// Validator for configuration file content
-    config_validator: Validator,
     /// Tracking map for in-progress executions: `exec_id` -> `DbUpdateExecution`
     executions: Arc<RwLock<HashMap<String, UpdateExecution>>>,
     /// If true, call `update_mdd_uncompressed()` after Apply for each MDD file
@@ -66,8 +63,7 @@ impl<
     Store: Storage,
     UpdateSecurityPlugin: RuntimeUpdateSecurityPlugin<Lock, Store::CollectionHandle>,
     Lock: LockStateProvider,
-    Validator: ConfigValidator,
-> DefaultRuntimeUpdatePlugin<Store, UpdateSecurityPlugin, Lock, Validator>
+> DefaultRuntimeUpdatePlugin<Store, UpdateSecurityPlugin, Lock>
 {
     /// Creates a new plugin instance.
     ///
@@ -78,7 +74,6 @@ impl<
     /// * `lock_provider` - Provides lock state for security validation
     /// * `mdd_decompress` - Whether to decompress MDD files after apply
     /// * `update_in_progress` - Shared flag read by other components to gate operations
-    /// * `config_validator` - Validator for configuration file content (use `()` if not needed)
     pub fn new(
         storage: Arc<Store>,
         reloader_plugin: Arc<dyn RuntimeReloaderPlugin>,
@@ -86,14 +81,12 @@ impl<
         lock_provider: Arc<Lock>,
         mdd_decompress: bool,
         update_in_progress: Arc<AtomicBool>,
-        config_validator: Validator,
     ) -> Self {
         Self {
             storage,
             reloader_plugin,
             security_handler,
             lock_provider,
-            config_validator,
             executions: Arc::new(RwLock::new(HashMap::default())),
             mdd_decompress,
             update_in_progress,
@@ -106,9 +99,7 @@ impl<
     Store: Storage + Send + Sync + 'static,
     UpdateSecurityPlugin: RuntimeUpdateSecurityPlugin<Lock, Store::CollectionHandle>,
     Lock: LockStateProvider,
-    Validator: ConfigValidator,
-> RuntimeFilesUpdatePlugin
-    for DefaultRuntimeUpdatePlugin<Store, UpdateSecurityPlugin, Lock, Validator>
+> RuntimeFilesUpdatePlugin for DefaultRuntimeUpdatePlugin<Store, UpdateSecurityPlugin, Lock>
 {
     async fn list_current(
         &self,
@@ -135,13 +126,7 @@ impl<
         &self,
         files: Vec<UploadFile>,
     ) -> Result<BulkDataCreatedList, RuntimeUpdateError> {
-        crate::storage::upload_files(
-            &*self.storage,
-            &*self.security_handler,
-            files,
-            &self.config_validator as &dyn ConfigValidator,
-        )
-        .await
+        crate::storage::upload_files(&*self.storage, &*self.security_handler, files).await
     }
 
     async fn delete_nextupdate(&self) -> Result<Vec<String>, RuntimeUpdateError> {
@@ -195,13 +180,13 @@ mod tests {
         DefaultRuntimeUpdatePlugin,
         test_utils::{
             MockLockProvider, MockSecurityHandler, NoopReloadHandler, make_storage,
-            make_upload_files, make_valid_config, make_valid_mdd, write_test_file,
+            make_upload_files, make_valid_config, write_test_file,
         },
     };
 
     fn make_plugin(
         storage: LocalStorage,
-    ) -> DefaultRuntimeUpdatePlugin<LocalStorage, MockSecurityHandler, MockLockProvider, ()> {
+    ) -> DefaultRuntimeUpdatePlugin<LocalStorage, MockSecurityHandler, MockLockProvider> {
         make_state_with_lock(storage, Some("test-user"), false)
     }
 
@@ -209,7 +194,7 @@ mod tests {
         storage: LocalStorage,
         owner: Option<&str>,
         has_conflicts: bool,
-    ) -> DefaultRuntimeUpdatePlugin<LocalStorage, MockSecurityHandler, MockLockProvider, ()> {
+    ) -> DefaultRuntimeUpdatePlugin<LocalStorage, MockSecurityHandler, MockLockProvider> {
         DefaultRuntimeUpdatePlugin::new(
             Arc::new(storage),
             Arc::new(NoopReloadHandler),
@@ -220,7 +205,6 @@ mod tests {
             }),
             false,
             Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            (),
         )
     }
 
@@ -348,20 +332,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_nextupdate_clears_both_collections() {
+    async fn delete_nextupdate_clears_mdd_collection() {
         let (storage, _dir) = make_storage();
         write_test_file(
             &storage,
             &CollectionName::DiagnosticDatabaseNextUpdate,
             "ecu.mdd",
             b"data",
-        )
-        .await;
-        write_test_file(
-            &storage,
-            &CollectionName::ConfigurationNextUpdate,
-            "cfg.toml",
-            b"[cfg]",
         )
         .await;
         let plugin = make_plugin(storage);
@@ -440,20 +417,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_backup_clears_both_backup_collections() {
+    async fn delete_backup_clears_mdd_backup_collection() {
         let (storage, _dir) = make_storage();
         write_test_file(
             &storage,
             &CollectionName::DiagnosticDatabaseBackup,
             "ecu.mdd",
             b"backup",
-        )
-        .await;
-        write_test_file(
-            &storage,
-            &CollectionName::ConfigurationBackup,
-            "cfg.toml",
-            b"[bak]",
         )
         .await;
         let state = make_plugin(storage);
@@ -466,19 +436,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn upload_mdd_and_config_delegates_to_storage() {
+    async fn upload_rejects_config_files() {
         let (storage, _dir) = make_storage();
         let plugin = make_plugin(storage);
-        let mdd = make_valid_mdd("ComboECU");
         let config = make_valid_config();
-        let files = make_upload_files(&[("combo.mdd", &mdd), ("opensovd-cda.toml", &config)]);
+        let files = make_upload_files(&[("opensovd-cda.toml", &config)]);
 
-        let result = plugin.upload(files).await.unwrap();
+        let result = plugin.upload(files).await;
 
-        assert_eq!(result.items.len(), 2);
-        let ids: Vec<&str> = result.items.iter().map(|f| f.id.as_str()).collect();
-        assert!(ids.contains(&"combo.mdd"));
-        assert!(ids.contains(&"opensovd-cda.toml"));
+        assert!(matches!(
+            result,
+            Err(RuntimeUpdateError::InvalidFileType(_))
+        ));
     }
 
     #[tokio::test]

--- a/cda-plugin-runtime-update/src/default_runtime_update_plugin.rs
+++ b/cda-plugin-runtime-update/src/default_runtime_update_plugin.rs
@@ -26,29 +26,32 @@ use async_trait::async_trait;
 use cda_interfaces::{
     HashMap,
     runtime_update_api::{
-        BulkDataCreatedList, BulkDataList, ExecutionMode, LockStateProvider,
-        RuntimeFileReloadHandler, RuntimeFilesQuery, RuntimeFilesUpdatePlugin,
-        RuntimeFilesUpdateSecurityHandler, RuntimeUpdateError, UpdateExecution, UploadFile,
+        BulkDataCreatedList, BulkDataList, ConfigValidator, ExecutionMode, LockStateProvider,
+        RuntimeFilesQuery, RuntimeFilesUpdatePlugin, RuntimeReloaderPlugin, RuntimeUpdateError,
+        RuntimeUpdateSecurityPlugin, UpdateExecution, UploadFile,
     },
     storage_api::Storage,
 };
 use tokio::sync::RwLock;
 
 /// Default implementation of [`RuntimeFilesUpdatePlugin`] with injectable security and storage.
-pub struct DefaultRuntimeFilesUpdatePlugin<
-    S: Storage,
-    R: RuntimeFileReloadHandler,
-    T: RuntimeFilesUpdateSecurityHandler<L, S::CollectionHandle>,
-    L: LockStateProvider,
+///
+pub struct DefaultRuntimeUpdatePlugin<
+    Store: Storage,
+    UpdateSecurityPlugin: RuntimeUpdateSecurityPlugin<Lock, Store::CollectionHandle>,
+    Lock: LockStateProvider,
+    Validator: ConfigValidator,
 > {
     /// Access to the persistent storage layer (all mutations go through this)
-    storage: Arc<S>,
+    storage: Arc<Store>,
     /// Hot-reload notification handler
-    reload_handler: Arc<R>,
+    reloader_plugin: Arc<dyn RuntimeReloaderPlugin>,
     /// Security and file integrity handler
-    security_handler: Arc<T>,
+    security_handler: Arc<UpdateSecurityPlugin>,
     /// Lock state provider passed to security checks
-    lock_provider: Arc<L>,
+    lock_provider: Arc<Lock>,
+    /// Validator for configuration file content
+    config_validator: Validator,
     /// Tracking map for in-progress executions: `exec_id` -> `DbUpdateExecution`
     executions: Arc<RwLock<HashMap<String, UpdateExecution>>>,
     /// If true, call `update_mdd_uncompressed()` after Apply for each MDD file
@@ -60,11 +63,11 @@ pub struct DefaultRuntimeFilesUpdatePlugin<
 }
 
 impl<
-    S: Storage,
-    R: RuntimeFileReloadHandler,
-    T: RuntimeFilesUpdateSecurityHandler<L, S::CollectionHandle>,
-    L: LockStateProvider,
-> DefaultRuntimeFilesUpdatePlugin<S, R, T, L>
+    Store: Storage,
+    UpdateSecurityPlugin: RuntimeUpdateSecurityPlugin<Lock, Store::CollectionHandle>,
+    Lock: LockStateProvider,
+    Validator: ConfigValidator,
+> DefaultRuntimeUpdatePlugin<Store, UpdateSecurityPlugin, Lock, Validator>
 {
     /// Creates a new plugin instance.
     ///
@@ -75,19 +78,22 @@ impl<
     /// * `lock_provider` - Provides lock state for security validation
     /// * `mdd_decompress` - Whether to decompress MDD files after apply
     /// * `update_in_progress` - Shared flag read by other components to gate operations
+    /// * `config_validator` - Validator for configuration file content (use `()` if not needed)
     pub fn new(
-        storage: Arc<S>,
-        reload_handler: Arc<R>,
-        security_handler: Arc<T>,
-        lock_provider: Arc<L>,
+        storage: Arc<Store>,
+        reloader_plugin: Arc<dyn RuntimeReloaderPlugin>,
+        security_handler: Arc<UpdateSecurityPlugin>,
+        lock_provider: Arc<Lock>,
         mdd_decompress: bool,
         update_in_progress: Arc<AtomicBool>,
+        config_validator: Validator,
     ) -> Self {
         Self {
             storage,
-            reload_handler,
+            reloader_plugin,
             security_handler,
             lock_provider,
+            config_validator,
             executions: Arc::new(RwLock::new(HashMap::default())),
             mdd_decompress,
             update_in_progress,
@@ -97,11 +103,12 @@ impl<
 
 #[async_trait]
 impl<
-    S: Storage + Send + Sync + 'static,
-    R: RuntimeFileReloadHandler,
-    T: RuntimeFilesUpdateSecurityHandler<L, S::CollectionHandle>,
-    L: LockStateProvider,
-> RuntimeFilesUpdatePlugin for DefaultRuntimeFilesUpdatePlugin<S, R, T, L>
+    Store: Storage + Send + Sync + 'static,
+    UpdateSecurityPlugin: RuntimeUpdateSecurityPlugin<Lock, Store::CollectionHandle>,
+    Lock: LockStateProvider,
+    Validator: ConfigValidator,
+> RuntimeFilesUpdatePlugin
+    for DefaultRuntimeUpdatePlugin<Store, UpdateSecurityPlugin, Lock, Validator>
 {
     async fn list_current(
         &self,
@@ -128,7 +135,13 @@ impl<
         &self,
         files: Vec<UploadFile>,
     ) -> Result<BulkDataCreatedList, RuntimeUpdateError> {
-        crate::storage::upload_files(&*self.storage, &*self.security_handler, files).await
+        crate::storage::upload_files(
+            &*self.storage,
+            &*self.security_handler,
+            files,
+            &self.config_validator as &dyn ConfigValidator,
+        )
+        .await
     }
 
     async fn delete_nextupdate(&self) -> Result<Vec<String>, RuntimeUpdateError> {
@@ -147,7 +160,7 @@ impl<
         let params = crate::operations::executions::ExecutionParams {
             storage: &self.storage,
             security_handler: &self.security_handler,
-            reload_handler: &self.reload_handler,
+            reload_handler: &self.reloader_plugin,
             executions: &self.executions,
             update_in_progress: &self.update_in_progress,
             mdd_decompress: self.mdd_decompress,
@@ -179,7 +192,7 @@ mod tests {
     use cda_storage::LocalStorage;
 
     use crate::{
-        DefaultRuntimeFilesUpdatePlugin,
+        DefaultRuntimeUpdatePlugin,
         test_utils::{
             MockLockProvider, MockSecurityHandler, NoopReloadHandler, make_storage,
             make_upload_files, make_valid_config, make_valid_mdd, write_test_file,
@@ -188,12 +201,7 @@ mod tests {
 
     fn make_plugin(
         storage: LocalStorage,
-    ) -> DefaultRuntimeFilesUpdatePlugin<
-        LocalStorage,
-        NoopReloadHandler,
-        MockSecurityHandler,
-        MockLockProvider,
-    > {
+    ) -> DefaultRuntimeUpdatePlugin<LocalStorage, MockSecurityHandler, MockLockProvider, ()> {
         make_state_with_lock(storage, Some("test-user"), false)
     }
 
@@ -201,13 +209,8 @@ mod tests {
         storage: LocalStorage,
         owner: Option<&str>,
         has_conflicts: bool,
-    ) -> DefaultRuntimeFilesUpdatePlugin<
-        LocalStorage,
-        NoopReloadHandler,
-        MockSecurityHandler,
-        MockLockProvider,
-    > {
-        DefaultRuntimeFilesUpdatePlugin::new(
+    ) -> DefaultRuntimeUpdatePlugin<LocalStorage, MockSecurityHandler, MockLockProvider, ()> {
+        DefaultRuntimeUpdatePlugin::new(
             Arc::new(storage),
             Arc::new(NoopReloadHandler),
             Arc::new(MockSecurityHandler::new()),
@@ -217,6 +220,7 @@ mod tests {
             }),
             false,
             Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            (),
         )
     }
 

--- a/cda-plugin-runtime-update/src/lib.rs
+++ b/cda-plugin-runtime-update/src/lib.rs
@@ -11,20 +11,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// SPDX-License-Identifier: Apache-2.0
-//
-// See the NOTICE file(s) distributed with this work for additional
-// information regarding copyright ownership.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Apache License Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0
-
-pub use default_runtime_update_plugin::DefaultRuntimeFilesUpdatePlugin;
+pub use default_runtime_update_plugin::DefaultRuntimeUpdatePlugin;
+pub use security::DefaultUpdateSecurityHandler;
 
 pub mod config;
+pub mod default_runtime_reloader_plugin;
+pub use default_runtime_reloader_plugin::{DefaultReloadContext, RuntimeReloaderConfig};
 pub mod default_runtime_update_plugin;
 pub mod operations;
+pub mod security;
 pub mod storage;
 
 /// Shared test utilities for the runtime update plugin tests.
@@ -39,7 +34,7 @@ pub(crate) mod test_utils {
     use bytes::Bytes;
     use cda_interfaces::{
         runtime_update_api::{
-            LockStateProvider, ReloadError, RuntimeFileReloadHandler, RuntimeUpdateError,
+            LockStateProvider, ReloadError, RuntimeReloaderPlugin, RuntimeUpdateError,
             UpdateFileType, UploadFile, VerificationError,
         },
         storage_api::{
@@ -87,7 +82,7 @@ pub(crate) mod test_utils {
 
     #[async_trait]
     impl<L: LockStateProvider, C: Collection + DirectFileAccess + Send + Sync + 'static>
-        cda_interfaces::runtime_update_api::RuntimeFilesUpdateSecurityHandler<L, C>
+        cda_interfaces::runtime_update_api::RuntimeUpdateSecurityPlugin<L, C>
         for MockSecurityHandler
     {
         async fn check_apply_allowed(
@@ -106,7 +101,7 @@ pub(crate) mod test_utils {
 
         async fn check_file_integrity(
             &self,
-            _type: UpdateFileType,
+            _type: UpdateFileType<'_>,
             _path: &std::path::Path,
         ) -> Result<(), VerificationError> {
             Ok(())
@@ -201,7 +196,7 @@ pub(crate) mod test_utils {
     }
 
     #[async_trait]
-    impl RuntimeFileReloadHandler for RecordingReloadHandler {
+    impl RuntimeReloaderPlugin for RecordingReloadHandler {
         async fn reload_databases(&self, paths: Vec<PathBuf>) -> Result<(), ReloadError> {
             self.reload_calls.lock().unwrap().push(paths);
             Ok(())
@@ -213,11 +208,11 @@ pub(crate) mod test_utils {
         }
     }
 
-    /// A [`RuntimeFileReloadHandler`] that does nothing, useful as a default in tests.
+    /// A [`RuntimeReloaderPlugin`] that does nothing, useful as a default in tests.
     pub struct NoopReloadHandler;
 
     #[async_trait]
-    impl RuntimeFileReloadHandler for NoopReloadHandler {
+    impl RuntimeReloaderPlugin for NoopReloadHandler {
         async fn reload_databases(&self, _mdd_paths: Vec<PathBuf>) -> Result<(), ReloadError> {
             Ok(())
         }
@@ -227,13 +222,13 @@ pub(crate) mod test_utils {
         }
     }
 
-    /// A [`RuntimeFileReloadHandler`] whose database reload always fails, useful for
+    /// A [`RuntimeReloaderPlugin`] whose database reload always fails, useful for
     /// exercising the async-failure path of an execution that has otherwise been
     /// accepted (i.e. that got past all synchronous pre-checks in `start_execution`).
     pub struct FailingReloadHandler;
 
     #[async_trait]
-    impl RuntimeFileReloadHandler for FailingReloadHandler {
+    impl RuntimeReloaderPlugin for FailingReloadHandler {
         async fn reload_databases(&self, _mdd_paths: Vec<PathBuf>) -> Result<(), ReloadError> {
             Err(ReloadError("simulated reload failure".to_string()))
         }

--- a/cda-plugin-runtime-update/src/lib.rs
+++ b/cda-plugin-runtime-update/src/lib.rs
@@ -34,8 +34,8 @@ pub(crate) mod test_utils {
     use bytes::Bytes;
     use cda_interfaces::{
         runtime_update_api::{
-            LockStateProvider, ReloadError, RuntimeReloaderPlugin, RuntimeUpdateError,
-            UpdateFileType, UploadFile, VerificationError,
+            LockStateProvider, ReloadError, RuntimeReloaderPlugin, RuntimeUpdateError, UploadFile,
+            VerificationError,
         },
         storage_api::{
             Collection, CollectionName, DirectFileAccess, ReadableStream, Storage, Transaction,
@@ -101,7 +101,6 @@ pub(crate) mod test_utils {
 
         async fn check_file_integrity(
             &self,
-            _type: UpdateFileType<'_>,
             _path: &std::path::Path,
         ) -> Result<(), VerificationError> {
             Ok(())
@@ -183,14 +182,12 @@ pub(crate) mod test_utils {
 
     pub struct RecordingReloadHandler {
         pub reload_calls: Arc<Mutex<Vec<Vec<PathBuf>>>>,
-        pub config_calls: Arc<Mutex<Vec<PathBuf>>>,
     }
 
     impl RecordingReloadHandler {
         pub fn new() -> Self {
             Self {
                 reload_calls: Arc::new(Mutex::new(Vec::new())),
-                config_calls: Arc::new(Mutex::new(Vec::new())),
             }
         }
     }
@@ -201,11 +198,6 @@ pub(crate) mod test_utils {
             self.reload_calls.lock().unwrap().push(paths);
             Ok(())
         }
-
-        async fn reload_configuration(&self, path: PathBuf) -> Result<(), ReloadError> {
-            self.config_calls.lock().unwrap().push(path);
-            Ok(())
-        }
     }
 
     /// A [`RuntimeReloaderPlugin`] that does nothing, useful as a default in tests.
@@ -214,10 +206,6 @@ pub(crate) mod test_utils {
     #[async_trait]
     impl RuntimeReloaderPlugin for NoopReloadHandler {
         async fn reload_databases(&self, _mdd_paths: Vec<PathBuf>) -> Result<(), ReloadError> {
-            Ok(())
-        }
-
-        async fn reload_configuration(&self, _config_path: PathBuf) -> Result<(), ReloadError> {
             Ok(())
         }
     }
@@ -231,10 +219,6 @@ pub(crate) mod test_utils {
     impl RuntimeReloaderPlugin for FailingReloadHandler {
         async fn reload_databases(&self, _mdd_paths: Vec<PathBuf>) -> Result<(), ReloadError> {
             Err(ReloadError("simulated reload failure".to_string()))
-        }
-
-        async fn reload_configuration(&self, _config_path: PathBuf) -> Result<(), ReloadError> {
-            Ok(())
         }
     }
 }

--- a/cda-plugin-runtime-update/src/operations.rs
+++ b/cda-plugin-runtime-update/src/operations.rs
@@ -23,7 +23,7 @@
 use std::sync::Arc;
 
 use cda_interfaces::{
-    runtime_update_api::{RuntimeFileReloadHandler, RuntimeUpdateError},
+    runtime_update_api::{RuntimeReloaderPlugin, RuntimeUpdateError},
     storage_api::{
         Collection, CollectionName, DirectFileAccess, Storage, StorageError, Transaction,
     },
@@ -56,7 +56,10 @@ pub(crate) async fn delete_collection_ignore_missing<S: Storage>(
     }
 }
 
-pub(crate) async fn reload_configuration_if_present<S: Storage, R: RuntimeFileReloadHandler>(
+pub(crate) async fn reload_configuration_if_present<
+    S: Storage,
+    R: RuntimeReloaderPlugin + ?Sized,
+>(
     storage: &S,
     reload_handler: &R,
 ) -> Result<(), RuntimeUpdateError> {
@@ -74,7 +77,7 @@ pub(crate) async fn reload_configuration_if_present<S: Storage, R: RuntimeFileRe
     Ok(())
 }
 
-pub(crate) async fn reload_database_if_present<S: Storage, R: RuntimeFileReloadHandler>(
+pub(crate) async fn reload_database_if_present<S: Storage, R: RuntimeReloaderPlugin + ?Sized>(
     storage: &S,
     reload_handler: &R,
     decompress: bool,

--- a/cda-plugin-runtime-update/src/operations.rs
+++ b/cda-plugin-runtime-update/src/operations.rs
@@ -56,27 +56,6 @@ pub(crate) async fn delete_collection_ignore_missing<S: Storage>(
     }
 }
 
-pub(crate) async fn reload_configuration_if_present<
-    S: Storage,
-    R: RuntimeReloaderPlugin + ?Sized,
->(
-    storage: &S,
-    reload_handler: &R,
-) -> Result<(), RuntimeUpdateError> {
-    let config_col = storage
-        .get_or_create_collection(&CollectionName::Configuration)
-        .await?;
-    let config_keys = config_col.list().await?;
-    if let Some(first_key) = config_keys.first() {
-        let path = config_col.file_path(first_key)?;
-        reload_handler
-            .reload_configuration(path)
-            .await
-            .map_err(|e| RuntimeUpdateError::ReloadFailed(e.to_string()))?;
-    }
-    Ok(())
-}
-
 pub(crate) async fn reload_database_if_present<S: Storage, R: RuntimeReloaderPlugin + ?Sized>(
     storage: &S,
     reload_handler: &R,
@@ -132,10 +111,7 @@ pub(crate) async fn reload_database_if_present<S: Storage, R: RuntimeReloaderPlu
 mod tests {
     use cda_interfaces::storage_api::{CollectionName, Storage as _, StorageError};
 
-    use super::{
-        delete_collection_ignore_missing, reload_configuration_if_present,
-        reload_database_if_present, try_get_collection,
-    };
+    use super::{delete_collection_ignore_missing, reload_database_if_present, try_get_collection};
     use crate::test_utils::{
         RecordingReloadHandler, init_collection, make_storage, write_test_file,
     };
@@ -204,55 +180,6 @@ mod tests {
         tx.commit().await.unwrap();
 
         assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn reload_configuration_calls_handler_when_config_file_present() {
-        let (storage, _dir) = make_storage();
-        write_test_file(
-            &storage,
-            &CollectionName::Configuration,
-            "opensovd-cda.toml",
-            b"[server]\nport = 8080\n",
-        )
-        .await;
-
-        let handler = RecordingReloadHandler::new();
-        reload_configuration_if_present(&storage, &handler)
-            .await
-            .unwrap();
-
-        let calls = handler.config_calls.lock().unwrap();
-        assert_eq!(calls.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn reload_configuration_does_not_call_handler_when_collection_empty() {
-        let (storage, _dir) = make_storage();
-        storage
-            .get_or_create_collection(&CollectionName::Configuration)
-            .await
-            .unwrap();
-
-        let handler = RecordingReloadHandler::new();
-        reload_configuration_if_present(&storage, &handler)
-            .await
-            .unwrap();
-
-        let calls = handler.config_calls.lock().unwrap();
-        assert!(calls.is_empty());
-    }
-
-    #[tokio::test]
-    async fn reload_configuration_creates_collection_and_is_ok_when_absent() {
-        let (storage, _dir) = make_storage();
-
-        let handler = RecordingReloadHandler::new();
-        let result = reload_configuration_if_present(&storage, &handler).await;
-
-        assert!(result.is_ok());
-        let calls = handler.config_calls.lock().unwrap();
-        assert!(calls.is_empty());
     }
 
     #[tokio::test]

--- a/cda-plugin-runtime-update/src/operations/apply.rs
+++ b/cda-plugin-runtime-update/src/operations/apply.rs
@@ -12,7 +12,7 @@
  */
 
 use cda_interfaces::{
-    runtime_update_api::{RuntimeFileReloadHandler, RuntimeUpdateError},
+    runtime_update_api::{RuntimeReloaderPlugin, RuntimeUpdateError},
     storage_api::{CollectionName, Storage, Transaction},
 };
 
@@ -46,7 +46,7 @@ async fn swap_collection<S: Storage>(
 ///
 /// # Errors
 /// Returns [`RuntimeUpdateError`] if validation, transaction, or reload fails.
-pub async fn execute_apply<S: Storage, R: RuntimeFileReloadHandler>(
+pub async fn execute_apply<S: Storage, R: RuntimeReloaderPlugin + ?Sized>(
     storage: &S,
     reload_handler: &R,
     mdd_decompress: bool,
@@ -137,7 +137,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl cda_interfaces::runtime_update_api::RuntimeFileReloadHandler for OrderingReloadHandler {
+    impl cda_interfaces::runtime_update_api::RuntimeReloaderPlugin for OrderingReloadHandler {
         async fn reload_databases(
             &self,
             _paths: Vec<std::path::PathBuf>,

--- a/cda-plugin-runtime-update/src/operations/apply.rs
+++ b/cda-plugin-runtime-update/src/operations/apply.rs
@@ -16,9 +16,7 @@ use cda_interfaces::{
     storage_api::{CollectionName, Storage, Transaction},
 };
 
-use crate::operations::{
-    reload_configuration_if_present, reload_database_if_present, try_get_collection,
-};
+use crate::operations::{reload_database_if_present, try_get_collection};
 
 async fn swap_collection<S: Storage>(
     storage: &S,
@@ -32,16 +30,15 @@ async fn swap_collection<S: Storage>(
     Ok(storage.delete_collection(tx, next_update).await?)
 }
 
-/// Atomically applies pending MDD files (and optionally config) from the staging
-/// `NextUpdate` collections into the live `DiagnosticDatabase` (and `Configuration`)
-/// collections, backing up current files first.
+/// Atomically applies pending MDD files from staging into the live database,
+/// backing up current files first.
 ///
 /// The 'apply' performs a **snapshot swap**: the entire `NextUpdate` collection replaces the
 /// current collection. Files absent from `NextUpdate` are removed from current.
 ///
 /// # Parameters
 /// - `storage`: The storage backend.
-/// - `reload_handler`: Notified after commit so the runtime can hot-reload databases/config.
+/// - `reload_handler`: Notified after commit so the runtime can hot-reload databases.
 /// - `mdd_decompress`: If true, decompress MDD files in-place after commit.
 ///
 /// # Errors
@@ -53,9 +50,7 @@ pub async fn execute_apply<S: Storage, R: RuntimeReloaderPlugin + ?Sized>(
 ) -> Result<(), RuntimeUpdateError> {
     let mdd_next =
         try_get_collection(storage, &CollectionName::DiagnosticDatabaseNextUpdate).await?;
-    let cfg_next = try_get_collection(storage, &CollectionName::ConfigurationNextUpdate).await?;
-
-    if mdd_next.is_none() && cfg_next.is_none() {
+    if mdd_next.is_none() {
         return Err(RuntimeUpdateError::NoPendingUpdate);
     }
 
@@ -68,15 +63,6 @@ pub async fn execute_apply<S: Storage, R: RuntimeReloaderPlugin + ?Sized>(
             .get_or_create_collection(&CollectionName::DiagnosticDatabaseBackup)
             .await?;
     }
-    if cfg_next.is_some() {
-        storage
-            .get_or_create_collection(&CollectionName::Configuration)
-            .await?;
-        storage
-            .get_or_create_collection(&CollectionName::ConfigurationBackup)
-            .await?;
-    }
-
     let mut tx = storage.begin_transaction()?;
 
     if mdd_next.is_some() {
@@ -90,22 +76,7 @@ pub async fn execute_apply<S: Storage, R: RuntimeReloaderPlugin + ?Sized>(
         .await?;
     }
 
-    if cfg_next.is_some() {
-        swap_collection(
-            storage,
-            &mut tx,
-            &CollectionName::Configuration,
-            &CollectionName::ConfigurationBackup,
-            &CollectionName::ConfigurationNextUpdate,
-        )
-        .await?;
-    }
-
     tx.commit().await?;
-
-    if cfg_next.is_some() {
-        reload_configuration_if_present(storage, reload_handler).await?;
-    }
 
     if mdd_next.is_some() {
         reload_database_if_present(storage, reload_handler, mdd_decompress).await?;
@@ -116,9 +87,6 @@ pub async fn execute_apply<S: Storage, R: RuntimeReloaderPlugin + ?Sized>(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
-
-    use async_trait::async_trait;
     use cda_interfaces::{
         runtime_update_api::RuntimeUpdateError,
         storage_api::{
@@ -130,30 +98,6 @@ mod tests {
     use crate::test_utils::{
         NoopReloadHandler, RecordingReloadHandler, init_collection, make_storage,
     };
-
-    #[derive(Clone, Default)]
-    struct OrderingReloadHandler {
-        call_order: Arc<Mutex<Vec<&'static str>>>,
-    }
-
-    #[async_trait]
-    impl cda_interfaces::runtime_update_api::RuntimeReloaderPlugin for OrderingReloadHandler {
-        async fn reload_databases(
-            &self,
-            _paths: Vec<std::path::PathBuf>,
-        ) -> Result<(), cda_interfaces::runtime_update_api::ReloadError> {
-            self.call_order.lock().unwrap().push("databases");
-            Ok(())
-        }
-
-        async fn reload_configuration(
-            &self,
-            _path: std::path::PathBuf,
-        ) -> Result<(), cda_interfaces::runtime_update_api::ReloadError> {
-            self.call_order.lock().unwrap().push("configuration");
-            Ok(())
-        }
-    }
 
     #[tokio::test]
     async fn apply_updates_current_and_creates_backup() {
@@ -325,188 +269,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn apply_with_config_updates_configuration() {
-        let (storage, _dir) = make_storage();
-
-        init_collection(
-            &storage,
-            &CollectionName::DiagnosticDatabaseNextUpdate,
-            &[("ecu1.mdd", b"mdd_data")],
-        )
-        .await;
-
-        init_collection(
-            &storage,
-            &CollectionName::Configuration,
-            &[("config.toml", b"[old_config]")],
-        )
-        .await;
-
-        init_collection(
-            &storage,
-            &CollectionName::ConfigurationNextUpdate,
-            &[("config.toml", b"[new_config]")],
-        )
-        .await;
-
-        execute_apply(&storage, &NoopReloadHandler, false)
-            .await
-            .unwrap();
-
-        // Configuration should have new config
-        let config_col = storage
-            .get_or_create_collection(&CollectionName::Configuration)
-            .await
-            .unwrap();
-        let handle = config_col.read("config.toml").await.unwrap();
-        let size = usize::try_from(handle.data_size().unwrap()).expect("size fits usize");
-        let mut buf = vec![0u8; size];
-        handle.read_at(0, &mut buf).unwrap();
-        assert_eq!(&buf, b"[new_config]");
-
-        // ConfigurationBackup should have old config
-        let backup_col = storage
-            .get_or_create_collection(&CollectionName::ConfigurationBackup)
-            .await
-            .unwrap();
-        let handle = backup_col.read("config.toml").await.unwrap();
-        let size = usize::try_from(handle.data_size().unwrap()).expect("size fits usize");
-        let mut buf = vec![0u8; size];
-        handle.read_at(0, &mut buf).unwrap();
-        assert_eq!(&buf, b"[old_config]");
-
-        // ConfigurationNextUpdate should be gone
-        let result = storage
-            .get_collection(&CollectionName::ConfigurationNextUpdate)
-            .await;
-        assert!(matches!(result, Err(StorageError::CollectionNotFound(_))));
-    }
-
-    #[tokio::test]
-    async fn apply_mdd_only_leaves_config_untouched() {
-        let (storage, _dir) = make_storage();
-
-        init_collection(
-            &storage,
-            &CollectionName::DiagnosticDatabaseNextUpdate,
-            &[("ecu1.mdd", b"mdd_new")],
-        )
-        .await;
-
-        init_collection(
-            &storage,
-            &CollectionName::Configuration,
-            &[("config.toml", b"[original]")],
-        )
-        .await;
-
-        execute_apply(&storage, &NoopReloadHandler, false)
-            .await
-            .unwrap();
-
-        // Configuration unchanged
-        {
-            let config_col = storage
-                .get_or_create_collection(&CollectionName::Configuration)
-                .await
-                .unwrap();
-            let handle = config_col.read("config.toml").await.unwrap();
-            let size = usize::try_from(handle.data_size().unwrap()).expect("size fits usize");
-            let mut buf = vec![0u8; size];
-            handle.read_at(0, &mut buf).unwrap();
-            assert_eq!(&buf, b"[original]");
-        }
-
-        let backup_col = storage
-            .get_or_create_collection(&CollectionName::ConfigurationBackup)
-            .await
-            .unwrap();
-        assert!(backup_col.is_empty().await.unwrap());
-    }
-
-    #[tokio::test]
-    async fn apply_calls_reload_configuration_when_config_updated() {
-        let (storage, _dir) = make_storage();
-
-        init_collection(
-            &storage,
-            &CollectionName::DiagnosticDatabaseNextUpdate,
-            &[("ecu1.mdd", b"mdd_data")],
-        )
-        .await;
-
-        init_collection(
-            &storage,
-            &CollectionName::ConfigurationNextUpdate,
-            &[("config.toml", b"[new_config]")],
-        )
-        .await;
-
-        let handler = RecordingReloadHandler::new();
-        execute_apply(&storage, &handler, false).await.unwrap();
-
-        let config_calls = handler.config_calls.lock().unwrap();
-        assert_eq!(
-            config_calls.len(),
-            1,
-            "reload_configuration should be called once"
-        );
-        let Some(first_call) = config_calls.first() else {
-            panic!("expected call")
-        };
-        assert!(
-            first_call.ends_with("config.toml"),
-            "reload_configuration should receive the config file path"
-        );
-    }
-
-    #[tokio::test]
-    async fn apply_reloads_configuration_before_databases() {
-        let (storage, _dir) = make_storage();
-
-        init_collection(
-            &storage,
-            &CollectionName::DiagnosticDatabaseNextUpdate,
-            &[("ecu1.mdd", b"mdd_data")],
-        )
-        .await;
-
-        init_collection(
-            &storage,
-            &CollectionName::ConfigurationNextUpdate,
-            &[("config.toml", b"[new_config]")],
-        )
-        .await;
-
-        let handler = OrderingReloadHandler::default();
-        execute_apply(&storage, &handler, false).await.unwrap();
-
-        let call_order = handler.call_order.lock().unwrap();
-        assert_eq!(call_order.as_slice(), ["configuration", "databases"]);
-    }
-
-    #[tokio::test]
-    async fn apply_does_not_call_reload_configuration_without_config() {
-        let (storage, _dir) = make_storage();
-
-        init_collection(
-            &storage,
-            &CollectionName::DiagnosticDatabaseNextUpdate,
-            &[("ecu1.mdd", b"data")],
-        )
-        .await;
-
-        let handler = RecordingReloadHandler::new();
-        execute_apply(&storage, &handler, false).await.unwrap();
-
-        let config_calls = handler.config_calls.lock().unwrap();
-        assert!(
-            config_calls.is_empty(),
-            "reload_configuration should not be called"
-        );
-    }
-
-    #[tokio::test]
     async fn apply_with_mdd_decompress_false_succeeds() {
         let (storage, _dir) = make_storage();
 
@@ -521,83 +283,6 @@ mod tests {
         execute_apply(&storage, &NoopReloadHandler, false)
             .await
             .unwrap();
-    }
-
-    #[tokio::test]
-    async fn apply_config_only_without_mdd_succeeds() {
-        let (storage, _dir) = make_storage();
-
-        init_collection(
-            &storage,
-            &CollectionName::Configuration,
-            &[("config.toml", b"[old_config]")],
-        )
-        .await;
-
-        init_collection(
-            &storage,
-            &CollectionName::ConfigurationNextUpdate,
-            &[("config.toml", b"[new_config]")],
-        )
-        .await;
-
-        execute_apply(&storage, &NoopReloadHandler, false)
-            .await
-            .expect("config-only apply should succeed");
-
-        // Configuration should have new config
-        let config_col = storage
-            .get_or_create_collection(&CollectionName::Configuration)
-            .await
-            .unwrap();
-        let handle = config_col.read("config.toml").await.unwrap();
-        let size = usize::try_from(handle.data_size().unwrap()).expect("size fits usize");
-        let mut buf = vec![0u8; size];
-        handle.read_at(0, &mut buf).unwrap();
-        assert_eq!(&buf, b"[new_config]");
-
-        // ConfigurationNextUpdate should be gone
-        let result = storage
-            .get_collection(&CollectionName::ConfigurationNextUpdate)
-            .await;
-        assert!(matches!(result, Err(StorageError::CollectionNotFound(_))));
-
-        // DiagnosticDatabase should be untouched (not even created)
-        let mdd_result = storage
-            .get_collection(&CollectionName::DiagnosticDatabase)
-            .await;
-        assert!(
-            matches!(mdd_result, Err(StorageError::CollectionNotFound(_))),
-            "DiagnosticDatabase should not be touched in a config-only apply"
-        );
-    }
-
-    #[tokio::test]
-    async fn apply_config_only_calls_reload_configuration_but_not_reload_databases() {
-        let (storage, _dir) = make_storage();
-
-        init_collection(
-            &storage,
-            &CollectionName::ConfigurationNextUpdate,
-            &[("config.toml", b"[new_config]")],
-        )
-        .await;
-
-        let handler = RecordingReloadHandler::new();
-        execute_apply(&storage, &handler, false).await.unwrap();
-
-        let config_calls = handler.config_calls.lock().unwrap();
-        assert_eq!(
-            config_calls.len(),
-            1,
-            "reload_configuration should be called once"
-        );
-
-        let reload_calls = handler.reload_calls.lock().unwrap();
-        assert!(
-            reload_calls.is_empty(),
-            "reload_databases should not be called"
-        );
     }
 
     #[tokio::test]

--- a/cda-plugin-runtime-update/src/operations/cleanup.rs
+++ b/cda-plugin-runtime-update/src/operations/cleanup.rs
@@ -29,16 +29,12 @@ use super::delete_collection_ignore_missing;
 
 /// Clear all staging and backup collections atomically.
 ///
-/// Deletes the `NextUpdate` collections entirely and clears all entries from the backup collections
-/// in a single transaction:
+/// Deletes MDD staging and clears the MDD backup in a single transaction:
 /// - [`CollectionName::DiagnosticDatabaseNextUpdate`] - deleted (collection removed)
 /// - [`CollectionName::DiagnosticDatabaseBackup`] - cleared
-/// - [`CollectionName::ConfigurationNextUpdate`] - deleted (collection removed)
-/// - [`CollectionName::ConfigurationBackup`] - cleared
 ///
 /// This operation is idempotent - calling it when collections are already absent or empty succeeds.
-/// The current database ([`CollectionName::DiagnosticDatabase`]) and active configuration
-/// ([`CollectionName::Configuration`]) are never touched.
+/// The current database ([`CollectionName::DiagnosticDatabase`]) is never touched.
 /// # Errors
 ///
 /// Returns [`RuntimeUpdateError`] if any storage operation fails.
@@ -46,10 +42,6 @@ pub async fn execute_cleanup<S: Storage>(storage: &S) -> Result<(), RuntimeUpdat
     let mdd_backup = storage
         .get_or_create_collection(&CollectionName::DiagnosticDatabaseBackup)
         .await?;
-    let cfg_backup = storage
-        .get_or_create_collection(&CollectionName::ConfigurationBackup)
-        .await?;
-
     let mut tx = storage.begin_transaction()?;
 
     delete_collection_ignore_missing(
@@ -59,9 +51,6 @@ pub async fn execute_cleanup<S: Storage>(storage: &S) -> Result<(), RuntimeUpdat
     )
     .await?;
     mdd_backup.delete_all(&mut tx).await?;
-    delete_collection_ignore_missing(storage, &mut tx, &CollectionName::ConfigurationNextUpdate)
-        .await?;
-    cfg_backup.delete_all(&mut tx).await?;
 
     tx.commit().await?;
     Ok(())
@@ -123,41 +112,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cleanup_clears_configuration_next_update() {
-        let (storage, _dir) = make_storage();
-        write_dummy(
-            &storage,
-            &CollectionName::ConfigurationNextUpdate,
-            "cfg.toml",
-        )
-        .await;
-
-        execute_cleanup(&storage).await.unwrap();
-
-        let result = storage
-            .get_collection(&CollectionName::ConfigurationNextUpdate)
-            .await;
-        assert!(
-            matches!(result, Err(StorageError::CollectionNotFound(_))),
-            "NextUpdate should be gone after cleanup"
-        );
-    }
-
-    #[tokio::test]
-    async fn cleanup_clears_configuration_backup() {
-        let (storage, _dir) = make_storage();
-        write_dummy(&storage, &CollectionName::ConfigurationBackup, "cfg.toml").await;
-
-        execute_cleanup(&storage).await.unwrap();
-
-        let col = storage
-            .get_or_create_collection(&CollectionName::ConfigurationBackup)
-            .await
-            .unwrap();
-        assert!(col.is_empty().await.unwrap());
-    }
-
-    #[tokio::test]
     async fn cleanup_is_idempotent_when_all_collections_empty() {
         let (storage, _dir) = make_storage();
 
@@ -179,21 +133,5 @@ mod tests {
         assert!(!col.is_empty().await.unwrap());
         let keys = col.list().await.unwrap();
         assert!(keys.contains(&"ecu.mdd".to_string()));
-    }
-
-    #[tokio::test]
-    async fn cleanup_does_not_modify_configuration() {
-        let (storage, _dir) = make_storage();
-        write_dummy(&storage, &CollectionName::Configuration, "config.toml").await;
-
-        execute_cleanup(&storage).await.unwrap();
-
-        let col = storage
-            .get_or_create_collection(&CollectionName::Configuration)
-            .await
-            .unwrap();
-        assert!(!col.is_empty().await.unwrap());
-        let keys = col.list().await.unwrap();
-        assert!(keys.contains(&"config.toml".to_string()));
     }
 }

--- a/cda-plugin-runtime-update/src/operations/executions.rs
+++ b/cda-plugin-runtime-update/src/operations/executions.rs
@@ -28,14 +28,14 @@ use std::sync::{
 use cda_interfaces::{
     HashMap,
     runtime_update_api::{
-        ExecutionMode, ExecutionStatus, LockStateProvider, RuntimeFileReloadHandler,
-        RuntimeFilesUpdateSecurityHandler, RuntimeUpdateError, UpdateCollections, UpdateExecution,
+        ExecutionMode, ExecutionStatus, LockStateProvider, RuntimeReloaderPlugin,
+        RuntimeUpdateError, RuntimeUpdateSecurityPlugin, UpdateCollections, UpdateExecution,
     },
     storage_api::{CollectionName, Storage},
 };
 use tokio::sync::RwLock;
 
-pub(crate) struct ExecutionParams<'a, S, R, T, L> {
+pub(crate) struct ExecutionParams<'a, S, R: ?Sized, T, L> {
     pub(crate) storage: &'a Arc<S>,
     pub(crate) security_handler: &'a Arc<T>,
     pub(crate) reload_handler: &'a Arc<R>,
@@ -44,15 +44,14 @@ pub(crate) struct ExecutionParams<'a, S, R, T, L> {
     pub(crate) mdd_decompress: bool,
     pub(crate) lock_state_provider: &'a L,
 }
-
 pub(crate) async fn start_execution<S, R, T, L>(
     params: &ExecutionParams<'_, S, R, T, L>,
     mode: ExecutionMode,
 ) -> Result<String, RuntimeUpdateError>
 where
     S: Storage + Send + Sync + 'static,
-    R: RuntimeFileReloadHandler,
-    T: RuntimeFilesUpdateSecurityHandler<L, S::CollectionHandle>,
+    R: RuntimeReloaderPlugin + ?Sized,
+    T: RuntimeUpdateSecurityPlugin<L, S::CollectionHandle>,
     L: LockStateProvider,
 {
     params
@@ -190,7 +189,7 @@ async fn execute_operation<S, R>(
 ) -> Result<(), RuntimeUpdateError>
 where
     S: Storage + Send + Sync + 'static,
-    R: RuntimeFileReloadHandler,
+    R: RuntimeReloaderPlugin + ?Sized,
 {
     match mode {
         ExecutionMode::Apply => {

--- a/cda-plugin-runtime-update/src/operations/executions.rs
+++ b/cda-plugin-runtime-update/src/operations/executions.rs
@@ -65,19 +65,9 @@ where
             .get_collection(&CollectionName::DiagnosticDatabaseNextUpdate)
             .await
             .ok(),
-        pending_config: params
-            .storage
-            .get_collection(&CollectionName::ConfigurationNextUpdate)
-            .await
-            .ok(),
         current_mdd: params
             .storage
             .get_collection(&CollectionName::DiagnosticDatabase)
-            .await
-            .ok(),
-        current_config: params
-            .storage
-            .get_collection(&CollectionName::Configuration)
             .await
             .ok(),
     };
@@ -121,10 +111,7 @@ where
     // before spawning the task so that the 404 is returned synchronously instead of
     // 202 being sent with a later Failed status (execute_apply's own check runs
     // inside the spawned task and is too late to affect the HTTP response).
-    if mode == ExecutionMode::Apply
-        && collections.pending_mdd.is_none()
-        && collections.pending_config.is_none()
-    {
+    if mode == ExecutionMode::Apply && collections.pending_mdd.is_none() {
         params.update_in_progress.store(false, Ordering::Release);
         return Err(RuntimeUpdateError::NoPendingUpdate);
     }
@@ -328,7 +315,7 @@ mod tests {
     async fn start_execution_apply_with_no_pending_update_rejected_synchronously() {
         let f = make_fixture();
 
-        // Nothing seeded into DiagnosticDatabaseNextUpdate or ConfigurationNextUpdate:
+        // Nothing seeded into DiagnosticDatabaseNextUpdate:
         // Apply must be rejected synchronously (i.e. `start_execution` itself returns
         // an error) rather than accepted (202-equivalent execution id) only to fail
         // later inside the spawned task.

--- a/cda-plugin-runtime-update/src/operations/rollback.rs
+++ b/cda-plugin-runtime-update/src/operations/rollback.rs
@@ -21,7 +21,7 @@
 // https://www.apache.org/licenses/LICENSE-2.0
 
 use cda_interfaces::{
-    runtime_update_api::{RuntimeFileReloadHandler, RuntimeUpdateError},
+    runtime_update_api::{RuntimeReloaderPlugin, RuntimeUpdateError},
     storage_api::{Collection, CollectionName, Storage, Transaction},
 };
 
@@ -46,7 +46,7 @@ async fn restore_from_backup<S: Storage, C: Collection>(
 /// Roll back the entire update from the backup.
 /// # Errors
 /// Returns [`RuntimeUpdateError`] if restore or reload fails.
-pub async fn execute_rollback<S: Storage, R: RuntimeFileReloadHandler>(
+pub async fn execute_rollback<S: Storage, R: RuntimeReloaderPlugin + ?Sized>(
     storage: &S,
     reload_handler: &R,
 ) -> Result<(), RuntimeUpdateError> {
@@ -373,7 +373,7 @@ mod tests {
     }
 
     #[async_trait::async_trait]
-    impl cda_interfaces::runtime_update_api::RuntimeFileReloadHandler for OrderingReloadHandler {
+    impl cda_interfaces::runtime_update_api::RuntimeReloaderPlugin for OrderingReloadHandler {
         async fn reload_databases(
             &self,
             _paths: Vec<std::path::PathBuf>,

--- a/cda-plugin-runtime-update/src/operations/rollback.rs
+++ b/cda-plugin-runtime-update/src/operations/rollback.rs
@@ -25,9 +25,7 @@ use cda_interfaces::{
     storage_api::{Collection, CollectionName, Storage, Transaction},
 };
 
-use crate::operations::{
-    delete_collection_ignore_missing, reload_configuration_if_present, reload_database_if_present,
-};
+use crate::operations::{delete_collection_ignore_missing, reload_database_if_present};
 
 async fn restore_from_backup<S: Storage, C: Collection>(
     storage: &S,
@@ -53,16 +51,11 @@ pub async fn execute_rollback<S: Storage, R: RuntimeReloaderPlugin + ?Sized>(
     let mdd_backup_col = storage
         .get_or_create_collection(&CollectionName::DiagnosticDatabaseBackup)
         .await?;
-    let config_backup_col = storage
-        .get_or_create_collection(&CollectionName::ConfigurationBackup)
-        .await?;
-
     let mdd_backup_empty = mdd_backup_col.is_empty().await?;
-    let config_backup_empty = config_backup_col.is_empty().await?;
 
     // Guard also checked synchronously in `start_execution` before the task is spawned,
     // so 404 is returned before 202 is sent. Kept here for correctness if called directly.
-    if mdd_backup_empty && config_backup_empty {
+    if mdd_backup_empty {
         return Err(RuntimeUpdateError::NoBackup);
     }
 
@@ -80,23 +73,7 @@ pub async fn execute_rollback<S: Storage, R: RuntimeReloaderPlugin + ?Sized>(
         .await?;
     }
 
-    if !config_backup_empty {
-        restore_from_backup(
-            storage,
-            &mut tx,
-            &CollectionName::ConfigurationBackup,
-            &CollectionName::Configuration,
-            &CollectionName::ConfigurationNextUpdate,
-            config_backup_col.as_ref(),
-        )
-        .await?;
-    }
-
     tx.commit().await?;
-
-    if !config_backup_empty {
-        reload_configuration_if_present(storage, reload_handler).await?;
-    }
 
     if !mdd_backup_empty {
         reload_database_if_present(storage, reload_handler, false).await?;
@@ -107,8 +84,6 @@ pub async fn execute_rollback<S: Storage, R: RuntimeReloaderPlugin + ?Sized>(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
-
     use cda_interfaces::{
         runtime_update_api::RuntimeUpdateError,
         storage_api::{
@@ -222,98 +197,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rollback_with_config_backup_restores_configuration() {
-        let (storage, _dir) = make_storage();
-
-        init_collection(
-            &storage,
-            &CollectionName::DiagnosticDatabaseBackup,
-            &[("ecu1.mdd", b"mdd_backup")],
-        )
-        .await;
-
-        init_collection(
-            &storage,
-            &CollectionName::ConfigurationBackup,
-            &[("config.toml", b"[backup_config]")],
-        )
-        .await;
-
-        init_collection(
-            &storage,
-            &CollectionName::Configuration,
-            &[("config.toml", b"[current_config]")],
-        )
-        .await;
-
-        execute_rollback(&storage, &NoopReloadHandler)
-            .await
-            .unwrap();
-
-        let config_col = storage
-            .get_or_create_collection(&CollectionName::Configuration)
-            .await
-            .unwrap();
-
-        let handle = config_col.read("config.toml").await.unwrap();
-        let size = usize::try_from(handle.data_size().unwrap()).expect("size fits usize");
-        let mut buf = vec![0u8; size];
-        handle.read_at(0, &mut buf).unwrap();
-        assert_eq!(&buf, b"[backup_config]");
-
-        let config_backup_col = storage
-            .get_or_create_collection(&CollectionName::ConfigurationBackup)
-            .await
-            .unwrap();
-        assert!(config_backup_col.is_empty().await.unwrap());
-    }
-
-    #[tokio::test]
-    async fn rollback_mdd_only_leaves_config_collections_untouched() {
-        let (storage, _dir) = make_storage();
-
-        init_collection(
-            &storage,
-            &CollectionName::DiagnosticDatabaseBackup,
-            &[("ecu1.mdd", b"mdd_backup")],
-        )
-        .await;
-
-        init_collection(
-            &storage,
-            &CollectionName::Configuration,
-            &[("config.toml", b"[original_config]")],
-        )
-        .await;
-        init_collection(
-            &storage,
-            &CollectionName::ConfigurationNextUpdate,
-            &[("config.toml", b"[pending_config]")],
-        )
-        .await;
-
-        execute_rollback(&storage, &NoopReloadHandler)
-            .await
-            .unwrap();
-
-        let config_col = storage
-            .get_or_create_collection(&CollectionName::Configuration)
-            .await
-            .unwrap();
-        let handle = config_col.read("config.toml").await.unwrap();
-        let size = usize::try_from(handle.data_size().unwrap()).expect("size fits usize");
-        let mut buf = vec![0u8; size];
-        handle.read_at(0, &mut buf).unwrap();
-        assert_eq!(&buf, b"[original_config]");
-
-        let config_next_col = storage
-            .get_or_create_collection(&CollectionName::ConfigurationNextUpdate)
-            .await
-            .unwrap();
-        assert!(!config_next_col.is_empty().await.unwrap());
-    }
-
-    #[tokio::test]
     async fn rollback_calls_reload_handler() {
         let (storage, _dir) = make_storage();
 
@@ -329,188 +212,6 @@ mod tests {
 
         let calls = handler.reload_calls.lock().unwrap();
         assert_eq!(calls.len(), 1, "reload_databases should be called once");
-    }
-
-    #[tokio::test]
-    async fn rollback_calls_reload_configuration_when_config_restored() {
-        let (storage, _dir) = make_storage();
-
-        init_collection(
-            &storage,
-            &CollectionName::DiagnosticDatabaseBackup,
-            &[("ecu1.mdd", b"mdd_backup")],
-        )
-        .await;
-
-        init_collection(
-            &storage,
-            &CollectionName::ConfigurationBackup,
-            &[("config.toml", b"[backup_config]")],
-        )
-        .await;
-
-        let handler = RecordingReloadHandler::new();
-        execute_rollback(&storage, &handler).await.unwrap();
-
-        let config_calls = handler.config_calls.lock().unwrap();
-        assert_eq!(
-            config_calls.len(),
-            1,
-            "reload_configuration should be called once"
-        );
-        let Some(first_call) = config_calls.first() else {
-            panic!("expected call")
-        };
-        assert!(
-            first_call.ends_with("config.toml"),
-            "reload_configuration should receive the config file path"
-        );
-    }
-
-    #[derive(Clone, Default)]
-    struct OrderingReloadHandler {
-        call_order: Arc<Mutex<Vec<&'static str>>>,
-    }
-
-    #[async_trait::async_trait]
-    impl cda_interfaces::runtime_update_api::RuntimeReloaderPlugin for OrderingReloadHandler {
-        async fn reload_databases(
-            &self,
-            _paths: Vec<std::path::PathBuf>,
-        ) -> Result<(), cda_interfaces::runtime_update_api::ReloadError> {
-            self.call_order.lock().unwrap().push("databases");
-            Ok(())
-        }
-
-        async fn reload_configuration(
-            &self,
-            _path: std::path::PathBuf,
-        ) -> Result<(), cda_interfaces::runtime_update_api::ReloadError> {
-            self.call_order.lock().unwrap().push("configuration");
-            Ok(())
-        }
-    }
-
-    #[tokio::test]
-    async fn rollback_reloads_configuration_before_databases() {
-        let (storage, _dir) = make_storage();
-
-        init_collection(
-            &storage,
-            &CollectionName::DiagnosticDatabaseBackup,
-            &[("ecu1.mdd", b"mdd_backup")],
-        )
-        .await;
-
-        init_collection(
-            &storage,
-            &CollectionName::ConfigurationBackup,
-            &[("config.toml", b"[backup_config]")],
-        )
-        .await;
-
-        let handler = OrderingReloadHandler::default();
-        execute_rollback(&storage, &handler).await.unwrap();
-
-        let call_order = handler.call_order.lock().unwrap();
-        assert_eq!(call_order.as_slice(), ["configuration", "databases"]);
-    }
-
-    #[tokio::test]
-    async fn rollback_config_only_restores_config() {
-        let (storage, _dir) = make_storage();
-
-        init_collection(
-            &storage,
-            &CollectionName::ConfigurationBackup,
-            &[("config.toml", b"[backup_config]")],
-        )
-        .await;
-
-        init_collection(
-            &storage,
-            &CollectionName::Configuration,
-            &[("config.toml", b"[current_config]")],
-        )
-        .await;
-
-        let handler = RecordingReloadHandler::new();
-        execute_rollback(&storage, &handler).await.unwrap();
-
-        let config_col = storage
-            .get_or_create_collection(&CollectionName::Configuration)
-            .await
-            .unwrap();
-
-        let handle = config_col.read("config.toml").await.unwrap();
-        let size = usize::try_from(handle.data_size().unwrap()).expect("size fits usize");
-        let mut buf = vec![0u8; size];
-        handle.read_at(0, &mut buf).unwrap();
-        assert_eq!(&buf, b"[backup_config]");
-
-        let config_backup_col = storage
-            .get_or_create_collection(&CollectionName::ConfigurationBackup)
-            .await
-            .unwrap();
-        assert!(config_backup_col.is_empty().await.unwrap());
-
-        let reload_calls = handler.reload_calls.lock().unwrap();
-        assert_eq!(
-            reload_calls.len(),
-            0,
-            "reload_databases should NOT be called for config-only rollback"
-        );
-
-        let config_calls = handler.config_calls.lock().unwrap();
-        assert_eq!(
-            config_calls.len(),
-            1,
-            "reload_configuration should be called once"
-        );
-        let Some(first_call) = config_calls.first() else {
-            panic!("expected call")
-        };
-        assert!(
-            first_call.ends_with("config.toml"),
-            "reload_configuration should receive the config file path"
-        );
-    }
-
-    #[tokio::test]
-    async fn rollback_config_only_does_not_touch_mdd_collections() {
-        let (storage, _dir) = make_storage();
-
-        init_collection(
-            &storage,
-            &CollectionName::ConfigurationBackup,
-            &[("config.toml", b"[backup_config]")],
-        )
-        .await;
-
-        init_collection(
-            &storage,
-            &CollectionName::DiagnosticDatabase,
-            &[("ecu1.mdd", b"current_mdd")],
-        )
-        .await;
-
-        execute_rollback(&storage, &NoopReloadHandler)
-            .await
-            .unwrap();
-
-        let db_col = storage
-            .get_or_create_collection(&CollectionName::DiagnosticDatabase)
-            .await
-            .unwrap();
-
-        let handle = db_col.read("ecu1.mdd").await.unwrap();
-        let size = usize::try_from(handle.data_size().unwrap()).expect("size fits usize");
-        let mut buf = vec![0u8; size];
-        handle.read_at(0, &mut buf).unwrap();
-        assert_eq!(
-            &buf, b"current_mdd",
-            "MDD should be untouched in config-only rollback"
-        );
     }
 
     #[tokio::test]

--- a/cda-plugin-runtime-update/src/security.rs
+++ b/cda-plugin-runtime-update/src/security.rs
@@ -17,18 +17,27 @@ use async_trait::async_trait;
 use cda_database::mmap_and_decode_mdd;
 use cda_interfaces::{
     runtime_update_api::{
-        ActivityGuard, LockStateProvider, RuntimeFilesUpdateSecurityHandler, RuntimeUpdateError,
+        ActivityGuard, LockStateProvider, RuntimeUpdateError, RuntimeUpdateSecurityPlugin,
         UpdateCollections, UpdateFileType, VerificationError,
     },
     storage_api::{Collection, DirectFileAccess},
 };
 
-pub struct UpdateSecurityHandler<L: LockStateProvider> {
+/// Default implementation of the runtime update security handler.
+///
+/// Validates vehicle lock ownership, detects lock conflicts, and verifies
+/// file integrity for both MDD databases and configuration files.
+pub struct DefaultUpdateSecurityHandler<L: LockStateProvider> {
     guard: Vec<Box<dyn ActivityGuard>>,
     _lock_provider: std::marker::PhantomData<L>,
 }
 
-impl<L: LockStateProvider> UpdateSecurityHandler<L> {
+impl<L: LockStateProvider> DefaultUpdateSecurityHandler<L> {
+    /// Creates a new security handler with the given activity guards.
+    ///
+    /// # Arguments
+    /// * `_lock_provider` - The lock state provider (used for type inference)
+    /// * `guard` - Activity guards that prevent updates while operations are in progress
     pub fn new(_lock_provider: Arc<L>, guard: Vec<Box<dyn ActivityGuard>>) -> Self {
         Self {
             guard,
@@ -39,7 +48,7 @@ impl<L: LockStateProvider> UpdateSecurityHandler<L> {
 
 #[async_trait]
 impl<L: LockStateProvider, C: Collection + DirectFileAccess + Send + Sync + 'static>
-    RuntimeFilesUpdateSecurityHandler<L, C> for UpdateSecurityHandler<L>
+    RuntimeUpdateSecurityPlugin<L, C> for DefaultUpdateSecurityHandler<L>
 {
     /// Validates that the caller is allowed to start an execution (apply/rollback/cleanup).
     ///
@@ -84,7 +93,7 @@ impl<L: LockStateProvider, C: Collection + DirectFileAccess + Send + Sync + 'sta
 
     async fn check_file_integrity(
         &self,
-        type_: UpdateFileType,
+        type_: UpdateFileType<'_>,
         path: &std::path::Path,
     ) -> Result<(), VerificationError> {
         match type_ {
@@ -96,18 +105,18 @@ impl<L: LockStateProvider, C: Collection + DirectFileAccess + Send + Sync + 'sta
                     VerificationError(format!("Failed to parse MDD '{}': {e}", path.display()))
                 })?;
             }
-            UpdateFileType::Config => {
+            UpdateFileType::Config(config_validator) => {
                 let content = tokio::fs::read_to_string(path).await.map_err(|e| {
                     VerificationError(format!("Failed to read config '{}': {e}", path.display()))
                 })?;
-                toml::from_str::<crate::config::configfile::Configuration>(&content).map_err(
-                    |e| {
-                        VerificationError(format!(
-                            "Failed to parse config '{}': {e}",
-                            path.display()
-                        ))
-                    },
-                )?;
+
+                // Validate config content using the embedded validator
+                config_validator.validate(&content).map_err(|e| {
+                    VerificationError(format!(
+                        "Failed to validate config '{}': {e}",
+                        path.display()
+                    ))
+                })?;
             }
         }
         Ok(())
@@ -149,8 +158,8 @@ mod tests {
     use async_trait::async_trait;
     use cda_interfaces::{
         runtime_update_api::{
-            RuntimeFilesUpdateSecurityHandler, RuntimeUpdateError, UpdateCollections,
-            UpdateFileType,
+            ConfigValidationError, ConfigValidator, RuntimeUpdateError,
+            RuntimeUpdateSecurityPlugin, UpdateCollections, UpdateFileType,
         },
         storage_api::{CollectionName, Storage as _},
     };
@@ -182,6 +191,17 @@ mod tests {
         }
     }
 
+    /// A simple test config validator that checks if content is valid TOML
+    struct TestConfigValidator;
+
+    impl ConfigValidator for TestConfigValidator {
+        fn validate(&self, content: &str) -> Result<(), ConfigValidationError> {
+            toml::from_str::<toml::Table>(content)
+                .map(|_| ())
+                .map_err(|e| ConfigValidationError(e.to_string()))
+        }
+    }
+
     fn make_lock_provider(
         owner: Option<&str>,
         has_ecu_conflicts: bool,
@@ -195,11 +215,11 @@ mod tests {
     }
 
     async fn check_file_integrity(
-        handler: &UpdateSecurityHandler<MockLockProvider>,
-        type_: UpdateFileType,
+        handler: &DefaultUpdateSecurityHandler<MockLockProvider>,
+        type_: UpdateFileType<'_>,
         path: &std::path::Path,
     ) -> Result<(), VerificationError> {
-        <UpdateSecurityHandler<_> as RuntimeFilesUpdateSecurityHandler<
+        <DefaultUpdateSecurityHandler<_> as RuntimeUpdateSecurityPlugin<
             MockLockProvider,
             LocalCollection,
         >>::check_file_integrity(handler, type_, path)
@@ -258,9 +278,12 @@ mod tests {
         owner: Option<&str>,
         has_ecu_conflicts: bool,
         has_fg_conflicts: bool,
-    ) -> (UpdateSecurityHandler<MockLockProvider>, MockLockProvider) {
+    ) -> (
+        DefaultUpdateSecurityHandler<MockLockProvider>,
+        MockLockProvider,
+    ) {
         let lock_provider = make_lock_provider(owner, has_ecu_conflicts, has_fg_conflicts);
-        let handler = UpdateSecurityHandler::new(
+        let handler = DefaultUpdateSecurityHandler::new(
             Arc::new(MockLockProvider {
                 owner: owner.map(ToOwned::to_owned),
                 has_ecu_conflicts,
@@ -340,7 +363,9 @@ mod tests {
     async fn check_file_integrity_config_fails_on_nonexistent_file() {
         let (handler, _) = make_handler(Some("user-a"), false, false);
         let path = PathBuf::from("/nonexistent/config.toml");
-        let result = check_file_integrity(&handler, UpdateFileType::Config, &path).await;
+        let validator = TestConfigValidator;
+        let result =
+            check_file_integrity(&handler, UpdateFileType::Config(&validator), &path).await;
         assert!(result.is_err());
     }
 
@@ -350,19 +375,35 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("bad.toml");
         std::fs::write(&path, "this is not valid toml {{{").unwrap();
-        let result = check_file_integrity(&handler, UpdateFileType::Config, &path).await;
+        let validator = TestConfigValidator;
+        let result =
+            check_file_integrity(&handler, UpdateFileType::Config(&validator), &path).await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn check_file_integrity_config_succeeds_on_valid_toml() {
         let (handler, _) = make_handler(Some("user-a"), false, false);
-        let config = crate::config::configfile::Configuration::default();
-        let toml_str = toml::to_string(&config).unwrap();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("valid.toml");
-        std::fs::write(&path, &toml_str).unwrap();
-        let result = check_file_integrity(&handler, UpdateFileType::Config, &path).await;
+        std::fs::write(&path, "[section]\nkey = \"value\"\n").unwrap();
+        let validator = TestConfigValidator;
+        let result =
+            check_file_integrity(&handler, UpdateFileType::Config(&validator), &path).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn check_file_integrity_config_succeeds_without_validation() {
+        // With NoOpConfigValidator, only file readability is checked (TOML validation is skipped)
+        let (handler, _) = make_handler(Some("user-a"), false, false);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("any.toml");
+        std::fs::write(&path, "any content even invalid {{{").unwrap();
+        let validator = ();
+        let result =
+            check_file_integrity(&handler, UpdateFileType::Config(&validator), &path).await;
+        // Should succeed because NoOpConfigValidator always returns Ok
         assert!(result.is_ok());
     }
 

--- a/cda-plugin-runtime-update/src/security.rs
+++ b/cda-plugin-runtime-update/src/security.rs
@@ -18,7 +18,7 @@ use cda_database::mmap_and_decode_mdd;
 use cda_interfaces::{
     runtime_update_api::{
         ActivityGuard, LockStateProvider, RuntimeUpdateError, RuntimeUpdateSecurityPlugin,
-        UpdateCollections, UpdateFileType, VerificationError,
+        UpdateCollections, VerificationError,
     },
     storage_api::{Collection, DirectFileAccess},
 };
@@ -26,7 +26,7 @@ use cda_interfaces::{
 /// Default implementation of the runtime update security handler.
 ///
 /// Validates vehicle lock ownership, detects lock conflicts, and verifies
-/// file integrity for both MDD databases and configuration files.
+/// MDD file integrity.
 pub struct DefaultUpdateSecurityHandler<L: LockStateProvider> {
     guard: Vec<Box<dyn ActivityGuard>>,
     _lock_provider: std::marker::PhantomData<L>,
@@ -91,34 +91,13 @@ impl<L: LockStateProvider, C: Collection + DirectFileAccess + Send + Sync + 'sta
         Ok(())
     }
 
-    async fn check_file_integrity(
-        &self,
-        type_: UpdateFileType<'_>,
-        path: &std::path::Path,
-    ) -> Result<(), VerificationError> {
-        match type_ {
-            UpdateFileType::Mdd => {
-                let path_str = path.to_str().ok_or_else(|| {
-                    VerificationError(format!("Invalid UTF-8 path: {}", path.display()))
-                })?;
-                mmap_and_decode_mdd(path_str).map_err(|e| {
-                    VerificationError(format!("Failed to parse MDD '{}': {e}", path.display()))
-                })?;
-            }
-            UpdateFileType::Config(config_validator) => {
-                let content = tokio::fs::read_to_string(path).await.map_err(|e| {
-                    VerificationError(format!("Failed to read config '{}': {e}", path.display()))
-                })?;
-
-                // Validate config content using the embedded validator
-                config_validator.validate(&content).map_err(|e| {
-                    VerificationError(format!(
-                        "Failed to validate config '{}': {e}",
-                        path.display()
-                    ))
-                })?;
-            }
-        }
+    async fn check_file_integrity(&self, path: &std::path::Path) -> Result<(), VerificationError> {
+        let path_str = path
+            .to_str()
+            .ok_or_else(|| VerificationError(format!("Invalid UTF-8 path: {}", path.display())))?;
+        mmap_and_decode_mdd(path_str).map_err(|e| {
+            VerificationError(format!("Failed to parse MDD '{}': {e}", path.display()))
+        })?;
         Ok(())
     }
 }
@@ -157,10 +136,7 @@ mod tests {
 
     use async_trait::async_trait;
     use cda_interfaces::{
-        runtime_update_api::{
-            ConfigValidationError, ConfigValidator, RuntimeUpdateError,
-            RuntimeUpdateSecurityPlugin, UpdateCollections, UpdateFileType,
-        },
+        runtime_update_api::{RuntimeUpdateError, RuntimeUpdateSecurityPlugin, UpdateCollections},
         storage_api::{CollectionName, Storage as _},
     };
     use cda_storage::{LocalCollection, LocalStorage};
@@ -191,17 +167,6 @@ mod tests {
         }
     }
 
-    /// A simple test config validator that checks if content is valid TOML
-    struct TestConfigValidator;
-
-    impl ConfigValidator for TestConfigValidator {
-        fn validate(&self, content: &str) -> Result<(), ConfigValidationError> {
-            toml::from_str::<toml::Table>(content)
-                .map(|_| ())
-                .map_err(|e| ConfigValidationError(e.to_string()))
-        }
-    }
-
     fn make_lock_provider(
         owner: Option<&str>,
         has_ecu_conflicts: bool,
@@ -216,13 +181,12 @@ mod tests {
 
     async fn check_file_integrity(
         handler: &DefaultUpdateSecurityHandler<MockLockProvider>,
-        type_: UpdateFileType<'_>,
         path: &std::path::Path,
     ) -> Result<(), VerificationError> {
         <DefaultUpdateSecurityHandler<_> as RuntimeUpdateSecurityPlugin<
             MockLockProvider,
             LocalCollection,
-        >>::check_file_integrity(handler, type_, path)
+        >>::check_file_integrity(handler, path)
         .await
     }
 
@@ -259,16 +223,8 @@ mod tests {
                 .get_collection(&CollectionName::DiagnosticDatabaseNextUpdate)
                 .await
                 .ok(),
-            pending_config: storage
-                .get_collection(&CollectionName::ConfigurationNextUpdate)
-                .await
-                .ok(),
             current_mdd: storage
                 .get_collection(&CollectionName::DiagnosticDatabase)
-                .await
-                .ok(),
-            current_config: storage
-                .get_collection(&CollectionName::Configuration)
                 .await
                 .ok(),
         }
@@ -360,58 +316,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn check_file_integrity_config_fails_on_nonexistent_file() {
-        let (handler, _) = make_handler(Some("user-a"), false, false);
-        let path = PathBuf::from("/nonexistent/config.toml");
-        let validator = TestConfigValidator;
-        let result =
-            check_file_integrity(&handler, UpdateFileType::Config(&validator), &path).await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn check_file_integrity_config_fails_on_invalid_toml() {
-        let (handler, _) = make_handler(Some("user-a"), false, false);
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("bad.toml");
-        std::fs::write(&path, "this is not valid toml {{{").unwrap();
-        let validator = TestConfigValidator;
-        let result =
-            check_file_integrity(&handler, UpdateFileType::Config(&validator), &path).await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn check_file_integrity_config_succeeds_on_valid_toml() {
-        let (handler, _) = make_handler(Some("user-a"), false, false);
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("valid.toml");
-        std::fs::write(&path, "[section]\nkey = \"value\"\n").unwrap();
-        let validator = TestConfigValidator;
-        let result =
-            check_file_integrity(&handler, UpdateFileType::Config(&validator), &path).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn check_file_integrity_config_succeeds_without_validation() {
-        // With NoOpConfigValidator, only file readability is checked (TOML validation is skipped)
-        let (handler, _) = make_handler(Some("user-a"), false, false);
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("any.toml");
-        std::fs::write(&path, "any content even invalid {{{").unwrap();
-        let validator = ();
-        let result =
-            check_file_integrity(&handler, UpdateFileType::Config(&validator), &path).await;
-        // Should succeed because NoOpConfigValidator always returns Ok
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
     async fn check_file_integrity_mdd_fails_on_nonexistent_file() {
         let (handler, _) = make_handler(Some("user-a"), false, false);
         let path = PathBuf::from("/nonexistent/test.mdd");
-        let result = check_file_integrity(&handler, UpdateFileType::Mdd, &path).await;
+        let result = check_file_integrity(&handler, &path).await;
         assert!(result.is_err());
     }
 
@@ -421,7 +329,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("bad.mdd");
         std::fs::write(&path, b"not a valid mdd file").unwrap();
-        let result = check_file_integrity(&handler, UpdateFileType::Mdd, &path).await;
+        let result = check_file_integrity(&handler, &path).await;
         assert!(result.is_err());
     }
 

--- a/cda-plugin-runtime-update/src/storage.rs
+++ b/cda-plugin-runtime-update/src/storage.rs
@@ -24,9 +24,9 @@ use std::{fmt::Write, sync::Arc};
 
 use cda_interfaces::{
     runtime_update_api::{
-        BulkDataCreated, BulkDataCreatedList, BulkDataDescriptor, BulkDataList, HashAlgorithm,
-        LockStateProvider, RuntimeFilesQuery, RuntimeFilesUpdateSecurityHandler,
-        RuntimeUpdateError, UpdateFileType, UploadFile,
+        BulkDataCreated, BulkDataCreatedList, BulkDataDescriptor, BulkDataList, ConfigValidator,
+        HashAlgorithm, LockStateProvider, RuntimeFilesQuery, RuntimeUpdateError,
+        RuntimeUpdateSecurityPlugin, UpdateFileType, UploadFile,
     },
     storage_api::{
         Collection, CollectionName, DirectFileAccess, RandomAccessData, Storage, StorageError,
@@ -405,12 +405,13 @@ async fn get_nextupdate_or_current_items(
 /// deleted (best-effort) and the error is returned; previously accepted files are kept.
 pub(crate) async fn upload_files<
     S: Storage + 'static,
-    T: RuntimeFilesUpdateSecurityHandler<L, S::CollectionHandle>,
+    T: RuntimeUpdateSecurityPlugin<L, S::CollectionHandle>,
     L: LockStateProvider,
 >(
     storage: &S,
     security_handler: &T,
     files: Vec<UploadFile>,
+    config_validator: &dyn ConfigValidator,
 ) -> Result<BulkDataCreatedList, RuntimeUpdateError> {
     let mut result = BulkDataCreatedList::default();
     let mut config_seen = false;
@@ -503,7 +504,7 @@ pub(crate) async fn upload_files<
                     security_handler,
                     &cfg_collection,
                     &key,
-                    UpdateFileType::Config,
+                    UpdateFileType::Config(config_validator),
                 )
                 .await?;
 
@@ -518,14 +519,14 @@ pub(crate) async fn upload_files<
 
 async fn check_file_integrity_and_roll_back_on_error<
     S: Storage + 'static,
-    T: RuntimeFilesUpdateSecurityHandler<L, S::CollectionHandle>,
+    T: RuntimeUpdateSecurityPlugin<L, S::CollectionHandle>,
     L: LockStateProvider,
 >(
     storage: &S,
     security_handler: &T,
     collection: &Arc<impl Collection + DirectFileAccess>,
     key: &String,
-    file_type: UpdateFileType,
+    file_type: UpdateFileType<'_>,
 ) -> Result<(), RuntimeUpdateError> {
     if let Err(verification_error) = security_handler
         .check_file_integrity(file_type, &collection.file_path(key)?)
@@ -612,16 +613,23 @@ mod tests {
         storage: &S,
         files: Vec<UploadFile>,
     ) -> Result<BulkDataCreatedList, RuntimeUpdateError> {
+        let noop: () = ();
         upload_files::<S, MockSecurityHandler, MockLockProvider>(
             storage,
             &MockSecurityHandler::new(),
             files,
+            &noop,
         )
         .await
     }
 
+    enum RejectKind {
+        Mdd,
+        Config,
+    }
+
     struct RejectingSecurityHandler {
-        reject_type: cda_interfaces::runtime_update_api::UpdateFileType,
+        reject_type: RejectKind,
     }
 
     #[async_trait::async_trait]
@@ -632,7 +640,7 @@ mod tests {
             + Send
             + Sync
             + 'static,
-    > cda_interfaces::runtime_update_api::RuntimeFilesUpdateSecurityHandler<L, C>
+    > cda_interfaces::runtime_update_api::RuntimeUpdateSecurityPlugin<L, C>
         for RejectingSecurityHandler
     {
         async fn check_apply_allowed(
@@ -645,19 +653,20 @@ mod tests {
 
         async fn check_file_integrity(
             &self,
-            type_: cda_interfaces::runtime_update_api::UpdateFileType,
+            type_: cda_interfaces::runtime_update_api::UpdateFileType<'_>,
             _path: &std::path::Path,
         ) -> Result<(), cda_interfaces::runtime_update_api::VerificationError> {
-            if matches!(
+            let rejected = matches!(
                 (&type_, &self.reject_type),
                 (
                     cda_interfaces::runtime_update_api::UpdateFileType::Mdd,
-                    cda_interfaces::runtime_update_api::UpdateFileType::Mdd,
+                    RejectKind::Mdd,
                 ) | (
-                    cda_interfaces::runtime_update_api::UpdateFileType::Config,
-                    cda_interfaces::runtime_update_api::UpdateFileType::Config,
+                    cda_interfaces::runtime_update_api::UpdateFileType::Config(_),
+                    RejectKind::Config,
                 )
-            ) {
+            );
+            if rejected {
                 return Err(cda_interfaces::runtime_update_api::VerificationError(
                     "rejected".to_string(),
                 ));
@@ -669,12 +678,16 @@ mod tests {
     async fn upload_rejecting<S: cda_interfaces::storage_api::Storage + 'static>(
         storage: &S,
         files: Vec<cda_interfaces::runtime_update_api::UploadFile>,
-        reject_type: cda_interfaces::runtime_update_api::UpdateFileType,
+        reject_kind: RejectKind,
     ) -> Result<BulkDataCreatedList, RuntimeUpdateError> {
+        let noop: () = ();
         upload_files::<S, RejectingSecurityHandler, MockLockProvider>(
             storage,
-            &RejectingSecurityHandler { reject_type },
+            &RejectingSecurityHandler {
+                reject_type: reject_kind,
+            },
             files,
+            &noop,
         )
         .await
     }
@@ -691,7 +704,7 @@ mod tests {
             + Send
             + Sync
             + 'static,
-    > cda_interfaces::runtime_update_api::RuntimeFilesUpdateSecurityHandler<L, C>
+    > cda_interfaces::runtime_update_api::RuntimeUpdateSecurityPlugin<L, C>
         for RejectingByNameSecurityHandler
     {
         async fn check_apply_allowed(
@@ -704,7 +717,7 @@ mod tests {
 
         async fn check_file_integrity(
             &self,
-            _type_: cda_interfaces::runtime_update_api::UpdateFileType,
+            _type_: cda_interfaces::runtime_update_api::UpdateFileType<'_>,
             path: &std::path::Path,
         ) -> Result<(), cda_interfaces::runtime_update_api::VerificationError> {
             if path.file_name().and_then(|n| n.to_str()) == Some(self.reject_filename) {
@@ -721,10 +734,12 @@ mod tests {
         files: Vec<cda_interfaces::runtime_update_api::UploadFile>,
         reject_filename: &'static str,
     ) -> Result<BulkDataCreatedList, RuntimeUpdateError> {
+        let noop: () = ();
         upload_files::<S, RejectingByNameSecurityHandler, MockLockProvider>(
             storage,
             &RejectingByNameSecurityHandler { reject_filename },
             files,
+            &noop,
         )
         .await
     }
@@ -1705,13 +1720,9 @@ mod tests {
         let mdd = make_valid_mdd("TestECU");
         let files = make_upload_files(&[("test.mdd", &mdd)]);
 
-        let err = upload_rejecting(
-            &storage,
-            files,
-            cda_interfaces::runtime_update_api::UpdateFileType::Mdd,
-        )
-        .await
-        .unwrap_err();
+        let err = upload_rejecting(&storage, files, RejectKind::Mdd)
+            .await
+            .unwrap_err();
 
         assert!(
             matches!(err, RuntimeUpdateError::ValidationFailed(_)),
@@ -1726,12 +1737,7 @@ mod tests {
         let mdd = make_valid_mdd("TestECU");
         let files = make_upload_files(&[("test.mdd", &mdd)]);
 
-        let _ = upload_rejecting(
-            &storage,
-            files,
-            cda_interfaces::runtime_update_api::UpdateFileType::Mdd,
-        )
-        .await;
+        let _ = upload_rejecting(&storage, files, RejectKind::Mdd).await;
 
         let col = storage
             .get_or_create_collection(&CollectionName::DiagnosticDatabaseNextUpdate)
@@ -1754,7 +1760,7 @@ mod tests {
         let _ = upload_rejecting(
             &storage,
             make_upload_files(&[("ecu2.mdd", &mdd2)]),
-            cda_interfaces::runtime_update_api::UpdateFileType::Mdd,
+            RejectKind::Mdd,
         )
         .await;
 
@@ -1772,12 +1778,7 @@ mod tests {
         let mdd = make_valid_mdd("TestECU");
         let files = make_upload_files(&[("test.mdd", &mdd)]);
 
-        let result = upload_rejecting(
-            &storage,
-            files,
-            cda_interfaces::runtime_update_api::UpdateFileType::Mdd,
-        )
-        .await;
+        let result = upload_rejecting(&storage, files, RejectKind::Mdd).await;
 
         assert!(result.is_err());
     }
@@ -1788,13 +1789,9 @@ mod tests {
         let config = make_valid_config();
         let files = make_upload_files(&[("opensovd-cda.toml", &config)]);
 
-        let upload_err = upload_rejecting(
-            &storage,
-            files,
-            cda_interfaces::runtime_update_api::UpdateFileType::Config,
-        )
-        .await
-        .unwrap_err();
+        let upload_err = upload_rejecting(&storage, files, RejectKind::Config)
+            .await
+            .unwrap_err();
         let col = storage
             .get_or_create_collection(&CollectionName::ConfigurationNextUpdate)
             .await

--- a/cda-plugin-runtime-update/src/storage.rs
+++ b/cda-plugin-runtime-update/src/storage.rs
@@ -24,9 +24,9 @@ use std::{fmt::Write, sync::Arc};
 
 use cda_interfaces::{
     runtime_update_api::{
-        BulkDataCreated, BulkDataCreatedList, BulkDataDescriptor, BulkDataList, ConfigValidator,
-        HashAlgorithm, LockStateProvider, RuntimeFilesQuery, RuntimeUpdateError,
-        RuntimeUpdateSecurityPlugin, UpdateFileType, UploadFile,
+        BulkDataCreated, BulkDataCreatedList, BulkDataDescriptor, BulkDataList, HashAlgorithm,
+        LockStateProvider, RuntimeFilesQuery, RuntimeUpdateError, RuntimeUpdateSecurityPlugin,
+        UploadFile,
     },
     storage_api::{
         Collection, CollectionName, DirectFileAccess, RandomAccessData, Storage, StorageError,
@@ -34,18 +34,6 @@ use cda_interfaces::{
     },
 };
 use sha2::{Digest, Sha256};
-
-pub(crate) fn mime_for_key(key: &str) -> String {
-    match std::path::Path::new(key)
-        .extension()
-        .and_then(|e| e.to_str())
-        .map(str::to_lowercase)
-        .as_deref()
-    {
-        Some("toml") => "application/toml".to_string(),
-        _ => "application/octet-stream".to_string(),
-    }
-}
 
 /// Lazily initializes `destination` from `source` the first time a file targets that collection.
 /// No-op if the destination already existed or was already initialized in this transaction.
@@ -107,7 +95,7 @@ pub(crate) async fn list_collection_files(
     for key in &keys {
         let mut item = BulkDataDescriptor {
             id: key.clone(),
-            mimetype: mime_for_key(key),
+            mimetype: "application/octet-stream".to_owned(),
             name: Some(key.clone()),
             size: None,
             hash: None,
@@ -166,9 +154,7 @@ pub(crate) async fn list_current_files(
     storage: &impl Storage,
     query: &RuntimeFilesQuery,
 ) -> Result<BulkDataList, RuntimeUpdateError> {
-    let mut items =
-        get_collection_items(storage, &CollectionName::DiagnosticDatabase, query).await?;
-    items.extend(get_collection_items(storage, &CollectionName::Configuration, query).await?);
+    let items = get_collection_items(storage, &CollectionName::DiagnosticDatabase, query).await?;
     Ok(BulkDataList {
         items,
         schema: None,
@@ -179,9 +165,8 @@ pub(crate) async fn list_backup_files(
     storage: &impl Storage,
     query: &RuntimeFilesQuery,
 ) -> Result<BulkDataList, RuntimeUpdateError> {
-    let mut items =
+    let items =
         get_collection_items(storage, &CollectionName::DiagnosticDatabaseBackup, query).await?;
-    items.extend(get_collection_items(storage, &CollectionName::ConfigurationBackup, query).await?);
     Ok(BulkDataList {
         items,
         schema: None,
@@ -212,10 +197,6 @@ pub(crate) async fn delete_nextupdate_file(
         Some("mdd") => (
             CollectionName::DiagnosticDatabaseNextUpdate,
             CollectionName::DiagnosticDatabase,
-        ),
-        Some("toml") => (
-            CollectionName::ConfigurationNextUpdate,
-            CollectionName::Configuration,
         ),
         _ => return Err(RuntimeUpdateError::InvalidFileType(file_id.to_string())),
     };
@@ -260,10 +241,7 @@ pub(crate) async fn delete_all_nextupdate(
     storage: &impl Storage,
 ) -> Result<Vec<String>, RuntimeUpdateError> {
     let mut deleted_ids = Vec::new();
-    for collection_name in [
-        CollectionName::DiagnosticDatabaseNextUpdate,
-        CollectionName::ConfigurationNextUpdate,
-    ] {
+    for collection_name in [CollectionName::DiagnosticDatabaseNextUpdate] {
         match storage.get_collection(&collection_name).await {
             Ok(collection) => deleted_ids.extend(collection.list().await?),
             Err(StorageError::CollectionNotFound(_)) => {}
@@ -280,29 +258,18 @@ pub(crate) async fn delete_all_nextupdate(
         Err(e) => return Err(RuntimeUpdateError::from(e)),
     }
 
-    match storage
-        .delete_collection(&mut tx, &CollectionName::ConfigurationNextUpdate)
-        .await
-    {
-        Ok(()) | Err(StorageError::CollectionNotFound(_)) => {}
-        Err(e) => return Err(RuntimeUpdateError::from(e)),
-    }
-
     tx.commit().await?;
     Ok(deleted_ids)
 }
 
-/// Returns `true` if both backup collections (MDD and configuration) are empty or do not exist.
+/// Returns `true` if the MDD backup collection is empty or does not exist.
 ///
 /// Used as a pre-condition check before starting a Rollback execution.
 pub(crate) async fn is_backup_empty(storage: &impl Storage) -> Result<bool, RuntimeUpdateError> {
     let mdd_backup = storage
         .get_or_create_collection(&CollectionName::DiagnosticDatabaseBackup)
         .await?;
-    let cfg_backup = storage
-        .get_or_create_collection(&CollectionName::ConfigurationBackup)
-        .await?;
-    Ok(mdd_backup.is_empty().await? && cfg_backup.is_empty().await?)
+    Ok(mdd_backup.is_empty().await?)
 }
 
 pub(crate) async fn delete_all_backup(
@@ -311,32 +278,21 @@ pub(crate) async fn delete_all_backup(
     let mdd_backup = storage
         .get_or_create_collection(&CollectionName::DiagnosticDatabaseBackup)
         .await?;
-    let cfg_backup = storage
-        .get_or_create_collection(&CollectionName::ConfigurationBackup)
-        .await?;
-
     let mut tx = storage.begin_transaction()?;
-    let mut deleted_ids = mdd_backup.list().await?;
-    deleted_ids.extend(cfg_backup.list().await?);
+    let deleted_ids = mdd_backup.list().await?;
     mdd_backup.delete_all(&mut tx).await?;
-    cfg_backup.delete_all(&mut tx).await?;
     tx.commit().await?;
     Ok(deleted_ids)
 }
 
-/// Computes the "next update" state from the pending `NextUpdate` collections, falling back to
-/// the currently active collection when no update is pending yet.
+/// Computes the MDD "next update" state, falling back to the currently active database when no
+/// update is pending yet.
 ///
-/// For each collection pair (MDD and Configuration), the logic is:
+/// The logic is:
 /// - If the `NextUpdate` collection **exists** (even if empty), its contents represent the target
-///   state for that category - an empty `NextUpdate` means "delete all" for that category.
+///   state - an empty `NextUpdate` means "delete all".
 /// - If the `NextUpdate` collection **does not exist** (`CollectionNotFound`), the contents of the
-///   corresponding current collection (`DiagnosticDatabase` / `Configuration`) are returned
-///   instead - no update is pending yet, so the next update mirrors the currently active
-///   database, per spec.
-///
-/// MDD and Configuration are handled **independently** - one may have a pending update while the
-/// other still mirrors current.
+///   current `DiagnosticDatabase` collection are returned instead.
 ///
 /// This is a **read-only** operation - no writes or transactions are performed.
 ///
@@ -354,16 +310,7 @@ pub async fn compute_nextupdate_state(
         query,
     )
     .await?;
-    let config_items = get_nextupdate_or_current_items(
-        storage,
-        &CollectionName::ConfigurationNextUpdate,
-        &CollectionName::Configuration,
-        query,
-    )
-    .await?;
-
     let mut items = mdd_items;
-    items.extend(config_items);
     items.sort_by(|a, b| a.id.cmp(&b.id));
 
     Ok(BulkDataList {
@@ -375,9 +322,8 @@ pub async fn compute_nextupdate_state(
 /// Returns the items of `next_collection` if it exists, otherwise falls back to the items of
 /// `current_collection`.
 ///
-/// Used to compute the next-update state for a single category (MDD or Configuration): if no
-/// update has been staged yet (`next_collection` doesn't exist), the next update mirrors the
-/// currently active database.
+/// If no update has been staged yet (`next_collection` doesn't exist), the next update mirrors
+/// the currently active database.
 async fn get_nextupdate_or_current_items(
     storage: &impl Storage,
     next_collection: &CollectionName,
@@ -393,12 +339,10 @@ async fn get_nextupdate_or_current_items(
     }
 }
 
-/// Upload files into the appropriate `NextUpdate` collections.
+/// Upload MDD files into `DiagnosticDatabaseNextUpdate`.
 ///
-/// MDD files go to `DiagnosticDatabaseNextUpdate`, TOML files go to `ConfigurationNextUpdate`.
-/// Each collection is lazily initialized from its current counterpart on first write.
-/// Only one TOML config file per request is allowed; uploading a config replaces any existing
-/// content in the config next-update collection.
+/// The collection is lazily initialized from the current database on first write. All other file
+/// types, including TOML configuration files, are rejected.
 ///
 /// Each file is written and committed individually. Immediately after each commit, the file's
 /// integrity is verified via `security_handler`. If verification fails, the failing file is
@@ -411,32 +355,29 @@ pub(crate) async fn upload_files<
     storage: &S,
     security_handler: &T,
     files: Vec<UploadFile>,
-    config_validator: &dyn ConfigValidator,
 ) -> Result<BulkDataCreatedList, RuntimeUpdateError> {
     let mut result = BulkDataCreatedList::default();
-    let mut config_seen = false;
+
+    if let Some(file) = files.iter().find(|file| {
+        std::path::Path::new(&file.filename)
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_none_or(|extension| !extension.eq_ignore_ascii_case("mdd"))
+    }) {
+        return Err(RuntimeUpdateError::InvalidFileType(file.filename.clone()));
+    }
 
     // Check existence BEFORE begin_transaction (disk reads).
     let mdd_already_exists = storage
         .get_collection(&CollectionName::DiagnosticDatabaseNextUpdate)
         .await
         .is_ok();
-    let cfg_already_exists = storage
-        .get_collection(&CollectionName::ConfigurationNextUpdate)
-        .await
-        .is_ok();
-
     // Ensure directories exist on disk (must be before begin_transaction).
     let mdd_collection = storage
         .get_or_create_collection(&CollectionName::DiagnosticDatabaseNextUpdate)
         .await?;
 
-    let cfg_collection = storage
-        .get_or_create_collection(&CollectionName::ConfigurationNextUpdate)
-        .await?;
-
     let mut mdd_initialized = false;
-    let mut cfg_initialized = false;
 
     for file in files {
         let ext = std::path::Path::new(&file.filename)
@@ -468,43 +409,6 @@ pub(crate) async fn upload_files<
                     security_handler,
                     &mdd_collection,
                     &key,
-                    UpdateFileType::Mdd,
-                )
-                .await?;
-
-                result.items.push(BulkDataCreated { id: key });
-            }
-            Some("toml") => {
-                if config_seen {
-                    return Err(RuntimeUpdateError::ValidationFailed(
-                        "Only one config file per request is allowed".to_string(),
-                    ));
-                }
-                config_seen = true;
-
-                let mut tx = storage.begin_transaction()?;
-                init_collection_from_copy_if_missing(
-                    storage,
-                    &mut tx,
-                    cfg_already_exists,
-                    &mut cfg_initialized,
-                    &CollectionName::Configuration,
-                    &CollectionName::ConfigurationNextUpdate,
-                )
-                .await?;
-
-                cfg_collection.delete_all(&mut tx).await?;
-
-                let mut stream: &[u8] = &file.data;
-                cfg_collection.write(&mut tx, &key, &mut stream).await?;
-                tx.commit().await?;
-
-                check_file_integrity_and_roll_back_on_error(
-                    storage,
-                    security_handler,
-                    &cfg_collection,
-                    &key,
-                    UpdateFileType::Config(config_validator),
                 )
                 .await?;
 
@@ -526,10 +430,9 @@ async fn check_file_integrity_and_roll_back_on_error<
     security_handler: &T,
     collection: &Arc<impl Collection + DirectFileAccess>,
     key: &String,
-    file_type: UpdateFileType<'_>,
 ) -> Result<(), RuntimeUpdateError> {
     if let Err(verification_error) = security_handler
-        .check_file_integrity(file_type, &collection.file_path(key)?)
+        .check_file_integrity(&collection.file_path(key)?)
         .await
     {
         tracing::warn!(
@@ -605,27 +508,24 @@ mod tests {
 
     use super::{compute_nextupdate_state, compute_sha256, list_collection_files, upload_files};
     use crate::test_utils::{
-        MockLockProvider, MockSecurityHandler, make_storage, make_upload_files, make_valid_config,
-        make_valid_mdd, make_valid_mdd_with_revision, write_file,
+        MockLockProvider, MockSecurityHandler, make_storage, make_upload_files, make_valid_mdd,
+        make_valid_mdd_with_revision, write_file,
     };
 
     async fn upload<S: cda_interfaces::storage_api::Storage + 'static>(
         storage: &S,
         files: Vec<UploadFile>,
     ) -> Result<BulkDataCreatedList, RuntimeUpdateError> {
-        let noop: () = ();
         upload_files::<S, MockSecurityHandler, MockLockProvider>(
             storage,
             &MockSecurityHandler::new(),
             files,
-            &noop,
         )
         .await
     }
 
     enum RejectKind {
         Mdd,
-        Config,
     }
 
     struct RejectingSecurityHandler {
@@ -653,19 +553,9 @@ mod tests {
 
         async fn check_file_integrity(
             &self,
-            type_: cda_interfaces::runtime_update_api::UpdateFileType<'_>,
             _path: &std::path::Path,
         ) -> Result<(), cda_interfaces::runtime_update_api::VerificationError> {
-            let rejected = matches!(
-                (&type_, &self.reject_type),
-                (
-                    cda_interfaces::runtime_update_api::UpdateFileType::Mdd,
-                    RejectKind::Mdd,
-                ) | (
-                    cda_interfaces::runtime_update_api::UpdateFileType::Config(_),
-                    RejectKind::Config,
-                )
-            );
+            let rejected = matches!(self.reject_type, RejectKind::Mdd);
             if rejected {
                 return Err(cda_interfaces::runtime_update_api::VerificationError(
                     "rejected".to_string(),
@@ -680,14 +570,12 @@ mod tests {
         files: Vec<cda_interfaces::runtime_update_api::UploadFile>,
         reject_kind: RejectKind,
     ) -> Result<BulkDataCreatedList, RuntimeUpdateError> {
-        let noop: () = ();
         upload_files::<S, RejectingSecurityHandler, MockLockProvider>(
             storage,
             &RejectingSecurityHandler {
                 reject_type: reject_kind,
             },
             files,
-            &noop,
         )
         .await
     }
@@ -717,7 +605,6 @@ mod tests {
 
         async fn check_file_integrity(
             &self,
-            _type_: cda_interfaces::runtime_update_api::UpdateFileType<'_>,
             path: &std::path::Path,
         ) -> Result<(), cda_interfaces::runtime_update_api::VerificationError> {
             if path.file_name().and_then(|n| n.to_str()) == Some(self.reject_filename) {
@@ -734,12 +621,10 @@ mod tests {
         files: Vec<cda_interfaces::runtime_update_api::UploadFile>,
         reject_filename: &'static str,
     ) -> Result<BulkDataCreatedList, RuntimeUpdateError> {
-        let noop: () = ();
         upload_files::<S, RejectingByNameSecurityHandler, MockLockProvider>(
             storage,
             &RejectingByNameSecurityHandler { reject_filename },
             files,
-            &noop,
         )
         .await
     }
@@ -1235,51 +1120,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn compute_nextupdate_mirrors_config_when_not_initialized() {
-        let (storage, _dir) = make_storage();
-        let cfg = storage
-            .get_or_create_collection(&CollectionName::Configuration)
-            .await
-            .unwrap();
-        write_test_file_by_name(&storage, &*cfg, "config.toml", b"[cfg]").await;
-
-        let query = RuntimeFilesQuery::default();
-        let result = compute_nextupdate_state(&storage, &query).await.unwrap();
-        let ids: Vec<&str> = result.items.iter().map(|i| i.id.as_str()).collect();
-        assert!(
-            ids.contains(&"config.toml"),
-            "no ConfigurationNextUpdate = no pending changes = mirrors current config"
-        );
-    }
-
-    #[tokio::test]
-    async fn compute_nextupdate_shows_config_nextupdate_when_initialized() {
-        let (storage, _dir) = make_storage();
-        let cfg = storage
-            .get_or_create_collection(&CollectionName::Configuration)
-            .await
-            .unwrap();
-        write_test_file_by_name(&storage, &*cfg, "old.toml", b"[old]").await;
-        let cfg_next = storage
-            .get_or_create_collection(&CollectionName::ConfigurationNextUpdate)
-            .await
-            .unwrap();
-        write_test_file_by_name(&storage, &*cfg_next, "new.toml", b"[new]").await;
-
-        let query = RuntimeFilesQuery::default();
-        let result = compute_nextupdate_state(&storage, &query).await.unwrap();
-        let ids: Vec<&str> = result.items.iter().map(|i| i.id.as_str()).collect();
-        assert!(
-            ids.contains(&"new.toml"),
-            "should show ConfigurationNextUpdate content"
-        );
-        assert!(
-            !ids.contains(&"old.toml"),
-            "should NOT show current config when NextUpdate initialized"
-        );
-    }
-
-    #[tokio::test]
     async fn compute_nextupdate_empty_mdd_nextupdate_shows_empty_mdd() {
         let (storage, _dir) = make_storage();
         let db = storage
@@ -1309,31 +1149,6 @@ mod tests {
             mdd_ids.is_empty(),
             "empty NextUpdate = target state is empty (delete all)"
         );
-    }
-
-    #[tokio::test]
-    async fn compute_nextupdate_mdd_and_config_independent() {
-        let (storage, _dir) = make_storage();
-        let mdd_next = storage
-            .get_or_create_collection(&CollectionName::DiagnosticDatabaseNextUpdate)
-            .await
-            .unwrap();
-        write_test_file_by_name(&storage, &*mdd_next, "ecu1.mdd", b"data").await;
-        let cfg = storage
-            .get_or_create_collection(&CollectionName::Configuration)
-            .await
-            .unwrap();
-        write_test_file_by_name(&storage, &*cfg, "config.toml", b"[cfg]").await;
-
-        let query = RuntimeFilesQuery::default();
-        let result = compute_nextupdate_state(&storage, &query).await.unwrap();
-        let ids: Vec<&str> = result.items.iter().map(|i| i.id.as_str()).collect();
-        assert!(ids.contains(&"ecu1.mdd"), "MDD from NextUpdate");
-        assert!(
-            ids.contains(&"config.toml"),
-            "Config has no NextUpdate = mirrors current config"
-        );
-        assert_eq!(result.items.len(), 2);
     }
 
     #[tokio::test]
@@ -1401,48 +1216,6 @@ mod tests {
             result,
             Err(RuntimeUpdateError::InvalidFileType(_))
         ));
-    }
-
-    #[tokio::test]
-    async fn delete_all_nextupdate_then_compute_mirrors_current() {
-        let (storage, _dir) = make_storage();
-        let db = storage
-            .get_or_create_collection(&CollectionName::DiagnosticDatabase)
-            .await
-            .unwrap();
-        write_test_file_by_name(&storage, &*db, "ecu1.mdd", b"data").await;
-        let cfg = storage
-            .get_or_create_collection(&CollectionName::Configuration)
-            .await
-            .unwrap();
-        write_test_file_by_name(&storage, &*cfg, "app.toml", b"[app]").await;
-
-        // Initialize NextUpdate collections
-        let mdd_next = storage
-            .get_or_create_collection(&CollectionName::DiagnosticDatabaseNextUpdate)
-            .await
-            .unwrap();
-        write_test_file_by_name(&storage, &*mdd_next, "other.mdd", b"other").await;
-        let cfg_next = storage
-            .get_or_create_collection(&CollectionName::ConfigurationNextUpdate)
-            .await
-            .unwrap();
-        write_test_file_by_name(&storage, &*cfg_next, "other.toml", b"[other]").await;
-
-        super::delete_all_nextupdate(&storage).await.unwrap();
-
-        // After delete_all_nextupdate, collections are gone -> no pending changes = mirrors current
-        let query = RuntimeFilesQuery::default();
-        let result = compute_nextupdate_state(&storage, &query).await.unwrap();
-        let ids: Vec<&str> = result.items.iter().map(|i| i.id.as_str()).collect();
-        assert!(
-            ids.contains(&"ecu1.mdd") && ids.contains(&"app.toml"),
-            "no NextUpdate collections = nextupdate mirrors current, got {ids:?}"
-        );
-        assert!(
-            !ids.contains(&"other.mdd") && !ids.contains(&"other.toml"),
-            "stale NextUpdate content must be gone after delete_all_nextupdate, got {ids:?}"
-        );
     }
 
     #[tokio::test]
@@ -1518,57 +1291,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn upload_valid_config_stored_in_configuration_next_update() {
-        let (storage, _dir) = make_storage();
-        let config = make_valid_config();
-        let files = make_upload_files(&[("opensovd-cda.toml", &config)]);
-
-        let result = upload(&storage, files).await.unwrap();
-
-        assert_eq!(result.items.len(), 1);
-        assert_eq!(result.items.first().unwrap().id, "opensovd-cda.toml");
-
-        let col = storage
-            .get_or_create_collection(&CollectionName::ConfigurationNextUpdate)
-            .await
-            .unwrap();
-        let keys = col.list().await.unwrap();
-        assert!(keys.contains(&"opensovd-cda.toml".to_string()));
-    }
-
-    #[tokio::test]
-    async fn upload_second_config_returns_err() {
-        let (storage, _dir) = make_storage();
-        let config = make_valid_config();
-        let files = make_upload_files(&[
-            ("opensovd-cda.toml", &config),
-            ("opensovd-cda.toml", &config),
-        ]);
-
-        let err = upload(&storage, files).await.unwrap_err();
-
-        assert!(matches!(
-            err,
-            RuntimeUpdateError::ValidationFailed(ref msg) if msg.contains("one config")
-        ));
-    }
-
-    #[tokio::test]
-    async fn upload_mdd_and_config_together() {
-        let (storage, _dir) = make_storage();
-        let mdd = make_valid_mdd("ComboECU");
-        let config = make_valid_config();
-        let files = make_upload_files(&[("combo.mdd", &mdd), ("opensovd-cda.toml", &config)]);
-
-        let result = upload(&storage, files).await.unwrap();
-
-        assert_eq!(result.items.len(), 2);
-        let ids: Vec<&str> = result.items.iter().map(|f| f.id.as_str()).collect();
-        assert!(ids.contains(&"combo.mdd"));
-        assert!(ids.contains(&"opensovd-cda.toml"));
-    }
-
-    #[tokio::test]
     async fn field_without_filename_is_skipped() {
         let (storage, _dir) = make_storage();
         let mdd = make_valid_mdd("RealECU");
@@ -1600,27 +1322,6 @@ mod tests {
         let keys = col.list().await.unwrap();
         assert!(keys.contains(&"existing.mdd".to_string()));
         assert!(keys.contains(&"new.mdd".to_string()));
-    }
-
-    #[tokio::test]
-    async fn upload_config_always_replaces_previous_content() {
-        let (storage, _dir) = make_storage();
-        let cfg = storage
-            .get_or_create_collection(&CollectionName::Configuration)
-            .await
-            .unwrap();
-        write_test_file_by_name(&storage, &*cfg, "old.toml", b"[old]\nval = 1").await;
-
-        let config = b"[new]\nval = 2".to_vec();
-        let files = make_upload_files(&[("new.toml", &config)]);
-        upload(&storage, files).await.unwrap();
-
-        let col = storage
-            .get_or_create_collection(&CollectionName::ConfigurationNextUpdate)
-            .await
-            .unwrap();
-        let keys = col.list().await.unwrap();
-        assert_eq!(keys, vec!["new.toml"]);
     }
 
     #[tokio::test]
@@ -1694,27 +1395,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn upload_config_replaces_even_when_nextupdate_exists() {
-        let (storage, _dir) = make_storage();
-        let cfg_next = storage
-            .get_or_create_collection(&CollectionName::ConfigurationNextUpdate)
-            .await
-            .unwrap();
-        write_test_file_by_name(&storage, &*cfg_next, "old.toml", b"[old]").await;
-
-        let config = b"[replaced]\nfoo = true".to_vec();
-        let files = make_upload_files(&[("replaced.toml", &config)]);
-        upload(&storage, files).await.unwrap();
-
-        let col = storage
-            .get_or_create_collection(&CollectionName::ConfigurationNextUpdate)
-            .await
-            .unwrap();
-        let keys = col.list().await.unwrap();
-        assert_eq!(keys, vec!["replaced.toml"]);
-    }
-
-    #[tokio::test]
     async fn upload_integrity_failure_returns_validation_error() {
         let (storage, _dir) = make_storage();
         let mdd = make_valid_mdd("TestECU");
@@ -1781,27 +1461,6 @@ mod tests {
         let result = upload_rejecting(&storage, files, RejectKind::Mdd).await;
 
         assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn upload_config_integrity_failure_removes_written_config() {
-        let (storage, _dir) = make_storage();
-        let config = make_valid_config();
-        let files = make_upload_files(&[("opensovd-cda.toml", &config)]);
-
-        let upload_err = upload_rejecting(&storage, files, RejectKind::Config)
-            .await
-            .unwrap_err();
-        let col = storage
-            .get_or_create_collection(&CollectionName::ConfigurationNextUpdate)
-            .await
-            .unwrap();
-        let keys = col.list().await.unwrap();
-        assert!(
-            keys.is_empty(),
-            "{}",
-            format!("keys={keys:#?}, upload_err={upload_err:?}")
-        );
     }
 
     #[tokio::test]

--- a/cda-sovd/Cargo.toml
+++ b/cda-sovd/Cargo.toml
@@ -28,9 +28,7 @@ workspace = true
 # internal dependencies
 async-trait = { workspace = true }
 cda-interfaces = { workspace = true }
-cda-plugin-runtime-update = { workspace = true }
 cda-plugin-security = { workspace = true }
-cda-tracing = { workspace = true }
 opensovd-axum-extra = { workspace = true, features = [
   "forwarded",
   "x-forwarded-host",
@@ -40,7 +38,7 @@ opensovd-axum-extra = { workspace = true, features = [
 sovd-interfaces = { workspace = true }
 
 # external
-tokio = { workspace = true, features = ["net"] }
+tokio = { workspace = true, features = ["net", "sync"] }
 
 # openapi generation
 aide = { workspace = true, features = [

--- a/cda-sovd/src/sovd/apps/sovd2uds/bulk_data/runtimefiles.rs
+++ b/cda-sovd/src/sovd/apps/sovd2uds/bulk_data/runtimefiles.rs
@@ -118,7 +118,6 @@ impl IntoResponse for DbUpdateErrorResponse {
                 None,
             ),
             RuntimeUpdateError::InvalidMddFile(_)
-            | RuntimeUpdateError::InvalidConfig(_)
             | RuntimeUpdateError::InvalidFileType(_)
             | RuntimeUpdateError::ValidationFailed(_) => build_api_error_response(
                 StatusCode::BAD_REQUEST,

--- a/cda-sovd/src/sovd/update_guard.rs
+++ b/cda-sovd/src/sovd/update_guard.rs
@@ -56,14 +56,6 @@ impl UpdateGuardState {
         }
     }
 
-    /// Returns a shared handle to the in-progress flag.
-    ///
-    /// Callers can set or clear this flag to signal whether an update is currently active.
-    #[must_use]
-    pub fn busy_handle(&self) -> Arc<AtomicBool> {
-        Arc::clone(&self.busy)
-    }
-
     /// Registers a single route that should bypass the update guard.
     pub async fn add_exempt(&self, route: ExemptRoute) {
         self.exempt_routes.write().await.push(route);
@@ -72,6 +64,23 @@ impl UpdateGuardState {
     /// Registers multiple routes that should bypass the update guard.
     pub async fn extend_exempt(&self, routes: impl IntoIterator<Item = ExemptRoute>) {
         self.exempt_routes.write().await.extend(routes);
+    }
+
+    /// Returns `true` when an update is currently in progress.
+    #[must_use]
+    pub fn is_busy(&self) -> bool {
+        self.busy.load(Ordering::Acquire)
+    }
+
+    /// Returns a shared handle to the busy flag.
+    #[must_use]
+    pub fn busy_handle(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.busy)
+    }
+
+    /// Returns a snapshot of the exempt routes list at the time of calling.
+    pub async fn exempt_routes(&self) -> Vec<ExemptRoute> {
+        self.exempt_routes.read().await.clone()
     }
 }
 
@@ -127,10 +136,10 @@ where
         // Heap-allocate the future because async blocks are opaque, unsized types
         // that cannot satisfy the concrete `Pin<Box<dyn Future>>` return type directly.
         Box::pin(async move {
-            if state.busy.load(Ordering::Acquire) {
+            if state.is_busy() {
                 let path = req.uri().path().to_owned();
                 let method = req.method().clone();
-                let exempt_routes = state.exempt_routes.read().await;
+                let exempt_routes = state.exempt_routes().await;
                 let is_exempt = exempt_routes.iter().any(|exempt| {
                     path.starts_with(&exempt.prefix) && exempt.methods.contains(&method)
                 });

--- a/docs/03_architecture/05_plugins/02_diagnostic_database_update.rst
+++ b/docs/03_architecture/05_plugins/02_diagnostic_database_update.rst
@@ -93,43 +93,8 @@ Diagnostic Database Update Plugin
        - ``x-sovd2uds-include-revision`` (boolean, default: false) - to include the revision inside the files
        - ``created-after`` and ``created-before`` (string:date-time) are accepted for ISO 17978-3 compatibility but do not currently filter results.
 
-    **Configuration File Support**
-
-    In addition to MDD database files (``.mdd``), the plugin supports uploading CDA configuration
-    files (``.toml``) through the **same** ``runtimefiles-*`` bulk-data endpoints. The upload handler
-    routes each file to the appropriate internal storage collection based on its extension:
-
-    - ``.mdd`` files go to the ``DiagnosticDatabase*`` collections.
-    - ``.toml`` files go to the ``Configuration*`` collections.
-
-    Only one ``.toml`` configuration file per upload request is supported; uploading more than one
-    in a single ``POST`` to ``runtimefiles-nextupdate`` is rejected.
-
-    All GET endpoints (``runtimefiles-current``, ``runtimefiles-nextupdate``, ``runtimefiles-backup``)
-    return both MDD and configuration file entries in a single combined response.
-
-    The HTTP handler implementation for the bulk-data endpoints resides in
-    ``cda-sovd/src/sovd/apps/sovd2uds/bulk_data/runtimefiles.rs``. The execution endpoints
-    (Apply/Rollback/Cleanup) reside in ``cda-sovd/src/sovd/apps/sovd2uds/operations.rs``.
-
-    **Coupled MDD and Configuration Updates**
-
-    When an MDD file update requires a simultaneous configuration change (e.g., a new MDD file
-    introduces changes that require updated communication parameters in the CDA configuration), both
-    files must be uploaded to ``runtimefiles-nextupdate`` and applied via a **single** ``Apply``
-    execution. A single ``Apply`` execution will atomically apply all pending MDD and configuration
-    changes together in one transaction, provided both ``NextUpdate`` collections are populated.
-
-    .. warning::
-
-        There is **no guaranteed atomic coupling** when MDD and configuration updates are applied
-        in separate executions. Applying them independently means they take effect at different
-        points in time, which may leave the system in a partially updated state during the interval
-        between the two applies.
-
-        Users must account for this by uploading all related files (MDD and configuration) in the
-        same ``runtimefiles-nextupdate`` batch and triggering a single ``Apply``. This is an accepted
-        limitation of the unified endpoint design.
+    The runtime update plugin accepts MDD database files (``.mdd``). CDA configuration files cannot
+    be updated through the runtime-files endpoints.
 
     **Limitations to bulk-data operations**
 

--- a/docs/03_architecture/05_plugins/02_diagnostic_database_update.rst
+++ b/docs/03_architecture/05_plugins/02_diagnostic_database_update.rst
@@ -154,6 +154,37 @@ Diagnostic Database Update Plugin
     The verification includes, but is not limited to, signature verification, hash verification, and version checks
     of the currently active database, as well as the new one.
 
+    **Providing a Custom Update Plugin**
+
+    Applications embedding CDA can replace the complete runtime update implementation at startup.
+    Implement ``cda_interfaces::runtime_update_api::RuntimeFilesUpdatePlugin`` and pass a builder
+    to ``Setup::with_update_plugin``. The builder receives ``CdaRuntime``, which exposes the live
+    configuration, UDS manager, DoIP gateway, lock provider, storage directory, update guard, and
+    reload-related infrastructure required by an implementation.
+
+    The ``update_plugin_fn`` helper adapts an async closure without requiring a separate builder
+    type:
+
+    .. code:: rust
+
+       use opensovd_cda_lib::{Setup, run_with_ext_from_config};
+       use opensovd_cda_lib::update::update_plugin_fn;
+
+       let setup = Setup::<MySecurityPlugin, MySecurityLoader>::new()
+           .with_update_plugin(update_plugin_fn(|runtime| async move {
+               Ok(MyRuntimeUpdatePlugin::new(runtime))
+           }));
+
+       run_with_ext_from_config(config, setup).await?;
+
+    CDA mounts the returned plugin on the standard ``runtimefiles-*`` endpoints and wraps it
+    with read/write mutual exclusion. A replacement plugin therefore implements the complete
+    update lifecycle (listing, upload, deletion, apply, rollback, cleanup, and execution status).
+
+    Implementations that only need custom authorization, signature checks, version policy, or
+    reload behavior should normally retain ``DefaultRuntimeUpdatePlugin`` and provide custom
+    ``RuntimeUpdateSecurityPlugin`` and/or ``RuntimeReloaderPlugin`` implementations instead.
+
 
     **Application of the update**
 

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -27,7 +27,6 @@ use cda_interfaces::{
 };
 use cda_plugin_security::{DefaultSecurityPlugin, DefaultSecurityPluginData};
 use cda_tracing::LoggingConfig;
-use futures::FutureExt as _;
 use http::{Method, StatusCode};
 use opensovd_cda_lib::{
     cda_version,
@@ -453,10 +452,9 @@ pub(crate) fn start_cda(config: Configuration) {
         let (shutdown_tx, mut shutdown_rx) = tokio::sync::broadcast::channel(1);
         *CDA_SHUTDOWN.lock().await = Some(shutdown_tx);
 
-        let clonable_shutdown_signal = async move {
+        let clonable_shutdown_signal = cda_interfaces::shutdown_signal(async move {
             shutdown_rx.recv().await.ok();
-        }
-        .shared();
+        });
 
         // Launch the webserver with deferred initialization
         let (dynamic_router, webserver_join_handle) =
@@ -490,7 +488,7 @@ pub(crate) fn start_cda(config: Configuration) {
         };
         let health = Some(health);
 
-        let vehicle_data = opensovd_cda_lib::load_vehicle_data::<_, DefaultSecurityPluginData>(
+        let vehicle_data = opensovd_cda_lib::load_vehicle_data::<DefaultSecurityPluginData>(
             &config,
             clonable_shutdown_signal.clone(),
             health.as_ref(),

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -762,10 +762,6 @@
 
 # Configuration for update plugin, i.e. storage paths
 [runtime_update_config]
-# When `true` and the `Configuration` storage collection is empty,
-# seed it from the configuration file loaded from disk on first startup.
-# Default: `false`.
-# init_storage_from_config_file = false
 # When `true` and the `DiagnosticDatabase` storage collection is empty,
 # seed it from `database.path` on first startup by copying all `.mdd` files.
 # Default: `false`.
@@ -774,7 +770,7 @@
 # temporarily unavailable due to a busy transaction.
 # Default: 1 second.
 # retry_after_seconds = 1
-# Directory where the updatable configuration and database are stored.
+# Directory where the updatable database is stored.
 # storage_dir = "."
 # Maximum upload body size in bytes for multipart file uploads.
 # Default: 50MB. Axum's built-in limit is 2MB which is too low for MDD files.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Prior to this commit the update plugin was not plugable
without rewriting the app init logic,
as setup_vehicle_and_routes hard coded the default plugin.

The init now gains a builder pattern where new plugins
be added easily later.


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Commits will be squashed when merging, they are kept verbose right now on purpose to make the history clear, as this was partially reviewed already.


Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)