### PR TITLE
Clarify that seeding only triggers on first load

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It handles the communication to the ECUs, by using the communication parameters 
 2. Start the CDA, pointing it at your databases directory and DoIP interface:
 
    ```shell
-   cargo run --release -- --databases-path ./databases --tester-address <YOUR_IP>
+   cargo run --release -- --seed-databases-dir ./databases --tester-address <YOUR_IP>
    ```
 
 3. Wait a few seconds for DoIP discovery, then confirm the CDA found your ECUs:
@@ -55,14 +55,14 @@ It handles the communication to the ECUs, by using the communication parameters 
 
 To run the CDA you will need at least one `MDD` file. Check out [eclipse-opensovd/odx-converter](https://github.com/eclipse-opensovd/odx-converter) on how to get started with creating `MDD`(s) from ODX.
 
-Once you have the `MDD`(s) you can update the config in `opensovd-cda.toml` to point `databases_path` to the directory containing the files. Alternatively you can pass the config via arg `--databases-path MY_PATH`.
+Once you have the `MDD`(s) you can update the config in `opensovd-cda.toml` to point `database.seed_dir` to the directory containing the files. Alternatively you can pass the config via arg `--seed-databases-dir MY_PATH`.
 
 ### running
 
 Ensure that the config (`opensovd-cda.toml`) fits your setup:
 
 - tester_address is set to the IP of your DoIP interface.
-- databases_path points to a valid path containing one or more `.mdd` files.
+- database.seed_dir points to a valid path containing one or more `.mdd` files.
 
 Run the cda via `cargo run --release` or after building from the target directory `./opensovd-cda`
 
@@ -79,7 +79,7 @@ Use `--protocol-name` to select the DoIP protocol variant used for com-param loo
 
 ```shell
 # Offboard
-cargo run --release -- --databases-path ./databases --tester-address <YOUR_IP> --protocol-name UDS_Ethernet_DoIP
+cargo run --release -- --seed-databases-dir ./databases --tester-address <YOUR_IP> --protocol-name UDS_Ethernet_DoIP
 ```
 
 ## ODX to SOVD path mapping

--- a/cda-database/src/lib.rs
+++ b/cda-database/src/lib.rs
@@ -29,8 +29,8 @@ use serde::{Deserialize, Serialize};
 )]
 #[derive(Deserialize, Serialize, Clone, Debug, schemars::JsonSchema)]
 pub struct DatabaseConfig {
-    /// Path to load the databases from, this must be a directory.
-    pub path: String,
+    /// Directory to load the databases from, if none have been loaded into storage before.
+    pub seed_dir: String,
     pub naming_convention: DatabaseNamingConvention,
     /// If true, the application will exit if no database could be loaded.
     pub exit_no_database_loaded: bool,
@@ -58,7 +58,7 @@ pub struct DatabaseConfig {
 impl Default for DatabaseConfig {
     fn default() -> Self {
         Self {
-            path: ".".to_owned(),
+            seed_dir: ".".to_owned(),
             naming_convention: DatabaseNamingConvention::default(),
             exit_no_database_loaded: false,
             fallback_to_base_variant: true,

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -89,8 +89,9 @@ pub struct AppArgs {
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    #[arg(short, long)]
-    pub databases_path: Option<String>,
+    /// Directory with diagnostic databases to load, if none have been loaded into storage before.
+    #[arg(short = 'd', long)]
+    pub seed_databases_dir: Option<String>,
 
     #[arg(short, long)]
     pub tester_address: Option<String>,
@@ -167,8 +168,8 @@ impl AppArgs {
         )
     )]
     pub fn update_config(self, config: &mut Configuration) {
-        if let Some(databases_path) = self.databases_path {
-            config.database.path = databases_path;
+        if let Some(seed_databases_dir) = self.seed_databases_dir {
+            config.database.seed_dir = seed_databases_dir;
         }
         if let Some(exit_no_database_loaded) = self.exit_no_database_loaded {
             config.database.exit_no_database_loaded = exit_no_database_loaded;
@@ -518,7 +519,7 @@ pub async fn load_vehicle_data<S: SecurityPlugin>(
 ) -> Result<VehicleData<S>, AppError> {
     let mdd_paths: Vec<PathBuf> = {
         let storage_dir = &config.runtime_update_config.storage_dir;
-        let paths = resolve_mdd_paths(storage_dir, &config.database.path).await;
+        let paths = resolve_mdd_paths(storage_dir, &config.database.seed_dir).await;
         if paths.is_empty() && config.database.exit_no_database_loaded {
             return Err(AppError::InitializationFailed(
                 "No MDD files found".to_string(),

--- a/cda-main/src/mdd.rs
+++ b/cda-main/src/mdd.rs
@@ -219,8 +219,8 @@ pub async fn load_databases<S: SecurityPlugin>(
 }
 
 /// Returns paths to MDD files, preferring files found in the CDA storage at `storage_dir`.
-/// Falls back to the configured `database_path` directory if storage is unavailable or empty.
-pub async fn resolve_mdd_paths(storage_dir: &str, database_path: &str) -> Vec<PathBuf> {
+/// Falls back to the configured `database_dir` directory if storage is unavailable or empty.
+pub async fn resolve_mdd_paths(storage_dir: &str, database_dir: &str) -> Vec<PathBuf> {
     let storage_paths = load_mdd_paths_from_storage(storage_dir).await;
     if let Some(storage_paths) = storage_paths
         && !storage_paths.is_empty()
@@ -228,15 +228,15 @@ pub async fn resolve_mdd_paths(storage_dir: &str, database_path: &str) -> Vec<Pa
         tracing::info!(
             count = storage_paths.len(),
             storage_dir,
-            "Using MDD files from CDA storage (overrides configured database path)"
+            "Using MDD files from CDA storage (overrides configured database dir)"
         );
         storage_paths
     } else {
         tracing::info!(
-            configured_path = %database_path,
-            "No MDD files found in storage, falling back to configured database path"
+            configured_dir = %database_dir,
+            "No MDD files found in storage, falling back to configured database dir"
         );
-        match std::fs::read_dir(database_path) {
+        match std::fs::read_dir(database_dir) {
             Ok(files) => get_mdd_files_and_size(files)
                 .into_iter()
                 .map(|(p, _)| p)
@@ -293,20 +293,23 @@ async fn load_mdd_paths_from_storage(storage_dir: &str) -> Option<Vec<PathBuf>> 
     )
 }
 
-/// Seeds the `DiagnosticDatabase` storage collection from `database_path` when the collection
+/// Seeds the `DiagnosticDatabase` storage collection from `database_dir` when the collection
 /// is empty. This copies all `.mdd` files from the filesystem into storage so that the runtime
 /// update plugin has a populated baseline to work with.
-pub async fn seed_storage_from_database_path(storage_dir: &str, database_path: &str) {
-    let mdd_files = match std::fs::read_dir(database_path) {
+pub async fn seed_storage_if_empty_from_database_dir(storage_dir: &str, database_dir: &str) {
+    let mdd_files = match std::fs::read_dir(database_dir) {
         Ok(entries) => get_mdd_files_and_size(entries),
         Err(e) => {
-            tracing::warn!(error = %e, database_path, "Cannot read database path for seeding");
+            tracing::warn!(error = %e, database_dir, "Cannot read database directory for seeding");
             return;
         }
     };
 
     if mdd_files.is_empty() {
-        tracing::debug!(database_path, "No MDD files found in database path to seed");
+        tracing::debug!(
+            database_dir,
+            "No MDD files found in database directory to seed"
+        );
         return;
     }
 
@@ -337,7 +340,7 @@ pub async fn seed_storage_from_database_path(storage_dir: &str, database_path: &
         }
     };
 
-    if let Some(count) = cda_storage::storage_seed::seed_storage_collection(
+    if let Some(count) = cda_storage::storage_seed::seed_storage_collection_if_empty(
         &storage,
         &CollectionName::DiagnosticDatabase,
         entries,
@@ -346,9 +349,9 @@ pub async fn seed_storage_from_database_path(storage_dir: &str, database_path: &
     {
         tracing::info!(
             count,
-            database_path,
+            database_dir,
             storage_dir,
-            "Seeded DiagnosticDatabase collection from database path"
+            "Seeded DiagnosticDatabase collection from database directory"
         );
     }
 }
@@ -697,7 +700,7 @@ mod tests {
     use cda_interfaces::storage_api::{Collection as _, CollectionName, DirectFileAccess, Storage};
     use cda_storage::LocalStorage;
 
-    use super::{resolve_mdd_paths, seed_storage_from_database_path};
+    use super::{resolve_mdd_paths, seed_storage_if_empty_from_database_dir};
 
     /// Helper: create a temp dir with `.mdd` files containing given data.
     fn create_database_dir(files: &[(&str, &[u8])]) -> tempfile::TempDir {
@@ -716,7 +719,7 @@ mod tests {
             ("ecu_b.mdd", b"MDD_CONTENT_B"),
         ]);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -753,7 +756,7 @@ mod tests {
         tx.commit().await.unwrap();
         drop(storage);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -778,7 +781,7 @@ mod tests {
             ("data.bin", b"BIN"),
         ]);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -798,7 +801,7 @@ mod tests {
         let storage_dir = tempfile::tempdir().expect("storage dir");
         let db_dir = tempfile::tempdir().expect("empty db dir");
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -813,11 +816,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn seed_handles_nonexistent_database_path() {
+    async fn seed_handles_nonexistent_database_dir() {
         let storage_dir = tempfile::tempdir().expect("storage dir");
 
         // Should not panic, just return early.
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             "/tmp/nonexistent_cda_test_path_12345",
         )
@@ -836,7 +839,7 @@ mod tests {
         let storage_dir = tempfile::tempdir().expect("storage dir");
         let db_dir = create_database_dir(&[("ECU_UPPER.mdd", b"UPPER_DATA")]);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -857,7 +860,7 @@ mod tests {
         let original_data = b"MDD_BINARY_PAYLOAD_1234567890";
         let db_dir = create_database_dir(&[("FLXC1000.mdd", original_data)]);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -885,7 +888,7 @@ mod tests {
         let storage_str = storage_dir.path().to_str().unwrap();
         let db_str = db_dir.path().to_str().unwrap();
 
-        seed_storage_from_database_path(storage_str, db_str).await;
+        seed_storage_if_empty_from_database_dir(storage_str, db_str).await;
         let paths = resolve_mdd_paths(storage_str, db_str).await;
 
         assert_eq!(paths.len(), 2, "Expected 2 MDD paths from storage");

--- a/cda-storage/src/storage_seed.rs
+++ b/cda-storage/src/storage_seed.rs
@@ -17,7 +17,7 @@ use cda_interfaces::storage_api::{Collection, CollectionName, Storage};
 /// empty.  No-op if the collection is already populated or the iterator yields no items.
 ///
 /// Returns the number of entries written, or `None` when seeding was skipped.
-pub async fn seed_storage_collection(
+pub async fn seed_storage_collection_if_empty(
     storage: &impl Storage,
     collection_name: &CollectionName,
     entries: impl IntoIterator<Item = (String, Vec<u8>)>,

--- a/integration-tests/tests/sovd/configuration.rs
+++ b/integration-tests/tests/sovd/configuration.rs
@@ -26,7 +26,7 @@ async fn cda_stays_running_when_no_database_loaded_and_exit_flag_is_false() {
 
     let mut config = Configuration {
         database: DatabaseConfig {
-            path: empty_db_dir.path().to_string_lossy().into_owned(),
+            seed_dir: empty_db_dir.path().to_string_lossy().into_owned(),
             exit_no_database_loaded: false,
             ..Default::default()
         },

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -273,7 +273,7 @@ fn base_test_config(
         },
         can: None,
         database: DatabaseConfig {
-            path: mdd_file_path()?,
+            seed_dir: mdd_file_path()?,
             naming_convention: DatabaseNamingConvention::default(),
             exit_no_database_loaded: true,
             fallback_to_base_variant: true,
@@ -770,7 +770,7 @@ fn write_config_toml(
     config.functional_description.description_database = "functional_groups".into();
 
     "0.0.0.0".clone_into(&mut config.server.address);
-    "/app/odx".clone_into(&mut config.database.path);
+    "/app/odx".clone_into(&mut config.database.seed_dir);
 
     // In docker the socketcand daemon runs in its own service, reachable by
     // service name over the bridge network (not the host loopback used locally).

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -452,8 +452,8 @@
 # attempting a lookup with this flag set against a multi-protocol database
 # returns `DiagServiceError::InvalidDatabase`.
 # ignore_protocol = false
-# Path to load the databases from, this must be a directory.
-# path = "."
+# Directory to load the databases from, if none have been loaded into storage before.
+# seed_dir = "."
 
 # Holds configuration for diagnostic service naming conventions.
 #


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
It is already the current behavior, that seeding the configuration and databases only does something when nothing has been previously seeded. This PR documents that behavior.

For this, the CLI flags `--config` and `--databases-path` were renamed to `--seed-config` and `--seed-databases-dir`. The configuration flag for the databases directory was similarly adjusted.

Additionally, a `--force-seed-config` flag was introduced to seed from the configuration file even when the storage already contains an entry.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

* I've taken the liberty to rename it from `databases-path` to `-dir`, to make it more obvious that it should be a directory. Since the renaming is already a breaking change, it makes sense to group these together.

* The respective `--force-seed-databases` flag will come later. To implement it, I will also need to fix that the databases are currently not seeded to begin with, so this felt like something for a separate PR.

---

Frank Märkle [frank.maerkle@mercedes-benz.com](mailto:frank.maerkle@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)