### PR TITLE
fix(cda-core): match generic service by full request prefix, not SID alone

### DIFF
--- a/cda-core/src/diag_kernel/diag_comm_lookup.rs
+++ b/cda-core/src/diag_kernel/diag_comm_lookup.rs
@@ -85,43 +85,7 @@ impl<S: SecurityPlugin> DiagCommLookup for EcuManager<S> {
         let services: Vec<_> = self
             .lookup_services_by_sid(service_id)?
             .iter()
-            .filter(|service| {
-                let mut byte_idx = 0usize;
-                for param in service.extract_sequential_coded_consts() {
-                    let param_byte_count = param.byte_count();
-                    if param_byte_count > 4 {
-                        return false;
-                    }
-                    let Some(end_idx) = byte_idx.checked_add(param_byte_count) else {
-                        return false;
-                    };
-                    // Ran out of caller-provided bytes, all provided bytes matched, accept
-                    if end_idx > request_bytes.len() {
-                        return true;
-                    }
-                    let Some(param_slice) = request_bytes.get(byte_idx..end_idx) else {
-                        return false;
-                    };
-
-                    let mut buf = [0u8; 4];
-                    // calculate where in the 4-byte buffer to place the parameter bytes.
-                    // i.e. a 2 byte param goes into buf[2..4],
-                    // leaving buf[0..2] as zero-padding,
-                    // copy this into the buffer and convert into u32 big endian.
-                    let start = 4usize.saturating_sub(param_byte_count);
-                    let Some(buf_slice) = buf.get_mut(start..) else {
-                        return false;
-                    };
-                    buf_slice.copy_from_slice(param_slice);
-
-                    let expected_value = u32::from_be_bytes(buf);
-                    if param.value != expected_value {
-                        return false;
-                    }
-                    byte_idx = end_idx;
-                }
-                true // all consts iterated and all matched
-            })
+            .filter(|service| service.matches_request_prefix(request_bytes))
             .filter_map(|service| service.diag_comm())
             .filter_map(|dc| {
                 let short_name = dc.short_name()?;

--- a/cda-core/src/diag_kernel/payload_encode.rs
+++ b/cda-core/src/diag_kernel/payload_encode.rs
@@ -37,22 +37,26 @@ impl<S: SecurityPlugin> PayloadEncoder for EcuManager<S> {
             DiagServiceError::BadPayload("Expected at least 1 byte to read SID".to_owned())
         })?;
 
-        // iterate through the services and for each service, resolve the parameters
-        // sort the parameters by byte_pos & bit_pos, and take the first parameter
-        // this is the service id. check if the provided rawdata matches the expected
-        // bytes for the service id, and if yes, return this service.
-        // If no service with a matching SIDRQ can be found, DiagServiceError::NotFound
-        // is returned to the caller.
-        let matched_services = self.get_services_from_variant_and_parent_refs(|service| {
-            service
-                .request_id()
-                .is_some_and(|service_id| raw_data_sid == service_id)
-        });
-        let mapped_service = matched_services.first().ok_or_else(|| {
-            DiagServiceError::NotFound(format!(
-                "No matching generic service found for SID {raw_data_sid:#04X}"
-            ))
-        })?;
+        // First narrow down to all services matching the SID (first byte), then
+        // further narrow down by comparing the full sequence of coded-constant
+        // bytes (SID, sub-function, DID, ...) against the provided raw payload.
+        // This is required because multiple services commonly share the same
+        // SID (e.g. every WriteDataByIdentifier DID is typically its own
+        // service entry, all sharing SID 0x2E), so matching on the SID alone is
+        // not sufficient to identify the correct service - doing so would pick
+        // an arbitrary service with that SID, causing the wrong service to be
+        // used for the access check (and thus reported in any resulting error).
+        // If no service with a matching prefix can be found,
+        // DiagServiceError::NotFound is returned to the caller.
+        let sid_matched_services = self.lookup_services_by_sid(raw_data_sid)?;
+        let mapped_service = sid_matched_services
+            .iter()
+            .find(|service| service.matches_request_prefix(&rawdata))
+            .ok_or_else(|| {
+                DiagServiceError::NotFound(format!(
+                    "No matching generic service found for request prefix: {rawdata:02X?}"
+                ))
+            })?;
         let mapped_dc = mapped_service.diag_comm().map(datatypes::DiagComm).ok_or(
             DiagServiceError::InvalidDatabase("Service is missing DiagComm".to_owned()),
         )?;
@@ -1030,7 +1034,7 @@ fn process_coded_constants(
 #[cfg(test)]
 mod tests {
     use cda_interfaces::{
-        PayloadDecoder, PayloadEncoder, diagservices::UdsPayloadData, service_ids,
+        PayloadDecoder, PayloadEncoder, diagservices::UdsPayloadData, service_ids, util::std_ext,
     };
     use cda_plugin_security::DefaultSecurityPluginData;
     use serde_json::json;
@@ -1038,7 +1042,9 @@ mod tests {
     use super::*;
     use crate::diag_kernel::test_utils::ecu_manager_builder::{
         create_ecu_manager_with_end_pdu_request_service,
-        create_ecu_manager_with_length_key_request_service, create_ecu_manager_with_mux_service,
+        create_ecu_manager_with_length_key_request_service,
+        create_ecu_manager_with_multiple_routine_control_services,
+        create_ecu_manager_with_multiple_write_did_services, create_ecu_manager_with_mux_service,
         create_ecu_manager_with_mux_service_and_default_case,
         create_ecu_manager_with_param_length_info_service,
         create_ecu_manager_with_phys_const_normal_dop_service,
@@ -1989,6 +1995,156 @@ mod tests {
         assert!(
             result.is_err(),
             "Expected an error when providing more items than max_number_of_items allows"
+        );
+    }
+
+    /// Regression test for `check_genericservice` incorrectly matching services
+    /// by SID alone. When multiple services share the same SID (e.g. several
+    /// `WriteDataByIdentifier` services, each for a different DID, all sharing
+    /// SID `0x2E`), the raw payload bytes *following* the SID (the DID) must
+    /// also be compared, otherwise an arbitrary same-SID service can be
+    /// selected - resulting in the wrong service being used for the
+    /// precondition/access check (and thus the wrong service name being
+    /// reported in any resulting error).
+    #[tokio::test]
+    async fn test_check_genericservice_matches_correct_did_not_first_same_sid_service() {
+        let (
+            ecu_manager,
+            unrestricted_did,
+            unrestricted_name,
+            programming_only_did,
+            programming_only_name,
+        ) = create_ecu_manager_with_multiple_write_did_services();
+
+        // Default state: LockedSecurity / DefaultSession - does NOT satisfy the
+        // ProgrammingSecurity precondition of the second service.
+        {
+            let mut guard = std_ext::lock_write(&ecu_manager.runtime_state.service_states);
+            guard.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_string());
+            guard.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_string());
+        }
+
+        let sid = service_ids::WRITE_DATA_BY_IDENTIFIER;
+        let did_hi = |did: u16| (did >> 8) as u8;
+        let did_lo = |did: u16| (did & 0xFF) as u8;
+
+        // Raw payload for the unrestricted DID must succeed, regardless of
+        // which same-SID service happens to be evaluated first.
+        let unrestricted_payload = vec![sid, did_hi(unrestricted_did), did_lo(unrestricted_did)];
+        let unrestricted_result = ecu_manager
+            .check_genericservice(&skip_sec_plugin!(), unrestricted_payload)
+            .await;
+        assert!(
+            unrestricted_result.is_ok(),
+            "Expected genericservice call for unrestricted DID {unrestricted_did:#06X} \
+             ({unrestricted_name}) to succeed, got: {:?}",
+            unrestricted_result.err()
+        );
+
+        // Raw payload for the DID that requires ProgrammingSecurity must be
+        // rejected, and the error must reference the *actually matched*
+        // service, not an arbitrary same-SID service.
+        let programming_only_payload = vec![
+            sid,
+            did_hi(programming_only_did),
+            did_lo(programming_only_did),
+        ];
+        let programming_only_result = ecu_manager
+            .check_genericservice(&skip_sec_plugin!(), programming_only_payload)
+            .await;
+        let err = programming_only_result.expect_err(&format!(
+            "Expected genericservice call for restricted DID {programming_only_did:#06X} \
+             ({programming_only_name}) to fail due to unmet ProgrammingSecurity precondition"
+        ));
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains(&programming_only_name),
+            "Expected error message to reference the actually matched service \
+             '{programming_only_name}', got: {err_msg}"
+        );
+        assert!(
+            !err_msg.contains(&unrestricted_name),
+            "Error message should not reference the unrelated service '{unrestricted_name}', got: \
+             {err_msg}"
+        );
+    }
+
+    /// Regression test for `check_genericservice` incorrectly matching services
+    /// by SID alone, for a service (`RoutineControl`, SID `0x31`) whose
+    /// disambiguating bytes span a sub-function byte *and* a routine
+    /// identifier, rather than a single DID immediately following the SID.
+    /// Matching by SID alone would arbitrarily pick a same-SID service,
+    /// resulting in the wrong service being used for the precondition/access
+    /// check (and thus the wrong service name being reported in any resulting
+    /// error).
+    #[tokio::test]
+    async fn test_check_genericservice_matches_correct_routine_not_first_same_sid_service() {
+        let (
+            ecu_manager,
+            unrestricted_routine_id,
+            unrestricted_name,
+            programming_only_routine_id,
+            programming_only_name,
+        ) = create_ecu_manager_with_multiple_routine_control_services();
+
+        // Default state: LockedSecurity / DefaultSession - does NOT satisfy the
+        // ProgrammingSecurity precondition of the second service.
+        {
+            let mut guard = std_ext::lock_write(&ecu_manager.runtime_state.service_states);
+            guard.insert(service_ids::SESSION_CONTROL, "DefaultSession".to_string());
+            guard.insert(service_ids::SECURITY_ACCESS, "LockedSecurity".to_string());
+        }
+
+        let sid = service_ids::ROUTINE_CONTROL;
+        let subfunction = cda_interfaces::subfunction_ids::routine::REQUEST_RESULTS;
+        let id_hi = |id: u16| (id >> 8) as u8;
+        let id_lo = |id: u16| (id & 0xFF) as u8;
+
+        // Raw payload for the unrestricted routine ID must succeed, regardless
+        // of which same-SID service happens to be evaluated first.
+        let unrestricted_payload = vec![
+            sid,
+            subfunction,
+            id_hi(unrestricted_routine_id),
+            id_lo(unrestricted_routine_id),
+        ];
+        let unrestricted_result = ecu_manager
+            .check_genericservice(&skip_sec_plugin!(), unrestricted_payload)
+            .await;
+        assert!(
+            unrestricted_result.is_ok(),
+            "Expected genericservice call for unrestricted routine ID \
+             {unrestricted_routine_id:#06X} ({unrestricted_name}) to succeed, got: {:?}",
+            unrestricted_result.err()
+        );
+
+        // Raw payload for the routine ID that requires ProgrammingSecurity must
+        // be rejected, and the error must reference the *actually matched*
+        // service, not an arbitrary same-SID service.
+        let programming_only_payload = vec![
+            sid,
+            subfunction,
+            id_hi(programming_only_routine_id),
+            id_lo(programming_only_routine_id),
+        ];
+        let programming_only_result = ecu_manager
+            .check_genericservice(&skip_sec_plugin!(), programming_only_payload)
+            .await;
+        let err = programming_only_result.expect_err(&format!(
+            "Expected genericservice call for restricted routine ID \
+             {programming_only_routine_id:#06X} ({programming_only_name}) to fail due to unmet \
+             ProgrammingSecurity precondition"
+        ));
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains(&programming_only_name),
+            "Expected error message to reference the actually matched service \
+             '{programming_only_name}', got: {err_msg}"
+        );
+        assert!(
+            !err_msg.contains(&unrestricted_name),
+            "Error message should not reference the unrelated service '{unrestricted_name}', got: \
+             {err_msg}"
         );
     }
 }

--- a/cda-core/src/diag_kernel/test_utils/ecu_manager_builder.rs
+++ b/cda-core/src/diag_kernel/test_utils/ecu_manager_builder.rs
@@ -1822,6 +1822,224 @@ pub(crate) fn create_ecu_manager_with_state_transitions(
     (new_ecu_manager(db), dc)
 }
 
+/// Build an ECU manager with two services that share the same SID but are
+/// distinguished by the coded-constant bytes following the SID (as described
+/// by `extra_params`). The second service additionally requires a
+/// `ProgrammingSecurity` precondition, which a freshly created ECU manager
+/// (default `LockedSecurity`/`DefaultSession`) does not satisfy.
+///
+/// `extra_params` describes the layout of the coded-constant parameters that
+/// follow the SID (shared by both services): `(name, byte_position,
+/// bit_length)`. `unrestricted_values` / `programming_only_values` provide the
+/// per-service values for each of those parameters, in the same order.
+///
+/// This is used to verify that service lookups which only match the SID byte
+/// of a raw UDS payload are NOT sufficient to identify the correct service -
+/// the bytes following the SID must also be compared, otherwise an arbitrary
+/// same-SID service could be selected, resulting in the wrong service being
+/// used for the access/precondition check.
+fn create_ecu_manager_with_two_same_sid_services(
+    sid: u8,
+    extra_params: &[(&str, u32, u32)],
+    unrestricted_name: &str,
+    unrestricted_values: &[u32],
+    programming_only_name: &str,
+    programming_only_values: &[u32],
+) -> crate::diag_kernel::ecumanager::EcuManager<DefaultSecurityPluginData> {
+    let mut db_builder = EcuDataBuilder::new();
+    let protocol_name = Protocol::default().to_string();
+    let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
+    let cp_ref = db_builder.create_com_param_ref(None, None, None, Some(protocol), None);
+
+    // Security states - a freshly created ECU manager defaults to LockedSecurity.
+    let locked_state = db_builder.create_state("LockedSecurity", None);
+    let programming_state = db_builder.create_state("ProgrammingSecurity", None);
+    let locked_to_programming_transition = db_builder.create_state_transition(
+        "LockedToProgramming",
+        Some("LockedSecurity"),
+        Some("ProgrammingSecurity"),
+    );
+
+    // Session states - a freshly created ECU manager defaults to DefaultSession.
+    let default_session_state = db_builder.create_state("DefaultSession", None);
+
+    let semantics = Semantics::default();
+    let security_state_chart = db_builder.create_state_chart(
+        "SecurityAccess",
+        Some(&semantics.security),
+        Some(vec![locked_to_programming_transition]),
+        Some("LockedSecurity"),
+        Some(vec![locked_state, programming_state]),
+    );
+    let session_state_chart = db_builder.create_state_chart(
+        "Session",
+        Some(&semantics.session),
+        None,
+        Some("DefaultSession"),
+        Some(vec![default_session_state]),
+    );
+
+    // Builds a request consisting of the SID followed by `extra_params`'
+    // coded-constant parameters, using the given per-parameter `values`.
+    macro_rules! build_request {
+        ($values:expr) => {{
+            let mut params = vec![create_sid_param!(db_builder, sid)];
+            for ((name, byte_pos, bit_length), value) in extra_params.iter().zip($values) {
+                params.push(db_builder.create_coded_const_param(
+                    name,
+                    &value.to_string(),
+                    *byte_pos,
+                    0,
+                    *bit_length,
+                    DataType::UInt32,
+                ));
+            }
+            db_builder.create_request(Some(params), None)
+        }};
+    }
+
+    // Service 1: unrestricted
+    let unrestricted_diag_comm = db_builder.create_diag_comm(DiagCommParams {
+        short_name: unrestricted_name,
+        diag_class_type: DiagClassType::START_COMM,
+        protocols: Some(vec![protocol]),
+        ..Default::default()
+    });
+    let unrestricted_request = build_request!(unrestricted_values);
+    let unrestricted_service = new_diag_service!(
+        db_builder,
+        unrestricted_diag_comm,
+        unrestricted_request,
+        vec![],
+        vec![]
+    );
+
+    // Service 2: requires ProgrammingSecurity
+    let precondition_ref = db_builder.create_pre_condition_state_ref(programming_state);
+    let programming_only_diag_comm = db_builder.create_diag_comm(DiagCommParams {
+        short_name: programming_only_name,
+        diag_class_type: DiagClassType::START_COMM,
+        protocols: Some(vec![protocol]),
+        pre_condition_state_refs: Some(vec![precondition_ref]),
+        ..Default::default()
+    });
+    let programming_only_request = build_request!(programming_only_values);
+    let programming_only_service = new_diag_service!(
+        db_builder,
+        programming_only_diag_comm,
+        programming_only_request,
+        vec![],
+        vec![]
+    );
+
+    let diag_layer = db_builder.create_diag_layer(DiagLayerParams {
+        short_name: "TestVariantDiagLayer",
+        com_param_refs: Some(vec![cp_ref]),
+        diag_services: Some(vec![unrestricted_service, programming_only_service]),
+        state_charts: Some(vec![session_state_chart, security_state_chart]),
+        ..Default::default()
+    });
+
+    let variant = db_builder.create_variant(diag_layer, true, None, None);
+    let db = db_builder.finish(EcuDataParams {
+        revision: "revision_1",
+        version: "1.0.0",
+        variants: Some(vec![variant]),
+        ..Default::default()
+    });
+
+    new_ecu_manager(db)
+}
+
+/// Build an ECU manager with two `WriteDataByIdentifier` (SID `0x2E`) services
+/// that share the same SID but target different, distinct 2-byte DIDs:
+/// - `WriteDid_Unrestricted` (DID `0xF190`): no precondition, always allowed.
+/// - `WriteDid_ProgrammingOnly` (DID `0xF191`): requires `ProgrammingSecurity`
+///   precondition state, which a freshly created ECU manager (default
+///   `LockedSecurity`/`DefaultSession`) does not satisfy.
+///
+/// See [`create_ecu_manager_with_two_same_sid_services`] for the rationale.
+///
+/// Returns `(ecu_manager, unrestricted_did, unrestricted_name,
+/// programming_only_did, programming_only_name)`.
+pub(crate) fn create_ecu_manager_with_multiple_write_did_services() -> (
+    crate::diag_kernel::ecumanager::EcuManager<DefaultSecurityPluginData>,
+    u16,
+    String,
+    u16,
+    String,
+) {
+    const UNRESTRICTED_DID: u16 = 0xF190;
+    const PROGRAMMING_ONLY_DID: u16 = 0xF191;
+    const UNRESTRICTED_NAME: &str = "WriteDid_Unrestricted";
+    const PROGRAMMING_ONLY_NAME: &str = "WriteDid_ProgrammingOnly";
+
+    let ecu_manager = create_ecu_manager_with_two_same_sid_services(
+        service_ids::WRITE_DATA_BY_IDENTIFIER,
+        &[("DID", 1, 16)],
+        UNRESTRICTED_NAME,
+        &[u32::from(UNRESTRICTED_DID)],
+        PROGRAMMING_ONLY_NAME,
+        &[u32::from(PROGRAMMING_ONLY_DID)],
+    );
+
+    (
+        ecu_manager,
+        UNRESTRICTED_DID,
+        UNRESTRICTED_NAME.to_owned(),
+        PROGRAMMING_ONLY_DID,
+        PROGRAMMING_ONLY_NAME.to_owned(),
+    )
+}
+
+/// Build an ECU manager with two `RoutineControl` (SID `0x31`) services that
+/// share the same SID and sub-function, but target different, distinct
+/// 2-byte routine identifiers:
+/// - `RoutineControl_Unrestricted` (routine ID `0x0A5C`): no precondition,
+///   always allowed.
+/// - `RoutineControl_ProgrammingOnly` (routine ID `0x0A5D`): requires
+///   `ProgrammingSecurity` precondition state, which a freshly created ECU
+///   manager (default `LockedSecurity`/`DefaultSession`) does not satisfy.
+///
+/// This mirrors [`create_ecu_manager_with_multiple_write_did_services`], but
+/// for a service (`RoutineControl`) whose disambiguating bytes span a
+/// sub-function byte *and* a routine identifier, rather than a DID
+/// immediately following the SID. See
+/// [`create_ecu_manager_with_two_same_sid_services`] for the rationale.
+///
+/// Returns `(ecu_manager, unrestricted_routine_id, unrestricted_name,
+/// programming_only_routine_id, programming_only_name)`.
+pub(crate) fn create_ecu_manager_with_multiple_routine_control_services() -> (
+    crate::diag_kernel::ecumanager::EcuManager<DefaultSecurityPluginData>,
+    u16,
+    String,
+    u16,
+    String,
+) {
+    const UNRESTRICTED_ROUTINE_ID: u16 = 0x0A5C;
+    const PROGRAMMING_ONLY_ROUTINE_ID: u16 = 0x0A5D;
+    const UNRESTRICTED_NAME: &str = "RoutineControl_Unrestricted";
+    const PROGRAMMING_ONLY_NAME: &str = "RoutineControl_ProgrammingOnly";
+    let subfunction = u32::from(subfunction_ids::routine::REQUEST_RESULTS);
+
+    let ecu_manager = create_ecu_manager_with_two_same_sid_services(
+        service_ids::ROUTINE_CONTROL,
+        &[("RoutineControlType", 1, 8), ("RoutineIdentifier", 2, 16)],
+        UNRESTRICTED_NAME,
+        &[subfunction, u32::from(UNRESTRICTED_ROUTINE_ID)],
+        PROGRAMMING_ONLY_NAME,
+        &[subfunction, u32::from(PROGRAMMING_ONLY_ROUTINE_ID)],
+    );
+
+    (
+        ecu_manager,
+        UNRESTRICTED_ROUTINE_ID,
+        UNRESTRICTED_NAME.to_owned(),
+        PROGRAMMING_ONLY_ROUTINE_ID,
+        PROGRAMMING_ONLY_NAME.to_owned(),
+    )
+}
+
 /// Helper that builds an ECU manager whose variant has a service with a
 /// `ProgrammingSecurity` precondition **and** a functional group containing
 /// the same service. Returns `(ecu_manager, diag_comm, sid)`.

--- a/cda-database/src/datatypes.rs
+++ b/cda-database/src/datatypes.rs
@@ -273,6 +273,58 @@ impl DiagService<'_> {
 
         result
     }
+
+    #[must_use]
+    /// Check whether this service's sequential coded-constant parameters (SID,
+    /// sub-function, DID, etc.) match the given raw request bytes.
+    ///
+    /// This compares every coded-constant parameter of the service (as returned
+    /// by [`Self::extract_sequential_coded_consts`]) against the corresponding
+    /// bytes in `request_bytes`. If `request_bytes` is shorter than a given
+    /// parameter's expected position, the match is still considered successful
+    /// for the bytes provided so far (partial prefixes are accepted).
+    ///
+    /// This is used to disambiguate between multiple services that share the
+    /// same SID (e.g. several `WriteDataByIdentifier` service entries, one per
+    /// DID, all sharing SID `0x2E`), by also comparing the bytes following the
+    /// SID (such as the DID) rather than only the first byte.
+    pub fn matches_request_prefix(&self, request_bytes: &[u8]) -> bool {
+        let mut byte_idx = 0usize;
+        for param in self.extract_sequential_coded_consts() {
+            let param_byte_count = param.byte_count();
+            if param_byte_count > 4 {
+                return false;
+            }
+            let Some(end_idx) = byte_idx.checked_add(param_byte_count) else {
+                return false;
+            };
+            // Ran out of caller-provided bytes, all provided bytes matched, accept
+            if end_idx > request_bytes.len() {
+                return true;
+            }
+            let Some(param_slice) = request_bytes.get(byte_idx..end_idx) else {
+                return false;
+            };
+
+            let mut buf = [0u8; 4];
+            // calculate where in the 4-byte buffer to place the parameter bytes.
+            // i.e. a 2 byte param goes into buf[2..4],
+            // leaving buf[0..2] as zero-padding,
+            // copy this into the buffer and convert into u32 big endian.
+            let start = 4usize.saturating_sub(param_byte_count);
+            let Some(buf_slice) = buf.get_mut(start..) else {
+                return false;
+            };
+            buf_slice.copy_from_slice(param_slice);
+
+            let expected_value = u32::from_be_bytes(buf);
+            if param.value != expected_value {
+                return false;
+            }
+            byte_idx = end_idx;
+        }
+        true // all consts iterated and all matched
+    }
 }
 
 impl TryInto<cda_interfaces::DiagComm> for DiagService<'_> {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
check_genericservice (used by the /genericservice raw UDS passthrough endpoint) only matched services by their SID byte and then took the first match. For write-style requests such as WriteDataByIdentifier (0x2E xx yy), multiple DB service entries commonly share the same SID (one per DID), so matching on the SID alone picked an arbitrary same-SID service instead of the one actually addressed by the raw payload.

This caused the access/precondition check to be evaluated against the wrong service, and any resulting error to report that wrong service's name instead of the one the client actually invoked.

Fix by reusing the same full request-prefix matching already used by lookup_diagcomms_by_request_prefix (which compares the sequential coded-constant bytes - SID, sub-function, DID, etc. - against the raw payload), extracted into a shared DiagService::matches_request_prefix helper.

Adds a regression test with two WriteDataByIdentifier services sharing SID 0x2E but different DIDs, one gated behind a precondition, verifying the correct service is matched and reported.


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
