### PR TITLE
fix(storage): retain current collection when apply rename fails

### DIFF
--- a/cda-interfaces/src/storage_api/transaction.rs
+++ b/cda-interfaces/src/storage_api/transaction.rs
@@ -63,6 +63,8 @@ pub enum Operation {
         source: CollectionName,
         /// The destination collection.
         dest: CollectionName,
+        /// Whether the destination existed before the transaction began.
+        dest_existed: bool,
     },
 }
 

--- a/cda-storage/src/local_storage.rs
+++ b/cda-storage/src/local_storage.rs
@@ -238,6 +238,7 @@ impl Storage for LocalStorage {
         let op = Operation::CopyCollection {
             source: source.clone(),
             dest: dest.clone(),
+            dest_existed: self.collection_dir(dest)?.exists(),
         };
         wal::append_operation(tx.journal_path(), &op)?;
         tx.record(op);
@@ -365,68 +366,69 @@ impl LocalStorageCommitter {
     /// In these cases, it's better to continue with the commit instead of failing it,
     /// as the end result is the same (the file/directory is gone).
     fn apply_operations(&self, operations: &[Operation]) -> Result<(), StorageError> {
-        for op in operations {
-            match op {
-                Operation::Write {
-                    collection,
-                    key,
-                    staged_path,
-                } => {
-                    let target_dir = self.collections_dir.join(collection.as_str());
-                    std::fs::create_dir_all(&target_dir)?;
-                    let target = target_dir.join(key);
+        operations
+            .iter()
+            .try_for_each(|op| -> Result<(), StorageError> {
+                match op {
+                    Operation::Write {
+                        collection,
+                        key,
+                        staged_path,
+                    } => {
+                        let target_dir = self.collections_dir.join(collection.as_str());
+                        std::fs::create_dir_all(&target_dir)?;
+                        let target = target_dir.join(key);
 
-                    // Backup existing file if present.
-                    if target.exists() {
-                        let backup = append_extension(&target, BACKUP_EXTENSION);
-                        std::fs::rename(&target, &backup)?;
-                    }
+                        // Backup existing file if present.
+                        if target.exists() {
+                            let backup = append_extension(&target, BACKUP_EXTENSION);
+                            std::fs::rename(&target, &backup)?;
+                        }
 
-                    // Move staged file into place.
-                    std::fs::rename(staged_path, &target)?;
-                }
-                Operation::Delete { collection, key } => {
-                    let target = self.collections_dir.join(collection.as_str()).join(key);
-                    if target.exists() {
-                        let backup = append_extension(&target, BACKUP_EXTENSION);
-                        std::fs::rename(&target, &backup)?;
+                        // Move staged file into place.
+                        std::fs::rename(staged_path, &target)?;
                     }
-                }
-                Operation::DeleteAll { collection } => {
-                    let dir = self.collections_dir.join(collection.as_str());
-                    if dir.exists() {
-                        backup_all_files_in_dir(&dir)?;
+                    Operation::Delete { collection, key } => {
+                        let target = self.collections_dir.join(collection.as_str()).join(key);
+                        if target.exists() {
+                            let backup = append_extension(&target, BACKUP_EXTENSION);
+                            std::fs::rename(&target, &backup)?;
+                        }
                     }
-                }
-                Operation::CreateCollection { name } => {
-                    let dir = self.collections_dir.join(name.as_str());
-                    std::fs::create_dir_all(&dir)?;
-                }
-                Operation::DeleteCollection { name } => {
-                    let dir = self.collections_dir.join(name.as_str());
-                    if dir.exists() {
-                        let backup = append_extension(&dir, BACKUP_EXTENSION);
-                        std::fs::rename(&dir, &backup)?;
+                    Operation::DeleteAll { collection } => {
+                        let dir = self.collections_dir.join(collection.as_str());
+                        if dir.exists() {
+                            backup_all_files_in_dir(&dir)?;
+                        }
                     }
-                }
-                Operation::CopyCollection { source, dest } => {
-                    let source_dir = self.collections_dir.join(source.as_str());
-                    let dest_dir = self.collections_dir.join(dest.as_str());
+                    Operation::CreateCollection { name } => {
+                        let dir = self.collections_dir.join(name.as_str());
+                        std::fs::create_dir_all(&dir)?;
+                    }
+                    Operation::DeleteCollection { name } => {
+                        let dir = self.collections_dir.join(name.as_str());
+                        if dir.exists() {
+                            let backup = append_extension(&dir, BACKUP_EXTENSION);
+                            std::fs::rename(&dir, &backup)?;
+                        }
+                    }
+                    Operation::CopyCollection { source, dest, .. } => {
+                        let source_dir = self.collections_dir.join(source.as_str());
+                        let dest_dir = self.collections_dir.join(dest.as_str());
 
-                    // Back up existing destination for rollback, then create a fresh directory.
-                    // This ensures "replace" semantics: the destination ends up with exactly
-                    // the source's contents, not a merge of old and new files.
-                    if dest_dir.exists() {
-                        let backup = append_extension(&dest_dir, BACKUP_EXTENSION);
-                        std::fs::rename(&dest_dir, &backup)?;
-                    }
+                        // Back up an existing destination before creating the replacement.
+                        if dest_dir.exists() {
+                            let backup = append_extension(&dest_dir, BACKUP_EXTENSION);
+                            std::fs::rename(&dest_dir, &backup)?;
+                        }
 
-                    std::fs::create_dir_all(&dest_dir)?;
-                    copy_dir_contents(&source_dir, &dest_dir)?;
+                        // Create a fresh directory to provide replace rather than merge semantics.
+                        std::fs::create_dir_all(&dest_dir)?;
+                        copy_dir_contents(&source_dir, &dest_dir)?;
+                    }
                 }
-            }
-        }
-        Ok(())
+                Ok(())
+            })
     }
 }
 

--- a/cda-storage/src/recovery.rs
+++ b/cda-storage/src/recovery.rs
@@ -192,13 +192,14 @@ pub(crate) fn remove_new_artifacts(
                     tracing::debug!(path = %dir.display(), "Removed newly created collection dir");
                 }
             }
-            Operation::CopyCollection { dest, .. } => {
+            Operation::CopyCollection {
+                dest, dest_existed, ..
+            } => {
                 let dest_dir = collections_dir.join(dest.as_str());
                 let backup = append_bak_extension(&dest_dir);
-                // If a .bak exists, the dest pre-existed and was backed up --
-                // rollback_partial_commit will restore it. Only remove if no .bak
-                // (dest was newly created by this op).
-                if dest_dir.exists() && !backup.exists() {
+                // Existing destinations are restored from their .bak file. Only remove a
+                // destination that was created by this transaction and has no backup.
+                if !dest_existed && dest_dir.exists() && !backup.exists() {
                     std::fs::remove_dir_all(&dest_dir)?;
                     tracing::debug!(
                         path = %dest_dir.display(),
@@ -280,10 +281,12 @@ fn has_new_artifacts(collections_dir: &Path, operations: &[Operation]) -> bool {
                     return true;
                 }
             }
-            Operation::CopyCollection { dest, .. } => {
+            Operation::CopyCollection {
+                dest, dest_existed, ..
+            } => {
                 let dest_dir = collections_dir.join(dest.as_str());
                 let backup = append_bak_extension(&dest_dir);
-                if dest_dir.exists() && !backup.exists() {
+                if !dest_existed && dest_dir.exists() && !backup.exists() {
                     return true;
                 }
             }

--- a/cda-storage/tests/local_storage_tests.rs
+++ b/cda-storage/tests/local_storage_tests.rs
@@ -865,6 +865,45 @@ async fn recovery_create_collection_with_write_removes_orphaned_dir() {
     );
 }
 
+/// A failed collection swap can leave a COMMITTING WAL where a pre-existing destination was
+/// never renamed to its backup (for example, when `rename` returns EXDEV). Recovery must retain
+/// that untouched current collection rather than treating it as an artifact of the failed copy.
+#[tokio::test]
+async fn recovery_preserves_untouched_existing_copy_destination() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let collections_dir = root.join("collections");
+    let journal_dir = root.join("journal");
+    let staging_dir = journal_dir.join("staging");
+    let current_dir = collections_dir.join("diagnostic_database");
+    std::fs::create_dir_all(&current_dir).unwrap();
+    std::fs::create_dir_all(&staging_dir).unwrap();
+    std::fs::write(current_dir.join("ecu1.mdd"), b"current data").unwrap();
+
+    let wal_path = journal_dir.join("transaction.wal");
+    cda_storage::wal::create_wal(&wal_path).unwrap();
+    cda_storage::wal::append_operation(
+        &wal_path,
+        &cda_interfaces::storage_api::Operation::CopyCollection {
+            source: CollectionName::DiagnosticDatabaseNextUpdate,
+            dest: CollectionName::DiagnosticDatabase,
+            dest_existed: true,
+        },
+    )
+    .unwrap();
+    cda_storage::wal::mark_committing(&wal_path).unwrap();
+
+    let storage = LocalStorage::new(root).unwrap();
+    let current = storage
+        .get_collection(&CollectionName::DiagnosticDatabase)
+        .await
+        .unwrap();
+    let handle = current.read("ecu1.mdd").await.unwrap();
+    let mut data = vec![0; "current data".len()];
+    handle.read_at(0, &mut data).unwrap();
+    assert_eq!(data, b"current data");
+}
+
 /// Regression test for a bug where `list()` returned a file's on-disk (possibly mixed-case)
 /// name verbatim, while `metadata()`/`read()`/`file_path()` normalize keys to lowercase before
 /// resolving them to a path. On a case-sensitive filesystem this mismatch caused every


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
A failed collection-copy rename could leave a pre-existing current collection without a backup. Rollback then treated it as newly created and removed it, causing subsequent current requests to return no files.

Record whether a copy destination existed before the transaction and use that state during rollback and recovery so untouched current collections are preserved.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
