### PR TITLE
fix(cda-main): expose create_default_update_plugin as pub

### DIFF
--- a/cda-main/src/update.rs
+++ b/cda-main/src/update.rs
@@ -127,7 +127,7 @@ pub async fn add_runtime_update_routes<S, P>(
 ///
 /// # Errors
 /// Returns [`AppError::RuntimeUpdateError`] if plugin initialization fails.
-pub(crate) async fn create_default_update_plugin<SP, SL>(
+pub async fn create_default_update_plugin<SP, SL>(
     infra: CdaRuntime<SP>,
 ) -> Result<impl RuntimeFilesUpdatePlugin, AppError>
 where


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
create_default_update_plugin() was pub(crate), so external consumers of opensovd-cda that use Setup::with_update_plugin() together with a custom pre-load hook (via run_with_ext) had no way to opt into the standard DefaultRuntimeUpdatePlugin wiring; they were forced to either give up runtime-update support entirely or duplicate the ~30 lines of Setup/CdaRuntime plumbing this function already implements.

Make it pub so it can be reused via update_plugin_fn() from outside the crate, matching the visibility of the other Setup-related helpers (update_plugin_fn, UpdatePluginBuilder, CdaRuntime) that were already public.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
