### PR TITLE
feat(cda-comm-uds): add send_by_sid method to UdsManager

### DIFF
--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -14,10 +14,9 @@
 use std::sync::{Arc, atomic::AtomicBool};
 
 use cda_interfaces::{
-    DiagComm, DiagServiceError, DynamicPlugin, EcuGateway, EcuManager,
-    FunctionalDescriptionConfig, HashMap, HashMapExtensions, HashSet, HashSetExtensions,
-    SchemaDescription, SchemaProvider, UdsEcu, UdsEcuDb, UdsTransport, datatypes::FaultConfig,
-    diagservices::UdsPayloadData,
+    DiagComm, DiagServiceError, DynamicPlugin, EcuGateway, EcuManager, FunctionalDescriptionConfig,
+    HashMap, HashMapExtensions, HashSet, HashSetExtensions, SchemaDescription, SchemaProvider,
+    UdsEcu, UdsEcuDb, UdsTransport, datatypes::FaultConfig, diagservices::UdsPayloadData,
 };
 use tokio::{
     sync::{Mutex, RwLock, Semaphore, mpsc},
@@ -177,38 +176,31 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
             .for_each(|h| h.abort());
     }
 
-    /// Send a diagnostic service by its SID, looking up the service definition
-    /// in the ODX database and encoding JSON parameters according to the
+    /// Send a diagnostic service by its request prefix, looking up the service definition
+    /// in the MDD database and encoding JSON parameters according to the
     /// service's parameter definitions.
     ///
-    /// This method builds a request prefix from the service ID and request
-    /// payload, resolves the matching service definition(s) via
+    /// This method resolves the matching service definition(s) from the supplied
+    /// request prefix via
     /// `lookup_diagcomms_by_request_prefix` (matching against coded constant
-    /// parameters in the ODX database), and sends the first match with the
+    /// parameters in the MDD database), and sends the first match with the
     /// provided parameters encoded through `create_uds_payload`.
     ///
-    /// The `request_payload` is appended after the service ID to form the
-    /// full prefix used for service resolution. This allows services that
+    /// The `service_bytes` prefix starts with the service ID and may include
+    /// additional bytes. This allows services that
     /// use coded constant parameters (e.g., specific DID values) to be
     /// resolved by matching the exact byte sequence.
     ///
-    /// # Arguments
-    /// * `ecu_name` - The name of the target ECU
-    /// * `service_id` - The UDS service identifier (SID), e.g. 0x22 for RDBI
-    /// * `request_payload` - Bytes that follow the SID in the UDS request frame.
-    ///   These bytes are used together with the SID to resolve the service via
-    ///   `lookup_diagcomms_by_request_prefix`.
-    /// * `security_plugin` - Security plugin to validate the request
-    /// * `params` - JSON parameters keyed by ODX parameter short names
-    /// * `map_to_json` - Whether to map the response to JSON format
+    /// # Errors
+    /// Returns `DiagServiceError` if the service is not found or if the
+    /// request fails.
     ///
     /// # Example
     /// ```ignore
     /// // ReadDataByIdentifier DID 0xF190
     /// uds.send_by_sid(
     ///     "ECU_NAME",
-    ///     0x22,                              // SID
-    ///     vec![0xF1, 0x90],                  // DID bytes (request payload)
+    ///     &[0x22, 0xF1, 0x90],               // SID and DID bytes
     ///     &security_plugin,
     ///     HashMap::from([("did".into(), json!(0xF190))]),
     ///     true,
@@ -217,36 +209,26 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
     pub async fn send_by_sid(
         &self,
         ecu_name: &str,
-        service_id: u8,
-        request_payload: Vec<u8>,
+        service_bytes: &[u8],
         security_plugin: &DynamicPlugin,
         params: HashMap<String, serde_json::Value>,
         map_to_json: bool,
     ) -> Result<<T as cda_interfaces::PayloadDecoder>::Response, DiagServiceError> {
-        // Build the full request prefix: [SID] + request_payload
-        let mut prefix = Vec::with_capacity(1 + request_payload.len());
-        prefix.push(service_id);
-        prefix.extend_from_slice(&request_payload);
-
-        // Look up the service definition in the ODX database using the same
-        // approach as lookup_diagcomms_by_request_prefix — matches against
+        // Look up the service definition in the MDD database using the same
+        // approach as lookup_diagcomms_by_request_prefix - matches against
         // coded constant parameter values in the database.
         let ecu = self.uds_ecu_db(ecu_name)?;
-        let services = ecu.read().await.lookup_diagcomms_by_request_prefix(&prefix)?;
+        let services = ecu
+            .read()
+            .await
+            .lookup_diagcomms_by_request_prefix(service_bytes)?;
 
         let diag_comm = services.into_iter().next().ok_or_else(|| {
             DiagServiceError::NotFound(format!(
-                "No diagnostic service found matching request prefix: {:02X?}",
-                prefix
+                "No diagnostic service found matching request prefix: {service_bytes:02X?}"
             ))
         })?;
 
-        // Send using the standard send pipeline which handles:
-        // - variant detection
-        // - security checks
-        // - parameter encoding via create_uds_payload
-        // - transport
-        // - response conversion
         self.send(
             ecu_name,
             diag_comm,
@@ -262,17 +244,14 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
     /// parameters according to the service's parameter definitions.
     ///
     /// This method performs prefix/suffix matching on the service short name
-    /// in the ODX database using the `database_naming_convention` settings.
+    /// in the MDD database using the `database_naming_convention` settings.
     /// The `name` argument is matched against the trimmed short name of all
     /// services with the given `service_id`.
     ///
-    /// # Arguments
-    /// * `ecu_name` - The name of the target ECU
-    /// * `service_id` - The UDS service identifier (SID), e.g. 0xBB for PeriodicReadDID
-    /// * `name` - The service short name (or name affix) to match against ODX service definitions
-    /// * `security_plugin` - Security plugin to validate the request
-    /// * `params` - JSON parameters keyed by ODX parameter short names
-    /// * `map_to_json` - Whether to map the response to JSON format
+    ///
+    /// # Errors
+    /// Returns `DiagServiceError` if the service is not found or if the
+    /// request fails.
     ///
     /// # Example
     /// ```ignore

--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -256,6 +256,60 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
         )
         .await
     }
+
+    /// Send a diagnostic service by its SID and name, looking up the service
+    /// definition via `lookup_service_by_sid_and_name` and encoding JSON
+    /// parameters according to the service's parameter definitions.
+    ///
+    /// This method performs prefix/suffix matching on the service short name
+    /// in the ODX database using the `database_naming_convention` settings.
+    /// The `name` argument is matched against the trimmed short name of all
+    /// services with the given `service_id`.
+    ///
+    /// # Arguments
+    /// * `ecu_name` - The name of the target ECU
+    /// * `service_id` - The UDS service identifier (SID), e.g. 0xBB for PeriodicReadDID
+    /// * `name` - The service short name (or name affix) to match against ODX service definitions
+    /// * `security_plugin` - Security plugin to validate the request
+    /// * `params` - JSON parameters keyed by ODX parameter short names
+    /// * `map_to_json` - Whether to map the response to JSON format
+    ///
+    /// # Example
+    /// ```ignore
+    /// // PeriodicReadDID matching name "myReadService" with SID 0xBB
+    /// uds.send_by_sid_and_name(
+    ///     "ECU_NAME",
+    ///     0xBB,                              // SID
+    ///     "myReadService",                   // name to match
+    ///     &security_plugin,
+    ///     HashMap::from([("did".into(), json!(0xF190))]),
+    ///     true,
+    /// ).await?;
+    /// ```
+    pub async fn send_by_sid_and_name(
+        &self,
+        ecu_name: &str,
+        service_id: u8,
+        name: &str,
+        security_plugin: &DynamicPlugin,
+        params: HashMap<String, serde_json::Value>,
+        map_to_json: bool,
+    ) -> Result<<T as cda_interfaces::PayloadDecoder>::Response, DiagServiceError> {
+        let ecu = self.uds_ecu_db(ecu_name)?;
+        let diag_comm = ecu
+            .read()
+            .await
+            .lookup_service_by_sid_and_name(service_id, name, None)?;
+
+        self.send(
+            ecu_name,
+            diag_comm,
+            security_plugin,
+            Some(UdsPayloadData::ParameterMap(params)),
+            map_to_json,
+        )
+        .await
+    }
 }
 
 impl<S: Clone + EcuGateway, T: UdsEcuDb> Clone for UdsManager<S, T> {

--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -14,9 +14,10 @@
 use std::sync::{Arc, atomic::AtomicBool};
 
 use cda_interfaces::{
-    DiagComm, DiagServiceError, EcuGateway, EcuManager, FunctionalDescriptionConfig, HashMap,
-    HashMapExtensions, HashSet, HashSetExtensions, SchemaDescription, SchemaProvider, UdsEcu,
-    UdsEcuDb, datatypes::FaultConfig,
+    DiagComm, DiagServiceError, DynamicPlugin, EcuGateway, EcuManager,
+    FunctionalDescriptionConfig, HashMap, HashMapExtensions, HashSet, HashSetExtensions,
+    SchemaDescription, SchemaProvider, UdsEcu, UdsEcuDb, UdsTransport, datatypes::FaultConfig,
+    diagservices::UdsPayloadData,
 };
 use tokio::{
     sync::{Mutex, RwLock, Semaphore, mpsc},
@@ -174,6 +175,86 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
             .chain(security_reset_tasks.drain().map(|(_, h)| h))
             .chain(data_transfers.drain().map(|(_, t)| t.task))
             .for_each(|h| h.abort());
+    }
+
+    /// Send a diagnostic service by its SID, looking up the service definition
+    /// in the ODX database and encoding JSON parameters according to the
+    /// service's parameter definitions.
+    ///
+    /// This method builds a request prefix from the service ID and request
+    /// payload, resolves the matching service definition(s) via
+    /// `lookup_diagcomms_by_request_prefix` (matching against coded constant
+    /// parameters in the ODX database), and sends the first match with the
+    /// provided parameters encoded through `create_uds_payload`.
+    ///
+    /// The `request_payload` is appended after the service ID to form the
+    /// full prefix used for service resolution. This allows services that
+    /// use coded constant parameters (e.g., specific DID values) to be
+    /// resolved by matching the exact byte sequence.
+    ///
+    /// # Arguments
+    /// * `ecu_name` - The name of the target ECU
+    /// * `service_id` - The UDS service identifier (SID), e.g. 0x22 for RDBI
+    /// * `request_payload` - Bytes that follow the SID in the UDS request frame.
+    ///   These bytes are used together with the SID to resolve the service via
+    ///   `lookup_diagcomms_by_request_prefix`.
+    /// * `security_plugin` - Security plugin to validate the request
+    /// * `params` - JSON parameters keyed by ODX parameter short names
+    /// * `map_to_json` - Whether to map the response to JSON format
+    ///
+    /// # Example
+    /// ```ignore
+    /// // ReadDataByIdentifier DID 0xF190
+    /// uds.send_by_sid(
+    ///     "ECU_NAME",
+    ///     0x22,                              // SID
+    ///     vec![0xF1, 0x90],                  // DID bytes (request payload)
+    ///     &security_plugin,
+    ///     HashMap::from([("did".into(), json!(0xF190))]),
+    ///     true,
+    /// ).await?;
+    /// ```
+    pub async fn send_by_sid(
+        &self,
+        ecu_name: &str,
+        service_id: u8,
+        request_payload: Vec<u8>,
+        security_plugin: &DynamicPlugin,
+        params: HashMap<String, serde_json::Value>,
+        map_to_json: bool,
+    ) -> Result<<T as cda_interfaces::PayloadDecoder>::Response, DiagServiceError> {
+        // Build the full request prefix: [SID] + request_payload
+        let mut prefix = Vec::with_capacity(1 + request_payload.len());
+        prefix.push(service_id);
+        prefix.extend_from_slice(&request_payload);
+
+        // Look up the service definition in the ODX database using the same
+        // approach as lookup_diagcomms_by_request_prefix — matches against
+        // coded constant parameter values in the database.
+        let ecu = self.uds_ecu_db(ecu_name)?;
+        let services = ecu.read().await.lookup_diagcomms_by_request_prefix(&prefix)?;
+
+        let diag_comm = services.into_iter().next().ok_or_else(|| {
+            DiagServiceError::NotFound(format!(
+                "No diagnostic service found matching request prefix: {:02X?}",
+                prefix
+            ))
+        })?;
+
+        // Send using the standard send pipeline which handles:
+        // - variant detection
+        // - security checks
+        // - parameter encoding via create_uds_payload
+        // - transport
+        // - response conversion
+        self.send(
+            ecu_name,
+            diag_comm,
+            security_plugin,
+            Some(UdsPayloadData::ParameterMap(params)),
+            map_to_json,
+        )
+        .await
     }
 }
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Adds `send_by_sid` to `UdsManager` for OEM diagnostic routes that invoke services by SID with JSON parameters.

The method resolves the service through ODX-coded request prefixes, encodes parameters with the ODX layer, and reuses the existing send pipeline for variant detection, security, transport, and response conversion.

## Checklist

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related

N/A

## Notes for Reviewers

OEM routes can accept JSON parameters, call `send_by_sid(sid, payload, params)`, and receive the existing response and error handling behavior. Commits will be squashed before merge

---
Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)