### PR TITLE
Fix seed config overwriting storage on every startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It handles the communication to the ECUs, by using the communication parameters 
 2. Start the CDA, pointing it at your databases directory and DoIP interface:
 
    ```shell
-   cargo run --release -- --databases-path ./databases --tester-address <YOUR_IP>
+   cargo run --release -- --seed-databases-path ./databases --tester-address <YOUR_IP>
    ```
 
 3. Wait a few seconds for DoIP discovery, then confirm the CDA found your ECUs:
@@ -55,7 +55,7 @@ It handles the communication to the ECUs, by using the communication parameters 
 
 To run the CDA you will need at least one `MDD` file. Check out [eclipse-opensovd/odx-converter](https://github.com/eclipse-opensovd/odx-converter) on how to get started with creating `MDD`(s) from ODX.
 
-Once you have the `MDD`(s) you can update the config in `opensovd-cda.toml` to point `databases_path` to the directory containing the files. Alternatively you can pass the config via arg `--databases-path MY_PATH`.
+Once you have the `MDD`(s) you can update the config in `opensovd-cda.toml` to point `database.seed_path` to the directory containing the files. Alternatively you can pass the config via arg `--seed-databases-path MY_PATH`.
 
 ### running
 
@@ -79,7 +79,7 @@ Use `--protocol-name` to select the DoIP protocol variant used for com-param loo
 
 ```shell
 # Offboard
-cargo run --release -- --databases-path ./databases --tester-address <YOUR_IP> --protocol-name UDS_Ethernet_DoIP
+cargo run --release -- --seed-databases-path ./databases --tester-address <YOUR_IP> --protocol-name UDS_Ethernet_DoIP
 ```
 
 ## ODX to SOVD path mapping

--- a/cda-database/src/lib.rs
+++ b/cda-database/src/lib.rs
@@ -29,8 +29,8 @@ use serde::{Deserialize, Serialize};
 )]
 #[derive(Deserialize, Serialize, Clone, Debug, schemars::JsonSchema)]
 pub struct DatabaseConfig {
-    /// Path to load the databases from, this must be a directory.
-    pub path: String,
+    /// Directory to load the databases from, if none have been loaded into storage before.
+    pub seed_dir: String,
     pub naming_convention: DatabaseNamingConvention,
     /// If true, the application will exit if no database could be loaded.
     pub exit_no_database_loaded: bool,
@@ -58,7 +58,7 @@ pub struct DatabaseConfig {
 impl Default for DatabaseConfig {
     fn default() -> Self {
         Self {
-            path: ".".to_owned(),
+            seed_dir: ".".to_owned(),
             naming_convention: DatabaseNamingConvention::default(),
             exit_no_database_loaded: false,
             fallback_to_base_variant: true,

--- a/cda-main/src/config.rs
+++ b/cda-main/src/config.rs
@@ -13,6 +13,7 @@
 use std::path::Path;
 
 use cda_interfaces::storage_api::{Collection, RandomAccessData, Storage};
+use cda_storage::LocalStorage;
 use figment::{
     Figment,
     providers::{Env, Format as _, Serialized, Toml},
@@ -23,6 +24,75 @@ use crate::AppError;
 pub mod com_params;
 pub mod configfile;
 pub mod generate;
+
+pub(super) async fn load_config_from_file_or_storage(
+    config_file: Option<&Path>,
+) -> Result<configfile::Configuration, AppError> {
+    let config_file = match config_file {
+        Some(config_file) => {
+            if config_file.exists() {
+                config_file
+            } else {
+                // ignore `config-optional` feature here, because it's specifically for when no config was specified
+                return Err(AppError::ConfigurationError {
+                    message: format!(
+                        "Specified configuration file {} does not exist",
+                        config_file.display()
+                    ),
+                    source: None,
+                });
+            }
+        }
+        None => Path::new("opensovd-cda.toml"),
+    };
+
+    let storage_dir_override = None; //only needed for tests
+    load_config_from_file_or_storage_with_storage_dir_override(config_file, storage_dir_override)
+        .await
+}
+
+async fn load_config_from_file_or_storage_with_storage_dir_override(
+    config_file: &Path,
+    storage_override: Option<LocalStorage>,
+) -> Result<configfile::Configuration, AppError> {
+    let (figment_config, loaded_via_figment) = match load_config(config_file) {
+        Ok(c) => (c, true),
+        Err(e) => {
+            println!("Failed to load configuration: {e}");
+            (default_config(), false)
+        }
+    };
+
+    let storage = match storage_override {
+        Some(storage) => storage,
+        None => match LocalStorage::new(&figment_config.runtime_update_config.storage_dir) {
+            Ok(storage) => storage,
+            Err(e) => {
+                tracing::warn!(error = %e, "Storage not available, not loading config from storage, nor seeding it.");
+                return Ok(figment_config);
+            }
+        },
+    };
+
+    let config = if let Some(storage_config) = load_config_with_storage_override(&storage).await? {
+        storage_config
+    } else {
+        if !loaded_via_figment {
+            require_config_source()?;
+        }
+
+        if figment_config
+            .runtime_update_config
+            .init_storage_from_config_file
+        {
+            seed_storage_if_empty_from_config_file(&storage, config_file).await?;
+        }
+
+        figment_config
+    };
+
+    Ok(config)
+}
 
 /// Loads the configuration, merged with defaults and `CDA`-prefixed env vars.
 ///
@@ -46,30 +116,17 @@ pub fn default_config() -> configfile::Configuration {
     configfile::Configuration::default()
 }
 
-/// Attempt to load config from file; on failure, fall back to defaults.
-/// Returns the configuration and whether it was successfully loaded from file.
-#[must_use]
-pub fn load_config_with_fallback(config_path: &Path) -> (configfile::Configuration, bool) {
-    match load_config(config_path) {
-        Ok(c) => (c, true),
-        Err(e) => {
-            println!("Failed to load configuration: {e}");
-            (default_config(), false)
-        }
-    }
-}
-
 /// Checks whether a configuration source is available.
 ///
 /// # Errors
-/// Returns [`AppError`](crate::AppError) when no configuration source is found
+/// Returns [`AppError`] when no configuration source is found
 /// (only when the `config-optional` feature is disabled).
-pub fn require_config_source() -> Result<(), crate::AppError> {
+pub fn require_config_source() -> Result<(), AppError> {
     if cfg!(feature = "config-optional") {
         println!("No configuration found on disk or in storage. Using default values.");
         Ok(())
     } else {
-        Err(crate::AppError::ConfigurationError {
+        Err(AppError::ConfigurationError {
             message: "No configuration found. Provide a configuration file, store one via runtime \
                       update, or build with the 'config-optional' feature to allow starting \
                       without one."
@@ -84,12 +141,12 @@ pub fn require_config_source() -> Result<(), crate::AppError> {
 /// has a populated baseline to work with.
 ///
 /// # Errors
-/// Returns [`AppError`](crate::AppError) when no configuration file
+/// Returns [`AppError`] when no configuration file
 /// is accessible.
-pub async fn seed_storage_from_config_file(
-    storage: &cda_storage::LocalStorage,
+pub async fn seed_storage_if_empty_from_config_file(
+    storage: &LocalStorage,
     config_file: &Path,
-) -> Result<(), crate::AppError> {
+) -> Result<(), AppError> {
     let data = tokio::fs::read(config_file).await.map_err(|source| {
         crate::AppError::ConfigurationError {
             message: format!(
@@ -112,7 +169,7 @@ pub async fn seed_storage_from_config_file(
         .to_string_lossy()
         .to_string();
 
-    let count = cda_storage::storage_seed::seed_storage_collection(
+    let count = cda_storage::storage_seed::seed_storage_collection_if_empty(
         storage,
         &cda_interfaces::storage_api::CollectionName::Configuration,
         std::iter::once((key.clone(), data)),
@@ -145,7 +202,7 @@ pub async fn seed_storage_from_config_file(
 /// - `Ok(None)` - storage is unavailable or the collection is empty (no override).
 /// - `Ok(Some(config))` - exactly one configuration was found and parsed successfully.
 pub async fn load_config_with_storage_override(
-    storage: &cda_storage::LocalStorage,
+    storage: &LocalStorage,
 ) -> Result<Option<configfile::Configuration>, AppError> {
     let collection = match storage
         .get_or_create_collection(&cda_interfaces::storage_api::CollectionName::Configuration)
@@ -218,21 +275,67 @@ pub async fn load_config_with_storage_override(
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::path::PathBuf;
 
-    use cda_interfaces::storage_api::{CollectionName, RandomAccessData, Storage};
-    use cda_storage::LocalStorage;
+    use cda_interfaces::storage_api::CollectionName;
 
     use super::*;
 
     #[tokio::test]
+    async fn should_load_config_from_file_when_storage_is_empty() {
+        let fixture = StorageFixture::new();
+
+        let mut config = default_config();
+        config.database.path = "configured_dir/".to_string();
+        fixture.write_config(&config);
+
+        let result = load_config_from_file_or_storage_with_storage_dir_override(
+            &fixture.config_file,
+            Some(fixture.storage),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.database.path, "configured_dir/");
+    }
+
+    #[tokio::test]
+    async fn should_load_config_from_storage_when_storage_has_been_seeded() {
+        let fixture = StorageFixture::new();
+
+        {
+            let mut config = default_config();
+            config.database.path = "stored_dir/".to_string();
+            fixture.write_config(&config);
+
+            seed_storage_if_empty_from_config_file(&fixture.storage, &fixture.config_file)
+                .await
+                .unwrap();
+        }
+
+        {
+            let mut config = default_config();
+            config.database.path = "configured_dir/".to_string();
+            fixture.write_config(&config);
+        }
+
+        let result = load_config_from_file_or_storage_with_storage_dir_override(
+            &fixture.config_file,
+            Some(fixture.storage),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.database.path, "stored_dir/");
+    }
+
+    #[tokio::test]
     async fn seed_copies_config_file_into_empty_storage() {
         let fixture = StorageFixture::new();
-        let config_dir = tempfile::tempdir().expect("config dir");
-        let config_file = config_dir.path().join("opensovd-cda.toml");
-        std::fs::write(&config_file, b"[database]\npath = \".\"").expect("write config");
 
-        seed_storage_from_config_file(&fixture.storage, &config_file)
+        std::fs::write(&fixture.config_file, b"[database]\npath = \".\"").expect("write config");
+
+        seed_storage_if_empty_from_config_file(&fixture.storage, &fixture.config_file)
             .await
             .unwrap();
 
@@ -248,9 +351,8 @@ mod tests {
     #[tokio::test]
     async fn seed_skips_when_collection_already_populated() {
         let fixture = StorageFixture::new();
-        let config_dir = tempfile::tempdir().expect("config dir");
-        let config_file = config_dir.path().join("new.toml");
-        std::fs::write(&config_file, b"[database]\npath = \".\"").expect("write config");
+
+        std::fs::write(&fixture.config_file, b"[database]\npath = \".\"").expect("write config");
 
         // Pre-populate storage with an existing entry.
         let collection = fixture
@@ -266,7 +368,7 @@ mod tests {
             .unwrap();
         tx.commit().await.unwrap();
 
-        seed_storage_from_config_file(&fixture.storage, &config_file)
+        seed_storage_if_empty_from_config_file(&fixture.storage, &fixture.config_file)
             .await
             .unwrap();
 
@@ -284,7 +386,7 @@ mod tests {
     async fn seed_errors_on_nonexistent_config_file() {
         let fixture = StorageFixture::new();
 
-        let result = seed_storage_from_config_file(
+        let result = seed_storage_if_empty_from_config_file(
             &fixture.storage,
             Path::new("/tmp/nonexistent_cda_config_test_12345.toml"),
         )
@@ -296,12 +398,11 @@ mod tests {
     #[tokio::test]
     async fn seed_preserves_config_content_through_storage_roundtrip() {
         let fixture = StorageFixture::new();
-        let config_dir = tempfile::tempdir().expect("config dir");
-        let original_data = b"[database]\npath = \"/app/database\"\n";
-        let config_file = config_dir.path().join("opensovd-cda.toml");
-        std::fs::write(&config_file, original_data).expect("write config");
 
-        seed_storage_from_config_file(&fixture.storage, &config_file)
+        let original_data = b"[database]\npath = \"/app/database\"\n";
+        std::fs::write(&fixture.config_file, original_data).expect("write config");
+
+        seed_storage_if_empty_from_config_file(&fixture.storage, &fixture.config_file)
             .await
             .unwrap();
 
@@ -336,17 +437,25 @@ mod tests {
 
     struct StorageFixture {
         storage: LocalStorage,
+        config_file: PathBuf,
         /// Carried along, so that it gets dropped at the end of the test
         _temp_dir: tempfile::TempDir,
     }
     impl StorageFixture {
         fn new() -> Self {
-            let temp_dir = tempfile::tempdir().expect("storage dir");
+            let temp_dir = tempfile::tempdir().expect("temp dir");
             let storage = LocalStorage::new(temp_dir.path()).unwrap();
+            let config_file = temp_dir.path().join("opensovd-cda.toml");
             Self {
                 storage,
+                config_file,
                 _temp_dir: temp_dir,
             }
+        }
+        fn write_config(&self, config: &configfile::Configuration) {
+            let config = toml::to_string(&config).unwrap();
+
+            std::fs::write(&self.config_file, config).expect("write config");
         }
     }
 }

--- a/cda-main/src/config.rs
+++ b/cda-main/src/config.rs
@@ -27,6 +27,7 @@ pub mod generate;
 
 pub(super) async fn load_config_from_file_or_storage(
     config_file: Option<&Path>,
+    force_seed_config: bool,
 ) -> Result<configfile::Configuration, AppError> {
     let config_file = match config_file {
         Some(config_file) => {
@@ -47,13 +48,18 @@ pub(super) async fn load_config_from_file_or_storage(
     };
 
     let storage_dir_override = None; //only needed for tests
-    load_config_from_file_or_storage_with_storage_dir_override(config_file, storage_dir_override)
-        .await
+    load_config_from_file_or_storage_with_storage_dir_override(
+        config_file,
+        storage_dir_override,
+        force_seed_config,
+    )
+    .await
 }
 
 async fn load_config_from_file_or_storage_with_storage_dir_override(
     config_file: &Path,
     storage_override: Option<LocalStorage>,
+    force_seed_config: bool,
 ) -> Result<configfile::Configuration, AppError> {
     let (figment_config, loaded_via_figment) = match load_config(config_file) {
         Ok(c) => (c, true),
@@ -85,7 +91,7 @@ async fn load_config_from_file_or_storage_with_storage_dir_override(
             .runtime_update_config
             .init_storage_from_config_file
         {
-            seed_storage_if_empty_from_config_file(&storage, config_file).await?;
+            seed_storage_if_empty_from_config_file(&storage, config_file, force_seed_config).await?;
         }
 
         figment_config
@@ -146,6 +152,7 @@ pub fn require_config_source() -> Result<(), AppError> {
 pub async fn seed_storage_if_empty_from_config_file(
     storage: &LocalStorage,
     config_file: &Path,
+    force_seed_config: bool,
 ) -> Result<(), AppError> {
     let data = tokio::fs::read(config_file).await.map_err(|source| {
         crate::AppError::ConfigurationError {
@@ -173,6 +180,7 @@ pub async fn seed_storage_if_empty_from_config_file(
         storage,
         &cda_interfaces::storage_api::CollectionName::Configuration,
         std::iter::once((key.clone(), data)),
+        force_seed_config,
     )
     .await;
 
@@ -284,6 +292,7 @@ mod tests {
     #[tokio::test]
     async fn should_load_config_from_file_when_storage_is_empty() {
         let fixture = StorageFixture::new();
+        let force_seed_config = false;
 
         let mut config = default_config();
         config.database.seed_dir = "configured_dir/".to_string();
@@ -292,6 +301,7 @@ mod tests {
         let result = load_config_from_file_or_storage_with_storage_dir_override(
             &fixture.config_file,
             Some(fixture.storage),
+            force_seed_config,
         )
         .await
         .unwrap();
@@ -302,15 +312,20 @@ mod tests {
     #[tokio::test]
     async fn should_load_config_from_storage_when_storage_has_been_seeded() {
         let fixture = StorageFixture::new();
+        let force_seed_config = false;
 
         {
             let mut config = default_config();
             config.database.seed_dir = "stored_dir/".to_string();
             fixture.write_config(&config);
 
-            seed_storage_if_empty_from_config_file(&fixture.storage, &fixture.config_file)
-                .await
-                .unwrap();
+            seed_storage_if_empty_from_config_file(
+                &fixture.storage,
+                &fixture.config_file,
+                force_seed_config,
+            )
+            .await
+            .unwrap();
         }
 
         {
@@ -322,6 +337,7 @@ mod tests {
         let result = load_config_from_file_or_storage_with_storage_dir_override(
             &fixture.config_file,
             Some(fixture.storage),
+            force_seed_config,
         )
         .await
         .unwrap();
@@ -332,12 +348,16 @@ mod tests {
     #[tokio::test]
     async fn seed_copies_config_file_into_empty_storage() {
         let fixture = StorageFixture::new();
-
         std::fs::write(&fixture.config_file, b"[database]\npath = \".\"").expect("write config");
 
-        seed_storage_if_empty_from_config_file(&fixture.storage, &fixture.config_file)
-            .await
-            .unwrap();
+        let force_seed_config = false;
+        seed_storage_if_empty_from_config_file(
+            &fixture.storage,
+            &fixture.config_file,
+            force_seed_config,
+        )
+        .await
+        .unwrap();
 
         let collection = fixture
             .storage
@@ -368,9 +388,14 @@ mod tests {
             .unwrap();
         tx.commit().await.unwrap();
 
-        seed_storage_if_empty_from_config_file(&fixture.storage, &fixture.config_file)
-            .await
-            .unwrap();
+        let force_seed_config = false;
+        seed_storage_if_empty_from_config_file(
+            &fixture.storage,
+            &fixture.config_file,
+            force_seed_config,
+        )
+        .await
+        .unwrap();
 
         // Verify collection was NOT modified.
         let collection = fixture
@@ -386,9 +411,11 @@ mod tests {
     async fn seed_errors_on_nonexistent_config_file() {
         let fixture = StorageFixture::new();
 
+        let force_seed_config = false;
         let result = seed_storage_if_empty_from_config_file(
             &fixture.storage,
             Path::new("/tmp/nonexistent_cda_config_test_12345.toml"),
+            force_seed_config,
         )
         .await;
 
@@ -399,26 +426,70 @@ mod tests {
     async fn seed_preserves_config_content_through_storage_roundtrip() {
         let fixture = StorageFixture::new();
 
-        let original_data = b"[database]\npath = \"/app/database\"\n";
+        let original_data = "[database]\npath = \"/app/database\"\n";
         std::fs::write(&fixture.config_file, original_data).expect("write config");
 
-        seed_storage_if_empty_from_config_file(&fixture.storage, &fixture.config_file)
+        let force_seed_config = false;
+        seed_storage_if_empty_from_config_file(
+            &fixture.storage,
+            &fixture.config_file,
+            force_seed_config,
+        )
+        .await
+        .unwrap();
+
+        let result = fixture.read_config_from_storage().await;
+        assert_eq!(
+            result, original_data,
+            "Storage must preserve config content byte-for-byte"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_seed_already_populated_collection_when_forced() {
+        let fixture = StorageFixture::new();
+
+        {
+            // seed with data to later overwrite
+            let old_config = "[database]\npath = \"old\"";
+            std::fs::write(&fixture.config_file, old_config).expect("write config");
+
+            let force_seed_config = false;
+            seed_storage_if_empty_from_config_file(
+                &fixture.storage,
+                &fixture.config_file,
+                force_seed_config,
+            )
             .await
             .unwrap();
 
-        let collection = fixture
-            .storage
-            .get_or_create_collection(&CollectionName::Configuration)
+            let result = fixture.read_config_from_storage().await;
+            assert_eq!(
+                result, old_config,
+                "Pre-seeding data into storage should work."
+            );
+        }
+
+        {
+            // force seed
+            let new_config = "[database]\npath = \"new\"";
+            std::fs::write(&fixture.config_file, new_config).expect("write config");
+
+            let force_seed_config = true;
+            seed_storage_if_empty_from_config_file(
+                &fixture.storage,
+                &fixture.config_file,
+                force_seed_config,
+            )
             .await
             .unwrap();
-        let data_handle = collection.read("opensovd-cda.toml").await.unwrap();
-        let size = data_handle.data_size().unwrap();
-        let mut buf = vec![0u8; usize::try_from(size).expect("size fits in usize")];
-        data_handle.read_at(0, &mut buf).unwrap();
-        assert_eq!(
-            buf, original_data,
-            "Storage must preserve config content byte-for-byte"
-        );
+
+            let result = fixture.read_config_from_storage().await;
+            assert_eq!(
+                result, new_config,
+                "Pre-seeding data into storage should work."
+            );
+        }
     }
 
     #[tokio::test]
@@ -452,10 +523,24 @@ mod tests {
                 _temp_dir: temp_dir,
             }
         }
+
         fn write_config(&self, config: &configfile::Configuration) {
             let config = toml::to_string(&config).unwrap();
 
             std::fs::write(&self.config_file, config).expect("write config");
+        }
+
+        async fn read_config_from_storage(&self) -> String {
+            let collection = self
+                .storage
+                .get_or_create_collection(&CollectionName::Configuration)
+                .await
+                .unwrap();
+            let data_handle = collection.read("opensovd-cda.toml").await.unwrap();
+            let size = data_handle.data_size().unwrap();
+            let mut buf = vec![0u8; usize::try_from(size).expect("size fits in usize")];
+            data_handle.read_at(0, &mut buf).unwrap();
+            String::from_utf8(buf).unwrap()
         }
     }
 }

--- a/cda-main/src/config.rs
+++ b/cda-main/src/config.rs
@@ -286,7 +286,7 @@ mod tests {
         let fixture = StorageFixture::new();
 
         let mut config = default_config();
-        config.database.path = "configured_dir/".to_string();
+        config.database.seed_dir = "configured_dir/".to_string();
         fixture.write_config(&config);
 
         let result = load_config_from_file_or_storage_with_storage_dir_override(
@@ -296,7 +296,7 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(result.database.path, "configured_dir/");
+        assert_eq!(result.database.seed_dir, "configured_dir/");
     }
 
     #[tokio::test]
@@ -305,7 +305,7 @@ mod tests {
 
         {
             let mut config = default_config();
-            config.database.path = "stored_dir/".to_string();
+            config.database.seed_dir = "stored_dir/".to_string();
             fixture.write_config(&config);
 
             seed_storage_if_empty_from_config_file(&fixture.storage, &fixture.config_file)
@@ -315,7 +315,7 @@ mod tests {
 
         {
             let mut config = default_config();
-            config.database.path = "configured_dir/".to_string();
+            config.database.seed_dir = "configured_dir/".to_string();
             fixture.write_config(&config);
         }
 
@@ -326,7 +326,7 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(result.database.path, "stored_dir/");
+        assert_eq!(result.database.seed_dir, "stored_dir/");
     }
 
     #[tokio::test]

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -75,14 +75,16 @@ pub enum Command {
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct AppArgs {
-    #[arg(short, long, env = "CDA_CONFIG_FILE")]
-    pub config: Option<PathBuf>,
+    /// Configuration file to load, if none has been loaded into storage before.
+    #[arg(short = 'c', long, env = "CDA_CONFIG_FILE")]
+    pub seed_config: Option<PathBuf>,
 
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    #[arg(short, long)]
-    pub databases_path: Option<String>,
+    /// Directory with diagnostic databases to load, if none have been loaded into storage before.
+    #[arg(short = 'd', long)]
+    pub seed_databases_dir: Option<String>,
 
     #[arg(short, long)]
     pub tester_address: Option<String>,
@@ -157,8 +159,8 @@ impl AppArgs {
         )
     )]
     pub fn update_config(self, config: &mut Configuration) {
-        if let Some(databases_path) = self.databases_path {
-            config.database.path = databases_path;
+        if let Some(seed_databases_path) = self.seed_databases_dir {
+            config.database.seed_dir = seed_databases_path;
         }
         if let Some(exit_no_database_loaded) = self.exit_no_database_loaded {
             config.database.exit_no_database_loaded = exit_no_database_loaded;
@@ -265,7 +267,7 @@ where
         return generate_config_cmd(output.as_ref());
     }
 
-    let mut config = config::load_config_from_file_or_storage(args.config.as_deref()).await?;
+    let mut config = config::load_config_from_file_or_storage(args.seed_config.as_deref()).await?;
 
     // Command line arguments always take precedence over loaded configuration
     args.update_config(&mut config);
@@ -574,7 +576,7 @@ pub async fn load_vehicle_data<
 ) -> Result<VehicleData<S>, AppError> {
     let mdd_paths: Vec<PathBuf> = {
         let storage_dir = &config.runtime_update_config.storage_dir;
-        let paths = resolve_mdd_paths(storage_dir, &config.database.path).await;
+        let paths = resolve_mdd_paths(storage_dir, &config.database.seed_dir).await;
         if paths.is_empty() && config.database.exit_no_database_loaded {
             return Err(AppError::InitializationFailed(
                 "No MDD files found".to_string(),

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -16,11 +16,7 @@
 // query depth (128) on stable 1.97. Default limit otherwise.
 #![recursion_limit = "256"]
 
-use std::{
-    future::Future,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{future::Future, path::PathBuf, sync::Arc};
 
 #[cfg(feature = "can")]
 use cda_comm_can::CanDiagGateway;
@@ -269,47 +265,9 @@ where
         return generate_config_cmd(output.as_ref());
     }
 
-    let config_file = match &args.config {
-        Some(config_file) => {
-            if config_file.exists() {
-                config_file
-            } else {
-                // ignore `config-optional` feature here, because it's specifically for when no config was specified
-                return Err(AppError::ConfigurationError {
-                    message: format!(
-                        "Specified configuration file {} does not exist",
-                        config_file.display()
-                    ),
-                    source: None,
-                });
-            }
-        }
-        None => Path::new("opensovd-cda.toml"),
-    };
+    let mut config = config::load_config_from_file_or_storage(args.config.as_deref()).await?;
 
-    let (mut config, disk_loaded) = config::load_config_with_fallback(config_file);
-
-    match cda_storage::LocalStorage::new(&config.runtime_update_config.storage_dir) {
-        Ok(storage) => {
-            if config.runtime_update_config.init_storage_from_config_file {
-                config::seed_storage_from_config_file(&storage, config_file).await?;
-            }
-
-            if let Some(storage_config) =
-                config::load_config_with_storage_override(&storage).await?
-            {
-                config = storage_config;
-            } else if !disk_loaded {
-                config::require_config_source()?;
-            }
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, "Storage not available, skipping seed and config override");
-            return Ok(());
-        }
-    }
-
-    // Command line arguments always take precedence over stored configuration
+    // Command line arguments always take precedence over loaded configuration
     args.update_config(&mut config);
 
     config.validate_sanity().map_err(AppError::from)?;

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -79,6 +79,11 @@ pub struct AppArgs {
     #[arg(short = 'c', long, env = "CDA_CONFIG_FILE")]
     pub seed_config: Option<PathBuf>,
 
+    /// Force overwrite storage config with config file content even if storage already has config
+    /// Force loading configuration file into storage, even if a config has been loaded into it previously.
+    #[arg(long)]
+    pub force_seed_config: bool,
+
     #[command(subcommand)]
     pub command: Option<Command>,
 
@@ -267,7 +272,11 @@ where
         return generate_config_cmd(output.as_ref());
     }
 
-    let mut config = config::load_config_from_file_or_storage(args.seed_config.as_deref()).await?;
+    let mut config = config::load_config_from_file_or_storage(
+        args.seed_config.as_deref(),
+        args.force_seed_config,
+    )
+    .await?;
 
     // Command line arguments always take precedence over loaded configuration
     args.update_config(&mut config);

--- a/cda-main/src/mdd.rs
+++ b/cda-main/src/mdd.rs
@@ -337,10 +337,12 @@ pub async fn seed_storage_if_empty_from_database_path(storage_dir: &str, databas
         }
     };
 
+    let force_seed = false;
     if let Some(count) = cda_storage::storage_seed::seed_storage_collection_if_empty(
         &storage,
         &CollectionName::DiagnosticDatabase,
         entries,
+        force_seed,
     )
     .await
     {

--- a/cda-main/src/mdd.rs
+++ b/cda-main/src/mdd.rs
@@ -296,7 +296,7 @@ async fn load_mdd_paths_from_storage(storage_dir: &str) -> Option<Vec<PathBuf>> 
 /// Seeds the `DiagnosticDatabase` storage collection from `database_path` when the collection
 /// is empty. This copies all `.mdd` files from the filesystem into storage so that the runtime
 /// update plugin has a populated baseline to work with.
-pub async fn seed_storage_from_database_path(storage_dir: &str, database_path: &str) {
+pub async fn seed_storage_if_empty_from_database_path(storage_dir: &str, database_path: &str) {
     let mdd_files = match std::fs::read_dir(database_path) {
         Ok(entries) => get_mdd_files_and_size(entries),
         Err(e) => {
@@ -337,7 +337,7 @@ pub async fn seed_storage_from_database_path(storage_dir: &str, database_path: &
         }
     };
 
-    if let Some(count) = cda_storage::storage_seed::seed_storage_collection(
+    if let Some(count) = cda_storage::storage_seed::seed_storage_collection_if_empty(
         &storage,
         &CollectionName::DiagnosticDatabase,
         entries,
@@ -697,7 +697,7 @@ mod tests {
     use cda_interfaces::storage_api::{Collection as _, CollectionName, DirectFileAccess, Storage};
     use cda_storage::LocalStorage;
 
-    use super::{resolve_mdd_paths, seed_storage_from_database_path};
+    use super::{resolve_mdd_paths, seed_storage_if_empty_from_database_path};
 
     /// Helper: create a temp dir with `.mdd` files containing given data.
     fn create_database_dir(files: &[(&str, &[u8])]) -> tempfile::TempDir {
@@ -716,7 +716,7 @@ mod tests {
             ("ecu_b.mdd", b"MDD_CONTENT_B"),
         ]);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_path(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -753,7 +753,7 @@ mod tests {
         tx.commit().await.unwrap();
         drop(storage);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_path(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -778,7 +778,7 @@ mod tests {
             ("data.bin", b"BIN"),
         ]);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_path(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -798,7 +798,7 @@ mod tests {
         let storage_dir = tempfile::tempdir().expect("storage dir");
         let db_dir = tempfile::tempdir().expect("empty db dir");
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_path(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -817,7 +817,7 @@ mod tests {
         let storage_dir = tempfile::tempdir().expect("storage dir");
 
         // Should not panic, just return early.
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_path(
             storage_dir.path().to_str().unwrap(),
             "/tmp/nonexistent_cda_test_path_12345",
         )
@@ -836,7 +836,7 @@ mod tests {
         let storage_dir = tempfile::tempdir().expect("storage dir");
         let db_dir = create_database_dir(&[("ECU_UPPER.mdd", b"UPPER_DATA")]);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_path(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -857,7 +857,7 @@ mod tests {
         let original_data = b"MDD_BINARY_PAYLOAD_1234567890";
         let db_dir = create_database_dir(&[("FLXC1000.mdd", original_data)]);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_path(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -885,7 +885,7 @@ mod tests {
         let storage_str = storage_dir.path().to_str().unwrap();
         let db_str = db_dir.path().to_str().unwrap();
 
-        seed_storage_from_database_path(storage_str, db_str).await;
+        seed_storage_if_empty_from_database_path(storage_str, db_str).await;
         let paths = resolve_mdd_paths(storage_str, db_str).await;
 
         assert_eq!(paths.len(), 2, "Expected 2 MDD paths from storage");

--- a/cda-storage/src/storage_seed.rs
+++ b/cda-storage/src/storage_seed.rs
@@ -21,6 +21,7 @@ pub async fn seed_storage_collection_if_empty(
     storage: &impl Storage,
     collection_name: &CollectionName,
     entries: impl IntoIterator<Item = (String, Vec<u8>)>,
+    force_seed: bool,
 ) -> Option<usize> {
     let collection = match storage.get_or_create_collection(collection_name).await {
         Ok(c) => c,
@@ -34,19 +35,23 @@ pub async fn seed_storage_collection_if_empty(
         }
     };
 
-    match collection.is_empty().await {
-        Ok(true) => {}
-        Ok(false) => {
-            tracing::debug!(collection = %collection_name, "Collection already populated, skipping seed");
-            return None;
-        }
-        Err(e) => {
-            tracing::warn!(
-                collection = %collection_name,
-                error = %e,
-                "Failed to check collection, skipping seed"
-            );
-            return None;
+    if force_seed {
+        tracing::debug!(collection = %collection_name, "Seeding is forced. Will update collection unconditionally.");
+    } else {
+        match collection.is_empty().await {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::debug!(collection = %collection_name, "Collection already populated, skipping seed");
+                return None;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    collection = %collection_name,
+                    error = %e,
+                    "Failed to check collection, skipping seed"
+                );
+                return None;
+            }
         }
     }
 

--- a/cda-storage/src/storage_seed.rs
+++ b/cda-storage/src/storage_seed.rs
@@ -17,7 +17,7 @@ use cda_interfaces::storage_api::{Collection, CollectionName, Storage};
 /// empty.  No-op if the collection is already populated or the iterator yields no items.
 ///
 /// Returns the number of entries written, or `None` when seeding was skipped.
-pub async fn seed_storage_collection(
+pub async fn seed_storage_collection_if_empty(
     storage: &impl Storage,
     collection_name: &CollectionName,
     entries: impl IntoIterator<Item = (String, Vec<u8>)>,

--- a/integration-tests/tests/sovd/configuration.rs
+++ b/integration-tests/tests/sovd/configuration.rs
@@ -26,7 +26,7 @@ async fn cda_stays_running_when_no_database_loaded_and_exit_flag_is_false() {
 
     let mut config = Configuration {
         database: DatabaseConfig {
-            path: empty_db_dir.path().to_string_lossy().into_owned(),
+            seed_dir: empty_db_dir.path().to_string_lossy().into_owned(),
             exit_no_database_loaded: false,
             ..Default::default()
         },

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -274,7 +274,7 @@ fn base_test_config(
         },
         can: None,
         database: DatabaseConfig {
-            path: mdd_file_path()?,
+            seed_dir: mdd_file_path()?,
             naming_convention: DatabaseNamingConvention::default(),
             exit_no_database_loaded: true,
             fallback_to_base_variant: true,
@@ -772,7 +772,7 @@ fn write_config_toml(
     config.functional_description.description_database = "functional_groups".into();
 
     "0.0.0.0".clone_into(&mut config.server.address);
-    "/app/odx".clone_into(&mut config.database.path);
+    "/app/odx".clone_into(&mut config.database.seed_dir);
 
     // In docker the socketcand daemon runs in its own service, reachable by
     // service name over the bridge network (not the host loopback used locally).

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -452,8 +452,8 @@
 # attempting a lookup with this flag set against a multi-protocol database
 # returns `DiagServiceError::InvalidDatabase`.
 # ignore_protocol = false
-# Path to load the databases from, this must be a directory.
-# path = "."
+# Directory to load the databases from, if none have been loaded into storage before.
+# seed_dir = "."
 
 # Holds configuration for diagnostic service naming conventions.
 #


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

# WIP
* [x] Unit tests for config loading algorithm.
* [ ] Tasks in #479.

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

Switches to a configuration loading algorithm like this:

0. Load config, to know where the LocalStorage is
1. if entry in storage
      1.a.1 load config from storage
   else
      1.b.1 load config from figment
      1.b.2 seed storage

2. Override config from args
3. Validate


---
### TODO extend this summary...
---


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->
Fixes #479.

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

---

Frank Märkle [frank.maerkle@mercedes-benz.com](mailto:frank.maerkle@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
