### PR TITLE
ci: Do not run `Update CRAP baseline` in forks.

### DIFF
--- a/.github/workflows/crap-baseline.yml
+++ b/.github/workflows/crap-baseline.yml
@@ -21,7 +21,8 @@ on:
 
 jobs:
   update:
-    if: github.event.workflow_run.conclusion == 'success'
+    # only run on success and do not run in forks
+    if: github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'eclipse-opensovd'
     uses: eclipse-opensovd/cicd-workflows/.github/workflows/crap-baseline.yml@07140bdd84f20b66fd4aff58a83c5148deec388c
     with:
       run-id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
The CI step broke in forks, because the reference branch `crap-baseline` will not normally exist there.

Now it is skipped when not being run in the `eclipse-opensovd` org: https://github.com/mbfm/classic-diagnostic-adapter/actions/runs/31386369174


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
---

Frank Märkle [frank.maerkle@mercedes-benz.com](mailto:frank.maerkle@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)