### PR TITLE
fix(db): do not exit if configured when no db found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,6 +1885,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sovd-interfaces",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "toml 0.9.8",

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -592,7 +592,7 @@ pub async fn load_vehicle_data<
     let mdd_paths: Vec<PathBuf> = {
         let storage_dir = &config.runtime_update_config.storage_dir;
         let paths = resolve_mdd_paths(storage_dir, &config.database.path).await;
-        if paths.is_empty() {
+        if paths.is_empty() && config.database.exit_no_database_loaded {
             return Err(AppError::InitializationFailed(
                 "No MDD files found".to_string(),
             ));

--- a/cda-main/src/mdd.rs
+++ b/cda-main/src/mdd.rs
@@ -202,7 +202,11 @@ pub async fn load_databases<S: SecurityPlugin>(
         "Loaded databases"
     );
 
-    let status = if databases.is_empty() {
+    // When `exit_no_database_loaded = false` the operator has explicitly opted
+    // into running without any ECU databases.  Marking health `Failed` in that
+    // case would block the readiness probe forever, so treat empty-but-allowed
+    // as `Up`.
+    let status = if databases.is_empty() && config.database.exit_no_database_loaded {
         cda_health::Status::Failed
     } else {
         cda_health::Status::Up

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -77,6 +77,8 @@ libc = { workspace = true }
 
 # compile time format
 const_format = { workspace = true }
+# temp directories for isolated tests
+tempfile = { workspace = true }
 
 [build-dependencies]
 cda-build = { workspace = true }

--- a/integration-tests/tests/sovd/configuration.rs
+++ b/integration-tests/tests/sovd/configuration.rs
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use opensovd_cda_lib::config::configfile::{Configuration, DatabaseConfig};
+
+use crate::util::runtime::{find_available_tcp_port, start_cda, stop_cda, wait_for_cda_online};
+
+/// A CDA configured with `exit_no_database_loaded = false` must not exit when
+/// its database path contains no MDD files.
+#[tokio::test]
+async fn cda_stays_running_when_no_database_loaded_and_exit_flag_is_false() {
+    let empty_db_dir = tempfile::tempdir().expect("create empty temp db dir");
+
+    let host = "127.0.0.1".to_owned();
+    let port = find_available_tcp_port(&host).expect("find free port");
+
+    let mut config = Configuration {
+        database: DatabaseConfig {
+            path: empty_db_dir.path().to_string_lossy().into_owned(),
+            exit_no_database_loaded: false,
+            ..Default::default()
+        },
+        ..Configuration::default()
+    };
+    config.server.address.clone_from(&host);
+    config.server.port = port;
+    // Disable DoIP so no transport socket is bound, avoids binding failures on
+    // interfaces that only exist inside the compose network.
+    config.doip.enabled = false;
+
+    start_cda(config.clone());
+
+    wait_for_cda_online(&config.server)
+        .await
+        .expect("CDA with exit_no_database_loaded=false must stay running");
+
+    stop_cda().await.expect("Failed to stop CDA");
+}

--- a/integration-tests/tests/sovd/mod.rs
+++ b/integration-tests/tests/sovd/mod.rs
@@ -31,6 +31,7 @@ use crate::util::{
     },
 };
 
+mod configuration;
 mod custom_routes;
 mod data;
 mod ecu;

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -441,7 +441,7 @@ pub(crate) fn host() -> String {
     }
 }
 
-fn start_cda(config: Configuration) {
+pub(crate) fn start_cda(config: Configuration) {
     // Some unwraps are used here, this is on purpose
     // as we want the tests to fail hard if CDA fails to start.
     TOKIO_RUNTIME.spawn(async move {
@@ -568,7 +568,7 @@ fn start_cda(config: Configuration) {
     });
 }
 
-async fn stop_cda() -> Result<(), TestingError> {
+pub(crate) async fn stop_cda() -> Result<(), TestingError> {
     if let Some(sender) = CDA_SHUTDOWN.lock().await.as_ref() {
         sender.send(()).ok();
         Ok(())


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

Fix the exit_no_database_loaded flag so the app does not exit and health status does not show failure

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->



Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)