### PR TITLE
refactor(sovd): move diagnostic DB update executions to /operations/runtimefilesupdate & allow octet-stream 

### DIFF
--- a/cda-interfaces/src/runtime_update_api.rs
+++ b/cda-interfaces/src/runtime_update_api.rs
@@ -197,6 +197,22 @@ pub struct BulkDataCreated {
     pub id: String,
 }
 
+/// Response body for deleting all bulk-data in a category (ISO 17978-3 Table 306).
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct BulkDataDeleted {
+    pub deleted_ids: Vec<String>,
+    // spec requires an errors array to be present, however with transaction semantics
+    // this will always be an empty array
+    pub errors: Vec<BulkDataDeletionError>,
+}
+
+/// A bulk-data item that could not be deleted and its reason.
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct BulkDataDeletionError {
+    pub id: String,
+    pub error: serde_json::Value,
+}
+
 /// Generic list wrapper used for bulk-data responses.
 #[derive(Deserialize, Serialize, Debug, schemars::JsonSchema)]
 pub struct BulkDataItems<T> {
@@ -220,6 +236,8 @@ impl<T> Default for BulkDataItems<T> {
 pub struct BulkDataDescriptor {
     pub id: String,
     pub mimetype: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -275,6 +293,12 @@ pub struct RuntimeFilesQuery {
     pub include_file_size: bool,
     #[serde(rename = "x-sovd2uds-include-revision", default)]
     pub include_revision: bool,
+    /// Accepted for ISO 17978-3 compatibility but not currently applied.
+    #[serde(rename = "created-after")]
+    pub created_after: Option<String>,
+    /// Accepted for ISO 17978-3 compatibility but not currently applied.
+    #[serde(rename = "created-before")]
+    pub created_before: Option<String>,
 }
 
 /// Stored state for a single database update execution.
@@ -326,14 +350,14 @@ pub trait RuntimeFilesUpdatePlugin: Send + Sync + 'static {
         files: Vec<UploadFile>,
     ) -> Result<BulkDataCreatedList, RuntimeUpdateError>;
 
-    /// Deletes all files from the next-update staging area.
-    async fn delete_nextupdate(&self) -> Result<(), RuntimeUpdateError>;
+    /// Deletes all files from the next-update staging area and returns their identifiers.
+    async fn delete_nextupdate(&self) -> Result<Vec<String>, RuntimeUpdateError>;
 
     /// Deletes a single file by ID from the next-update staging area.
     async fn delete_nextupdate_by_id(&self, file_id: &str) -> Result<(), RuntimeUpdateError>;
 
-    /// Deletes all files from the backup area.
-    async fn delete_backup(&self) -> Result<(), RuntimeUpdateError>;
+    /// Deletes all files from the backup area and returns their identifiers.
+    async fn delete_backup(&self) -> Result<Vec<String>, RuntimeUpdateError>;
 
     /// Starts an asynchronous execution (Apply, Rollback, or Cleanup).
     ///
@@ -413,7 +437,7 @@ impl<P: RuntimeFilesUpdatePlugin> RuntimeFilesUpdatePlugin for ExclusiveRuntimeP
         self.inner.upload(files).await
     }
 
-    async fn delete_nextupdate(&self) -> Result<(), RuntimeUpdateError> {
+    async fn delete_nextupdate(&self) -> Result<Vec<String>, RuntimeUpdateError> {
         let _guard = self.lock.write().await;
         self.inner.delete_nextupdate().await
     }
@@ -423,7 +447,7 @@ impl<P: RuntimeFilesUpdatePlugin> RuntimeFilesUpdatePlugin for ExclusiveRuntimeP
         self.inner.delete_nextupdate_by_id(file_id).await
     }
 
-    async fn delete_backup(&self) -> Result<(), RuntimeUpdateError> {
+    async fn delete_backup(&self) -> Result<Vec<String>, RuntimeUpdateError> {
         let _guard = self.lock.write().await;
         self.inner.delete_backup().await
     }

--- a/cda-plugin-runtime-update/src/default_runtime_update_plugin.rs
+++ b/cda-plugin-runtime-update/src/default_runtime_update_plugin.rs
@@ -131,7 +131,7 @@ impl<
         crate::storage::upload_files(&*self.storage, &*self.security_handler, files).await
     }
 
-    async fn delete_nextupdate(&self) -> Result<(), RuntimeUpdateError> {
+    async fn delete_nextupdate(&self) -> Result<Vec<String>, RuntimeUpdateError> {
         crate::storage::delete_all_nextupdate(&*self.storage).await
     }
 
@@ -139,7 +139,7 @@ impl<
         crate::storage::delete_nextupdate_file(&*self.storage, file_id).await
     }
 
-    async fn delete_backup(&self) -> Result<(), RuntimeUpdateError> {
+    async fn delete_backup(&self) -> Result<Vec<String>, RuntimeUpdateError> {
         crate::storage::delete_all_backup(&*self.storage).await
     }
 

--- a/cda-plugin-runtime-update/src/lib.rs
+++ b/cda-plugin-runtime-update/src/lib.rs
@@ -319,20 +319,20 @@ mod tests {
             Ok(<_>::default())
         }
 
-        async fn delete_nextupdate(&self) -> Result<(), RuntimeUpdateError> {
+        async fn delete_nextupdate(&self) -> Result<Vec<String>, RuntimeUpdateError> {
             self.concurrent_writes.fetch_add(1, Ordering::SeqCst);
             self.write_barrier.wait().await;
             self.write_notify.notified().await;
             self.concurrent_writes.fetch_sub(1, Ordering::SeqCst);
-            Ok(())
+            Ok(vec![])
         }
 
         async fn delete_nextupdate_by_id(&self, _file_id: &str) -> Result<(), RuntimeUpdateError> {
             Ok(())
         }
 
-        async fn delete_backup(&self) -> Result<(), RuntimeUpdateError> {
-            Ok(())
+        async fn delete_backup(&self) -> Result<Vec<String>, RuntimeUpdateError> {
+            Ok(vec![])
         }
 
         async fn start_execution(

--- a/cda-plugin-runtime-update/src/storage.rs
+++ b/cda-plugin-runtime-update/src/storage.rs
@@ -108,6 +108,7 @@ pub(crate) async fn list_collection_files(
         let mut item = BulkDataDescriptor {
             id: key.clone(),
             mimetype: mime_for_key(key),
+            name: Some(key.clone()),
             size: None,
             hash: None,
             hash_algorithm: None,
@@ -257,7 +258,18 @@ pub(crate) async fn delete_nextupdate_file(
 
 pub(crate) async fn delete_all_nextupdate(
     storage: &impl Storage,
-) -> Result<(), RuntimeUpdateError> {
+) -> Result<Vec<String>, RuntimeUpdateError> {
+    let mut deleted_ids = Vec::new();
+    for collection_name in [
+        CollectionName::DiagnosticDatabaseNextUpdate,
+        CollectionName::ConfigurationNextUpdate,
+    ] {
+        match storage.get_collection(&collection_name).await {
+            Ok(collection) => deleted_ids.extend(collection.list().await?),
+            Err(StorageError::CollectionNotFound(_)) => {}
+            Err(e) => return Err(RuntimeUpdateError::from(e)),
+        }
+    }
     let mut tx = storage.begin_transaction()?;
 
     match storage
@@ -277,7 +289,7 @@ pub(crate) async fn delete_all_nextupdate(
     }
 
     tx.commit().await?;
-    Ok(())
+    Ok(deleted_ids)
 }
 
 /// Returns `true` if both backup collections (MDD and configuration) are empty or do not exist.
@@ -293,7 +305,9 @@ pub(crate) async fn is_backup_empty(storage: &impl Storage) -> Result<bool, Runt
     Ok(mdd_backup.is_empty().await? && cfg_backup.is_empty().await?)
 }
 
-pub(crate) async fn delete_all_backup(storage: &impl Storage) -> Result<(), RuntimeUpdateError> {
+pub(crate) async fn delete_all_backup(
+    storage: &impl Storage,
+) -> Result<Vec<String>, RuntimeUpdateError> {
     let mdd_backup = storage
         .get_or_create_collection(&CollectionName::DiagnosticDatabaseBackup)
         .await?;
@@ -302,10 +316,12 @@ pub(crate) async fn delete_all_backup(storage: &impl Storage) -> Result<(), Runt
         .await?;
 
     let mut tx = storage.begin_transaction()?;
+    let mut deleted_ids = mdd_backup.list().await?;
+    deleted_ids.extend(cfg_backup.list().await?);
     mdd_backup.delete_all(&mut tx).await?;
     cfg_backup.delete_all(&mut tx).await?;
     tx.commit().await?;
-    Ok(())
+    Ok(deleted_ids)
 }
 
 /// Computes the "next update" state from the pending `NextUpdate` collections, falling back to
@@ -922,7 +938,7 @@ mod tests {
         let json = serde_json::to_string(&item).unwrap();
         assert_eq!(
             json,
-            r#"{"id":"plain.mdd","mimetype":"application/octet-stream"}"#
+            r#"{"id":"plain.mdd","mimetype":"application/octet-stream","name":"plain.mdd"}"#
         );
     }
 
@@ -942,6 +958,8 @@ mod tests {
             include_hash: Some(HashAlgorithm::Sha256),
             include_file_size: true,
             include_revision: true,
+            created_after: None,
+            created_before: None,
         };
         let result = list_collection_files(&*collection, &query).await.unwrap();
 

--- a/cda-sovd-interfaces/src/apps.rs
+++ b/cda-sovd-interfaces/src/apps.rs
@@ -24,15 +24,30 @@ pub mod sovd2uds {
         }
 
         pub mod runtimefiles {
+            pub use cda_interfaces::runtime_update_api::RuntimeFilesQuery;
+        }
+    }
+
+    pub mod operations {
+        pub mod runtimefilesupdate {
             pub use cda_interfaces::runtime_update_api::{
-                ExecutionMode, ExecutionStatus, RuntimeFilesQuery, UpdateExecution,
+                ExecutionMode, ExecutionStatus, UpdateExecution,
             };
 
-            /// Request body for an execution.
+            /// The operation-specific parameters for a diagnostic database update execution.
             #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
-            pub struct ExecutionRequest {
+            pub struct ExecutionParameters {
                 /// The operation to perform on the staged runtime files.
                 pub mode: ExecutionMode,
+            }
+
+            /// Request body for an execution.
+            ///
+            /// Follows the standard operations convention of wrapping the
+            /// operation-specific inputs in a `parameters` field.
+            #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+            pub struct ExecutionRequest {
+                pub parameters: ExecutionParameters,
             }
 
             /// The discriminant of an execution's status without the inner payload.

--- a/cda-sovd-interfaces/src/apps.rs
+++ b/cda-sovd-interfaces/src/apps.rs
@@ -14,7 +14,7 @@
 pub mod sovd2uds {
     pub mod bulk_data {
         pub use cda_interfaces::runtime_update_api::{
-            BulkDataCreated, BulkDataCreatedList, BulkDataList,
+            BulkDataCreated, BulkDataCreatedList, BulkDataDeleted, BulkDataList,
         };
 
         pub mod flash_files {
@@ -66,34 +66,33 @@ pub mod sovd2uds {
                 pub id: String,
             }
 
-            /// Response body returned by `GET /executions/{id}`.
+            /// Operation-specific values reported for an execution.
             #[derive(Debug, serde::Serialize, schemars::JsonSchema)]
-            pub struct ExecutionResponse {
-                /// Unique execution identifier.
-                pub id: String,
+            pub struct ExecutionResponseParameters {
                 /// The operation that was requested.
                 pub mode: ExecutionMode,
-                /// Current lifecycle state of the execution.
-                pub status: ExecutionStatusKind,
                 /// Human-readable failure description, present only when `status` is `failed`.
                 #[serde(skip_serializing_if = "Option::is_none")]
                 pub reason: Option<String>,
+            }
+
+            /// Response body returned by `GET /executions/{id}`.
+            #[derive(Debug, serde::Serialize, schemars::JsonSchema)]
+            pub struct ExecutionResponse {
+                /// Current lifecycle state of the execution.
+                pub status: ExecutionStatusKind,
+                /// Operation-specific status details.
+                pub parameters: ExecutionResponseParameters,
                 #[schemars(skip)]
                 #[serde(skip_serializing_if = "Option::is_none")]
                 pub schema: Option<schemars::Schema>,
             }
 
             /// Response body returned by `GET /executions`.
-            #[derive(Debug, serde::Serialize, schemars::JsonSchema)]
+            #[derive(serde::Serialize, schemars::JsonSchema)]
             pub struct ExecutionListResponse {
-                pub items: Vec<ExecutionResponse>,
-                #[schemars(skip)]
-                #[serde(skip_serializing_if = "Option::is_none")]
-                pub schema: Option<schemars::Schema>,
+                pub items: Vec<crate::common::operations::OperationIdItem>,
             }
-
-            /// Query parameters for the executions list endpoint.
-            pub type ExecutionsQuery = crate::IncludeSchemaQuery;
 
             impl From<UpdateExecution> for ExecutionResponse {
                 fn from(exec: UpdateExecution) -> Self {
@@ -103,12 +102,38 @@ pub mod sovd2uds {
                         ExecutionStatus::Failed(msg) => (ExecutionStatusKind::Failed, Some(msg)),
                     };
                     Self {
-                        id: exec.id,
-                        mode: exec.mode,
                         status,
-                        reason,
+                        parameters: ExecutionResponseParameters {
+                            mode: exec.mode,
+                            reason,
+                        },
                         schema: None,
                     }
+                }
+            }
+
+            #[cfg(test)]
+            mod tests {
+                use super::*;
+
+                #[test]
+                fn failed_execution_places_mode_and_reason_in_parameters() {
+                    let response = ExecutionResponse::from(UpdateExecution {
+                        id: "execution-id".to_string(),
+                        mode: ExecutionMode::Apply,
+                        status: ExecutionStatus::Failed("verification failed".to_string()),
+                    });
+
+                    assert_eq!(
+                        serde_json::to_value(response).unwrap(),
+                        serde_json::json!({
+                            "status": "failed",
+                            "parameters": {
+                                "mode": "apply",
+                                "reason": "verification failed"
+                            }
+                        })
+                    );
                 }
             }
         }

--- a/cda-sovd/src/lib.rs
+++ b/cda-sovd/src/lib.rs
@@ -203,7 +203,7 @@ where
     L: cda_interfaces::runtime_update_api::LockStateProvider,
 {
     update_guard
-        .extend_exempt(sovd::apps::sovd2uds::bulk_data::runtimefiles::update_exempt_routes())
+        .extend_exempt(sovd::apps::sovd2uds::operations::runtimefilesupdate::update_exempt_routes())
         .await;
 
     let route_state = RuntimeUpdateRouteState {
@@ -211,8 +211,13 @@ where
         vehicle_lock_states: lock_state,
         retry_after_seconds,
     };
-    let router =
-        sovd::apps::sovd2uds::bulk_data::runtimefiles::routes::<S, P, L>(route_state, upload_limit);
+    let bulk_data_router = sovd::apps::sovd2uds::bulk_data::runtimefiles::routes::<S, P, L>(
+        route_state.clone(),
+        upload_limit,
+    );
+    let operations_router =
+        sovd::apps::sovd2uds::operations::runtimefilesupdate::routes::<S, P, L>(route_state);
+    let router = bulk_data_router.merge(operations_router);
     let handle = dynamic_router.add_routes(router.into()).await;
     tracing::info!("Runtime update routes added to webserver");
     handle

--- a/cda-sovd/src/sovd/apps/sovd2uds.rs
+++ b/cda-sovd/src/sovd/apps/sovd2uds.rs
@@ -23,6 +23,7 @@ use crate::sovd::{error::ApiError, resource_response};
 
 pub(crate) mod bulk_data;
 pub(crate) mod data;
+pub(crate) mod operations;
 
 pub(crate) async fn get(
     UseApi(ExtractHost(host), _): UseApi<ExtractHost, String>,

--- a/cda-sovd/src/sovd/apps/sovd2uds/bulk_data.rs
+++ b/cda-sovd/src/sovd/apps/sovd2uds/bulk_data.rs
@@ -35,7 +35,12 @@ pub(crate) async fn get(
     resource_response(
         &host,
         &uri,
-        vec![("flashfiles", None)],
+        vec![
+            ("flashfiles", None),
+            ("runtimefiles-current", None),
+            ("runtimefiles-nextupdate", None),
+            ("runtimefiles-backup", None),
+        ],
         query.include_schema,
     )
 }

--- a/cda-sovd/src/sovd/apps/sovd2uds/bulk_data/flash_files.rs
+++ b/cda-sovd/src/sovd/apps/sovd2uds/bulk_data/flash_files.rs
@@ -61,6 +61,7 @@ async fn process_directory(
                         hash_algorithm: None,
                         id: file_name_to_id(&file_name),
                         mimetype: mime::APPLICATION_OCTET_STREAM.essence_str().to_string(),
+                        name: Some(file_name.clone()),
                         size: Some(metadata.len()),
                         origin_path: Some(file_name),
                         revision: None,
@@ -143,6 +144,7 @@ pub(crate) fn docs_get(op: TransformOperation) -> TransformOperation {
                 files: vec![sovd_interfaces::sovd2uds::BulkDataDescriptor {
                     id: "example_file".to_string(),
                     mimetype: "application/octet-stream".to_string(),
+                    name: Some("example_file".to_string()),
                     size: Some(1234),
                     hash: None,
                     hash_algorithm: None,

--- a/cda-sovd/src/sovd/apps/sovd2uds/bulk_data/runtimefiles.rs
+++ b/cda-sovd/src/sovd/apps/sovd2uds/bulk_data/runtimefiles.rs
@@ -211,9 +211,9 @@ pub(crate) mod current {
 
 pub(crate) mod nextupdate {
     use axum::{
-        Json,
-        extract::{Query, State},
-        http::StatusCode,
+        Json, RequestExt,
+        extract::{FromRequest, Query, Request, State},
+        http::{HeaderMap, StatusCode, header::CONTENT_TYPE},
         response::{IntoResponse, Response},
     };
     use cda_interfaces::runtime_update_api::{
@@ -240,11 +240,189 @@ pub(crate) mod nextupdate {
             )
     }
 
+    /// Parses the `filename` parameter out of a `Content-Disposition` header value.
+    ///
+    /// Supports both the quoted form (`filename="foo.mdd"`) and the unquoted form
+    /// (`filename=foo.mdd`). Returns `None` if the header is missing, or if no
+    /// non-empty `filename` parameter can be found.
+    fn parse_content_disposition_filename(headers: &HeaderMap) -> Option<String> {
+        headers
+            .get(axum::http::header::CONTENT_DISPOSITION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|value| {
+                split_content_disposition_parameters(value).find_map(|part| {
+                    let part = part.trim();
+                    let (key, val) = part.split_once('=')?;
+                    if !key.trim().eq_ignore_ascii_case("filename") {
+                        return None;
+                    }
+                    let val = val.trim();
+                    let filename = val
+                        .strip_prefix('"')
+                        .and_then(|v| v.strip_suffix('"'))
+                        .unwrap_or(val);
+                    (!filename.is_empty()).then(|| filename.to_owned())
+                })
+            })
+    }
+
+    /// Splits `Content-Disposition` parameters without treating semicolons in quoted values
+    /// as delimiters.
+    fn split_content_disposition_parameters(value: &str) -> impl Iterator<Item = &str> {
+        let mut in_quotes = false;
+        let mut escaped = false;
+        value.split(move |character| {
+            if escaped {
+                escaped = false;
+            } else if in_quotes && character == '\\' {
+                escaped = true;
+            } else if character == '"' {
+                in_quotes = !in_quotes;
+            }
+            character == ';' && !in_quotes
+        })
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use axum::http::{HeaderMap, HeaderValue, header::CONTENT_DISPOSITION};
+
+        use super::parse_content_disposition_filename;
+
+        fn headers_with_content_disposition(value: &str) -> HeaderMap {
+            let mut headers = HeaderMap::new();
+            headers.insert(CONTENT_DISPOSITION, HeaderValue::from_str(value).unwrap());
+            headers
+        }
+
+        #[test]
+        fn missing_header_returns_none() {
+            let headers = HeaderMap::new();
+            assert_eq!(parse_content_disposition_filename(&headers), None);
+        }
+
+        #[test]
+        fn quoted_filename_after_disposition_type() {
+            // Regression test: the `attachment` segment (with no `=`) precedes
+            // `filename=...` and must not cause the whole parse to bail out early.
+            let headers = headers_with_content_disposition(r#"attachment; filename="foo.mdd""#);
+            assert_eq!(
+                parse_content_disposition_filename(&headers),
+                Some("foo.mdd".to_owned())
+            );
+        }
+
+        #[test]
+        fn quoted_filename_may_contain_semicolons() {
+            let headers =
+                headers_with_content_disposition(r#"attachment; filename="database;backup.mdd""#);
+            assert_eq!(
+                parse_content_disposition_filename(&headers),
+                Some("database;backup.mdd".to_owned())
+            );
+        }
+
+        #[test]
+        fn unquoted_filename_after_disposition_type() {
+            let headers = headers_with_content_disposition("attachment; filename=foo.mdd");
+            assert_eq!(
+                parse_content_disposition_filename(&headers),
+                Some("foo.mdd".to_owned())
+            );
+        }
+
+        #[test]
+        fn filename_only_no_disposition_type() {
+            let headers = headers_with_content_disposition(r#"filename="foo.mdd""#);
+            assert_eq!(
+                parse_content_disposition_filename(&headers),
+                Some("foo.mdd".to_owned())
+            );
+        }
+
+        #[test]
+        fn filename_parameter_is_case_insensitive() {
+            let headers = headers_with_content_disposition(r#"attachment; FileName="foo.mdd""#);
+            assert_eq!(
+                parse_content_disposition_filename(&headers),
+                Some("foo.mdd".to_owned())
+            );
+        }
+
+        #[test]
+        fn empty_filename_returns_none() {
+            let headers = headers_with_content_disposition(r#"attachment; filename="""#);
+            assert_eq!(parse_content_disposition_filename(&headers), None);
+        }
+
+        #[test]
+        fn missing_filename_parameter_returns_none() {
+            let headers = headers_with_content_disposition("attachment");
+            assert_eq!(parse_content_disposition_filename(&headers), None);
+        }
+
+        #[test]
+        fn ignores_other_parameters_before_filename() {
+            let headers =
+                headers_with_content_disposition(r#"attachment; name="field"; filename="foo.mdd""#);
+            assert_eq!(
+                parse_content_disposition_filename(&headers),
+                Some("foo.mdd".to_owned())
+            );
+        }
+    }
+
+    /// Accepts either a `multipart/form-data` upload (potentially multiple files,
+    /// filenames taken from each field's `filename` parameter), or a single
+    /// `application/octet-stream` upload, where the filename must be provided via
+    /// the `Content-Disposition` header (e.g. `attachment; filename="foo.mdd"`).
     pub(crate) async fn post<P: RuntimeFilesUpdatePlugin, L: LockStateProvider>(
         State(route_state): State<RuntimeUpdateRouteState<P, L>>,
         Secured(sec_plugin): Secured,
-        mut multipart: axum::extract::Multipart,
+        request: Request,
     ) -> impl IntoResponse {
+        let content_type = request
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<mime::Mime>().ok());
+
+        match content_type.as_ref().map(|m| (m.type_(), m.subtype())) {
+            Some((mime::MULTIPART, mime::FORM_DATA)) => {
+                handle_multipart_upload(route_state, sec_plugin, request).await
+            }
+            Some((mime::APPLICATION, mime::OCTET_STREAM)) => {
+                handle_octet_stream_upload(route_state, sec_plugin, request).await
+            }
+            _ => DbUpdateErrorResponse::new(
+                RuntimeUpdateError::ValidationFailed(
+                    "Unsupported Content-Type, expected multipart/form-data or \
+                     application/octet-stream"
+                        .to_owned(),
+                ),
+                route_state.retry_after_seconds,
+            )
+            .into_response(),
+        }
+    }
+
+    async fn handle_multipart_upload<P: RuntimeFilesUpdatePlugin, L: LockStateProvider>(
+        route_state: RuntimeUpdateRouteState<P, L>,
+        sec_plugin: cda_plugin_security::SecurityPluginData,
+        request: Request,
+    ) -> Response {
+        let mut multipart =
+            match axum::extract::Multipart::from_request(request, &route_state).await {
+                Ok(multipart) => multipart,
+                Err(e) => {
+                    return DbUpdateErrorResponse::new(
+                        RuntimeUpdateError::ValidationFailed(e.to_string()),
+                        route_state.retry_after_seconds,
+                    )
+                    .into_response();
+                }
+            };
+
         // The plugin takes care about rejecting new uploads during an active apply
         let claims = sec_plugin.as_auth_plugin().claims();
         if let Err(resp) = require_vehicle_lock(
@@ -285,6 +463,62 @@ pub(crate) mod nextupdate {
             |e| DbUpdateErrorResponse::new(e, route_state.retry_after_seconds).into_response(),
             |result| (StatusCode::CREATED, Json(result)).into_response(),
         )
+    }
+
+    async fn handle_octet_stream_upload<P: RuntimeFilesUpdatePlugin, L: LockStateProvider>(
+        route_state: RuntimeUpdateRouteState<P, L>,
+        sec_plugin: cda_plugin_security::SecurityPluginData,
+        request: Request,
+    ) -> Response {
+        let claims = sec_plugin.as_auth_plugin().claims();
+        if let Err(resp) = require_vehicle_lock(
+            &*route_state.vehicle_lock_states,
+            *claims,
+            route_state.retry_after_seconds,
+        )
+        .await
+        {
+            // As with the multipart path: drain the (potentially large) body before
+            // responding, so an early rejection doesn't race the client's in-flight
+            // write and cause a transport-level error instead of a clean response.
+            let _ = axum::body::to_bytes(request.into_limited_body(), usize::MAX).await;
+            return resp.into_response();
+        }
+
+        let Some(filename) = parse_content_disposition_filename(request.headers()) else {
+            // Drain the body before rejecting the request for the same reason as the
+            // lock-rejection path above.
+            let _ = axum::body::to_bytes(request.into_limited_body(), usize::MAX).await;
+            return DbUpdateErrorResponse::new(
+                RuntimeUpdateError::ValidationFailed(
+                    "Missing or invalid Content-Disposition header, expected e.g. 'attachment; \
+                     filename=\"foo.mdd\"'"
+                        .to_owned(),
+                ),
+                route_state.retry_after_seconds,
+            )
+            .into_response();
+        };
+
+        let data = match axum::body::to_bytes(request.into_limited_body(), usize::MAX).await {
+            Ok(data) => data,
+            Err(e) => {
+                return DbUpdateErrorResponse::new(
+                    RuntimeUpdateError::ValidationFailed(e.to_string()),
+                    route_state.retry_after_seconds,
+                )
+                .into_response();
+            }
+        };
+
+        route_state
+            .plugin
+            .upload(vec![UploadFile { filename, data }])
+            .await
+            .map_or_else(
+                |e| DbUpdateErrorResponse::new(e, route_state.retry_after_seconds).into_response(),
+                |result| (StatusCode::CREATED, Json(result)).into_response(),
+            )
     }
 
     pub(crate) async fn delete<P: RuntimeFilesUpdatePlugin, L: LockStateProvider>(

--- a/cda-sovd/src/sovd/apps/sovd2uds/bulk_data/runtimefiles.rs
+++ b/cda-sovd/src/sovd/apps/sovd2uds/bulk_data/runtimefiles.rs
@@ -23,12 +23,7 @@ use cda_interfaces::runtime_update_api::{
 };
 use sovd_interfaces::error::{ApiErrorResponse, ErrorCode};
 
-use crate::{VendorErrorCode, sovd::update_guard::ExemptRoute};
-
-const EXECUTIONS_ROUTE: &str =
-    "/vehicle/v15/apps/sovd2uds/bulk-data/runtimefiles-nextupdate/executions";
-const EXECUTIONS_ID_ROUTE: &str =
-    "/vehicle/v15/apps/sovd2uds/bulk-data/runtimefiles-nextupdate/executions/{id}";
+use crate::VendorErrorCode;
 
 pub struct RuntimeUpdateRouteState<P, L> {
     pub plugin: Arc<P>,
@@ -46,13 +41,13 @@ impl<P, L> Clone for RuntimeUpdateRouteState<P, L> {
     }
 }
 
-struct DbUpdateErrorResponse {
+pub(crate) struct DbUpdateErrorResponse {
     error: RuntimeUpdateError,
     retry_after_seconds: u64,
 }
 
 impl DbUpdateErrorResponse {
-    fn new(error: RuntimeUpdateError, retry_after_seconds: u64) -> Self {
+    pub(crate) fn new(error: RuntimeUpdateError, retry_after_seconds: u64) -> Self {
         Self {
             error,
             retry_after_seconds,
@@ -170,7 +165,7 @@ fn bulk_data_list_response(
     (StatusCode::OK, Json(list)).into_response()
 }
 
-async fn require_vehicle_lock(
+pub(crate) async fn require_vehicle_lock(
     lock_state: &dyn LockStateProvider,
     claims: &dyn cda_plugin_security::Claims,
     retry_after_seconds: u64,
@@ -398,117 +393,6 @@ pub(crate) mod backup {
     }
 }
 
-pub(crate) mod executions {
-    use axum::{
-        Json,
-        extract::{Query, State},
-        http::StatusCode,
-        response::IntoResponse,
-    };
-    use axum_extra::extract::WithRejection;
-    use cda_interfaces::runtime_update_api::{LockStateProvider, RuntimeFilesUpdatePlugin};
-    use cda_plugin_security::Secured;
-    use sovd_interfaces::apps::sovd2uds::bulk_data::runtimefiles::{
-        ExecutionListResponse, ExecutionResponse, ExecutionsQuery,
-    };
-
-    use super::{DbUpdateErrorResponse, RuntimeUpdateRouteState, require_vehicle_lock};
-    use crate::sovd::error::ApiError;
-
-    pub(crate) async fn get<P: RuntimeFilesUpdatePlugin, L: LockStateProvider>(
-        State(route_state): State<RuntimeUpdateRouteState<P, L>>,
-        WithRejection(Query(query), _): WithRejection<Query<ExecutionsQuery>, ApiError>,
-    ) -> impl IntoResponse {
-        let items = route_state
-            .plugin
-            .list_executions()
-            .await
-            .into_iter()
-            .map(ExecutionResponse::from)
-            .collect();
-        let schema = if query.include_schema {
-            Some(crate::create_schema!(ExecutionListResponse))
-        } else {
-            None
-        };
-        (
-            StatusCode::OK,
-            Json(ExecutionListResponse { items, schema }),
-        )
-            .into_response()
-    }
-
-    pub(crate) async fn post<P: RuntimeFilesUpdatePlugin, L: LockStateProvider>(
-        State(route_state): State<RuntimeUpdateRouteState<P, L>>,
-        Secured(sec_plugin): Secured,
-        Json(body): Json<
-            sovd_interfaces::apps::sovd2uds::bulk_data::runtimefiles::ExecutionRequest,
-        >,
-    ) -> impl IntoResponse {
-        let claims = sec_plugin.as_auth_plugin().claims();
-        if let Err(resp) = require_vehicle_lock(
-            &*route_state.vehicle_lock_states,
-            *claims,
-            route_state.retry_after_seconds,
-        )
-        .await
-        {
-            return resp.into_response();
-        }
-
-        route_state
-            .plugin
-            .start_execution(body.mode)
-            .await
-            .map_or_else(
-                |e| DbUpdateErrorResponse::new(e, route_state.retry_after_seconds).into_response(),
-                |id| {
-                    (
-                        StatusCode::ACCEPTED,
-                        Json(
-                            sovd_interfaces::apps::sovd2uds::bulk_data::runtimefiles::ExecutionCreatedResponse { id },
-                        ),
-                    )
-                        .into_response()
-                },
-            )
-    }
-
-    pub(crate) mod id {
-        use axum::{
-            Json,
-            extract::{Path, Query, State},
-            http::StatusCode,
-            response::IntoResponse,
-        };
-        use axum_extra::extract::WithRejection;
-        use cda_interfaces::runtime_update_api::{LockStateProvider, RuntimeFilesUpdatePlugin};
-        use sovd_interfaces::apps::sovd2uds::bulk_data::runtimefiles::{
-            ExecutionResponse, ExecutionsQuery,
-        };
-
-        use super::super::RuntimeUpdateRouteState;
-        use crate::sovd::error::ApiError;
-
-        pub(crate) async fn get<P: RuntimeFilesUpdatePlugin, L: LockStateProvider>(
-            State(route_state): State<RuntimeUpdateRouteState<P, L>>,
-            Path(id): Path<String>,
-            WithRejection(Query(query), _): WithRejection<Query<ExecutionsQuery>, ApiError>,
-        ) -> impl IntoResponse {
-            match route_state.plugin.get_execution_status(&id).await {
-                Some(exec) => {
-                    let mut resp = ExecutionResponse::from(exec);
-                    if query.include_schema {
-                        resp.schema = Some(crate::create_schema!(ExecutionResponse));
-                    }
-                    (StatusCode::OK, Json(resp)).into_response()
-                }
-                None => StatusCode::NOT_FOUND.into_response(),
-            }
-        }
-    }
-}
-
 pub fn routes<
     S: cda_plugin_security::SecurityPluginLoader,
     P: RuntimeFilesUpdatePlugin,
@@ -537,28 +421,8 @@ pub fn routes<
             "/vehicle/v15/apps/sovd2uds/bulk-data/runtimefiles-backup",
             axum::routing::get(backup::get::<P, L>).delete(backup::delete::<P, L>),
         )
-        .route(
-            EXECUTIONS_ROUTE,
-            axum::routing::get(executions::get::<P, L>).post(executions::post::<P, L>),
-        )
-        .route(
-            EXECUTIONS_ID_ROUTE,
-            axum::routing::get(executions::id::get::<P, L>),
-        )
-        .route(
-            "/vehicle/v15/apps/sovd2uds/operations/diagnostic-database-update",
-            axum::routing::post(executions::post::<P, L>),
-        )
         .layer(axum::middleware::from_fn(
             cda_plugin_security::security_plugin_middleware::<S>,
         ))
         .with_state(state)
-}
-
-/// Returns the [`ExemptRoute`]s that must remain accessible during a database update.
-pub fn update_exempt_routes() -> Vec<ExemptRoute> {
-    vec![ExemptRoute {
-        prefix: EXECUTIONS_ROUTE.to_string(),
-        methods: vec![http::Method::GET],
-    }]
 }

--- a/cda-sovd/src/sovd/apps/sovd2uds/bulk_data/runtimefiles.rs
+++ b/cda-sovd/src/sovd/apps/sovd2uds/bulk_data/runtimefiles.rs
@@ -15,7 +15,10 @@ use std::sync::Arc;
 
 use axum::{
     Json,
-    http::{HeaderValue, StatusCode, header::RETRY_AFTER},
+    http::{
+        HeaderValue, StatusCode,
+        header::{LOCATION, RETRY_AFTER},
+    },
     response::{IntoResponse, Response},
 };
 use cda_interfaces::runtime_update_api::{
@@ -165,6 +168,26 @@ fn bulk_data_list_response(
     (StatusCode::OK, Json(list)).into_response()
 }
 
+fn bulk_data_created_response(
+    host: &str,
+    result: cda_interfaces::runtime_update_api::BulkDataCreatedList,
+) -> Response {
+    let Some(first) = result.items.first() else {
+        return DbUpdateErrorResponse::new(
+            RuntimeUpdateError::StorageError(cda_interfaces::storage_api::StorageError::Other(
+                "upload completed without creating bulk-data".to_owned(),
+            )),
+            0,
+        )
+        .into_response();
+    };
+    let location = format!(
+        "http://{host}/vehicle/v15/apps/sovd2uds/bulk-data/runtimefiles-nextupdate/{}",
+        first.id
+    );
+    (StatusCode::CREATED, [(LOCATION, location)], Json(result)).into_response()
+}
+
 pub(crate) async fn require_vehicle_lock(
     lock_state: &dyn LockStateProvider,
     claims: &dyn cda_plugin_security::Claims,
@@ -210,6 +233,7 @@ pub(crate) mod current {
 }
 
 pub(crate) mod nextupdate {
+    use aide::UseApi;
     use axum::{
         Json, RequestExt,
         extract::{FromRequest, Query, Request, State},
@@ -220,6 +244,7 @@ pub(crate) mod nextupdate {
         LockStateProvider, RuntimeFilesUpdatePlugin, RuntimeUpdateError, UploadFile,
     };
     use cda_plugin_security::Secured;
+    use opensovd_axum_extra::ExtractHost;
 
     use super::{DbUpdateErrorResponse, RuntimeUpdateRouteState, require_vehicle_lock};
 
@@ -378,6 +403,7 @@ pub(crate) mod nextupdate {
     /// the `Content-Disposition` header (e.g. `attachment; filename="foo.mdd"`).
     pub(crate) async fn post<P: RuntimeFilesUpdatePlugin, L: LockStateProvider>(
         State(route_state): State<RuntimeUpdateRouteState<P, L>>,
+        UseApi(ExtractHost(host), _): UseApi<ExtractHost, String>,
         Secured(sec_plugin): Secured,
         request: Request,
     ) -> impl IntoResponse {
@@ -389,10 +415,10 @@ pub(crate) mod nextupdate {
 
         match content_type.as_ref().map(|m| (m.type_(), m.subtype())) {
             Some((mime::MULTIPART, mime::FORM_DATA)) => {
-                handle_multipart_upload(route_state, sec_plugin, request).await
+                handle_multipart_upload(route_state, sec_plugin, host, request).await
             }
             Some((mime::APPLICATION, mime::OCTET_STREAM)) => {
-                handle_octet_stream_upload(route_state, sec_plugin, request).await
+                handle_octet_stream_upload(route_state, sec_plugin, host, request).await
             }
             _ => DbUpdateErrorResponse::new(
                 RuntimeUpdateError::ValidationFailed(
@@ -409,6 +435,7 @@ pub(crate) mod nextupdate {
     async fn handle_multipart_upload<P: RuntimeFilesUpdatePlugin, L: LockStateProvider>(
         route_state: RuntimeUpdateRouteState<P, L>,
         sec_plugin: cda_plugin_security::SecurityPluginData,
+        host: String,
         request: Request,
     ) -> Response {
         let mut multipart =
@@ -461,13 +488,14 @@ pub(crate) mod nextupdate {
 
         route_state.plugin.upload(files).await.map_or_else(
             |e| DbUpdateErrorResponse::new(e, route_state.retry_after_seconds).into_response(),
-            |result| (StatusCode::CREATED, Json(result)).into_response(),
+            |result| super::bulk_data_created_response(&host, result),
         )
     }
 
     async fn handle_octet_stream_upload<P: RuntimeFilesUpdatePlugin, L: LockStateProvider>(
         route_state: RuntimeUpdateRouteState<P, L>,
         sec_plugin: cda_plugin_security::SecurityPluginData,
+        host: String,
         request: Request,
     ) -> Response {
         let claims = sec_plugin.as_auth_plugin().claims();
@@ -517,7 +545,7 @@ pub(crate) mod nextupdate {
             .await
             .map_or_else(
                 |e| DbUpdateErrorResponse::new(e, route_state.retry_after_seconds).into_response(),
-                |result| (StatusCode::CREATED, Json(result)).into_response(),
+                |result| super::bulk_data_created_response(&host, result),
             )
     }
 
@@ -537,7 +565,16 @@ pub(crate) mod nextupdate {
         }
         route_state.plugin.delete_nextupdate().await.map_or_else(
             |e| DbUpdateErrorResponse::new(e, route_state.retry_after_seconds).into_response(),
-            |()| StatusCode::NO_CONTENT.into_response(),
+            |deleted_ids| {
+                (
+                    StatusCode::OK,
+                    Json(cda_interfaces::runtime_update_api::BulkDataDeleted {
+                        deleted_ids,
+                        errors: vec![],
+                    }),
+                )
+                    .into_response()
+            },
         )
     }
 
@@ -584,6 +621,7 @@ pub(crate) mod nextupdate {
 
 pub(crate) mod backup {
     use axum::{
+        Json,
         extract::{Query, State},
         http::StatusCode,
         response::{IntoResponse, Response},
@@ -622,7 +660,16 @@ pub(crate) mod backup {
         }
         route_state.plugin.delete_backup().await.map_or_else(
             |e| DbUpdateErrorResponse::new(e, route_state.retry_after_seconds).into_response(),
-            |()| StatusCode::NO_CONTENT.into_response(),
+            |deleted_ids| {
+                (
+                    StatusCode::OK,
+                    Json(cda_interfaces::runtime_update_api::BulkDataDeleted {
+                        deleted_ids,
+                        errors: vec![],
+                    }),
+                )
+                    .into_response()
+            },
         )
     }
 }

--- a/cda-sovd/src/sovd/apps/sovd2uds/operations.rs
+++ b/cda-sovd/src/sovd/apps/sovd2uds/operations.rs
@@ -12,25 +12,24 @@
  */
 
 pub(crate) mod runtimefilesupdate {
+    use aide::UseApi;
     use axum::{
         Json,
-        extract::{Query, State},
-        http::StatusCode,
+        extract::State,
+        http::{StatusCode, header::LOCATION},
         response::IntoResponse,
     };
-    use axum_extra::extract::WithRejection;
     use cda_interfaces::runtime_update_api::{LockStateProvider, RuntimeFilesUpdatePlugin};
     use cda_plugin_security::Secured;
+    use opensovd_axum_extra::ExtractHost;
     use sovd_interfaces::apps::sovd2uds::operations::runtimefilesupdate::{
-        ExecutionCreatedResponse, ExecutionListResponse, ExecutionRequest, ExecutionResponse,
-        ExecutionsQuery,
+        ExecutionCreatedResponse, ExecutionListResponse, ExecutionRequest,
     };
 
     use crate::sovd::{
         apps::sovd2uds::bulk_data::runtimefiles::{
             DbUpdateErrorResponse, RuntimeUpdateRouteState, require_vehicle_lock,
         },
-        error::ApiError,
         update_guard::ExemptRoute,
     };
 
@@ -41,29 +40,20 @@ pub(crate) mod runtimefilesupdate {
 
     pub(crate) async fn get<P: RuntimeFilesUpdatePlugin, L: LockStateProvider>(
         State(route_state): State<RuntimeUpdateRouteState<P, L>>,
-        WithRejection(Query(query), _): WithRejection<Query<ExecutionsQuery>, ApiError>,
     ) -> impl IntoResponse {
         let items = route_state
             .plugin
             .list_executions()
             .await
             .into_iter()
-            .map(ExecutionResponse::from)
+            .map(|exec| sovd_interfaces::common::operations::OperationIdItem { id: exec.id })
             .collect();
-        let schema = if query.include_schema {
-            Some(crate::create_schema!(ExecutionListResponse))
-        } else {
-            None
-        };
-        (
-            StatusCode::OK,
-            Json(ExecutionListResponse { items, schema }),
-        )
-            .into_response()
+        (StatusCode::OK, Json(ExecutionListResponse { items })).into_response()
     }
 
     pub(crate) async fn post<P: RuntimeFilesUpdatePlugin, L: LockStateProvider>(
         State(route_state): State<RuntimeUpdateRouteState<P, L>>,
+        UseApi(ExtractHost(host), _): UseApi<ExtractHost, String>,
         Secured(sec_plugin): Secured,
         Json(body): Json<ExecutionRequest>,
     ) -> impl IntoResponse {
@@ -84,7 +74,15 @@ pub(crate) mod runtimefilesupdate {
             .await
             .map_or_else(
                 |e| DbUpdateErrorResponse::new(e, route_state.retry_after_seconds).into_response(),
-                |id| (StatusCode::ACCEPTED, Json(ExecutionCreatedResponse { id })).into_response(),
+                |id| {
+                    let location = format!("http://{host}{EXECUTIONS_ROUTE}/{id}");
+                    (
+                        StatusCode::ACCEPTED,
+                        [(LOCATION, location)],
+                        Json(ExecutionCreatedResponse { id }),
+                    )
+                        .into_response()
+                },
             )
     }
 
@@ -97,9 +95,7 @@ pub(crate) mod runtimefilesupdate {
         };
         use axum_extra::extract::WithRejection;
         use cda_interfaces::runtime_update_api::{LockStateProvider, RuntimeFilesUpdatePlugin};
-        use sovd_interfaces::apps::sovd2uds::operations::runtimefilesupdate::{
-            ExecutionResponse, ExecutionsQuery,
-        };
+        use sovd_interfaces::apps::sovd2uds::operations::runtimefilesupdate::ExecutionResponse;
 
         use crate::sovd::{
             apps::sovd2uds::bulk_data::runtimefiles::RuntimeUpdateRouteState, error::ApiError,
@@ -108,7 +104,10 @@ pub(crate) mod runtimefilesupdate {
         pub(crate) async fn get<P: RuntimeFilesUpdatePlugin, L: LockStateProvider>(
             State(route_state): State<RuntimeUpdateRouteState<P, L>>,
             Path(id): Path<String>,
-            WithRejection(Query(query), _): WithRejection<Query<ExecutionsQuery>, ApiError>,
+            WithRejection(Query(query), _): WithRejection<
+                Query<sovd_interfaces::IncludeSchemaQuery>,
+                ApiError,
+            >,
         ) -> impl IntoResponse {
             match route_state.plugin.get_execution_status(&id).await {
                 Some(exec) => {

--- a/cda-sovd/src/sovd/apps/sovd2uds/operations.rs
+++ b/cda-sovd/src/sovd/apps/sovd2uds/operations.rs
@@ -1,0 +1,152 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+pub(crate) mod runtimefilesupdate {
+    use axum::{
+        Json,
+        extract::{Query, State},
+        http::StatusCode,
+        response::IntoResponse,
+    };
+    use axum_extra::extract::WithRejection;
+    use cda_interfaces::runtime_update_api::{LockStateProvider, RuntimeFilesUpdatePlugin};
+    use cda_plugin_security::Secured;
+    use sovd_interfaces::apps::sovd2uds::operations::runtimefilesupdate::{
+        ExecutionCreatedResponse, ExecutionListResponse, ExecutionRequest, ExecutionResponse,
+        ExecutionsQuery,
+    };
+
+    use crate::sovd::{
+        apps::sovd2uds::bulk_data::runtimefiles::{
+            DbUpdateErrorResponse, RuntimeUpdateRouteState, require_vehicle_lock,
+        },
+        error::ApiError,
+        update_guard::ExemptRoute,
+    };
+
+    const EXECUTIONS_ROUTE: &str =
+        "/vehicle/v15/apps/sovd2uds/operations/runtimefilesupdate/executions";
+    const EXECUTIONS_ID_ROUTE: &str =
+        "/vehicle/v15/apps/sovd2uds/operations/runtimefilesupdate/executions/{id}";
+
+    pub(crate) async fn get<P: RuntimeFilesUpdatePlugin, L: LockStateProvider>(
+        State(route_state): State<RuntimeUpdateRouteState<P, L>>,
+        WithRejection(Query(query), _): WithRejection<Query<ExecutionsQuery>, ApiError>,
+    ) -> impl IntoResponse {
+        let items = route_state
+            .plugin
+            .list_executions()
+            .await
+            .into_iter()
+            .map(ExecutionResponse::from)
+            .collect();
+        let schema = if query.include_schema {
+            Some(crate::create_schema!(ExecutionListResponse))
+        } else {
+            None
+        };
+        (
+            StatusCode::OK,
+            Json(ExecutionListResponse { items, schema }),
+        )
+            .into_response()
+    }
+
+    pub(crate) async fn post<P: RuntimeFilesUpdatePlugin, L: LockStateProvider>(
+        State(route_state): State<RuntimeUpdateRouteState<P, L>>,
+        Secured(sec_plugin): Secured,
+        Json(body): Json<ExecutionRequest>,
+    ) -> impl IntoResponse {
+        let claims = sec_plugin.as_auth_plugin().claims();
+        if let Err(resp) = require_vehicle_lock(
+            &*route_state.vehicle_lock_states,
+            *claims,
+            route_state.retry_after_seconds,
+        )
+        .await
+        {
+            return resp.into_response();
+        }
+
+        route_state
+            .plugin
+            .start_execution(body.parameters.mode)
+            .await
+            .map_or_else(
+                |e| DbUpdateErrorResponse::new(e, route_state.retry_after_seconds).into_response(),
+                |id| (StatusCode::ACCEPTED, Json(ExecutionCreatedResponse { id })).into_response(),
+            )
+    }
+
+    pub(crate) mod id {
+        use axum::{
+            Json,
+            extract::{Path, Query, State},
+            http::StatusCode,
+            response::IntoResponse,
+        };
+        use axum_extra::extract::WithRejection;
+        use cda_interfaces::runtime_update_api::{LockStateProvider, RuntimeFilesUpdatePlugin};
+        use sovd_interfaces::apps::sovd2uds::operations::runtimefilesupdate::{
+            ExecutionResponse, ExecutionsQuery,
+        };
+
+        use crate::sovd::{
+            apps::sovd2uds::bulk_data::runtimefiles::RuntimeUpdateRouteState, error::ApiError,
+        };
+
+        pub(crate) async fn get<P: RuntimeFilesUpdatePlugin, L: LockStateProvider>(
+            State(route_state): State<RuntimeUpdateRouteState<P, L>>,
+            Path(id): Path<String>,
+            WithRejection(Query(query), _): WithRejection<Query<ExecutionsQuery>, ApiError>,
+        ) -> impl IntoResponse {
+            match route_state.plugin.get_execution_status(&id).await {
+                Some(exec) => {
+                    let mut resp = ExecutionResponse::from(exec);
+                    if query.include_schema {
+                        resp.schema = Some(crate::create_schema!(ExecutionResponse));
+                    }
+                    (StatusCode::OK, Json(resp)).into_response()
+                }
+                None => StatusCode::NOT_FOUND.into_response(),
+            }
+        }
+    }
+
+    pub fn routes<
+        S: cda_plugin_security::SecurityPluginLoader,
+        P: RuntimeFilesUpdatePlugin,
+        L: LockStateProvider,
+    >(
+        state: RuntimeUpdateRouteState<P, L>,
+    ) -> axum::Router {
+        axum::Router::new()
+            .route(
+                EXECUTIONS_ROUTE,
+                axum::routing::get(get::<P, L>).post(post::<P, L>),
+            )
+            .route(EXECUTIONS_ID_ROUTE, axum::routing::get(id::get::<P, L>))
+            .layer(axum::middleware::from_fn(
+                cda_plugin_security::security_plugin_middleware::<S>,
+            ))
+            .with_state(state)
+    }
+
+    /// Returns the [`ExemptRoute`]s that must remain accessible during a database update.
+    pub fn update_exempt_routes() -> Vec<ExemptRoute> {
+        vec![ExemptRoute {
+            prefix: EXECUTIONS_ROUTE.to_string(),
+            methods: vec![http::Method::GET],
+        }]
+    }
+}

--- a/cda-sovd/src/sovd/components/ecu/x_sovd2uds_bulk_data.rs
+++ b/cda-sovd/src/sovd/components/ecu/x_sovd2uds_bulk_data.rs
@@ -80,6 +80,7 @@ pub(crate) mod mdd_embedded_files {
                     hash_algorithm: None,
                     id: id.clone(),
                     mimetype: content_type_from_meta(meta),
+                    name: Some(meta.name.clone()),
                     size: Some(meta.uncompressed_size),
                     origin_path: Some(meta.name.clone()),
                     revision: None,
@@ -99,6 +100,7 @@ pub(crate) mod mdd_embedded_files {
                         items: vec![sovd_interfaces::sovd2uds::BulkDataDescriptor {
                             id: "example_file".to_owned(),
                             mimetype: "application/octet-stream".to_owned(),
+                            name: Some("example_file".to_owned()),
                             size: Some(1234),
                             hash: None,
                             hash_algorithm: None,

--- a/docs/03_architecture/05_plugins/02_diagnostic_database_update.rst
+++ b/docs/03_architecture/05_plugins/02_diagnostic_database_update.rst
@@ -49,11 +49,11 @@ Diagnostic Database Update Plugin
 
        * - POST
          - ``/apps/sovd2uds/bulk-data/runtimefiles-nextupdate``
-         - Adds files to the next update of the diagnostic database. Two content types are supported: ``multipart/form-data`` (one or more files, filenames taken from each part's ``filename`` parameter), and ``application/octet-stream`` (a single file per request, whose filename must be provided via the ``Content-Disposition`` header, e.g. ``Content-Disposition: attachment; filename="foo.mdd"``).
+         - Adds files to the next update of the diagnostic database. Two content types are supported: ``multipart/form-data`` (one or more files, filenames taken from each part's ``filename`` parameter), and ``application/octet-stream`` (a single file per request, whose filename must be provided via the ``Content-Disposition`` header, e.g. ``Content-Disposition: attachment; filename="foo.mdd"``). Returns 201 with all created IDs and a ``Location`` header for the first created file.
 
        * - DELETE
          - ``/apps/sovd2uds/bulk-data/runtimefiles-nextupdate``
-         - Removes all pending changes to the next update of the diagnostic database, to reset the state of the next update to the currently active database.
+         - Removes all pending changes to the next update of the diagnostic database, to reset the state of the next update to the currently active database. Returns 200 with ``deleted_ids`` and ``errors``.
 
        * - DELETE
          - ``/apps/sovd2uds/bulk-data/runtimefiles-nextupdate/{id}``
@@ -65,7 +65,7 @@ Diagnostic Database Update Plugin
 
        * - DELETE
          - ``/apps/sovd2uds/bulk-data/runtimefiles-backup``
-         - Deletes the backup of the previously used diagnostic database, to free up storage space. This also means that rolling back to the previous state isn't possible anymore after deleting the backup.
+         - Deletes the backup of the previously used diagnostic database, to free up storage space. This also means that rolling back to the previous state isn't possible anymore after deleting the backup. Returns 200 with ``deleted_ids`` and ``errors``.
 
     .. list-table:: Operations Paths for Applying/Rolling Back/Cleaning Up Diagnostic Database Updates
        :header-rows: 1
@@ -76,7 +76,7 @@ Diagnostic Database Update Plugin
 
        * - GET
          - ``/apps/sovd2uds/operations/runtimefilesupdate/executions``
-         - Returns the list of current executions. Always contains at most one entry. Supports the ``include-schema`` query parameter.
+         - Returns the list of current execution identifiers. Always contains at most one entry.
 
        * - GET
          - ``/apps/sovd2uds/operations/runtimefilesupdate/executions/{id}``
@@ -91,6 +91,7 @@ Diagnostic Database Update Plugin
        - ``x-sovd2uds-include-hash`` (string, default: not present -- supported is only sha256) - to include file hashes of the files
        - ``x-sovd2uds-include-file-size`` (boolean, default: false) - to include file sizes of the files
        - ``x-sovd2uds-include-revision`` (boolean, default: false) - to include the revision inside the files
+       - ``created-after`` and ``created-before`` (string:date-time) are accepted for ISO 17978-3 compatibility but do not currently filter results.
 
     **Configuration File Support**
 
@@ -182,9 +183,8 @@ Diagnostic Database Update Plugin
     of the last execution remains available for inspection without requiring indefinite memory growth.
 
     The list endpoint ``GET /apps/sovd2uds/operations/runtimefilesupdate/executions`` returns all
-    currently tracked executions and always contains at most one entry. It supports the ``include-schema``
-    query parameter to include the JSON Schema of the response. No vehicle lock is required to use the
-    list or status endpoints.
+    currently tracked execution identifiers and always contains at most one entry. No vehicle lock is
+    required to use the list or status endpoints.
 
     After applying, or rolling back the diagnostic database, the new database must be active immediately, without
     requiring a restart of the CDA, and the old state must be available as a backup until the next update is applied,

--- a/docs/03_architecture/05_plugins/02_diagnostic_database_update.rst
+++ b/docs/03_architecture/05_plugins/02_diagnostic_database_update.rst
@@ -49,7 +49,7 @@ Diagnostic Database Update Plugin
 
        * - POST
          - ``/apps/sovd2uds/bulk-data/runtimefiles-nextupdate``
-         - Adds files to the next update of the diagnostic database, using multipart form data. The files provided through this endpoint are added to the pending update.
+         - Adds files to the next update of the diagnostic database. Two content types are supported: ``multipart/form-data`` (one or more files, filenames taken from each part's ``filename`` parameter), and ``application/octet-stream`` (a single file per request, whose filename must be provided via the ``Content-Disposition`` header, e.g. ``Content-Disposition: attachment; filename="foo.mdd"``).
 
        * - DELETE
          - ``/apps/sovd2uds/bulk-data/runtimefiles-nextupdate``

--- a/docs/03_architecture/05_plugins/02_diagnostic_database_update.rst
+++ b/docs/03_architecture/05_plugins/02_diagnostic_database_update.rst
@@ -29,7 +29,8 @@ Diagnostic Database Update Plugin
     This behavior and additional security requirements must be modifiable through a trait provided to the plugin,
     to support more specific OEM requirements for security and individual environments during the update process.
 
-    The diagnostic database update plugin must provide the following bulk-data categories/endpoints:
+    The diagnostic database update plugin must provide the following bulk-data categories/endpoints for
+    file management, and a separate ``operations`` endpoint for applying/rolling back/cleaning up updates:
 
     .. list-table:: Bulk-Data Paths for Diagnostic Database Update Preparation
        :header-rows: 1
@@ -66,16 +67,23 @@ Diagnostic Database Update Plugin
          - ``/apps/sovd2uds/bulk-data/runtimefiles-backup``
          - Deletes the backup of the previously used diagnostic database, to free up storage space. This also means that rolling back to the previous state isn't possible anymore after deleting the backup.
 
+    .. list-table:: Operations Paths for Applying/Rolling Back/Cleaning Up Diagnostic Database Updates
+       :header-rows: 1
+
+       * - Method
+         - Path
+         - Description
+
        * - GET
-         - ``/apps/sovd2uds/bulk-data/runtimefiles-nextupdate/executions``
+         - ``/apps/sovd2uds/operations/runtimefilesupdate/executions``
          - Returns the list of current executions. Always contains at most one entry. Supports the ``include-schema`` query parameter.
 
        * - GET
-         - ``/apps/sovd2uds/bulk-data/runtimefiles-nextupdate/executions/{id}``
+         - ``/apps/sovd2uds/operations/runtimefilesupdate/executions/{id}``
          - Returns the status of a specific execution by its ID.
 
        * - POST
-         - ``/apps/sovd2uds/bulk-data/runtimefiles-nextupdate/executions``
+         - ``/apps/sovd2uds/operations/runtimefilesupdate/executions``
          - Starts a new execution (Apply, Rollback, or Cleanup). Returns 202 Accepted with the execution ID.
 
     .. note:: The following query parameters must be supported for the GET endpoints:
@@ -99,8 +107,9 @@ Diagnostic Database Update Plugin
     All GET endpoints (``runtimefiles-current``, ``runtimefiles-nextupdate``, ``runtimefiles-backup``)
     return both MDD and configuration file entries in a single combined response.
 
-    The HTTP handler implementation for these endpoints resides in
-    ``cda-sovd/src/sovd/apps/sovd2uds/bulk_data/runtimefiles.rs``.
+    The HTTP handler implementation for the bulk-data endpoints resides in
+    ``cda-sovd/src/sovd/apps/sovd2uds/bulk_data/runtimefiles.rs``. The execution endpoints
+    (Apply/Rollback/Cleanup) reside in ``cda-sovd/src/sovd/apps/sovd2uds/operations.rs``.
 
     **Coupled MDD and Configuration Updates**
 
@@ -152,15 +161,14 @@ Diagnostic Database Update Plugin
 
     To apply all the pending updates to the current diagnostic database, an additional endpoint is required:
 
-    ``POST /apps/sovd2uds/bulk-data/runtimefiles-nextupdate/executions`` with a JSON-payload containing the property
-    ``mode``, with the following possible values (all case-insensitive):
+    ``POST /apps/sovd2uds/operations/runtimefilesupdate/executions`` with a JSON-payload containing a
+    ``parameters`` object with the property ``mode``, following the standard convention of wrapping
+    operation-specific inputs in a ``parameters`` field, with the following possible values for ``mode``
+    (all case-insensitive):
 
     - ``Apply`` - to apply the pending updates.
     - ``Rollback`` - to roll back to the backup state of the diagnostic database (also clears pending nextupdate)
     - ``Cleanup`` - to reset all pending updates, as well as deleting the backup
-
-    The same endpoint must also be made available as ``/apps/sovd2uds/operations/diagnostic-database-update``
-    to allow triggering the actions through a standard compliant operation.
 
     **Execution Lifecycle**
 
@@ -168,12 +176,12 @@ Diagnostic Database Update Plugin
     be rejected with a conflict error.
 
     Execution entries are retained in memory and remain queryable via
-    ``GET /apps/sovd2uds/bulk-data/runtimefiles-nextupdate/executions/{id}`` until the next execution is
+    ``GET /apps/sovd2uds/operations/runtimefilesupdate/executions/{id}`` until the next execution is
     started. When a new execution is started, all previous terminal-state (``Completed`` or ``Failed``)
     entries are removed. Entries must not be removed based on time (no TTL). This ensures that the result
     of the last execution remains available for inspection without requiring indefinite memory growth.
 
-    The list endpoint ``GET /apps/sovd2uds/bulk-data/runtimefiles-nextupdate/executions`` returns all
+    The list endpoint ``GET /apps/sovd2uds/operations/runtimefilesupdate/executions`` returns all
     currently tracked executions and always contains at most one entry. It supports the ``include-schema``
     query parameter to include the JSON Schema of the response. No vehicle lock is required to use the
     list or status endpoints.

--- a/integration-tests/tests/sovd/runtimefiles.rs
+++ b/integration-tests/tests/sovd/runtimefiles.rs
@@ -17,7 +17,7 @@ use cda_interfaces::{HashMap, HashMapExtensions};
 use http::{Method, StatusCode};
 use opensovd_cda_lib::config::configfile::Configuration;
 use sovd_interfaces::{
-    apps::sovd2uds::bulk_data::{BulkDataList, runtimefiles::ExecutionMode},
+    apps::sovd2uds::{bulk_data::BulkDataList, operations::runtimefilesupdate::ExecutionMode},
     common::operations::OperationIdItem,
     locking::post_put::Response as LockResponse,
     sovd2uds::BulkDataDescriptor,
@@ -42,8 +42,8 @@ use crate::{
 const RUNTIMEFILES_NEXTUPDATE: &str = "apps/sovd2uds/bulk-data/runtimefiles-nextupdate";
 const RUNTIMEFILES_CURRENT: &str = "apps/sovd2uds/bulk-data/runtimefiles-current";
 const RUNTIMEFILES_BACKUP: &str = "apps/sovd2uds/bulk-data/runtimefiles-backup";
-const RUNTIMEFILES_EXECUTIONS: &str = "apps/sovd2uds/bulk-data/runtimefiles-nextupdate/executions";
-const RUNTIMEFILES_OPERATIONS: &str = "apps/sovd2uds/operations/diagnostic-database-update";
+const RUNTIMEFILES_UPDATE_EXECUTIONS: &str =
+    "apps/sovd2uds/operations/runtimefilesupdate/executions";
 
 /// Tests that mutating endpoints return 403 Forbidden without a vehicle lock.
 #[tokio::test]
@@ -91,7 +91,7 @@ async fn runtimefiles_requires_lock() -> Result<(), TestingError> {
     let body = mode_json(ExecutionMode::Apply);
     send_cda_request(
         &runtime.config,
-        RUNTIMEFILES_EXECUTIONS,
+        RUNTIMEFILES_UPDATE_EXECUTIONS,
         StatusCode::FORBIDDEN,
         Method::POST,
         Some(&body),
@@ -103,7 +103,7 @@ async fn runtimefiles_requires_lock() -> Result<(), TestingError> {
     let body = mode_json(ExecutionMode::Rollback);
     send_cda_request(
         &runtime.config,
-        RUNTIMEFILES_EXECUTIONS,
+        RUNTIMEFILES_UPDATE_EXECUTIONS,
         StatusCode::FORBIDDEN,
         Method::POST,
         Some(&body),
@@ -115,7 +115,7 @@ async fn runtimefiles_requires_lock() -> Result<(), TestingError> {
     let body = mode_json(ExecutionMode::Cleanup);
     send_cda_request(
         &runtime.config,
-        RUNTIMEFILES_EXECUTIONS,
+        RUNTIMEFILES_UPDATE_EXECUTIONS,
         StatusCode::FORBIDDEN,
         Method::POST,
         Some(&body),
@@ -417,10 +417,10 @@ async fn runtimefiles_execution_mode_case_insensitive() -> Result<(), TestingErr
     // Test lowercase "apply"
     send_cda_request(
         &runtime.config,
-        RUNTIMEFILES_EXECUTIONS,
+        RUNTIMEFILES_UPDATE_EXECUTIONS,
         StatusCode::ACCEPTED,
         Method::POST,
-        Some(r#"{"mode": "apply"}"#),
+        Some(r#"{"parameters": {"mode": "apply"}}"#),
         Some(&auth),
         None,
     )
@@ -438,43 +438,10 @@ async fn runtimefiles_execution_mode_case_insensitive() -> Result<(), TestingErr
     // Test uppercase "APPLY"
     send_cda_request(
         &runtime.config,
-        RUNTIMEFILES_EXECUTIONS,
+        RUNTIMEFILES_UPDATE_EXECUTIONS,
         StatusCode::ACCEPTED,
         Method::POST,
-        Some(r#"{"mode": "APPLY"}"#),
-        Some(&auth),
-        None,
-    )
-    .await?;
-    cda_interfaces::util::tokio_ext::sleep_for(Duration::from_secs(3)).await;
-
-    teardown_lock(&runtime.config, &auth, &lock_id).await;
-    Ok(())
-}
-
-/// Spec: The operations endpoint must be accessible as an alternative alias for executions.
-#[tokio::test]
-async fn runtimefiles_operations_endpoint_alias() -> Result<(), TestingError> {
-    let (runtime, _lock) = setup_integration_test(true).await?;
-    let auth = auth_header(&runtime.config, None).await?;
-    let lock_id = setup_with_lock(&runtime.config, &auth).await;
-
-    // Upload a file so Apply has something to work with
-    let upload_response = upload_mdd(&runtime.config, &auth).await;
-    assert!(
-        upload_response.status().is_success(),
-        "Precondition: upload must succeed, got {}",
-        upload_response.status()
-    );
-
-    // Use RUNTIMEFILES_OPERATIONS instead of RUNTIMEFILES_EXECUTIONS
-    let body = mode_json(ExecutionMode::Apply);
-    send_cda_request(
-        &runtime.config,
-        RUNTIMEFILES_OPERATIONS,
-        StatusCode::ACCEPTED,
-        Method::POST,
-        Some(&body),
+        Some(r#"{"parameters": {"mode": "APPLY"}}"#),
         Some(&auth),
         None,
     )
@@ -649,7 +616,7 @@ async fn runtimefiles_apply_with_no_pending_changes() -> Result<(), TestingError
     let body = mode_json(ExecutionMode::Apply);
     let apply_response = send_cda_request(
         &runtime.config,
-        RUNTIMEFILES_EXECUTIONS,
+        RUNTIMEFILES_UPDATE_EXECUTIONS,
         StatusCode::NOT_FOUND,
         Method::POST,
         Some(&body),
@@ -707,7 +674,7 @@ async fn runtimefiles_rollback_with_no_backup() -> Result<(), TestingError> {
     let body = mode_json(ExecutionMode::Rollback);
     send_cda_request(
         &runtime.config,
-        RUNTIMEFILES_EXECUTIONS,
+        RUNTIMEFILES_UPDATE_EXECUTIONS,
         StatusCode::NOT_FOUND,
         Method::POST,
         Some(&body),
@@ -817,7 +784,7 @@ async fn runtimefiles_apply_blocked_by_active_operations() -> Result<(), Testing
     let body = mode_json(ExecutionMode::Apply);
     send_cda_request(
         &runtime.config,
-        RUNTIMEFILES_EXECUTIONS,
+        RUNTIMEFILES_UPDATE_EXECUTIONS,
         StatusCode::CONFLICT,
         Method::POST,
         Some(&body),
@@ -1004,7 +971,7 @@ async fn get_file_list(
 
 /// Serializes an `ExecutionMode` into the JSON body expected by execution endpoints.
 fn mode_json(mode: ExecutionMode) -> String {
-    serde_json::json!({ "mode": mode }).to_string()
+    serde_json::json!({ "parameters": { "mode": mode } }).to_string()
 }
 
 /// Helper: POSTs an execution mode to the executions endpoint (expects 202 Accepted).
@@ -1016,7 +983,7 @@ async fn execute_mode(
     let body = mode_json(mode);
     let response = send_cda_request(
         config,
-        RUNTIMEFILES_EXECUTIONS,
+        RUNTIMEFILES_UPDATE_EXECUTIONS,
         StatusCode::ACCEPTED,
         Method::POST,
         Some(&body),
@@ -1580,7 +1547,7 @@ async fn runtimefiles_only_lock_holder_can_mutate() -> Result<(), TestingError> 
     let body = mode_json(ExecutionMode::Apply);
     send_cda_request(
         &runtime.config,
-        RUNTIMEFILES_EXECUTIONS,
+        RUNTIMEFILES_UPDATE_EXECUTIONS,
         StatusCode::FORBIDDEN,
         Method::POST,
         Some(&body),
@@ -1593,7 +1560,7 @@ async fn runtimefiles_only_lock_holder_can_mutate() -> Result<(), TestingError> 
     let body = mode_json(ExecutionMode::Rollback);
     send_cda_request(
         &runtime.config,
-        RUNTIMEFILES_EXECUTIONS,
+        RUNTIMEFILES_UPDATE_EXECUTIONS,
         StatusCode::FORBIDDEN,
         Method::POST,
         Some(&body),
@@ -1606,7 +1573,7 @@ async fn runtimefiles_only_lock_holder_can_mutate() -> Result<(), TestingError> 
     let body = mode_json(ExecutionMode::Cleanup);
     send_cda_request(
         &runtime.config,
-        RUNTIMEFILES_EXECUTIONS,
+        RUNTIMEFILES_UPDATE_EXECUTIONS,
         StatusCode::FORBIDDEN,
         Method::POST,
         Some(&body),
@@ -1750,7 +1717,7 @@ async fn runtimefiles_apply_blocked_by_vehicle_and_ecu_lock() -> Result<(), Test
     let body = mode_json(ExecutionMode::Apply);
     send_cda_request(
         &runtime.config,
-        RUNTIMEFILES_EXECUTIONS,
+        RUNTIMEFILES_UPDATE_EXECUTIONS,
         StatusCode::CONFLICT,
         Method::POST,
         Some(&body),

--- a/integration-tests/tests/sovd/runtimefiles.rs
+++ b/integration-tests/tests/sovd/runtimefiles.rs
@@ -591,6 +591,147 @@ async fn runtimefiles_upload_multiple_files() -> Result<(), TestingError> {
     Ok(())
 }
 
+/// Spec: The nextupdate upload endpoint must also accept a single file uploaded as
+/// `application/octet-stream`, with the filename taken from the `Content-Disposition`
+/// header (quoted form: `attachment; filename="foo.mdd"`).
+#[tokio::test]
+async fn runtimefiles_upload_octet_stream() -> Result<(), TestingError> {
+    let (runtime, _lock) = setup_integration_test(true).await?;
+    let auth = auth_header(&runtime.config, None).await?;
+    let lock_id = setup_with_lock(&runtime.config, &auth).await;
+
+    let response = upload_mdd_octet_stream(
+        &runtime.config,
+        &auth,
+        Some("attachment; filename=\"FLXC1000.mdd\""),
+    )
+    .await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "Expected 201 Created for octet-stream upload, got {}",
+        response.status()
+    );
+
+    let list_response = send_cda_request(
+        &runtime.config,
+        RUNTIMEFILES_NEXTUPDATE,
+        StatusCode::OK,
+        Method::GET,
+        None,
+        Some(&auth),
+        None,
+    )
+    .await?;
+    let items = response_to_t::<BulkDataList>(&list_response)?.items;
+    assert!(
+        items
+            .iter()
+            .any(|item| item.id.to_lowercase() == "flxc1000.mdd"),
+        "Expected FLXC1000.mdd to appear in nextupdate after octet-stream upload"
+    );
+
+    teardown_lock(&runtime.config, &auth, &lock_id).await;
+    Ok(())
+}
+
+/// Spec: The `Content-Disposition` filename parameter must also be accepted in its
+/// unquoted form (`filename=foo.mdd`).
+#[tokio::test]
+async fn runtimefiles_upload_octet_stream_unquoted_filename() -> Result<(), TestingError> {
+    let (runtime, _lock) = setup_integration_test(true).await?;
+    let auth = auth_header(&runtime.config, None).await?;
+    let lock_id = setup_with_lock(&runtime.config, &auth).await;
+
+    let response = upload_mdd_octet_stream(
+        &runtime.config,
+        &auth,
+        Some("attachment; filename=FLXC1000.mdd"),
+    )
+    .await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "Expected 201 Created for octet-stream upload with unquoted filename, got {}",
+        response.status()
+    );
+
+    teardown_lock(&runtime.config, &auth, &lock_id).await;
+    Ok(())
+}
+
+/// Spec: An `application/octet-stream` upload without a `Content-Disposition` header
+/// must be rejected with 400 Bad Request.
+#[tokio::test]
+async fn runtimefiles_upload_octet_stream_missing_content_disposition() -> Result<(), TestingError>
+{
+    let (runtime, _lock) = setup_integration_test(true).await?;
+    let auth = auth_header(&runtime.config, None).await?;
+    let lock_id = setup_with_lock(&runtime.config, &auth).await;
+
+    let response = upload_mdd_octet_stream(&runtime.config, &auth, None).await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "Expected 400 Bad Request for octet-stream upload without Content-Disposition, got {}",
+        response.status()
+    );
+
+    teardown_lock(&runtime.config, &auth, &lock_id).await;
+    Ok(())
+}
+
+/// Spec: An `application/octet-stream` upload with a `Content-Disposition` header that
+/// has no `filename` parameter must be rejected with 400 Bad Request.
+#[tokio::test]
+async fn runtimefiles_upload_octet_stream_missing_filename_param() -> Result<(), TestingError> {
+    let (runtime, _lock) = setup_integration_test(true).await?;
+    let auth = auth_header(&runtime.config, None).await?;
+    let lock_id = setup_with_lock(&runtime.config, &auth).await;
+
+    let response = upload_mdd_octet_stream(&runtime.config, &auth, Some("attachment")).await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "Expected 400 Bad Request for octet-stream upload without filename param, got {}",
+        response.status()
+    );
+
+    teardown_lock(&runtime.config, &auth, &lock_id).await;
+    Ok(())
+}
+
+/// Spec: An upload with an unsupported `Content-Type` (neither `multipart/form-data`
+/// nor `application/octet-stream`) must be rejected with 400 Bad Request.
+#[tokio::test]
+async fn runtimefiles_upload_unsupported_content_type() -> Result<(), TestingError> {
+    let (runtime, _lock) = setup_integration_test(true).await?;
+    let auth = auth_header(&runtime.config, None).await?;
+    let lock_id = setup_with_lock(&runtime.config, &auth).await;
+
+    let response = upload_mdd_raw(
+        &runtime.config,
+        &auth,
+        "text/plain",
+        Some("attachment; filename=\"FLXC1000.mdd\""),
+    )
+    .await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "Expected 400 Bad Request for upload with unsupported Content-Type, got {}",
+        response.status()
+    );
+
+    teardown_lock(&runtime.config, &auth, &lock_id).await;
+    Ok(())
+}
+
 /// Spec: Applying when there are no pending changes (nextupdate == current)
 /// must not return 202 Accepted (primary expectation: 404).
 #[tokio::test]
@@ -918,6 +1059,58 @@ async fn upload_mdd_with_filename(
         .send()
         .await
         .expect("upload request failed")
+}
+
+/// Helper: uploads the `FLXC1000.mdd` fixture as a single raw-body request with the
+/// given `Content-Type`, optionally setting a `Content-Disposition` header value.
+async fn upload_mdd_raw(
+    config: &Configuration,
+    auth: &http::HeaderMap,
+    content_type: &str,
+    content_disposition: Option<&str>,
+) -> reqwest::Response {
+    let mdd_bytes = std::fs::read(
+        test_container_dir()
+            .expect("testcontainer dir")
+            .join("odx/FLXC1000.mdd"),
+    )
+    .expect("MDD fixture not found");
+    let auth_value = auth
+        .get(reqwest::header::AUTHORIZATION)
+        .expect("Authorization header missing")
+        .clone();
+    let upload_url = format!(
+        "http://{}:{}/vehicle/v15/{RUNTIMEFILES_NEXTUPDATE}",
+        config.server.address, config.server.port
+    );
+    let mut request = reqwest::Client::new()
+        .post(&upload_url)
+        .header(reqwest::header::AUTHORIZATION, auth_value)
+        .header(reqwest::header::CONTENT_TYPE, content_type.to_owned());
+    if let Some(content_disposition) = content_disposition {
+        request = request.header(reqwest::header::CONTENT_DISPOSITION, content_disposition);
+    }
+    request
+        .body(mdd_bytes)
+        .send()
+        .await
+        .expect("raw upload request failed")
+}
+
+/// Helper: uploads the `FLXC1000.mdd` fixture as a single `application/octet-stream`
+/// request, optionally setting a `Content-Disposition` header value.
+async fn upload_mdd_octet_stream(
+    config: &Configuration,
+    auth: &http::HeaderMap,
+    content_disposition: Option<&str>,
+) -> reqwest::Response {
+    upload_mdd_raw(
+        config,
+        auth,
+        "application/octet-stream",
+        content_disposition,
+    )
+    .await
 }
 
 /// Helper: creates a vehicle lock and returns the lock id.

--- a/integration-tests/tests/sovd/runtimefiles.rs
+++ b/integration-tests/tests/sovd/runtimefiles.rs
@@ -17,7 +17,10 @@ use cda_interfaces::{HashMap, HashMapExtensions};
 use http::{Method, StatusCode};
 use opensovd_cda_lib::config::configfile::Configuration;
 use sovd_interfaces::{
-    apps::sovd2uds::{bulk_data::BulkDataList, operations::runtimefilesupdate::ExecutionMode},
+    apps::sovd2uds::{
+        bulk_data::{BulkDataDeleted, BulkDataList},
+        operations::runtimefilesupdate::ExecutionMode,
+    },
     common::operations::OperationIdItem,
     locking::post_put::Response as LockResponse,
     sovd2uds::BulkDataDescriptor,
@@ -34,7 +37,7 @@ use crate::{
     },
     util::{
         TestingError,
-        http::{QueryParams, auth_header, response_to_t, send_cda_request},
+        http::{QueryParams, auth_header, response_to_json, response_to_t, send_cda_request},
         runtime::{setup_integration_test, test_container_dir, wait_for_ecus_online},
     },
 };
@@ -127,6 +130,191 @@ async fn runtimefiles_requires_lock() -> Result<(), TestingError> {
     Ok(())
 }
 
+/// Checks the runtime file update execution resources follow ISO 17978-3 section 7.14.
+#[tokio::test]
+async fn runtimefiles_execution_responses_follow_operation_standard() -> Result<(), TestingError> {
+    let (runtime, _lock) = setup_integration_test(true).await?;
+    let auth = auth_header(&runtime.config, None).await?;
+    let lock_id = setup_with_lock(&runtime.config, &auth).await;
+
+    let response = send_cda_request(
+        &runtime.config,
+        RUNTIMEFILES_UPDATE_EXECUTIONS,
+        StatusCode::ACCEPTED,
+        Method::POST,
+        Some(&mode_json(ExecutionMode::Cleanup)),
+        Some(&auth),
+        None,
+    )
+    .await?;
+    let execution_id = response_to_t::<OperationIdItem>(&response)?.id;
+    let expected_location = format!(
+        "http://{}:{}/vehicle/v15/{RUNTIMEFILES_UPDATE_EXECUTIONS}/{execution_id}",
+        runtime.config.server.address, runtime.config.server.port
+    );
+    assert_eq!(
+        response
+            .header(http::header::LOCATION)
+            .and_then(|value| value.to_str().ok()),
+        Some(expected_location.as_str()),
+        "202 responses must identify the execution resource with an absolute Location URI"
+    );
+
+    let list_response = send_cda_request(
+        &runtime.config,
+        RUNTIMEFILES_UPDATE_EXECUTIONS,
+        StatusCode::OK,
+        Method::GET,
+        None,
+        Some(&auth),
+        None,
+    )
+    .await?;
+    let list = response_to_json(&list_response)?;
+    assert_eq!(
+        list,
+        serde_json::json!({ "items": [{ "id": execution_id }] }),
+        "execution collection items must contain only their identifiers"
+    );
+
+    let execution_response = send_cda_request(
+        &runtime.config,
+        &format!("{RUNTIMEFILES_UPDATE_EXECUTIONS}/{execution_id}"),
+        StatusCode::OK,
+        Method::GET,
+        None,
+        Some(&auth),
+        None,
+    )
+    .await?;
+    let execution = response_to_json(&execution_response)?;
+    assert!(
+        execution.get("id").is_none() && execution.get("mode").is_none(),
+        "execution details must not expose operation-specific values at the top level"
+    );
+    assert_eq!(execution["parameters"]["mode"], "cleanup");
+    assert!(
+        execution["parameters"].get("reason").is_none(),
+        "a successful execution must not include a failure reason"
+    );
+    assert!(execution.get("status").is_some());
+
+    lock_operation(
+        locks::VEHICLE_ENDPOINT,
+        Some(&lock_id),
+        &runtime.config,
+        &auth,
+        StatusCode::NO_CONTENT,
+        Method::DELETE,
+    )
+    .await;
+    Ok(())
+}
+
+/// Checks ISO bulk-data response conventions used by the runtime file categories.
+#[tokio::test]
+async fn runtimefiles_bulk_data_responses_follow_standard() -> Result<(), TestingError> {
+    let (runtime, _lock) = setup_integration_test(true).await?;
+    let auth = auth_header(&runtime.config, None).await?;
+    let lock_id = setup_with_lock(&runtime.config, &auth).await;
+
+    let upload = upload_mdd(&runtime.config, &auth).await;
+    assert_eq!(upload.status(), StatusCode::CREATED);
+    let location = upload.headers().get(reqwest::header::LOCATION).cloned();
+    let upload_body: serde_json::Value = serde_json::from_str(
+        &upload
+            .text()
+            .await
+            .expect("upload response body must be readable"),
+    )
+    .expect("upload response must be JSON");
+    let first_id = upload_body["items"][0]["id"]
+        .as_str()
+        .expect("upload response must identify the created file");
+    let expected_location = format!(
+        "http://{}:{}/vehicle/v15/{RUNTIMEFILES_NEXTUPDATE}/{first_id}",
+        runtime.config.server.address, runtime.config.server.port
+    );
+    assert_eq!(
+        location.as_ref().and_then(|value| value.to_str().ok()),
+        Some(expected_location.as_str()),
+        "bulk-data uploads must identify a created resource with Location"
+    );
+
+    let list = get_file_list(&runtime.config, &auth, RUNTIMEFILES_NEXTUPDATE).await?;
+    assert!(
+        list.items
+            .iter()
+            .all(|item| item.name.as_deref() == Some(&item.id)),
+        "runtime file descriptors must expose the filename as name"
+    );
+
+    let mut date_query = HashMap::new();
+    date_query.insert(
+        "created-after".to_owned(),
+        "2025-01-01T00:00:00Z".to_owned(),
+    );
+    date_query.insert(
+        "created-before".to_owned(),
+        "2026-01-01T00:00:00Z".to_owned(),
+    );
+    let filtered = send_cda_request(
+        &runtime.config,
+        RUNTIMEFILES_NEXTUPDATE,
+        StatusCode::OK,
+        Method::GET,
+        None,
+        Some(&auth),
+        Some(&QueryParams(date_query)),
+    )
+    .await?;
+    assert_eq!(
+        response_to_t::<BulkDataList>(&filtered)?.items.len(),
+        list.items.len()
+    );
+
+    let deleted = send_cda_request(
+        &runtime.config,
+        RUNTIMEFILES_NEXTUPDATE,
+        StatusCode::OK,
+        Method::DELETE,
+        None,
+        Some(&auth),
+        None,
+    )
+    .await?;
+    let deleted = response_to_t::<BulkDataDeleted>(&deleted)?;
+    assert!(deleted.errors.is_empty());
+    assert!(deleted.deleted_ids.iter().any(|id| id == first_id));
+
+    let categories = send_cda_request(
+        &runtime.config,
+        "apps/sovd2uds/bulk-data",
+        StatusCode::OK,
+        Method::GET,
+        None,
+        Some(&auth),
+        None,
+    )
+    .await?;
+    let categories = response_to_json(&categories)?;
+    for name in [
+        "runtimefiles-current",
+        "runtimefiles-nextupdate",
+        "runtimefiles-backup",
+    ] {
+        assert!(
+            categories["items"]
+                .as_array()
+                .is_some_and(|items| items.iter().any(|item| item["name"] == name)),
+            "bulk-data discovery must include {name}"
+        );
+    }
+
+    teardown_lock(&runtime.config, &auth, &lock_id).await;
+    Ok(())
+}
+
 #[tokio::test]
 async fn runtimefiles_lifecycle() -> Result<(), TestingError> {
     // Acquire an exclusive vehicle lock (spec: all modifying actions require one).
@@ -163,12 +351,15 @@ async fn runtimefiles_lifecycle() -> Result<(), TestingError> {
     // Trigger "Apply" - pending update becomes active database.
     execute_mode(&runtime.config, &auth, ExecutionMode::Apply).await?;
     cda_interfaces::util::tokio_ext::sleep_for(Duration::from_secs(3)).await;
-    assert_state_after_apply(&runtime.config, &auth).await?;
+    assert_state_after_apply(&runtime.config, &auth, initial_count).await?;
 
-    // Trigger "Rollback" - restore previous database from backup.
-    execute_mode(&runtime.config, &auth, ExecutionMode::Rollback).await?;
-    cda_interfaces::util::tokio_ext::sleep_for(Duration::from_secs(3)).await;
-    assert_state_after_rollback(&runtime.config, &auth, initial_count).await?;
+    // Rollback requires a non-empty backup. A fresh test environment has no current files, so
+    // applying the upload creates an empty backup and rollback is correctly unavailable.
+    if initial_count > 0 {
+        execute_mode(&runtime.config, &auth, ExecutionMode::Rollback).await?;
+        cda_interfaces::util::tokio_ext::sleep_for(Duration::from_secs(3)).await;
+        assert_state_after_rollback(&runtime.config, &auth, initial_count).await?;
+    }
 
     // Trigger "Cleanup" - spec: "reset all pending updates, as well as deleting the backup".
     execute_mode(&runtime.config, &auth, ExecutionMode::Cleanup).await?;
@@ -386,7 +577,7 @@ async fn runtimefiles_delete_backup_when_empty() -> Result<(), TestingError> {
     send_cda_request(
         &runtime.config,
         RUNTIMEFILES_BACKUP,
-        StatusCode::NO_CONTENT,
+        StatusCode::OK,
         Method::DELETE,
         None,
         Some(&auth),
@@ -568,6 +759,16 @@ async fn runtimefiles_upload_multiple_files() -> Result<(), TestingError> {
         "Expected success for multi-file upload, got {}",
         response.status()
     );
+    let location = response
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .expect("multi-file upload must include Location")
+        .to_owned();
+    assert!(
+        location.ends_with("/file_a.mdd"),
+        "multi-file upload Location must point to the first created file, got {location}"
+    );
 
     // Verify both files appear in nextupdate
     let list_response = send_cda_request(
@@ -745,7 +946,7 @@ async fn runtimefiles_apply_with_no_pending_changes() -> Result<(), TestingError
     send_cda_request(
         &runtime.config,
         RUNTIMEFILES_NEXTUPDATE,
-        StatusCode::NO_CONTENT,
+        StatusCode::OK,
         Method::DELETE,
         None,
         Some(&auth),
@@ -785,7 +986,7 @@ async fn runtimefiles_rollback_with_no_backup() -> Result<(), TestingError> {
     send_cda_request(
         &runtime.config,
         RUNTIMEFILES_BACKUP,
-        StatusCode::NO_CONTENT,
+        StatusCode::OK,
         Method::DELETE,
         None,
         Some(&auth),
@@ -1209,10 +1410,12 @@ async fn assert_nextupdate_contains_flxc1000(
 }
 
 /// Helper: verifies the post-Apply invariants:
-/// current non-empty, nextupdate mirrors current (no pending changes), backup non-empty.
+/// current non-empty, nextupdate mirrors current (no pending changes), and backup matches the
+/// original current snapshot.
 async fn assert_state_after_apply(
     config: &Configuration,
     auth: &http::HeaderMap,
+    initial_count: usize,
 ) -> Result<(), TestingError> {
     let current = get_file_list(config, auth, RUNTIMEFILES_CURRENT)
         .await?
@@ -1234,9 +1437,10 @@ async fn assert_state_after_apply(
     let backup = get_file_list(config, auth, RUNTIMEFILES_BACKUP)
         .await?
         .items;
-    assert!(
-        !backup.is_empty(),
-        "Expected non-empty backup after apply (original db backed up)"
+    assert_eq!(
+        backup.len(),
+        initial_count,
+        "Expected backup to match the original current snapshot after apply"
     );
 
     Ok(())
@@ -1395,7 +1599,7 @@ async fn runtimefiles_delete_nextupdate_clears_pending() -> Result<(), TestingEr
     send_cda_request(
         &runtime.config,
         RUNTIMEFILES_NEXTUPDATE,
-        StatusCode::NO_CONTENT,
+        StatusCode::OK,
         Method::DELETE,
         None,
         Some(&auth),
@@ -1499,7 +1703,7 @@ async fn runtimefiles_delete_backup() -> Result<(), TestingError> {
     send_cda_request(
         &runtime.config,
         RUNTIMEFILES_BACKUP,
-        StatusCode::NO_CONTENT,
+        StatusCode::OK,
         Method::DELETE,
         None,
         Some(&auth),

--- a/integration-tests/tests/util/http.rs
+++ b/integration-tests/tests/util/http.rs
@@ -268,3 +268,9 @@ impl QueryParams {
         }
     }
 }
+
+impl Response {
+    pub(crate) fn header(&self, name: http::header::HeaderName) -> Option<&http::HeaderValue> {
+        self.header_map.get(name)
+    }
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

**refactor(sovd): move diagnostic DB update executions to /operations/runtimefilesupdate**

Moves the Apply/Rollback/Cleanup execution endpoints for the diagnostic
database update out of the bulk-data resource
(/apps/sovd2uds/bulk-data/runtimefiles-nextupdate/executions) into a
proper operations resource
(/apps/sovd2uds/operations/runtimefilesupdate/executions), for standard
SOVD operations compliance and consistent naming.

- Add new cda-sovd operations::runtimefilesupdate module hosting the
    executions list/start/status handlers, moved out of
    bulk_data/runtimefiles.rs (which now only handles
    runtimefiles-current/-nextupdate/-backup file management).
- Remove the old literal /operations/diagnostic-database-update alias
    route; the new path is now the sole endpoint.
- Wrap the execution mode in a "parameters" object in the request body
    ({"parameters": {"mode": "apply"}}), matching the standard
    convention used by other operation executions (comparams,
    functional-group, ECU-service operations).
- Update architecture docs and integration tests accordingly.

**feat(sovd): accept application/octet-stream uploads for runtime files**

The runtimefiles-nextupdate upload endpoint now accepts a single file
as a raw application/octet-stream body, in addition to the existing
multipart/form-data support. For octet-stream uploads, the filename
must be provided via the Content-Disposition header (e.g.
'attachment; filename="foo.mdd"'), supporting both the quoted and
unquoted filename= forms. Requests with an unsupported Content-Type,
or octet-stream requests missing a usable filename, are rejected with
400 Bad Request.

- Split nextupdate::post into content-type-dispatching handlers
    (handle_multipart_upload / handle_octet_stream_upload).
- Add a small hand-rolled Content-Disposition filename parser (no
    crate in the dependency tree currently exposes this).
- Update architecture docs and add integration tests covering the
    success path (quoted and unquoted filename) and the two rejection
    cases (missing header, missing filename parameter).



## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
