### PR TITLE
fix(cda-comm-uds): remove stray shutdown method from SlowTeardownGateway test double

### DIFF
--- a/cda-comm-uds/src/transport.rs
+++ b/cda-comm-uds/src/transport.rs
@@ -1039,8 +1039,6 @@ mod send_tests {
     }
 
     impl EcuGateway for SlowTeardownGateway {
-        async fn shutdown(&mut self) {}
-
         fn get_gateway_network_address(
             &self,
             _logical_address: u16,


### PR DESCRIPTION
## Problem

`main` (commit 3051642) fails to build:

```
error[E0407]: method \`shutdown\` is not a member of trait \`EcuGateway\`
  --> cda-comm-uds/src/transport.rs:1042:9
```

## Root cause

\`EcuGateway::shutdown\` was removed from the trait in a28d7e5 (fix(update-plugin): make the update plugin actually pluggable), replaced by the separate \`ReusableTransportResource\`/runtime-reload mechanism.

3051642 introduced a new test double, \`SlowTeardownGateway\`, whose \`impl EcuGateway for SlowTeardownGateway\` block still contained a leftover \`async fn shutdown(&mut self) {}\`, presumably copied from an older version of \`TestGateway\` (or a pre-rebase branch state) that predates the trait method's removal. Since \`TestGateway\`'s own impl does not have this stray method, this only affects \`SlowTeardownGateway\`.

## Fix

Remove the stray \`shutdown\` method from \`SlowTeardownGateway\`'s \`EcuGateway\` impl.

## Testing

- \`cargo build --workspace --all-targets\` now succeeds.
- \`cargo test -p cda-comm-uds\`: 85 passed, 0 failed (including the new retry-teardown tests added in 3051642, e.g. \`test_send_with_raw_payload_awaits_previous_task_before_next_retry\` and \`test_send_with_raw_payload_proceeds_after_teardown_grace_when_task_never_finishes\`).


Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
