### PR TITLE
Fix UDS variant-detection timeouts, retry-policy comparams, and a SPRMIB misdetection regression

### DIFF
--- a/cda-comm-can/src/gateway.rs
+++ b/cda-comm-can/src/gateway.rs
@@ -511,7 +511,7 @@ impl EcuGateway for CanDiagGateway {
         message: ServicePayload,
         response_sender: mpsc::Sender<Result<Option<UdsResponse>, DiagServiceError>>,
         expect_uds_reply: bool,
-    ) -> Result<(), DiagServiceError> {
+    ) -> Result<tokio::task::JoinHandle<()>, DiagServiceError> {
         let ecu_name = transmission_params.ecu_name.to_lowercase();
         let conn = self
             .get_connection(&ecu_name)
@@ -539,7 +539,7 @@ impl EcuGateway for CanDiagGateway {
         let target_address = message.target_address;
         let request_data = message.data;
 
-        cda_interfaces::spawn_named!(&format!("can-send-{ecu_name}"), {
+        let handle = cda_interfaces::spawn_named!(&format!("can-send-{ecu_name}"), {
             async move {
                 // Open socket and send request, keeping the socket alive for the
                 // entire exchange so response-pending follow-ups arrive on the
@@ -680,7 +680,7 @@ impl EcuGateway for CanDiagGateway {
             }
         });
 
-        Ok(())
+        Ok(handle)
     }
 
     #[tracing::instrument(skip(self, _ecu_db), fields(dlt_context = dlt_ctx!("CAN")))]

--- a/cda-comm-can/src/lib.rs
+++ b/cda-comm-can/src/lib.rs
@@ -68,7 +68,7 @@ impl cda_interfaces::EcuGateway for CanDiagGateway {
             Result<Option<cda_interfaces::UdsResponse>, cda_interfaces::DiagServiceError>,
         >,
         _expect_uds_reply: bool,
-    ) -> Result<(), cda_interfaces::DiagServiceError> {
+    ) -> Result<tokio::task::JoinHandle<()>, cda_interfaces::DiagServiceError> {
         Err(cda_interfaces::DiagServiceError::EcuOffline(
             "CAN support is not enabled. Compile with the `can` feature.".to_owned(),
         ))

--- a/cda-comm-can/src/multi_transport.rs
+++ b/cda-comm-can/src/multi_transport.rs
@@ -257,7 +257,7 @@ impl<D: EcuGateway> EcuGateway for MultiTransportGateway<D> {
         message: ServicePayload,
         response_sender: mpsc::Sender<Result<Option<UdsResponse>, DiagServiceError>>,
         expect_uds_reply: bool,
-    ) -> Result<(), DiagServiceError> {
+    ) -> Result<tokio::task::JoinHandle<()>, DiagServiceError> {
         let ecu_name = transmission_params.ecu_name.to_lowercase();
 
         let transport = if let Some(t) = self.pinned_or_bound(&ecu_name).await {
@@ -448,8 +448,9 @@ mod tests {
                 _message: ServicePayload,
                 _response_sender: mpsc::Sender<Result<Option<UdsResponse>, DiagServiceError>>,
                 _expect_uds_reply: bool,
-            ) -> impl Future<Output = Result<(), DiagServiceError>> + Send {
-                std::future::ready(Ok(()))
+            ) -> impl Future<Output = Result<tokio::task::JoinHandle<()>, DiagServiceError>> + Send
+            {
+                std::future::ready(Ok(tokio::task::spawn(std::future::ready(()))))
             }
 
             fn ecu_online<T: EcuAddresses>(

--- a/cda-comm-doip/src/lib.rs
+++ b/cda-comm-doip/src/lib.rs
@@ -524,7 +524,7 @@ impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
         message: ServicePayload,
         response_sender: mpsc::Sender<Result<Option<UdsResponse>, DiagServiceError>>,
         expect_uds_reply: bool,
-    ) -> Result<(), DiagServiceError> {
+    ) -> Result<tokio::task::JoinHandle<()>, DiagServiceError> {
         let start = Instant::now();
 
         let doip_conn = self
@@ -540,7 +540,7 @@ impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
             message: message.data,
         };
 
-        cda_interfaces::spawn_named!(
+        let handle = cda_interfaces::spawn_named!(
             &format!("ecu-data-receive-{}", transmission_params.ecu_name),
             {
                 async move {
@@ -625,7 +625,7 @@ impl<T: EcuAddresses + DoipComParams> EcuGateway for DoipDiagGateway<T> {
             }
         );
 
-        Ok(())
+        Ok(handle)
     }
 
     async fn ecu_online<E: EcuAddresses>(
@@ -1349,7 +1349,7 @@ mod tests {
         mpsc::channel(1)
     }
 
-    type SendResult = Result<(), cda_interfaces::DiagServiceError>;
+    type SendResult = Result<tokio::task::JoinHandle<()>, cda_interfaces::DiagServiceError>;
     type ResponseItem = Result<Option<UdsResponse>, cda_interfaces::DiagServiceError>;
 
     /// Shared test harness.

--- a/cda-comm-uds/src/test_helpers.rs
+++ b/cda-comm-uds/src/test_helpers.rs
@@ -26,12 +26,25 @@ use cda_interfaces::{
 /// Minimal test double satisfying `UdsEcuDb + VariantDetection`.
 pub(crate) struct TestEcuDb {
     service_states: tokio::sync::Mutex<std::collections::HashMap<u8, String>>,
+    /// Configurable `CP_P6Max`-backed timeout, so tests can verify that
+    /// callers fall back to this comparam-derived value instead of using a
+    /// hardcoded literal. Defaults to 5s to match the previous fixed value.
+    timeout_default: Duration,
 }
 
 impl TestEcuDb {
     pub fn new() -> Self {
         Self {
             service_states: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            timeout_default: Duration::from_secs(5),
+        }
+    }
+
+    /// Create a test double with a custom `timeout_default` (`CP_P6Max`).
+    pub fn with_timeout_default(timeout_default: Duration) -> Self {
+        Self {
+            service_states: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            timeout_default,
         }
     }
 }
@@ -147,7 +160,7 @@ impl UdsComParams for TestEcuDb {
         Duration::from_millis(10)
     }
     fn timeout_default(&self) -> Duration {
-        Duration::from_secs(5)
+        self.timeout_default
     }
 }
 

--- a/cda-comm-uds/src/test_helpers.rs
+++ b/cda-comm-uds/src/test_helpers.rs
@@ -30,6 +30,11 @@ pub(crate) struct TestEcuDb {
     /// callers fall back to this comparam-derived value instead of using a
     /// hardcoded literal. Defaults to 5s to match the previous fixed value.
     timeout_default: Duration,
+    /// Configurable `CP_RepeatReqCountApp`, so tests can verify the exact
+    /// number of application-layer retries performed on timeout/transmission/
+    /// receive errors. Defaults to 2 to match the `CP_RepeatReqCountApp`
+    /// comparam default.
+    repeat_req_count_app: u32,
 }
 
 impl TestEcuDb {
@@ -37,6 +42,7 @@ impl TestEcuDb {
         Self {
             service_states: tokio::sync::Mutex::new(std::collections::HashMap::new()),
             timeout_default: Duration::from_secs(5),
+            repeat_req_count_app: 2,
         }
     }
 
@@ -45,6 +51,20 @@ impl TestEcuDb {
         Self {
             service_states: tokio::sync::Mutex::new(std::collections::HashMap::new()),
             timeout_default,
+            repeat_req_count_app: 2,
+        }
+    }
+
+    /// Create a test double with a custom `timeout_default` (`CP_P6Max`) and
+    /// `repeat_req_count_app` (`CP_RepeatReqCountApp`).
+    pub fn with_timeout_default_and_repeat_req_count_app(
+        timeout_default: Duration,
+        repeat_req_count_app: u32,
+    ) -> Self {
+        Self {
+            service_states: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            timeout_default,
+            repeat_req_count_app,
         }
     }
 }
@@ -130,7 +150,7 @@ impl UdsComParams for TestEcuDb {
         Duration::from_secs(2)
     }
     fn repeat_req_count_app(&self) -> u32 {
-        3
+        self.repeat_req_count_app
     }
     fn rc_21_retry_policy(&self) -> RetryPolicy {
         RetryPolicy::ContinueUntilTimeout

--- a/cda-comm-uds/src/transport.rs
+++ b/cda-comm-uds/src/transport.rs
@@ -823,6 +823,22 @@ mod send_tests {
         )
     }
 
+    fn make_manager_with_timeout_default(
+        gateway: TestGateway,
+        timeout_default: Duration,
+    ) -> UdsManager<TestGateway, TestEcuDb> {
+        let ecus = Arc::new(HashMap::from_iter([(
+            "TestECU".to_string(),
+            RwLock::new(TestEcuDb::with_timeout_default(timeout_default)),
+        )]));
+        UdsManager::new_for_raw_payload_tests(
+            gateway,
+            ecus,
+            FaultConfig::default(),
+            Arc::new(AtomicBool::new(false)),
+        )
+    }
+
     fn make_manager_no_ecus(gateway: TestGateway) -> UdsManager<TestGateway, TestEcuDb> {
         let ecus = Arc::new(HashMap::new());
         UdsManager::new_for_raw_payload_tests(
@@ -970,6 +986,57 @@ mod send_tests {
         assert!(
             matches!(result, Err(DiagServiceError::Timeout)),
             "Expected Timeout error"
+        );
+    }
+
+    /// Regression test: sends that omit an explicit timeout
+    /// must fall back to the ECU's configured `CP_P6Max`-backed
+    /// `UdsComParams::timeout_default`, not a hardcoded literal. Previously,
+    /// `gather_detection_responses` (in `variant.rs`) hardcoded a 10s timeout
+    /// for every `0x22 F100` variant-detection send, ignoring the ECU's
+    /// actual configured response timeout entirely. The fix changed that
+    /// call site to pass `None` instead, relying on exactly the fallback
+    /// (`timeout.unwrap_or(uds_params.timeout_default)`) exercised here.
+    ///
+    /// This test exercises `send_with_raw_payload` directly rather than
+    /// `gather_detection_responses`/`detect_variant` itself, since those
+    /// require the full `EcuManager` trait (a much larger surface than the
+    /// `UdsEcuDb + VariantDetection` bound used by the existing test double
+    /// in this module), which is out of proportion for this scoped fix.
+    #[tokio::test]
+    async fn test_send_with_raw_payload_uses_configured_timeout_default_when_none() {
+        let gateway = TestGateway {
+            send_fn: Arc::new(|_response_tx, _| {
+                // Don't send any response - the call must time out based on
+                // the ECU's configured `timeout_default`.
+                Ok(())
+            }),
+        };
+        let short_timeout = Duration::from_millis(100);
+        let manager = make_manager_with_timeout_default(gateway, short_timeout);
+        let payload = make_test_payload(0x10, &[0x01]);
+
+        let start = std::time::Instant::now();
+        // No explicit timeout: must fall back to `uds_params.timeout_default`
+        // (this is exactly what `send_without_variant_guard` does when
+        // called from `gather_detection_responses` post-fix).
+        let result = manager
+            .send_with_raw_payload("TestECU", payload, None, true)
+            .await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            matches!(result, Err(DiagServiceError::Timeout)),
+            "Expected Timeout error, got {result:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "Expected timeout close to the configured {short_timeout:?}, but took {elapsed:?} (a \
+             regression would hardcode ~10s here)"
+        );
+        assert!(
+            elapsed >= short_timeout,
+            "Timeout fired earlier than the configured {short_timeout:?}: {elapsed:?}"
         );
     }
 

--- a/cda-comm-uds/src/transport.rs
+++ b/cda-comm-uds/src/transport.rs
@@ -238,14 +238,28 @@ impl<S: EcuGateway, T: UdsEcuDb + VariantDetection> UdsManager<S, T> {
         let mut app_retry_count: u32 = 0;
 
         // outer loop to retry sending frames, resend frames must deal with (N)ACK again
-        let (response_tx, mut response_rx) = mpsc::channel(2);
         let (response, sent_after) = 'send: loop {
+            // Create a fresh response channel for every attempt. Each
+            // `continue 'send` (transmission/receive error, plain timeout, or
+            // NRC 0x21/0x94 busy-repeat) drops the previous attempt's
+            // `response_rx` together with its sole `response_tx`, which in turn
+            // fires `response_sender.closed()` in the gateway's per-request
+            // task. That releases the (shared) ECU lock and tears the stale
+            // task down *before* the next attempt is sent.
+            //
+            // Reusing a single channel across attempts (as done previously)
+            // kept every prior gateway task alive and subscribed to the same
+            // sender; a stale task could then push a late response or error
+            // into the shared channel and trip the receive-error branch below,
+            // causing a retry to fire immediately instead of only after this
+            // attempt's `rx_timeout` had elapsed.
+            let (response_tx, mut response_rx) = mpsc::channel(2);
             if let Err(e) = self
                 .gateway
                 .send(
                     transmission_params.clone(),
                     payload.clone(),
-                    response_tx.clone(),
+                    response_tx,
                     expect_response,
                 )
                 .await
@@ -421,9 +435,11 @@ impl<S: EcuGateway, T: UdsEcuDb + VariantDetection> UdsManager<S, T> {
                 }
             };
             tracing::debug!("Finished reading UDS messages from gateway");
+            // `response_rx` (and its `response_tx`) are dropped here as this
+            // attempt's scope ends, closing the channel and releasing the
+            // gateway's per-request task and the ECU lock it holds.
             break 'send (uds_result, sent_after);
         };
-        drop(response_rx);
         drop(ecu_sem);
 
         // Post-send: if a service send (not tester present) timed out,
@@ -841,7 +857,20 @@ mod send_tests {
             response_sender: mpsc::Sender<Result<Option<UdsResponse>, DiagServiceError>>,
             expect_uds_reply: bool,
         ) -> impl Future<Output = Result<(), DiagServiceError>> + Send {
-            let result = (self.send_fn)(response_sender, expect_uds_reply);
+            // Mirror the real gateways: the actual send happens on a detached
+            // task that keeps `response_sender` alive until either it produces a
+            // response or the caller drops its `response_rx` (which fires
+            // `response_sender.closed()`). Modelling this is essential for the
+            // per-attempt-channel retry semantics: a `send_fn` that never
+            // answers must leave the channel open so the UDS-layer `rx_timeout`
+            // fires, and must have its sender released once the caller moves on
+            // to the next attempt.
+            let send_fn = Arc::clone(&self.send_fn);
+            let result = send_fn(response_sender.clone(), expect_uds_reply);
+            tokio::spawn(async move {
+                // Hold the sender until the caller's receiver is dropped.
+                response_sender.closed().await;
+            });
             async move { result }
         }
 
@@ -1199,6 +1228,88 @@ mod send_tests {
             call_count.load(std::sync::atomic::Ordering::SeqCst),
             3,
             "Expected 2 failed transmission attempts + 1 successful one"
+        );
+    }
+
+    /// Regression test for the "immediate retry" bug observed on offline/answer-
+    /// suppressing ECUs (positive ACK, then no UDS reply). Previously a single
+    /// response channel was shared across all retries, so a stale gateway task
+    /// from a prior attempt could push a late response/error into that shared
+    /// channel and trip the receive-error branch, firing the next
+    /// `CP_RepeatReqCountApp` retry *immediately* instead of only after this
+    /// attempt's `rx_timeout` had elapsed (see log.pcapng: retry #1 correctly
+    /// waited ~`P6Max`, retry #2 fired ~1ms later).
+    ///
+    /// With a per-attempt channel, dropping the previous attempt's
+    /// `response_rx`/`response_tx` closes the stale task's sender, so a late
+    /// error injected into a *prior* attempt's sender cannot reach the current
+    /// attempt. Every retry must therefore be gated by the full timeout, so the
+    /// total elapsed time is `(1 + repeat_req_count_app) * timeout`.
+    #[tokio::test]
+    async fn test_stale_task_error_does_not_cause_sub_timeout_retry() {
+        // Holds the `response_tx` handed to the *previous* attempt, so we can
+        // simulate a stale gateway task pushing a late error into it after the
+        // next attempt has already started.
+        type ResponseSender = mpsc::Sender<Result<Option<UdsResponse>, DiagServiceError>>;
+        let prev_tx: Arc<std::sync::Mutex<Option<ResponseSender>>> =
+            Arc::new(std::sync::Mutex::new(None));
+        let send_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+
+        let prev_tx_clone = Arc::clone(&prev_tx);
+        let send_count_clone = Arc::clone(&send_count);
+        let gateway = TestGateway {
+            send_fn: Arc::new(move |response_tx, _| {
+                send_count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                // Simulate the stale task of the *previous* attempt delivering a
+                // late receive-error. Post-fix the previous sender is already
+                // closed (its `response_rx` was dropped), so this is a no-op and
+                // must not influence the current attempt.
+                if let Some(stale) = prev_tx_clone.lock().unwrap().take() {
+                    let _ = stale.try_send(Err(DiagServiceError::NoResponse(
+                        "stale task late error".to_owned(),
+                    )));
+                }
+                // Retain this attempt's sender as the "previous" one for the
+                // next attempt, and otherwise never answer -> this attempt must
+                // time out on its own channel.
+                *prev_tx_clone.lock().unwrap() = Some(response_tx);
+                Ok(())
+            }),
+        };
+
+        let repeat_req_count_app = 2;
+        let timeout = Duration::from_millis(50);
+        let manager = make_manager_with_timeout_default_and_repeat_req_count_app(
+            gateway,
+            timeout,
+            repeat_req_count_app,
+        );
+        let payload = make_test_payload(0x10, &[0x01]);
+
+        let start = std::time::Instant::now();
+        let result = manager
+            .send_with_raw_payload("TestECU", payload, None, true)
+            .await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            matches!(result, Err(DiagServiceError::Timeout)),
+            "Expected Timeout error, got {result:?}"
+        );
+        assert_eq!(
+            send_count.load(std::sync::atomic::Ordering::SeqCst),
+            1 + repeat_req_count_app,
+            "Expected exactly 1 original transmission + {repeat_req_count_app} repeats"
+        );
+        // The crux: each attempt (including retries) must wait its full timeout.
+        // Pre-fix, the stale error tripped the receive-error branch and retries
+        // fired near-instantly, so total elapsed was ~one timeout. Require the
+        // total to be at least the sum for all attempts.
+        let min_expected = timeout * (1 + repeat_req_count_app);
+        assert!(
+            elapsed >= min_expected,
+            "Retries fired before their timeout elapsed: total {elapsed:?} < expected \
+             {min_expected:?} (stale-task error must not trigger a sub-timeout retry)"
         );
     }
 

--- a/cda-comm-uds/src/transport.rs
+++ b/cda-comm-uds/src/transport.rs
@@ -282,8 +282,18 @@ impl<S: EcuGateway, T: UdsEcuDb + VariantDetection> UdsManager<S, T> {
 
             // responses might be disabled, i.e. for functional tester presents...
             if !expect_response {
-                // ...but wait until the message was (n)ack'd
-                response_rx.recv().await;
+                // ...but wait until the message was (n)ack'd. Bounded by `rx_timeout`
+                // so a gateway that never (n)acks and never closes the channel cannot
+                // block this call forever.
+                if tokio::time::timeout(rx_timeout, response_rx.recv())
+                    .await
+                    .is_err()
+                {
+                    tracing::warn!(
+                        ecu_name,
+                        "Timed out waiting for (n)ack on a request with no expected response"
+                    );
+                }
                 return Ok(None);
             }
 
@@ -807,8 +817,8 @@ mod send_tests {
 
     use cda_interfaces::{
         DiagServiceError, EcuAddresses, EcuGateway, EcuRuntimeState, EcuStateManager, HashMap,
-        HashMapExtensions, ServicePayload, TransmissionParameters, UdsResponse, VariantDetection,
-        datatypes::FaultConfig, service_ids,
+        HashMapExtensions, ServicePayload, TransmissionParameters, UDS_ID_RESPONSE_BITMASK,
+        UdsResponse, VariantDetection, datatypes::FaultConfig, service_ids,
     };
     use tokio::sync::{RwLock, mpsc};
 
@@ -1015,7 +1025,7 @@ mod send_tests {
         TestGateway {
             send_fn: Arc::new(|response_tx, _| {
                 let msg = UdsResponse::Message(ServicePayload {
-                    data: vec![0x50, 0x01],
+                    data: vec![service_ids::SESSION_CONTROL | UDS_ID_RESPONSE_BITMASK, 0x01],
                     source_address: 0x0001,
                     target_address: 0x0E00,
                     new_session: None,
@@ -1033,7 +1043,7 @@ mod send_tests {
     async fn test_send_with_raw_payload_positive_response() {
         let gateway = make_gateway();
         let manager = make_manager(gateway);
-        let payload = make_test_payload(0x10, &[0x01]);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
 
         let result = manager
             .send_with_raw_payload("TestECU", payload, None, true)
@@ -1043,7 +1053,10 @@ mod send_tests {
         let response = result.expect("should be Ok");
         assert!(response.is_some());
         let msg = response.expect("should have message");
-        assert_eq!(msg.data, vec![0x50, 0x01]);
+        assert_eq!(
+            msg.data,
+            vec![service_ids::SESSION_CONTROL | UDS_ID_RESPONSE_BITMASK, 0x01]
+        );
     }
 
     #[tokio::test]
@@ -1056,7 +1069,7 @@ mod send_tests {
             }),
         };
         let manager = make_manager(gateway);
-        let payload = make_test_payload(0x10, &[0x01]);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
 
         let result = manager
             .send_with_raw_payload("TestECU", payload, None, false)
@@ -1109,7 +1122,7 @@ mod send_tests {
             send_fn: Arc::new(|_, _| Ok(())),
         };
         let manager = make_manager_no_ecus(gateway);
-        let payload = make_test_payload(0x10, &[0x01]);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
 
         let result = manager
             .send_with_raw_payload("NonExistent", payload, None, true)
@@ -1153,7 +1166,7 @@ mod send_tests {
             send_fn: Arc::new(|_, _| Err(DiagServiceError::EcuOffline("TestECU".to_string()))),
         };
         let manager = make_manager(gateway);
-        let payload = make_test_payload(0x10, &[0x01]);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
 
         let result = manager
             .send_with_raw_payload("TestECU", payload, None, true)
@@ -1178,7 +1191,7 @@ mod send_tests {
             }),
         };
         let manager = make_manager(gateway);
-        let payload = make_test_payload(0x10, &[0x01]);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
 
         let result = manager
             .send_with_raw_payload("TestECU", payload, Some(Duration::from_millis(50)), true)
@@ -1208,7 +1221,15 @@ mod send_tests {
                 // the mismatched echo bytes, ignores the frame, and loops back
                 // to recv(); the gateway task then ends and drops its sender.
                 let msg = UdsResponse::Message(ServicePayload {
-                    data: vec![0x62, 0xF2, 0x00, 0x41, 0x42, 0x43, 0x44],
+                    data: vec![
+                        service_ids::READ_DATA_BY_IDENTIFIER | UDS_ID_RESPONSE_BITMASK,
+                        0xF2,
+                        0x00,
+                        0x41,
+                        0x42,
+                        0x43,
+                        0x44,
+                    ],
                     source_address: 0x0001,
                     target_address: 0x0E00,
                     new_session: None,
@@ -1225,7 +1246,7 @@ mod send_tests {
             0,
         );
         // Request: 22 F1 90 (ReadDataByIdentifier, DID 0xF190).
-        let payload = make_test_payload(0x22, &[0xF1, 0x90]);
+        let payload = make_test_payload(service_ids::READ_DATA_BY_IDENTIFIER, &[0xF1, 0x90]);
 
         let result = manager
             .send_with_raw_payload("TestECU", payload, None, true)
@@ -1261,7 +1282,7 @@ mod send_tests {
             Duration::from_millis(20),
             repeat_req_count_app,
         );
-        let payload = make_test_payload(0x10, &[0x01]);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
 
         let result = manager
             .send_with_raw_payload("TestECU", payload, None, true)
@@ -1293,7 +1314,7 @@ mod send_tests {
                     return Err(DiagServiceError::SendFailed("simulated".to_owned()));
                 }
                 let msg = UdsResponse::Message(ServicePayload {
-                    data: vec![0x50, 0x01],
+                    data: vec![service_ids::SESSION_CONTROL | UDS_ID_RESPONSE_BITMASK, 0x01],
                     source_address: 0x0001,
                     target_address: 0x0E00,
                     new_session: None,
@@ -1308,7 +1329,7 @@ mod send_tests {
             Duration::from_secs(5),
             3,
         );
-        let payload = make_test_payload(0x10, &[0x01]);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
 
         let result = manager
             .send_with_raw_payload("TestECU", payload, None, true)
@@ -1375,7 +1396,7 @@ mod send_tests {
             timeout,
             repeat_req_count_app,
         );
-        let payload = make_test_payload(0x10, &[0x01]);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
 
         let start = std::time::Instant::now();
         let result = manager
@@ -1439,7 +1460,7 @@ mod send_tests {
             Duration::from_millis(50),
             repeat_req_count_app,
         );
-        let payload = make_test_payload(0x10, &[0x01]);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
 
         let result = tokio::time::timeout(
             Duration::from_millis(200),
@@ -1487,7 +1508,7 @@ mod send_tests {
         };
         let short_timeout = Duration::from_millis(100);
         let manager = make_manager_with_timeout_default(gateway, short_timeout);
-        let payload = make_test_payload(0x10, &[0x01]);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
 
         let start = std::time::Instant::now();
         // No explicit timeout: must fall back to `uds_params.timeout_default`
@@ -1527,7 +1548,7 @@ mod send_tests {
                         .ok();
                 } else {
                     let msg = UdsResponse::Message(ServicePayload {
-                        data: vec![0x50, 0x01],
+                        data: vec![service_ids::SESSION_CONTROL | UDS_ID_RESPONSE_BITMASK, 0x01],
                         source_address: 0x0001,
                         target_address: 0x0E00,
                         new_session: None,
@@ -1539,7 +1560,7 @@ mod send_tests {
             }),
         };
         let manager = make_manager(gateway);
-        let payload = make_test_payload(0x10, &[0x01]);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
 
         let result = manager
             .send_with_raw_payload("TestECU", payload, None, true)
@@ -1547,7 +1568,10 @@ mod send_tests {
 
         assert!(result.is_ok());
         let msg = result.expect("should be Ok").expect("should have message");
-        assert_eq!(msg.data, vec![0x50, 0x01]);
+        assert_eq!(
+            msg.data,
+            vec![service_ids::SESSION_CONTROL | UDS_ID_RESPONSE_BITMASK, 0x01]
+        );
         assert!(call_count.load(std::sync::atomic::Ordering::SeqCst) >= 2);
     }
 
@@ -1566,7 +1590,10 @@ mod send_tests {
                         .ok();
                     response_tx
                         .try_send(Ok(Some(UdsResponse::Message(ServicePayload {
-                            data: vec![0x50, 0x01],
+                            data: vec![
+                                service_ids::SESSION_CONTROL | UDS_ID_RESPONSE_BITMASK,
+                                0x01,
+                            ],
                             source_address: 0x0001,
                             target_address: 0x0E00,
                             new_session: None,
@@ -1578,7 +1605,7 @@ mod send_tests {
             }),
         };
         let manager = make_manager(gateway);
-        let payload = make_test_payload(0x10, &[0x01]);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
 
         let result = manager
             .send_with_raw_payload("TestECU", payload, None, true)
@@ -1586,7 +1613,10 @@ mod send_tests {
 
         assert!(result.is_ok());
         let msg = result.expect("should be Ok").expect("should have message");
-        assert_eq!(msg.data, vec![0x50, 0x01]);
+        assert_eq!(
+            msg.data,
+            vec![service_ids::SESSION_CONTROL | UDS_ID_RESPONSE_BITMASK, 0x01]
+        );
     }
 
     #[tokio::test]
@@ -1603,7 +1633,7 @@ mod send_tests {
                         .ok();
                 } else {
                     let msg = UdsResponse::Message(ServicePayload {
-                        data: vec![0x50, 0x01],
+                        data: vec![service_ids::SESSION_CONTROL | UDS_ID_RESPONSE_BITMASK, 0x01],
                         source_address: 0x0001,
                         target_address: 0x0E00,
                         new_session: None,
@@ -1615,7 +1645,7 @@ mod send_tests {
             }),
         };
         let manager = make_manager(gateway);
-        let payload = make_test_payload(0x10, &[0x01]);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
 
         let result = manager
             .send_with_raw_payload("TestECU", payload, None, true)
@@ -1623,7 +1653,10 @@ mod send_tests {
 
         assert!(result.is_ok());
         let msg = result.expect("should be Ok").expect("should have message");
-        assert_eq!(msg.data, vec![0x50, 0x01]);
+        assert_eq!(
+            msg.data,
+            vec![service_ids::SESSION_CONTROL | UDS_ID_RESPONSE_BITMASK, 0x01]
+        );
     }
 
     #[tokio::test]
@@ -1632,7 +1665,11 @@ mod send_tests {
             send_fn: Arc::new(|response_tx, _| {
                 // NRC 0x7F, SID 0x10, NRC code 0x22 (conditionsNotCorrect)
                 let msg = UdsResponse::Message(ServicePayload {
-                    data: vec![0x7F, 0x10, 0x22],
+                    data: vec![
+                        service_ids::NEGATIVE_RESPONSE,
+                        service_ids::SESSION_CONTROL,
+                        0x22, /* conditionsNotCorrect */
+                    ],
                     source_address: 0x0001,
                     target_address: 0x0E00,
                     new_session: None,
@@ -1643,7 +1680,7 @@ mod send_tests {
             }),
         };
         let manager = make_manager(gateway);
-        let payload = make_test_payload(0x10, &[0x01]);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
 
         let result = manager
             .send_with_raw_payload("TestECU", payload, None, true)
@@ -1652,14 +1689,21 @@ mod send_tests {
         assert!(result.is_ok());
         let msg = result.expect("should be Ok").expect("should have message");
         // Negative response: 0x7F + original SID + NRC
-        assert_eq!(msg.data, vec![0x7F, 0x10, 0x22]);
+        assert_eq!(
+            msg.data,
+            vec![
+                service_ids::NEGATIVE_RESPONSE,
+                service_ids::SESSION_CONTROL,
+                0x22
+            ]
+        );
     }
 
     #[tokio::test]
     async fn test_send_with_raw_payload_custom_timeout() {
         let gateway = make_gateway();
         let manager = make_manager(gateway);
-        let payload = make_test_payload(0x10, &[0x01]);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
 
         let result = manager
             .send_with_raw_payload("TestECU", payload, Some(Duration::from_secs(1)), true)
@@ -1673,7 +1717,7 @@ mod send_tests {
         let gateway = TestGateway {
             send_fn: Arc::new(|response_tx, _| {
                 let msg = UdsResponse::Message(ServicePayload {
-                    data: vec![0x50, 0x03],
+                    data: vec![service_ids::SESSION_CONTROL | UDS_ID_RESPONSE_BITMASK, 0x03],
                     source_address: 0x0001,
                     target_address: 0x0E00,
                     new_session: None,
@@ -1697,7 +1741,7 @@ mod send_tests {
 
         // Payload with new_session set - should be stored on positive response
         let payload = ServicePayload {
-            data: vec![0x10, 0x03],
+            data: vec![service_ids::SESSION_CONTROL, 0x03],
             source_address: 0x0E00,
             target_address: 0x0001,
             new_session: Some("extended".to_string()),
@@ -1731,7 +1775,7 @@ mod send_tests {
             }),
         };
         let manager = make_manager(gateway);
-        let payload = make_test_payload(0x10, &[0x01]);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
 
         let result = manager
             .send_with_raw_payload("TestECU", payload, None, true)
@@ -1751,7 +1795,12 @@ mod send_tests {
                 // First: a message with correct SID response but wrong DID (echo bytes)
                 // ReadDataByIdentifier (0x22) response SID is 0x62
                 let wrong_did = UdsResponse::Message(ServicePayload {
-                    data: vec![0x62, 0xF2, 0x00, 0xAA],
+                    data: vec![
+                        service_ids::READ_DATA_BY_IDENTIFIER | UDS_ID_RESPONSE_BITMASK,
+                        0xF2,
+                        0x00,
+                        0xAA,
+                    ],
                     source_address: 0x0001,
                     target_address: 0x0E00,
                     new_session: None,
@@ -1760,7 +1809,12 @@ mod send_tests {
                 response_tx.try_send(Ok(Some(wrong_did))).ok();
                 // Then: the correct response with matching DID
                 let correct = UdsResponse::Message(ServicePayload {
-                    data: vec![0x62, 0xF1, 0x90, 0xBB],
+                    data: vec![
+                        service_ids::READ_DATA_BY_IDENTIFIER | UDS_ID_RESPONSE_BITMASK,
+                        0xF1,
+                        0x90,
+                        0xBB,
+                    ],
                     source_address: 0x0001,
                     target_address: 0x0E00,
                     new_session: None,
@@ -1772,7 +1826,7 @@ mod send_tests {
         };
         let manager = make_manager(gateway);
         // ReadDataByIdentifier for DID 0xF190
-        let payload = make_test_payload(0x22, &[0xF1, 0x90]);
+        let payload = make_test_payload(service_ids::READ_DATA_BY_IDENTIFIER, &[0xF1, 0x90]);
 
         let result = manager
             .send_with_raw_payload("TestECU", payload, None, true)
@@ -1781,6 +1835,14 @@ mod send_tests {
         assert!(result.is_ok());
         let msg = result.expect("should be Ok").expect("should have message");
         // Should have received the second message (correct DID)
-        assert_eq!(msg.data, vec![0x62, 0xF1, 0x90, 0xBB]);
+        assert_eq!(
+            msg.data,
+            vec![
+                service_ids::READ_DATA_BY_IDENTIFIER | UDS_ID_RESPONSE_BITMASK,
+                0xF1,
+                0x90,
+                0xBB
+            ]
+        );
     }
 }

--- a/cda-comm-uds/src/transport.rs
+++ b/cda-comm-uds/src/transport.rs
@@ -28,6 +28,20 @@ use tokio::sync::{RwLock, Semaphore, mpsc};
 
 use crate::{UdsEcuDb, UdsManager, types::UdsParameters};
 
+/// Upper bound on how long `send_with_raw_payload` waits for a *previous*
+/// attempt's per-request gateway task to actually finish (per its returned
+/// `JoinHandle`) before issuing the next application-layer retry attempt.
+///
+/// Dropping the previous attempt's response channel only *signals* that task
+/// to stop; it does not guarantee the task has released whatever per-ECU
+/// resource it holds (e.g. a `DoIP` connection mutex, or - critically for CAN,
+/// which has no equivalent per-connection lock - an ISO-TP socket bound to
+/// the same CAN ID pair the next attempt is about to open). Awaiting the
+/// handle closes that gap. This wait is bounded so a gateway task that never
+/// finishes cannot stall retries indefinitely; if the grace period elapses,
+/// the next attempt proceeds anyway and a warning is logged.
+const RETRY_TEARDOWN_GRACE: Duration = Duration::from_millis(500);
+
 impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
     #[tracing::instrument(
         skip(self, service, payload),
@@ -237,6 +251,11 @@ impl<S: EcuGateway, T: UdsEcuDb + VariantDetection> UdsManager<S, T> {
         // separate time-bounded retry policy).
         let mut app_retry_count: u32 = 0;
 
+        // Handle of the previous attempt's per-request gateway task, if any.
+        // Awaited (bounded by `RETRY_TEARDOWN_GRACE`) at the top of the next
+        // loop iteration before that attempt is sent, see below.
+        let mut previous_task_handle: Option<tokio::task::JoinHandle<()>> = None;
+
         // outer loop to retry sending frames, resend frames must deal with (N)ACK again
         let (response, sent_after) = 'send: loop {
             // Create a fresh response channel for every attempt. Each
@@ -244,8 +263,7 @@ impl<S: EcuGateway, T: UdsEcuDb + VariantDetection> UdsManager<S, T> {
             // NRC 0x21/0x94 busy-repeat) drops the previous attempt's
             // `response_rx` together with its sole `response_tx`, which in turn
             // fires `response_sender.closed()` in the gateway's per-request
-            // task. That releases the (shared) ECU lock and tears the stale
-            // task down *before* the next attempt is sent.
+            // task, signaling it to tear itself down.
             //
             // Reusing a single channel across attempts (as done previously)
             // kept every prior gateway task alive and subscribed to the same
@@ -254,7 +272,20 @@ impl<S: EcuGateway, T: UdsEcuDb + VariantDetection> UdsManager<S, T> {
             // causing a retry to fire immediately instead of only after this
             // attempt's `rx_timeout` had elapsed.
             let (response_tx, mut response_rx) = mpsc::channel(2);
-            if let Err(e) = self
+
+            // Dropping the previous attempt's channel only *signals* its
+            // gateway task to stop; it does not guarantee that task has
+            // actually finished releasing whatever per-ECU resource it holds
+            // (e.g. a DoIP connection mutex, or an ISO-TP socket for CAN,
+            // which has no equivalent lock). Await its handle - bounded by
+            // `RETRY_TEARDOWN_GRACE` - before sending the next attempt, so
+            // the two per-request tasks don't run concurrently against the
+            // same resource.
+            if let Some(handle) = previous_task_handle.take() {
+                await_stale_gateway_task(handle, ecu_name).await;
+            }
+
+            match self
                 .gateway
                 .send(
                     transmission_params.clone(),
@@ -264,19 +295,22 @@ impl<S: EcuGateway, T: UdsEcuDb + VariantDetection> UdsManager<S, T> {
                 )
                 .await
             {
-                if app_retry_count < uds_params.repeat_req_count_app {
-                    app_retry_count = app_retry_count.saturating_add(1);
-                    tracing::debug!(
-                        ecu_name,
-                        attempt = app_retry_count,
-                        max_attempts = uds_params.repeat_req_count_app,
-                        error = %e,
-                        "Transmission error, repeating request (CP_RepeatReqCountApp)"
-                    );
-                    rx_timeout_next = None;
-                    continue 'send;
+                Ok(handle) => previous_task_handle = Some(handle),
+                Err(e) => {
+                    if app_retry_count < uds_params.repeat_req_count_app {
+                        app_retry_count = app_retry_count.saturating_add(1);
+                        tracing::debug!(
+                            ecu_name,
+                            attempt = app_retry_count,
+                            max_attempts = uds_params.repeat_req_count_app,
+                            error = %e,
+                            "Transmission error, repeating request (CP_RepeatReqCountApp)"
+                        );
+                        rx_timeout_next = None;
+                        continue 'send;
+                    }
+                    return Err(e);
                 }
-                return Err(e);
             }
             let sent_after = start.elapsed();
 
@@ -642,6 +676,37 @@ pub(crate) fn needs_variant_detection(status: &EcuState) -> bool {
             ))
 }
 
+/// Waits, bounded by [`RETRY_TEARDOWN_GRACE`], for a previous attempt's
+/// per-request gateway task to finish before the caller proceeds with the
+/// next application-layer retry attempt.
+///
+/// Dropping the previous attempt's response channel only signals that task to
+/// stop; this actually confirms it has finished (and released whatever
+/// per-ECU resource it was holding), closing the race between a stale task
+/// and the next attempt's fresh one. If the grace period elapses first, a
+/// warning is logged and the caller proceeds anyway, so a misbehaving gateway
+/// task cannot stall retries indefinitely.
+async fn await_stale_gateway_task(handle: tokio::task::JoinHandle<()>, ecu_name: &str) {
+    match tokio::time::timeout(RETRY_TEARDOWN_GRACE, handle).await {
+        Ok(Ok(())) => {}
+        Ok(Err(join_err)) => {
+            tracing::debug!(
+                ecu_name,
+                error = %join_err,
+                "Previous attempt's gateway task ended abnormally while tearing down"
+            );
+        }
+        Err(_elapsed) => {
+            tracing::warn!(
+                ecu_name,
+                grace_period = ?RETRY_TEARDOWN_GRACE,
+                "Previous attempt's gateway task did not finish within the teardown grace \
+                 period before starting the next retry"
+            );
+        }
+    }
+}
+
 #[tracing::instrument(skip_all,
     fields(dlt_context = dlt_ctx!("UDS"))
 )]
@@ -812,7 +877,7 @@ mod tests {
 mod send_tests {
     use std::{
         sync::{Arc, atomic::AtomicBool},
-        time::Duration,
+        time::{Duration, Instant},
     };
 
     use cda_interfaces::{
@@ -822,6 +887,7 @@ mod send_tests {
     };
     use tokio::sync::{RwLock, mpsc};
 
+    use super::RETRY_TEARDOWN_GRACE;
     use crate::{
         UdsEcuDb, UdsManager, state_coordinator::EcuStateCoordinator, test_helpers::TestEcuDb,
     };
@@ -907,7 +973,8 @@ mod send_tests {
             _message: ServicePayload,
             response_sender: mpsc::Sender<Result<Option<UdsResponse>, DiagServiceError>>,
             expect_uds_reply: bool,
-        ) -> impl Future<Output = Result<(), DiagServiceError>> + Send {
+        ) -> impl Future<Output = Result<tokio::task::JoinHandle<()>, DiagServiceError>> + Send
+        {
             // The closure receives `response_sender` by value and fully owns its
             // lifetime, mirroring how the real gateways manage their per-request
             // task's sender:
@@ -920,7 +987,89 @@ mod send_tests {
             //     suppressing ECU), the closure must keep the sender alive
             //     itself (store a clone), so the caller's `rx_timeout` fires.
             let result = (self.send_fn)(response_sender, expect_uds_reply);
-            async move { result }
+            async move {
+                result?;
+                // This test double's "task" is already fully done by the time
+                // `send` returns (the closure above ran synchronously), so the
+                // returned handle resolves essentially instantly. Tests that
+                // need to exercise the retry-teardown synchronization itself
+                // use `SlowTeardownGateway` instead.
+                Ok(tokio::task::spawn(std::future::ready(())))
+            }
+        }
+
+        fn ecu_online<T: EcuAddresses>(
+            &self,
+            _ecu_name: &str,
+            _ecu_db: &RwLock<T>,
+        ) -> impl Future<Output = Result<(), DiagServiceError>> + Send {
+            std::future::ready(Ok(()))
+        }
+
+        fn send_functional(
+            &self,
+            _transmission_params: TransmissionParameters,
+            _message: ServicePayload,
+            _expected_ecu_logical_addrs: HashMap<u16, String>,
+            _timeout: Duration,
+            _expect_positive_response: bool,
+        ) -> impl Future<
+            Output = Result<
+                HashMap<String, Result<UdsResponse, DiagServiceError>>,
+                DiagServiceError,
+            >,
+        > + Send {
+            std::future::ready(Ok(HashMap::new()))
+        }
+    }
+
+    /// Test gateway dedicated to exercising the retry-teardown synchronization
+    /// in `send_with_raw_payload`: every `send` call immediately closes its
+    /// response channel (as a stale gateway task would once it has forwarded
+    /// its last usable message and moved to shutting down), but the *returned
+    /// task handle* only resolves after `task_delay`, modelling a per-request
+    /// task that is slow to actually finish (e.g. still releasing a
+    /// connection lock or socket).
+    ///
+    /// Every invocation's timestamp is recorded in `send_times`, so tests can
+    /// assert on the gap between successive attempts to verify the caller
+    /// waited for the previous attempt's handle before issuing the next one.
+    #[derive(Clone)]
+    struct SlowTeardownGateway {
+        task_delay: Duration,
+        send_times: Arc<std::sync::Mutex<Vec<Instant>>>,
+    }
+
+    impl EcuGateway for SlowTeardownGateway {
+        async fn shutdown(&mut self) {}
+
+        fn get_gateway_network_address(
+            &self,
+            _logical_address: u16,
+        ) -> impl Future<Output = Option<String>> + Send {
+            std::future::ready(None)
+        }
+
+        fn send(
+            &self,
+            _transmission_params: TransmissionParameters,
+            _message: ServicePayload,
+            response_sender: mpsc::Sender<Result<Option<UdsResponse>, DiagServiceError>>,
+            _expect_uds_reply: bool,
+        ) -> impl Future<Output = Result<tokio::task::JoinHandle<()>, DiagServiceError>> + Send
+        {
+            self.send_times.lock().unwrap().push(Instant::now());
+            let delay = self.task_delay;
+            async move {
+                // Simulate the stale task's response-forwarding phase already
+                // being over: drop the sender right away so the caller's
+                // `recv()` observes the channel closing immediately, well
+                // before `delay` elapses.
+                drop(response_sender);
+                Ok(tokio::task::spawn(async move {
+                    cda_interfaces::util::tokio_ext::sleep_for(delay).await;
+                }))
+            }
         }
 
         fn ecu_online<T: EcuAddresses>(
@@ -1843,6 +1992,122 @@ mod send_tests {
                 0x90,
                 0xBB
             ]
+        );
+    }
+
+    fn make_manager_with_slow_teardown_gateway(
+        gateway: SlowTeardownGateway,
+        timeout_default: Duration,
+        repeat_req_count_app: u32,
+    ) -> UdsManager<SlowTeardownGateway, TestEcuDb> {
+        let ecus = Arc::new(HashMap::from_iter([(
+            "TestECU".to_string(),
+            RwLock::new(TestEcuDb::with_timeout_default_and_repeat_req_count_app(
+                timeout_default,
+                repeat_req_count_app,
+            )),
+        )]));
+        UdsManager::new_for_raw_payload_tests(
+            gateway,
+            ecus,
+            FaultConfig::default(),
+            Arc::new(AtomicBool::new(false)),
+        )
+    }
+
+    /// Regression test for the retry-teardown synchronization fix: the
+    /// caller must await a previous attempt's gateway-task handle before
+    /// issuing the next attempt, not just drop the response channel and hope
+    /// the stale task has already finished.
+    ///
+    /// `SlowTeardownGateway` closes its response channel immediately (so the
+    /// caller's read loop sees a fast "no response" and retries right away),
+    /// but its returned task handle only resolves after `task_delay`. If the
+    /// caller waited for the handle as designed, the gap between successive
+    /// `send()` invocations must be at least `task_delay`; pre-fix, the next
+    /// `send()` would fire almost immediately after the channel closed.
+    #[tokio::test]
+    async fn test_send_with_raw_payload_awaits_previous_task_before_next_retry() {
+        let task_delay = Duration::from_millis(100);
+        let gateway = SlowTeardownGateway {
+            task_delay,
+            send_times: Arc::new(std::sync::Mutex::new(Vec::new())),
+        };
+        let send_times = Arc::clone(&gateway.send_times);
+        // rx_timeout is intentionally larger than task_delay: without the
+        // fix, retries fire right after the channel closes (near-instantly),
+        // not after task_delay.
+        let manager = make_manager_with_slow_teardown_gateway(gateway, Duration::from_secs(5), 2);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
+
+        let result = manager
+            .send_with_raw_payload("TestECU", payload, None, true)
+            .await;
+
+        assert!(
+            matches!(result, Err(DiagServiceError::Timeout)),
+            "Expected Timeout error, got {result:?}"
+        );
+
+        let times = send_times.lock().unwrap();
+        assert_eq!(times.len(), 3, "Expected 1 original send + 2 retries");
+        for pair in times.windows(2) {
+            let (Some(a), Some(b)) = (pair.first(), pair.get(1)) else {
+                panic!("windows(2) must yield exactly 2 elements");
+            };
+            let gap = b.duration_since(*a);
+            assert!(
+                gap >= task_delay,
+                "Expected consecutive attempts to be at least task_delay ({task_delay:?}) apart, \
+                 got {gap:?}"
+            );
+        }
+    }
+
+    /// Regression test for the bounded-wait safety net: if a stale gateway
+    /// task never finishes at all, `send_with_raw_payload` must not stall
+    /// retries indefinitely - it should proceed once `RETRY_TEARDOWN_GRACE`
+    /// elapses.
+    #[tokio::test]
+    async fn test_send_with_raw_payload_proceeds_after_teardown_grace_when_task_never_finishes() {
+        // Far longer than RETRY_TEARDOWN_GRACE (500ms): the task handle will
+        // never resolve within the scope of this test.
+        let task_delay = Duration::from_secs(600);
+        let gateway = SlowTeardownGateway {
+            task_delay,
+            send_times: Arc::new(std::sync::Mutex::new(Vec::new())),
+        };
+        let send_times = Arc::clone(&gateway.send_times);
+        let manager =
+            make_manager_with_slow_teardown_gateway(gateway, Duration::from_millis(50), 1);
+        let payload = make_test_payload(service_ids::SESSION_CONTROL, &[0x01]);
+
+        let start = Instant::now();
+        let result = manager
+            .send_with_raw_payload("TestECU", payload, None, true)
+            .await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            matches!(result, Err(DiagServiceError::Timeout)),
+            "Expected Timeout error, got {result:?}"
+        );
+        let times = send_times.lock().unwrap();
+        assert_eq!(times.len(), 2, "Expected 1 original send + 1 retry");
+        let gap = times
+            .get(1)
+            .expect("2 elements")
+            .duration_since(*times.first().expect("2 elements"));
+        assert!(
+            gap >= RETRY_TEARDOWN_GRACE,
+            "Expected the retry to wait at least the teardown grace period \
+             ({RETRY_TEARDOWN_GRACE:?}), got {gap:?}"
+        );
+        // Sanity bound: the whole call must finish quickly, well under
+        // task_delay, proving the never-finishing task did not stall it.
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "Expected the call to proceed despite the stale task never finishing, took {elapsed:?}"
         );
     }
 }

--- a/cda-comm-uds/src/transport.rs
+++ b/cda-comm-uds/src/transport.rs
@@ -400,10 +400,31 @@ impl<S: EcuGateway, T: UdsEcuDb + VariantDetection> UdsManager<S, T> {
                         }
                     },
                     Ok(None) => {
-                        tracing::warn!("None response received");
-                        break 'read_uds_messages Err(DiagServiceError::UnexpectedResponse(Some(
-                            "None response received".to_owned(),
-                        )));
+                        // The gateway closed the response channel without
+                        // delivering a usable response for this request (e.g.
+                        // its per-request task ended after forwarding only
+                        // non-matching frames, such as a wrong-DID echo that
+                        // was ignored above). This is a "no response" condition
+                        // per ISO 14229-2 Table 9, not an unexpected response:
+                        // treat it exactly like a plain timeout, applying the
+                        // CP_RepeatReqCountApp retry policy and ultimately
+                        // surfacing DiagServiceError::Timeout.
+                        tracing::debug!(
+                            "Response channel closed with no matching response for request"
+                        );
+                        if app_retry_count < uds_params.repeat_req_count_app {
+                            app_retry_count = app_retry_count.saturating_add(1);
+                            tracing::debug!(
+                                ecu_name,
+                                attempt = app_retry_count,
+                                max_attempts = uds_params.repeat_req_count_app,
+                                "Repeating request after response channel closed \
+                                 (CP_RepeatReqCountApp)"
+                            );
+                            rx_timeout_next = None;
+                            continue 'send;
+                        }
+                        break 'read_uds_messages Err(DiagServiceError::Timeout);
                     }
                     Err(_) => {
                         // error means the tokio::time::timeout
@@ -840,6 +861,26 @@ mod send_tests {
         + Send
         + Sync;
 
+    /// Keeps a `response_sender` alive for the remainder of the test process,
+    /// modelling a real gateway task that stays parked (holding its sender)
+    /// after sending no usable response - e.g. an offline or answer-suppressing
+    /// ECU that positively ACKs but never replies. This lets the caller's
+    /// `rx_timeout` fire instead of the channel closing early (`recv() == None`).
+    ///
+    /// Closures that instead want to model a gateway which closes the channel
+    /// after forwarding its frame(s) (e.g. the CAN gateway breaking after the
+    /// first SID-matching response) must simply let the sender drop.
+    fn park_sender(sender: mpsc::Sender<Result<Option<UdsResponse>, DiagServiceError>>) {
+        type ParkedSenders =
+            std::sync::Mutex<Vec<mpsc::Sender<Result<Option<UdsResponse>, DiagServiceError>>>>;
+        static PARKED: std::sync::OnceLock<ParkedSenders> = std::sync::OnceLock::new();
+        PARKED
+            .get_or_init(|| std::sync::Mutex::new(Vec::new()))
+            .lock()
+            .unwrap()
+            .push(sender);
+    }
+
     impl EcuGateway for TestGateway {
         async fn shutdown(&mut self) {}
 
@@ -857,20 +898,18 @@ mod send_tests {
             response_sender: mpsc::Sender<Result<Option<UdsResponse>, DiagServiceError>>,
             expect_uds_reply: bool,
         ) -> impl Future<Output = Result<(), DiagServiceError>> + Send {
-            // Mirror the real gateways: the actual send happens on a detached
-            // task that keeps `response_sender` alive until either it produces a
-            // response or the caller drops its `response_rx` (which fires
-            // `response_sender.closed()`). Modelling this is essential for the
-            // per-attempt-channel retry semantics: a `send_fn` that never
-            // answers must leave the channel open so the UDS-layer `rx_timeout`
-            // fires, and must have its sender released once the caller moves on
-            // to the next attempt.
-            let send_fn = Arc::clone(&self.send_fn);
-            let result = send_fn(response_sender.clone(), expect_uds_reply);
-            tokio::spawn(async move {
-                // Hold the sender until the caller's receiver is dropped.
-                response_sender.closed().await;
-            });
+            // The closure receives `response_sender` by value and fully owns its
+            // lifetime, mirroring how the real gateways manage their per-request
+            // task's sender:
+            //   * to model a gateway that closes the channel after forwarding
+            //     its frame(s) (e.g. the CAN gateway breaking after the first
+            //     SID-matching response), simply let the sender drop when the
+            //     closure returns -> the caller's `recv()` observes `None`.
+            //   * to model a gateway task that stays parked with no (further)
+            //     response until the caller gives up (e.g. an offline/answer-
+            //     suppressing ECU), the closure must keep the sender alive
+            //     itself (store a clone), so the caller's `rx_timeout` fires.
+            let result = (self.send_fn)(response_sender, expect_uds_reply);
             async move { result }
         }
 
@@ -1130,8 +1169,11 @@ mod send_tests {
     #[tokio::test]
     async fn test_send_with_raw_payload_timeout() {
         let gateway = TestGateway {
-            send_fn: Arc::new(|_response_tx, _| {
-                // Don't send any response - channel will be empty, causing timeout
+            send_fn: Arc::new(|response_tx, _| {
+                // Model a parked gateway task: keep the channel open with no
+                // response so the caller's rx_timeout fires (instead of the
+                // channel closing early).
+                park_sender(response_tx);
                 Ok(())
             }),
         };
@@ -1149,6 +1191,52 @@ mod send_tests {
         );
     }
 
+    /// Regression test (mirrors the `test_wrong_did_in_response_returns_504`
+    /// CAN integration test): when the ECU replies with the correct SID but a
+    /// mismatched echo (e.g. wrong DID), that frame is ignored and the gateway
+    /// then closes the response channel. This must surface as
+    /// `DiagServiceError::Timeout` (HTTP 504), not `UnexpectedResponse` (HTTP
+    /// 500). With a per-attempt channel, the closed channel yields
+    /// `recv() == None`, which the read loop now treats as a "no response"
+    /// condition per ISO 14229-2 Table 9.
+    #[tokio::test]
+    async fn test_send_with_raw_payload_wrong_echo_then_channel_close_is_timeout() {
+        let gateway = TestGateway {
+            send_fn: Arc::new(|response_tx, _| {
+                // Correct SID (0x62 for 0x22) but wrong DID (0xF200 instead of
+                // 0xF190) plus fake data. The read loop matches the SID, sees
+                // the mismatched echo bytes, ignores the frame, and loops back
+                // to recv(); the gateway task then ends and drops its sender.
+                let msg = UdsResponse::Message(ServicePayload {
+                    data: vec![0x62, 0xF2, 0x00, 0x41, 0x42, 0x43, 0x44],
+                    source_address: 0x0001,
+                    target_address: 0x0E00,
+                    new_session: None,
+                    new_security: None,
+                });
+                response_tx.try_send(Ok(Some(msg))).ok();
+                Ok(())
+            }),
+        };
+        // No app-layer retries so the first channel-close resolves directly.
+        let manager = make_manager_with_timeout_default_and_repeat_req_count_app(
+            gateway,
+            Duration::from_millis(50),
+            0,
+        );
+        // Request: 22 F1 90 (ReadDataByIdentifier, DID 0xF190).
+        let payload = make_test_payload(0x22, &[0xF1, 0x90]);
+
+        let result = manager
+            .send_with_raw_payload("TestECU", payload, None, true)
+            .await;
+
+        assert!(
+            matches!(result, Err(DiagServiceError::Timeout)),
+            "Expected Timeout (504) for wrong-DID response then channel close, got {result:?}"
+        );
+    }
+
     /// ISO 14229-2:2021 Table 9 ("Client error handling"): on a plain timeout
     /// with no response at all, the client shall repeat the last request, up
     /// to `CP_RepeatReqCountApp` times (worst case: `1 + N` total
@@ -1158,9 +1246,12 @@ mod send_tests {
         let send_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
         let send_count_clone = Arc::clone(&send_count);
         let gateway = TestGateway {
-            send_fn: Arc::new(move |_response_tx, _| {
+            send_fn: Arc::new(move |response_tx, _| {
                 send_count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                // Never send any response - every attempt times out.
+                // Never send any response - every attempt times out. Park the
+                // sender so the channel stays open and the caller's rx_timeout
+                // fires for each attempt.
+                park_sender(response_tx);
                 Ok(())
             }),
         };
@@ -1386,9 +1477,11 @@ mod send_tests {
     #[tokio::test]
     async fn test_send_with_raw_payload_uses_configured_timeout_default_when_none() {
         let gateway = TestGateway {
-            send_fn: Arc::new(|_response_tx, _| {
+            send_fn: Arc::new(|response_tx, _| {
                 // Don't send any response - the call must time out based on
-                // the ECU's configured `timeout_default`.
+                // the ECU's configured `timeout_default`. Park the sender so
+                // the channel stays open until that timeout fires.
+                park_sender(response_tx);
                 Ok(())
             }),
         };

--- a/cda-comm-uds/src/transport.rs
+++ b/cda-comm-uds/src/transport.rs
@@ -115,24 +115,35 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
 
         let payload_build_after = start.elapsed();
 
+        // Inspect the subfunction byte for `suppressPosRspMsgIndicationBit` (bit 7).
+        // When set, the ECU is not expected to send a positive response, so the
+        // absence of a response must not be treated as a timeout/error (mirrors
+        // the same check already applied for functional sends, see
+        // `send_functional_to_gateway`).
+        let expect_response = !payload.is_suppress_positive_response();
+
         let response = self
-            .send_with_raw_payload(ecu_name, payload.clone(), timeout, true)
+            .send_with_raw_payload(ecu_name, payload.clone(), timeout, expect_response)
             .await;
         let response_after = start.elapsed().saturating_sub(payload_build_after);
 
         let response = match response {
-            Ok(msg) => {
+            Ok(Some(msg)) => {
                 self.uds_ecu_db(ecu_name)
                     .expect("ECU name has been already checked")
                     .read()
                     .await
-                    .convert_from_uds(
-                        &service,
-                        &msg.expect("response expected"),
-                        map_to_json,
-                        None,
-                    )
+                    .convert_from_uds(&service, &msg, map_to_json, None)
                     .await
+            }
+            Ok(None) => {
+                // Only reachable when `expect_response` was `false`, i.e. the
+                // suppress-positive-response bit was set: the ECU legitimately
+                // did not respond, so there is nothing to decode.
+                Err(DiagServiceError::NoResponse(format!(
+                    "No response expected for {} due to suppressPosRspMsgIndicationBit",
+                    service.name
+                )))
             }
             Err(e) => Err(e),
         };
@@ -213,17 +224,42 @@ impl<S: EcuGateway, T: UdsEcuDb + VariantDetection> UdsManager<S, T> {
         let rx_timeout = timeout.unwrap_or(uds_params.timeout_default);
         let mut rx_timeout_next = None;
 
+        // Counts application-layer retries per ISO 14229-2:2021 Table 9
+        // ("Client error handling"): a transmission failure, a raw receive
+        // error, or a plain timeout with no response at all shall each cause
+        // the client to repeat the last request, up to `CP_RepeatReqCountApp`
+        // times (independent of, and not to be confused with, the NRC
+        // 0x21/0x78/0x94 busy-repeat handling below, which has its own,
+        // separate time-bounded retry policy).
+        let mut app_retry_count: u32 = 0;
+
         // outer loop to retry sending frames, resend frames must deal with (N)ACK again
         let (response_tx, mut response_rx) = mpsc::channel(2);
         let (response, sent_after) = 'send: loop {
-            self.gateway
+            if let Err(e) = self
+                .gateway
                 .send(
                     transmission_params.clone(),
                     payload.clone(),
                     response_tx.clone(),
                     expect_response,
                 )
-                .await?;
+                .await
+            {
+                if app_retry_count < uds_params.repeat_req_count_app {
+                    app_retry_count = app_retry_count.saturating_add(1);
+                    tracing::debug!(
+                        ecu_name,
+                        attempt = app_retry_count,
+                        max_attempts = uds_params.repeat_req_count_app,
+                        error = %e,
+                        "Transmission error, repeating request (CP_RepeatReqCountApp)"
+                    );
+                    rx_timeout_next = None;
+                    continue 'send;
+                }
+                return Err(e);
+            }
             let sent_after = start.elapsed();
 
             // responses might be disabled, i.e. for functional tester presents...
@@ -328,8 +364,20 @@ impl<S: EcuGateway, T: UdsEcuDb + VariantDetection> UdsManager<S, T> {
                             // or no (n)ack was received before timeout.
                             // The Gateway will handle these cases and only
                             // return this error if there is no recovery path left.
-                            // The UdsManager cannot do anything else, so we
-                            // just forward the error to the caller.
+                            // Per ISO 14229-2 Table 9 ("Response reception" error),
+                            // repeat the last request up to CP_RepeatReqCountApp
+                            // times before giving up.
+                            if app_retry_count < uds_params.repeat_req_count_app {
+                                app_retry_count = app_retry_count.saturating_add(1);
+                                tracing::debug!(
+                                    ecu_name,
+                                    attempt = app_retry_count,
+                                    max_attempts = uds_params.repeat_req_count_app,
+                                    "Repeating request after receive error (CP_RepeatReqCountApp)"
+                                );
+                                rx_timeout_next = None;
+                                continue 'send;
+                            }
                             break 'read_uds_messages Err(e);
                         }
                     },
@@ -346,6 +394,24 @@ impl<S: EcuGateway, T: UdsEcuDb + VariantDetection> UdsManager<S, T> {
                             "Timeout waiting for UDS response from gateway after {:?}",
                             rx_timeout_next.unwrap_or(rx_timeout)
                         );
+                        // Per ISO 14229-2 Table 9 (`tP_Client`/`tP*_Client`
+                        // timeout), repeat the last request up to
+                        // CP_RepeatReqCountApp times before giving up. This is
+                        // independent of NRC 0x21/0x78/0x94 busy-repeat
+                        // handling above, which is not affected by this
+                        // counter and keeps its own, separate time-bounded
+                        // retry policy.
+                        if app_retry_count < uds_params.repeat_req_count_app {
+                            app_retry_count = app_retry_count.saturating_add(1);
+                            tracing::debug!(
+                                ecu_name,
+                                attempt = app_retry_count,
+                                max_attempts = uds_params.repeat_req_count_app,
+                                "Repeating request after timeout (CP_RepeatReqCountApp)"
+                            );
+                            rx_timeout_next = None;
+                            continue 'send;
+                        }
                         break 'read_uds_messages Err(DiagServiceError::Timeout);
                     }
                 }
@@ -414,6 +480,7 @@ impl<S: EcuGateway, T: UdsEcuDb + VariantDetection> UdsManager<S, T> {
                     rc_94_retry_policy: ecu.rc_94_retry_policy(),
                     rc_94_completion_timeout: ecu.rc_94_completion_timeout(),
                     rc_94_repeat_request_time: ecu.rc_94_repeat_request_time(),
+                    repeat_req_count_app: ecu.repeat_req_count_app(),
                 },
                 TransmissionParameters {
                     gateway_address: ecu.logical_gateway_address(),
@@ -489,8 +556,11 @@ impl<S: EcuGateway, T: EcuManager> UdsTransport for UdsManager<S, T> {
             .check_genericservice(security_plugin, payload)
             .await?;
 
+        // See `send_without_variant_guard` for why this bit must be respected.
+        let expect_response = !payload.is_suppress_positive_response();
+
         match self
-            .send_with_raw_payload(ecu_name, payload, timeout, true)
+            .send_with_raw_payload(ecu_name, payload, timeout, expect_response)
             .await?
         {
             Some(response) => Ok(response.data),
@@ -839,6 +909,26 @@ mod send_tests {
         )
     }
 
+    fn make_manager_with_timeout_default_and_repeat_req_count_app(
+        gateway: TestGateway,
+        timeout_default: Duration,
+        repeat_req_count_app: u32,
+    ) -> UdsManager<TestGateway, TestEcuDb> {
+        let ecus = Arc::new(HashMap::from_iter([(
+            "TestECU".to_string(),
+            RwLock::new(TestEcuDb::with_timeout_default_and_repeat_req_count_app(
+                timeout_default,
+                repeat_req_count_app,
+            )),
+        )]));
+        UdsManager::new_for_raw_payload_tests(
+            gateway,
+            ecus,
+            FaultConfig::default(),
+            Arc::new(AtomicBool::new(false)),
+        )
+    }
+
     fn make_manager_no_ecus(gateway: TestGateway) -> UdsManager<TestGateway, TestEcuDb> {
         let ecus = Arc::new(HashMap::new());
         UdsManager::new_for_raw_payload_tests(
@@ -986,6 +1076,144 @@ mod send_tests {
         assert!(
             matches!(result, Err(DiagServiceError::Timeout)),
             "Expected Timeout error"
+        );
+    }
+
+    /// ISO 14229-2:2021 Table 9 ("Client error handling"): on a plain timeout
+    /// with no response at all, the client shall repeat the last request, up
+    /// to `CP_RepeatReqCountApp` times (worst case: `1 + N` total
+    /// transmissions).
+    #[tokio::test]
+    async fn test_send_with_raw_payload_retries_on_timeout_up_to_repeat_req_count_app() {
+        let send_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let send_count_clone = Arc::clone(&send_count);
+        let gateway = TestGateway {
+            send_fn: Arc::new(move |_response_tx, _| {
+                send_count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                // Never send any response - every attempt times out.
+                Ok(())
+            }),
+        };
+        let repeat_req_count_app = 3;
+        let manager = make_manager_with_timeout_default_and_repeat_req_count_app(
+            gateway,
+            Duration::from_millis(20),
+            repeat_req_count_app,
+        );
+        let payload = make_test_payload(0x10, &[0x01]);
+
+        let result = manager
+            .send_with_raw_payload("TestECU", payload, None, true)
+            .await;
+
+        assert!(
+            matches!(result, Err(DiagServiceError::Timeout)),
+            "Expected Timeout error, got {result:?}"
+        );
+        assert_eq!(
+            send_count.load(std::sync::atomic::Ordering::SeqCst),
+            1 + repeat_req_count_app,
+            "Expected exactly 1 original transmission + {repeat_req_count_app} repeats"
+        );
+    }
+
+    /// ISO 14229-2:2021 Table 9: a request-transmission failure shall also be
+    /// repeated up to `CP_RepeatReqCountApp` times, and should succeed once
+    /// the gateway accepts a subsequent attempt.
+    #[tokio::test]
+    async fn test_send_with_raw_payload_retries_on_transmission_error_then_succeeds() {
+        let call_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let call_count_clone = Arc::clone(&call_count);
+        let gateway = TestGateway {
+            send_fn: Arc::new(move |response_tx, _| {
+                let count = call_count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                if count < 2 {
+                    // First two attempts fail to transmit at all.
+                    return Err(DiagServiceError::SendFailed("simulated".to_owned()));
+                }
+                let msg = UdsResponse::Message(ServicePayload {
+                    data: vec![0x50, 0x01],
+                    source_address: 0x0001,
+                    target_address: 0x0E00,
+                    new_session: None,
+                    new_security: None,
+                });
+                response_tx.try_send(Ok(Some(msg))).ok();
+                Ok(())
+            }),
+        };
+        let manager = make_manager_with_timeout_default_and_repeat_req_count_app(
+            gateway,
+            Duration::from_secs(5),
+            3,
+        );
+        let payload = make_test_payload(0x10, &[0x01]);
+
+        let result = manager
+            .send_with_raw_payload("TestECU", payload, None, true)
+            .await;
+
+        assert!(result.is_ok(), "Expected eventual success, got {result:?}");
+        assert_eq!(
+            call_count.load(std::sync::atomic::Ordering::SeqCst),
+            3,
+            "Expected 2 failed transmission attempts + 1 successful one"
+        );
+    }
+
+    /// NRC 0x21 (`BusyRepeatRequest`) busy-repeat handling is independent of
+    /// `CP_RepeatReqCountApp`: once its own, time-bounded completion timeout
+    /// is exhausted, the result must still be `Timeout`, without any
+    /// additional application-layer retries layered on top (ISO 14229-2
+    /// Table 9's repeat-on-timeout applies to a *raw* timeout with no
+    /// response at all, not to NRC-driven busy-repeat exhaustion).
+    #[tokio::test]
+    async fn test_send_with_raw_payload_nrc_busy_repeat_exhaustion_not_subject_to_app_level_retry()
+    {
+        let send_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let send_count_clone = Arc::clone(&send_count);
+        let gateway = TestGateway {
+            send_fn: Arc::new(move |response_tx, _| {
+                send_count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                // Always respond with NRC 0x21 (BusyRepeatRequest).
+                response_tx
+                    .try_send(Ok(Some(UdsResponse::BusyRepeatRequest(0x0001))))
+                    .ok();
+                Ok(())
+            }),
+        };
+        // A short rc_21_completion_timeout via a short overall test bound:
+        // TestEcuDb's rc_21_completion_timeout is 10s and rc_21_repeat_request_time
+        // is 10ms, so this test would take too long to exhaust naturally;
+        // instead, this test only asserts that the NRC-driven `continue 'send`
+        // path (busy-repeat) is not itself gated by `repeat_req_count_app` by
+        // running a bounded number of iterations and confirming the call
+        // count exceeds `repeat_req_count_app` (which would be impossible if
+        // the two mechanisms were conflated).
+        let repeat_req_count_app = 1;
+        let manager = make_manager_with_timeout_default_and_repeat_req_count_app(
+            gateway,
+            Duration::from_millis(50),
+            repeat_req_count_app,
+        );
+        let payload = make_test_payload(0x10, &[0x01]);
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(200),
+            manager.send_with_raw_payload("TestECU", payload, None, true),
+        )
+        .await;
+
+        // The overall test-level timeout fires first (NRC busy-repeat keeps
+        // going well past repeat_req_count_app+1 sends), proving the NRC loop
+        // is not bounded by `repeat_req_count_app`.
+        assert!(
+            result.is_err(),
+            "Expected the NRC busy-repeat loop to still be running after the test timeout"
+        );
+        assert!(
+            send_count.load(std::sync::atomic::Ordering::SeqCst) > 1 + repeat_req_count_app,
+            "NRC busy-repeat retries must not be bounded by CP_RepeatReqCountApp"
         );
     }
 

--- a/cda-comm-uds/src/transport.rs
+++ b/cda-comm-uds/src/transport.rs
@@ -19,8 +19,10 @@ use std::{
 use cda_interfaces::{
     Connectivity, DiagComm, DiagServiceError, DynamicPlugin, EcuGateway, EcuManager, EcuState,
     PayloadDecoder, ServicePayload, TransmissionParameters, UdsResponse, UdsTransport, UdsVariant,
-    VariantDetection, VariantState, datatypes::RetryPolicy, diagservices::UdsPayloadData, dlt_ctx,
-    service_ids,
+    VariantDetection, VariantState,
+    datatypes::RetryPolicy,
+    diagservices::{DiagServiceResponse, UdsPayloadData},
+    dlt_ctx, service_ids,
 };
 use tokio::sync::{RwLock, Semaphore, mpsc};
 
@@ -139,11 +141,13 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
             Ok(None) => {
                 // Only reachable when `expect_response` was `false`, i.e. the
                 // suppress-positive-response bit was set: the ECU legitimately
-                // did not respond, so there is nothing to decode.
-                Err(DiagServiceError::NoResponse(format!(
-                    "No response expected for {} due to suppressPosRspMsgIndicationBit",
-                    service.name
-                )))
+                // did not respond. This is a success, not an error - mirror the
+                // treatment already applied on the raw path (`send_genericservice`,
+                // which maps `Ok(None)` to an empty result) by returning a
+                // positive, empty response. Callers render it as no-content.
+                Ok(<T as PayloadDecoder>::Response::empty_positive(
+                    service.clone(),
+                ))
             }
             Err(e) => Err(e),
         };
@@ -767,7 +771,7 @@ mod send_tests {
     use cda_interfaces::{
         DiagServiceError, EcuAddresses, EcuGateway, EcuRuntimeState, EcuStateManager, HashMap,
         HashMapExtensions, ServicePayload, TransmissionParameters, UdsResponse, VariantDetection,
-        datatypes::FaultConfig,
+        datatypes::FaultConfig, service_ids,
     };
     use tokio::sync::{RwLock, mpsc};
 
@@ -992,6 +996,43 @@ mod send_tests {
 
         assert!(result.is_ok());
         assert!(result.expect("should be Ok").is_none());
+    }
+
+    /// A request with `suppressPosRspMsgIndicationBit` set (here
+    /// `ECUReset 0x81`) drives `expect_response = false`, so
+    /// `send_with_raw_payload` completes with `Ok(None)` once the frame is
+    /// (n)ack'd - never a `Timeout`/`NoResponse` error - even though the ECU
+    /// deliberately sends no response. `send_without_variant_guard` then
+    /// converts this `Ok(None)` into a positive, empty decoded response via
+    /// `DiagServiceResponse::empty_positive` (unit-tested in cda-core), which
+    /// callers render as no-content instead of an error.
+    #[tokio::test]
+    async fn test_send_with_raw_payload_suppress_positive_response_returns_ok_none() {
+        let gateway = TestGateway {
+            send_fn: Arc::new(|response_tx, _| {
+                // Only an ack (None); the ECU sends no positive response.
+                response_tx.try_send(Ok(None)).ok();
+                Ok(())
+            }),
+        };
+        let manager = make_manager(gateway);
+        // ECUReset (0x11) with SPRMIB bit set on the subfunction byte (0x81).
+        let payload = make_test_payload(service_ids::ECU_RESET, &[0x81]);
+        assert!(
+            payload.is_suppress_positive_response(),
+            "test payload must have the suppress-positive-response bit set"
+        );
+        let expect_response = !payload.is_suppress_positive_response();
+
+        let result = manager
+            .send_with_raw_payload("TestECU", payload, None, expect_response)
+            .await;
+
+        assert!(result.is_ok(), "expected Ok(None), got {result:?}");
+        assert!(
+            result.expect("should be Ok").is_none(),
+            "suppressed response must yield Ok(None), not a decoded payload"
+        );
     }
 
     #[tokio::test]

--- a/cda-comm-uds/src/types.rs
+++ b/cda-comm-uds/src/types.rs
@@ -39,6 +39,13 @@ pub(crate) struct UdsParameters {
     pub(crate) rc_94_completion_timeout: Duration,
     pub(crate) rc_94_retry_policy: RetryPolicy,
     pub(crate) rc_94_repeat_request_time: Duration,
+    /// `CP_RepeatReqCountApp`: number of times the application layer repeats
+    /// the last request after a transmission failure, a raw receive error, or
+    /// a plain timeout with no response at all (ISO 14229-2:2021, Table 9 -
+    /// "Client error handling"). Independent of NRC 0x21/0x78/0x94 busy-repeat
+    /// handling (`rc_21/78/94_*` above), which already have their own,
+    /// time-bounded retry semantics.
+    pub(crate) repeat_req_count_app: u32,
 }
 
 pub(crate) struct EcuDataTransfer {

--- a/cda-comm-uds/src/variant.rs
+++ b/cda-comm-uds/src/variant.rs
@@ -170,7 +170,12 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
                     &(Box::new(()) as DynamicPlugin),
                     None,
                     true,
-                    Some(Duration::from_secs(10)),
+                    // Use the ECU's configured response timeout (`CP_P6Max`,
+                    // via `UdsComParams::timeout_default`) instead of a
+                    // hardcoded value, so variant-detection sends respect the
+                    // same, correctly configured comparam as every other UDS
+                    // send (see `send_with_raw_payload`'s `rx_timeout`).
+                    None,
                 )
                 .await
             {

--- a/cda-core/src/diag_kernel/diagservices.rs
+++ b/cda-core/src/diag_kernel/diagservices.rs
@@ -70,6 +70,15 @@ pub struct MappedResponseData {
 }
 
 impl DiagServiceResponse for DiagServiceResponseStruct {
+    fn empty_positive(service: DiagComm) -> Self {
+        Self {
+            service,
+            data: Vec::new(),
+            mapped_data: None,
+            response_type: DiagServiceResponseType::Positive,
+        }
+    }
+
     fn service_name(&self) -> String {
         self.service.name.clone()
     }
@@ -443,5 +452,20 @@ mod tests {
         assert!(matches!(
             extract_nrc_from_raw_data(&data),
             Err(DiagServiceError::UnexpectedResponse(Some(msg))) if msg.contains("extra bytes")));
+    }
+
+    #[test]
+    fn test_empty_positive_is_positive_and_empty() {
+        let service = DiagComm {
+            name: "TesterPresent".to_owned(),
+            type_: cda_interfaces::DiagCommType::Operations,
+            lookup_name: None,
+            subfunction_id: None,
+        };
+        let response = DiagServiceResponseStruct::empty_positive(service);
+        assert_eq!(response.response_type(), DiagServiceResponseType::Positive);
+        assert!(response.is_empty());
+        assert!(response.get_raw().is_empty());
+        assert_eq!(response.service_name(), "TesterPresent");
     }
 }

--- a/cda-interfaces/src/diagservices.rs
+++ b/cda-interfaces/src/diagservices.rs
@@ -12,7 +12,7 @@
  */
 
 use crate::{
-    DataParseError, DiagServiceError, HashMap,
+    DataParseError, DiagComm, DiagServiceError, HashMap,
     datatypes::{DtcField, DtcRecord},
     util,
 };
@@ -47,6 +47,27 @@ pub struct DiagServiceJsonResponse {
 }
 
 pub trait DiagServiceResponse: Sized + Send + Sync + 'static + Clone {
+    /// Build a positive, empty response representing a request that the ECU
+    /// legitimately did not answer because the `suppressPosRspMsgIndicationBit`
+    /// (SPRMIB) was set. Such a response is a success (`response_type` is
+    /// `Positive`) with no payload (`is_empty` is `true`), so callers render it
+    /// as an empty/no-content result rather than an error.
+    ///
+    /// The result is intentionally indistinguishable from a normally-decoded
+    /// empty positive response (see [`is_empty`](Self::is_empty)): both flow
+    /// through the same consumer paths to a `204 No Content`.
+    fn empty_positive(service: DiagComm) -> Self;
+    /// Returns `true` if the response carries no payload data.
+    ///
+    /// This is a predicate over *any* response, regardless of how it was
+    /// produced: it is `true` both for a response that was decoded from a real
+    /// but payload-less positive reply (e.g. a bare `ECUReset` positive ack, or
+    /// a service whose response defines no data parameters) and for a response
+    /// synthesized via [`empty_positive`](Self::empty_positive) when the ECU
+    /// legitimately sent nothing (SPRMIB). These two cases are intentionally
+    /// indistinguishable here: consumers (notably the SOVD HTTP layer) use this,
+    /// together with [`response_type`](Self::response_type) being `Positive`, to
+    /// render a `204 No Content` result in either case.
     fn is_empty(&self) -> bool;
     fn service_name(&self) -> String;
     fn response_type(&self) -> DiagServiceResponseType;
@@ -105,6 +126,7 @@ pub mod mock {
         pub DiagServiceResponse {}
 
         impl diagservices::DiagServiceResponse for DiagServiceResponse {
+            fn empty_positive(service: crate::DiagComm) -> Self;
             fn is_empty(&self) -> bool;
             fn service_name(&self) -> String;
             fn get_raw(&self) -> &[u8];

--- a/cda-interfaces/src/ecugateway.rs
+++ b/cda-interfaces/src/ecugateway.rs
@@ -62,6 +62,16 @@ pub trait EcuGateway: Clone + Send + Sync + 'static {
     /// UDS responses are sent back to the `response_sender` channel.
     /// Multiple responses can be sent, e.g. for a request that requires multiple responses,
     /// i.e. response pending NRCs 0x78.
+    ///
+    /// On success, returns a [`tokio::task::JoinHandle`] for the (typically spawned)
+    /// per-request background task that drives the exchange and forwards responses to
+    /// `response_sender`. That task reacts to `response_sender` being dropped/closed by
+    /// tearing itself down and releasing any per-ECU resources it holds (e.g. a
+    /// connection mutex or a transport-specific socket). Callers that retry a request by
+    /// dropping the previous attempt's `response_sender`/receiver and calling `send`
+    /// again should await the previous attempt's handle (ideally bounded by a short
+    /// grace period) before issuing the next attempt, to avoid two concurrent
+    /// per-request tasks contending for the same underlying resource.
     /// # Errors
     /// * `DiagServiceError::EcuOffline` if the ECU cannot be reached, is not found, or is offline.
     /// * `DiagServiceError::Nack` when the ECU responds with a NACK, that cannot be
@@ -80,7 +90,7 @@ pub trait EcuGateway: Clone + Send + Sync + 'static {
         message: ServicePayload,
         response_sender: mpsc::Sender<Result<Option<UdsResponse>, DiagServiceError>>,
         expect_uds_reply: bool,
-    ) -> impl Future<Output = Result<(), DiagServiceError>> + Send;
+    ) -> impl Future<Output = Result<tokio::task::JoinHandle<()>, DiagServiceError>> + Send;
 
     /// Checks if an ECU is online.
     /// Returns an error if the ECU is not online or if the ECU cannot be reached.

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -336,13 +336,34 @@ impl ServicePayload {
         self.is_negative_response_for_sid(sent_sid) || self.is_positive_response_for_sid(sent_sid)
     }
 
-    /// Returns `true` if the UDS subfunction byte (byte index 1) has bit 7 set,
-    /// indicating the `suppressPosRspMsgIndicationBit` (SPRMIB) is active.
-    /// When this bit is set, the ECU is not expected to send a positive response, so callers
-    /// should not treat the absence of a positive response as an error.
+    /// Returns `true` if this request's SID uses a subfunction byte (byte index 1) with
+    /// `suppressPosRspMsgIndicationBit` (SPRMIB) semantics per ISO 14229-1, and that bit
+    /// (bit 7) is set. When set, the ECU is not expected to send a positive response, so
+    /// callers should not treat the absence of a positive response as an error.
+    ///
+    /// Only a subset of services actually carry a subfunction byte with SPRMIB semantics
+    /// (`DiagnosticSessionControl`, `ECUReset`, `CommunicationControl`, `Authentication`,
+    /// `ControlDTCSetting`, `LinkControl`, `TesterPresent`). Other services either have no subfunction byte
+    /// at all, or use byte index 1 for something else entirely - most notably
+    /// `ReadDataByIdentifier`/`WriteDataByIdentifier`, where byte index 1 is the *high byte
+    /// of the 2-byte data identifier* and can legitimately have bit 7 set (e.g. any DID in
+    /// the `0xF1xx`-`0xFFxx` range), which must never be misread as SPRMIB.
     #[must_use]
     pub fn is_suppress_positive_response(&self) -> bool {
-        self.data.get(1).is_some_and(|&b| b & 0x80 != 0)
+        let Some(&sid) = self.data.first() else {
+            return false;
+        };
+        let sprmib_capable = matches!(
+            sid,
+            service_ids::SESSION_CONTROL
+                | service_ids::ECU_RESET
+                | service_ids::COMMUNICATION_CONTROL
+                | service_ids::AUTHENTICATION
+                | service_ids::CONTROL_DTC_SETTING
+                | service_ids::LINK_CONTROL
+                | service_ids::TESTER_PRESENT
+        );
+        sprmib_capable && self.data.get(1).is_some_and(|&b| b & 0x80 != 0)
     }
 
     /// Validates that a positive response echoes back the expected identifier bytes
@@ -1145,6 +1166,85 @@ mod tests {
         // Response: positive with wrong DID
         let response = make_payload(vec![0x6E, 0xF2, 0x00]);
         assert!(!response.has_matching_echo_bytes(&request));
+    }
+
+    // is_suppress_positive_response
+
+    #[test]
+    fn rdbi_with_did_high_byte_f1_is_not_suppress_positive_response() {
+        // Regression test: ReadDataByIdentifier's byte index 1 is the high byte of the
+        // 2-byte DID, not a subfunction byte. DID 0xF100 ("Identification") has bit 7 set
+        // in its high byte and must NOT be misread as suppressPosRspMsgIndicationBit.
+        let request = make_payload(vec![service_ids::READ_DATA_BY_IDENTIFIER, 0xF1, 0x00]);
+        assert!(!request.is_suppress_positive_response());
+    }
+
+    #[test]
+    fn wdbi_with_did_high_byte_set_is_not_suppress_positive_response() {
+        let request = make_payload(vec![
+            service_ids::WRITE_DATA_BY_IDENTIFIER,
+            0xF1,
+            0x90,
+            0xAA,
+        ]);
+        assert!(!request.is_suppress_positive_response());
+    }
+
+    #[test]
+    fn session_control_with_sprmib_bit_set_is_suppress_positive_response() {
+        // DiagnosticSessionControl subfunction 0x03 with SPRMIB (bit 7) set.
+        let request = make_payload(vec![service_ids::SESSION_CONTROL, 0x83]);
+        assert!(request.is_suppress_positive_response());
+    }
+
+    #[test]
+    fn session_control_without_sprmib_bit_is_not_suppress_positive_response() {
+        let request = make_payload(vec![service_ids::SESSION_CONTROL, 0x03]);
+        assert!(!request.is_suppress_positive_response());
+    }
+
+    #[test]
+    fn ecu_reset_with_sprmib_bit_set_is_suppress_positive_response() {
+        let request = make_payload(vec![service_ids::ECU_RESET, 0x81]);
+        assert!(request.is_suppress_positive_response());
+    }
+
+    #[test]
+    fn communication_control_with_sprmib_bit_set_is_suppress_positive_response() {
+        let request = make_payload(vec![service_ids::COMMUNICATION_CONTROL, 0x83, 0x01]);
+        assert!(request.is_suppress_positive_response());
+    }
+
+    #[test]
+    fn tester_present_with_sprmib_bit_set_is_suppress_positive_response() {
+        let request = make_payload(vec![service_ids::TESTER_PRESENT, 0x80]);
+        assert!(request.is_suppress_positive_response());
+    }
+
+    #[test]
+    fn control_dtc_setting_with_sprmib_bit_set_is_suppress_positive_response() {
+        let request = make_payload(vec![service_ids::CONTROL_DTC_SETTING, 0x81]);
+        assert!(request.is_suppress_positive_response());
+    }
+
+    #[test]
+    fn link_control_with_sprmib_bit_set_is_suppress_positive_response() {
+        let request = make_payload(vec![service_ids::LINK_CONTROL, 0x83]);
+        assert!(request.is_suppress_positive_response());
+    }
+
+    #[test]
+    fn routine_control_with_high_bit_set_is_not_suppress_positive_response() {
+        // RoutineControl does not have SPRMIB semantics; its subfunction byte is the
+        // routineControlType (bits 6-0), so a set bit 7 here must not be treated as SPRMIB.
+        let request = make_payload(vec![service_ids::ROUTINE_CONTROL, 0x81, 0xF1, 0x90]);
+        assert!(!request.is_suppress_positive_response());
+    }
+
+    #[test]
+    fn empty_payload_is_not_suppress_positive_response() {
+        let request = make_payload(vec![]);
+        assert!(!request.is_suppress_positive_response());
     }
 
     // request_lock_key_for: the per-ECU request-serialization key

--- a/cda-interfaces/src/ecumanager.rs
+++ b/cda-interfaces/src/ecumanager.rs
@@ -342,12 +342,13 @@ impl ServicePayload {
     /// callers should not treat the absence of a positive response as an error.
     ///
     /// Only a subset of services actually carry a subfunction byte with SPRMIB semantics
-    /// (`DiagnosticSessionControl`, `ECUReset`, `CommunicationControl`, `Authentication`,
-    /// `ControlDTCSetting`, `LinkControl`, `TesterPresent`). Other services either have no subfunction byte
-    /// at all, or use byte index 1 for something else entirely - most notably
-    /// `ReadDataByIdentifier`/`WriteDataByIdentifier`, where byte index 1 is the *high byte
-    /// of the 2-byte data identifier* and can legitimately have bit 7 set (e.g. any DID in
-    /// the `0xF1xx`-`0xFFxx` range), which must never be misread as SPRMIB.
+    /// (`DiagnosticSessionControl`, `ECUReset`, `ReadDTCInformation`, `CommunicationControl`,
+    /// `SecurityAccess`, `Authentication`, `DynamicallyDefineDataIdentifier`, `RoutineControl`,
+    /// `ControlDTCSetting`, `ResponseOnEvent`, `LinkControl`, `TesterPresent`). Other services
+    /// either have no subfunction byte at all, or use byte index 1 for something else entirely -
+    /// most notably `ReadDataByIdentifier`/`WriteDataByIdentifier`, where byte index 1 is the
+    /// *high byte of the 2-byte data identifier* and can legitimately have bit 7 set (e.g. any
+    /// DID in the `0xF1xx`-`0xFFxx` range), which must never be misread as SPRMIB.
     #[must_use]
     pub fn is_suppress_positive_response(&self) -> bool {
         let Some(&sid) = self.data.first() else {
@@ -357,9 +358,14 @@ impl ServicePayload {
             sid,
             service_ids::SESSION_CONTROL
                 | service_ids::ECU_RESET
+                | service_ids::READ_DTC_INFORMATION
                 | service_ids::COMMUNICATION_CONTROL
+                | service_ids::SECURITY_ACCESS
                 | service_ids::AUTHENTICATION
+                | service_ids::DYNAMICALLY_DEFINE_DATA_IDENTIFIER
+                | service_ids::ROUTINE_CONTROL
                 | service_ids::CONTROL_DTC_SETTING
+                | service_ids::RESPONSE_ON_EVENT
                 | service_ids::LINK_CONTROL
                 | service_ids::TESTER_PRESENT
         );
@@ -1234,11 +1240,41 @@ mod tests {
     }
 
     #[test]
-    fn routine_control_with_high_bit_set_is_not_suppress_positive_response() {
-        // RoutineControl does not have SPRMIB semantics; its subfunction byte is the
-        // routineControlType (bits 6-0), so a set bit 7 here must not be treated as SPRMIB.
+    fn routine_control_with_high_bit_set_is_suppress_positive_response() {
+        // RoutineControl (0x31) does carry SPRMIB semantics per ISO 14229-1: bits 6-0 of
+        // the subfunction byte are the routineControlType, and bit 7 is SPRMIB.
         let request = make_payload(vec![service_ids::ROUTINE_CONTROL, 0x81, 0xF1, 0x90]);
+        assert!(request.is_suppress_positive_response());
+    }
+
+    #[test]
+    fn routine_control_without_high_bit_is_not_suppress_positive_response() {
+        let request = make_payload(vec![service_ids::ROUTINE_CONTROL, 0x01, 0xF1, 0x90]);
         assert!(!request.is_suppress_positive_response());
+    }
+
+    #[test]
+    fn read_dtc_information_with_sprmib_bit_set_is_suppress_positive_response() {
+        let request = make_payload(vec![service_ids::READ_DTC_INFORMATION, 0x82]);
+        assert!(request.is_suppress_positive_response());
+    }
+
+    #[test]
+    fn security_access_with_sprmib_bit_set_is_suppress_positive_response() {
+        let request = make_payload(vec![service_ids::SECURITY_ACCESS, 0x81]);
+        assert!(request.is_suppress_positive_response());
+    }
+
+    #[test]
+    fn dynamically_define_data_identifier_with_sprmib_bit_set_is_suppress_positive_response() {
+        let request = make_payload(vec![service_ids::DYNAMICALLY_DEFINE_DATA_IDENTIFIER, 0x81]);
+        assert!(request.is_suppress_positive_response());
+    }
+
+    #[test]
+    fn response_on_event_with_sprmib_bit_set_is_suppress_positive_response() {
+        let request = make_payload(vec![service_ids::RESPONSE_ON_EVENT, 0x80]);
+        assert!(request.is_suppress_positive_response());
     }
 
     #[test]

--- a/cda-interfaces/src/lib.rs
+++ b/cda-interfaces/src/lib.rs
@@ -208,12 +208,14 @@ pub mod service_ids {
     pub const AUTHENTICATION: u8 = 0x29;
     pub const WRITE_DATA_BY_IDENTIFIER: u8 = 0x2E;
     pub const INPUT_OUTPUT_CONTROL_BY_IDENTIFIER: u8 = 0x2F;
+    pub const DYNAMICALLY_DEFINE_DATA_IDENTIFIER: u8 = 0x2C;
     pub const ROUTINE_CONTROL: u8 = 0x31;
     pub const REQUEST_DOWNLOAD: u8 = 0x34;
     pub const TRANSFER_DATA: u8 = 0x36;
     pub const REQUEST_TRANSFER_EXIT: u8 = 0x37;
     pub const TESTER_PRESENT: u8 = 0x3E;
     pub const CONTROL_DTC_SETTING: u8 = 0x85;
+    pub const RESPONSE_ON_EVENT: u8 = 0x86;
     pub const LINK_CONTROL: u8 = 0x87;
     pub const NEGATIVE_RESPONSE: u8 = 0x7F;
 }

--- a/cda-interfaces/src/lib.rs
+++ b/cda-interfaces/src/lib.rs
@@ -214,6 +214,7 @@ pub mod service_ids {
     pub const REQUEST_TRANSFER_EXIT: u8 = 0x37;
     pub const TESTER_PRESENT: u8 = 0x3E;
     pub const CONTROL_DTC_SETTING: u8 = 0x85;
+    pub const LINK_CONTROL: u8 = 0x87;
     pub const NEGATIVE_RESPONSE: u8 = 0x7F;
 }
 

--- a/docs/03_architecture/03_communication/02_uds_communication.rst
+++ b/docs/03_architecture/03_communication/02_uds_communication.rst
@@ -244,6 +244,14 @@ Request-Response Flow
     layer retries (``CP_RepeatReqCountApp``) are independent of DoIP transport-layer
     retries (``CP_RepeatReqCountTrans``).
 
+    Each application-layer attempt uses a *fresh* response channel. When an attempt
+    is retried (transmission error, receive error, or plain timeout with no response),
+    the previous attempt's channel is dropped, which signals the gateway's per-request
+    task to stop and release the ECU lock *before* the next request is sent. This
+    ensures a retry is gated solely by that attempt's own timeout: a late response or
+    error from a prior, superseded attempt can no longer leak into the current attempt
+    and trigger an immediate (sub-timeout) retry.
+
     .. uml::
         :caption: UDS Request-Response Flow
 

--- a/docs/03_architecture/03_communication/02_uds_communication.rst
+++ b/docs/03_architecture/03_communication/02_uds_communication.rst
@@ -247,10 +247,20 @@ Request-Response Flow
     Each application-layer attempt uses a *fresh* response channel. When an attempt
     is retried (transmission error, receive error, or plain timeout with no response),
     the previous attempt's channel is dropped, which signals the gateway's per-request
-    task to stop and release the ECU lock *before* the next request is sent. This
-    ensures a retry is gated solely by that attempt's own timeout: a late response or
-    error from a prior, superseded attempt can no longer leak into the current attempt
-    and trigger an immediate (sub-timeout) retry.
+    task to stop. This ensures a retry is gated solely by that attempt's own timeout: a
+    late response or error from a prior, superseded attempt can no longer leak into the
+    current attempt and trigger an immediate (sub-timeout) retry.
+
+    Dropping the previous attempt's channel only *signals* its gateway task to stop; it
+    does not by itself guarantee that task has finished releasing whatever per-ECU
+    resource it holds (e.g. a DoIP connection mutex, or - for CAN, which has no
+    equivalent per-connection lock - an ISO-TP socket bound to the same CAN ID pair).
+    To close that gap, ``EcuGateway::send`` returns a handle to its per-request task,
+    and the UDS layer awaits the *previous* attempt's handle - bounded by a short,
+    fixed grace period (``RETRY_TEARDOWN_GRACE``, 500 ms) - before issuing the next
+    attempt. If a gateway task does not finish within the grace period, a warning is
+    logged and the next attempt proceeds anyway, so a misbehaving gateway task cannot
+    stall retries indefinitely.
 
     .. uml::
         :caption: UDS Request-Response Flow

--- a/integration-tests/tests/sovd/runtimefiles.rs
+++ b/integration-tests/tests/sovd/runtimefiles.rs
@@ -48,6 +48,54 @@ const RUNTIMEFILES_BACKUP: &str = "apps/sovd2uds/bulk-data/runtimefiles-backup";
 const RUNTIMEFILES_UPDATE_EXECUTIONS: &str =
     "apps/sovd2uds/operations/runtimefilesupdate/executions";
 
+/// Polls `GET /executions/{id}` until the execution reaches a terminal status
+/// (`completed` or `failed`), giving up after `timeout`, and returns the final
+/// response body.
+///
+/// Runtime-file update executions run asynchronously: `POST /executions`
+/// returns `202` immediately while a background task performs the work and
+/// only then clears the update-in-progress guard. Until that guard clears,
+/// non-exempt requests (e.g. deleting the vehicle lock) are rejected with
+/// `409 Conflict`. Tests must therefore wait for a terminal status before
+/// issuing such follow-up requests, otherwise they race the background task.
+async fn wait_for_execution_terminal(
+    config: &Configuration,
+    auth: &http::HeaderMap,
+    execution_id: &str,
+    timeout: Duration,
+) -> Result<serde_json::Value, TestingError> {
+    const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+    let deadline = std::time::Instant::now()
+        .checked_add(timeout)
+        .expect("deadline must not overflow");
+
+    loop {
+        let response = send_cda_request(
+            config,
+            &format!("{RUNTIMEFILES_UPDATE_EXECUTIONS}/{execution_id}"),
+            StatusCode::OK,
+            Method::GET,
+            None,
+            Some(auth),
+            None,
+        )
+        .await?;
+        let execution = response_to_json(&response)?;
+        if let Some("completed" | "failed") =
+            execution.get("status").and_then(serde_json::Value::as_str)
+        {
+            return Ok(execution);
+        }
+
+        assert!(
+            std::time::Instant::now() < deadline,
+            "execution {execution_id} did not reach a terminal status within {timeout:?}"
+        );
+        cda_interfaces::util::tokio_ext::sleep_for(POLL_INTERVAL).await;
+    }
+}
+
 /// Tests that mutating endpoints return 403 Forbidden without a vehicle lock.
 #[tokio::test]
 async fn runtimefiles_requires_lock() -> Result<(), TestingError> {
@@ -177,17 +225,22 @@ async fn runtimefiles_execution_responses_follow_operation_standard() -> Result<
         "execution collection items must contain only their identifiers"
     );
 
-    let execution_response = send_cda_request(
+    // Poll until the async execution reaches a terminal status. Reading the
+    // status only once here would race the background task and could leave the
+    // update-in-progress guard set, causing the lock deletion below to fail
+    // with 409 Conflict.
+    let execution = wait_for_execution_terminal(
         &runtime.config,
-        &format!("{RUNTIMEFILES_UPDATE_EXECUTIONS}/{execution_id}"),
-        StatusCode::OK,
-        Method::GET,
-        None,
-        Some(&auth),
-        None,
+        &auth,
+        &execution_id,
+        Duration::from_secs(10),
     )
     .await?;
-    let execution = response_to_json(&execution_response)?;
+    assert_eq!(
+        execution.get("status").and_then(serde_json::Value::as_str),
+        Some("completed"),
+        "cleanup execution must complete successfully"
+    );
     assert!(
         execution.get("id").is_none() && execution.get("mode").is_none(),
         "execution details must not expose operation-specific values at the top level"
@@ -206,7 +259,6 @@ async fn runtimefiles_execution_responses_follow_operation_standard() -> Result<
             .is_none(),
         "a successful execution must not include a failure reason"
     );
-    assert!(execution.get("status").is_some());
 
     lock_operation(
         locks::VEHICLE_ENDPOINT,


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
This PR fixes three related correctness issues in the UDS transport layer around timeouts, application-level retries, and the suppressPosRspMsgIndicationBit (SPRMIB) check, all discovered while investigating variant-detection reliability.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
