### PR TITLE
docs: Add ADR for which error handling library we use.

### DIFF
--- a/docs/04_adr/05_error_handling_library.rst
+++ b/docs/04_adr/05_error_handling_library.rst
@@ -1,0 +1,52 @@
+.. SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+..
+.. See the NOTICE file(s) distributed with this work for additional
+.. information regarding copyright ownership.
+..
+.. This program and the accompanying materials are made available under the
+.. terms of the Apache License Version 2.0 which is available at
+.. https://www.apache.org/licenses/LICENSE-2.0
+..
+.. SPDX-License-Identifier: Apache-2.0
+
+ADR-005: Use thiserror as error handling library
+================================================
+
+Status
+------
+
+**Accepted**
+
+Date: 2026-07-28
+
+Context
+-------
+
+The Classic Diagnostic Adapter needs to provide detailed error information, both via its HTTP endpoints and when used as a library by OEMs to implement their concrete distribution.
+
+The different error cases need to be programmatically matchable, so that consumers can decide whether to retry operations or abort them altogether.
+
+
+Decision
+--------
+
+We will use **thiserror** as the error handling library for the Classic Diagnostic Adapter.
+
+We will explicitly not use **anyhow**, even though it is commonly paired with **thiserror** for use in application code,
+because virtually all production code in Classic Diagnostic Adapter can used as a library, when OEMs implement their distribution.
+
+
+Rationale
+---------
+
+Other error handling libraries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Other error handling libraries such as **snafu** or **eyre** were not evaluated in this decision.
+
+
+References
+----------
+
+- `thiserror <https://crates.io/crates/thiserror>`_
+- `anyhow <https://crates.io/crates/anyhow>`_

--- a/docs/04_adr/index.rst
+++ b/docs/04_adr/index.rst
@@ -14,7 +14,7 @@ Architecture Decision Records
 *****************************
 
 .. include:: 01_mimalloc.rst
-
 .. include:: 02_mbedtls_tls_backend.rst
 .. include:: 03_mmap_strategy.rst
 .. include:: 04_wal_format.rst
+.. include:: 05_error_handling_library.rst


### PR DESCRIPTION
This mainly just documents why we don't use `anyhow`. It's not a new decision.

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [x] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

---

Frank Märkle [frank.maerkle@mercedes-benz.com](mailto:frank.maerkle@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)