### PR TITLE
feat: allow overriding of version string via ENV

### DIFF
--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -1015,7 +1015,10 @@ pub fn setup_tracing(config: &Configuration) -> Result<TracingGuards, TracingSet
     })
 }
 
+/// Returns the CDA version string, which is either
+/// the value of the `CDA_VERSION` environment variable (if set)
+/// or the Cargo package version.
 #[must_use]
 pub fn cda_version() -> &'static str {
-    env!("CARGO_PKG_VERSION")
+    option_env!("CDA_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))
 }


### PR DESCRIPTION
Introduces CDA_VERSION env var that can be used at compile time to override the version string. If not present falls back to the cargo pkg version.

<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
---
Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)