### PR TITLE
Fix: MDD files do not get seeded during startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It handles the communication to the ECUs, by using the communication parameters 
 2. Start the CDA, pointing it at your databases directory and DoIP interface:
 
    ```shell
-   cargo run --release -- --databases-path ./databases --tester-address <YOUR_IP>
+   cargo run --release -- --seed-databases-dir ./databases --tester-address <YOUR_IP>
    ```
 
 3. Wait a few seconds for DoIP discovery, then confirm the CDA found your ECUs:
@@ -55,14 +55,14 @@ It handles the communication to the ECUs, by using the communication parameters 
 
 To run the CDA you will need at least one `MDD` file. Check out [eclipse-opensovd/odx-converter](https://github.com/eclipse-opensovd/odx-converter) on how to get started with creating `MDD`(s) from ODX.
 
-Once you have the `MDD`(s) you can update the config in `opensovd-cda.toml` to point `databases_path` to the directory containing the files. Alternatively you can pass the config via arg `--databases-path MY_PATH`.
+Once you have the `MDD`(s) you can update the config in `opensovd-cda.toml` to point `database.seed_dir` to the directory containing the files. Alternatively you can pass the config via arg `--seed-databases-dir MY_PATH`.
 
 ### running
 
 Ensure that the config (`opensovd-cda.toml`) fits your setup:
 
 - tester_address is set to the IP of your DoIP interface.
-- databases_path points to a valid path containing one or more `.mdd` files.
+- database.seed_dir points to a valid path containing one or more `.mdd` files.
 
 Run the cda via `cargo run --release` or after building from the target directory `./opensovd-cda`
 
@@ -79,7 +79,7 @@ Use `--protocol-name` to select the DoIP protocol variant used for com-param loo
 
 ```shell
 # Offboard
-cargo run --release -- --databases-path ./databases --tester-address <YOUR_IP> --protocol-name UDS_Ethernet_DoIP
+cargo run --release -- --seed-databases-dir ./databases --tester-address <YOUR_IP> --protocol-name UDS_Ethernet_DoIP
 ```
 
 ## ODX to SOVD path mapping

--- a/cda-database/src/lib.rs
+++ b/cda-database/src/lib.rs
@@ -29,8 +29,8 @@ use serde::{Deserialize, Serialize};
 )]
 #[derive(Deserialize, Serialize, Clone, Debug, schemars::JsonSchema)]
 pub struct DatabaseConfig {
-    /// Path to load the databases from, this must be a directory.
-    pub path: String,
+    /// Directory to load the databases from, if none have been loaded into storage before.
+    pub seed_dir: String,
     pub naming_convention: DatabaseNamingConvention,
     /// If true, the application will exit if no database could be loaded.
     pub exit_no_database_loaded: bool,
@@ -58,7 +58,7 @@ pub struct DatabaseConfig {
 impl Default for DatabaseConfig {
     fn default() -> Self {
         Self {
-            path: ".".to_owned(),
+            seed_dir: ".".to_owned(),
             naming_convention: DatabaseNamingConvention::default(),
             exit_no_database_loaded: false,
             fallback_to_base_variant: true,

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -89,8 +89,9 @@ pub struct AppArgs {
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    #[arg(short, long)]
-    pub databases_path: Option<String>,
+    /// Directory with diagnostic databases to load, if none have been loaded into storage before.
+    #[arg(short = 'd', long)]
+    pub seed_databases_dir: Option<String>,
 
     #[arg(short, long)]
     pub tester_address: Option<String>,
@@ -167,8 +168,8 @@ impl AppArgs {
         )
     )]
     pub fn update_config(self, config: &mut Configuration) {
-        if let Some(databases_path) = self.databases_path {
-            config.database.path = databases_path;
+        if let Some(seed_databases_dir) = self.seed_databases_dir {
+            config.database.seed_dir = seed_databases_dir;
         }
         if let Some(exit_no_database_loaded) = self.exit_no_database_loaded {
             config.database.exit_no_database_loaded = exit_no_database_loaded;
@@ -518,7 +519,7 @@ pub async fn load_vehicle_data<S: SecurityPlugin>(
 ) -> Result<VehicleData<S>, AppError> {
     let mdd_paths: Vec<PathBuf> = {
         let storage_dir = &config.runtime_update_config.storage_dir;
-        let paths = resolve_mdd_paths(storage_dir, &config.database.path).await;
+        let paths = resolve_mdd_paths(storage_dir, &config.database.seed_dir).await;
         if paths.is_empty() && config.database.exit_no_database_loaded {
             return Err(AppError::InitializationFailed(
                 "No MDD files found".to_string(),

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -95,8 +95,9 @@ pub struct AppArgs {
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    #[arg(short, long)]
-    pub databases_path: Option<String>,
+    /// Directory with diagnostic databases to load, if none have been loaded into storage before.
+    #[arg(short = 'd', long)]
+    pub seed_databases_dir: Option<String>,
 
     #[arg(short, long)]
     pub tester_address: Option<String>,
@@ -170,8 +171,8 @@ impl AppArgs {
         )
     )]
     pub fn update_config(self, config: &mut Configuration) {
-        if let Some(databases_path) = self.databases_path {
-            config.database.path = databases_path;
+        if let Some(seed_databases_dir) = self.seed_databases_dir {
+            config.database.seed_dir = seed_databases_dir;
         }
         if let Some(exit_no_database_loaded) = self.exit_no_database_loaded {
             config.database.exit_no_database_loaded = exit_no_database_loaded;
@@ -552,7 +553,7 @@ pub async fn load_vehicle_data<S: SecurityPlugin>(
 ) -> Result<VehicleData<S>, AppError> {
     let mdd_paths: Vec<PathBuf> = {
         let storage_dir = &config.runtime_update_config.storage_dir;
-        let paths = resolve_mdd_paths(storage_dir, &config.database.path).await;
+        let paths = resolve_mdd_paths(storage_dir, &config.database.seed_dir).await;
         if paths.is_empty() && config.database.exit_no_database_loaded {
             return Err(AppError::InitializationFailed(
                 "No MDD files found".to_string(),

--- a/cda-main/src/mdd.rs
+++ b/cda-main/src/mdd.rs
@@ -236,7 +236,7 @@ pub async fn resolve_mdd_paths(storage_dir: &str, database_dir: &str) -> Vec<Pat
             configured_dir = %database_dir,
             "No MDD files found in storage, falling back to configured database dir"
         );
-        match std::fs::read_dir(database_dir) {
+        let mdd_files = match std::fs::read_dir(database_dir) {
             Ok(files) => get_mdd_files_and_size(files)
                 .into_iter()
                 .map(|(p, _)| p)
@@ -245,7 +245,9 @@ pub async fn resolve_mdd_paths(storage_dir: &str, database_dir: &str) -> Vec<Pat
                 tracing::error!(error = %e, "Failed to read directory");
                 vec![]
             }
-        }
+        };
+        seed_storage_if_empty_from_mdd_files(storage_dir, &mdd_files).await;
+        mdd_files
     }
 }
 
@@ -293,44 +295,31 @@ async fn load_mdd_paths_from_storage(storage_dir: &str) -> Option<Vec<PathBuf>> 
     )
 }
 
-/// Seeds the `DiagnosticDatabase` storage collection from `database_dir` when the collection
-/// is empty. This copies all `.mdd` files from the filesystem into storage so that the runtime
+/// Seeds the `DiagnosticDatabase` storage collection from `mdd_files` when the collection
+/// is empty. This copies the passed file paths into storage so that the runtime
 /// update plugin has a populated baseline to work with.
-pub async fn seed_storage_if_empty_from_database_dir(storage_dir: &str, database_dir: &str) {
-    let mdd_files = match std::fs::read_dir(database_dir) {
-        Ok(entries) => get_mdd_files_and_size(entries),
-        Err(e) => {
-            tracing::warn!(error = %e, database_dir, "Cannot read database directory for seeding");
-            return;
-        }
-    };
-
-    if mdd_files.is_empty() {
-        tracing::debug!(
-            database_dir,
-            "No MDD files found in database directory to seed"
-        );
-        return;
-    }
-
-    let entries = mdd_files.into_iter().filter_map(|(path, _)| {
-        let key = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .map(str::to_lowercase)
-            .unwrap_or_default();
-        if key.is_empty() {
-            return None;
-        }
-        match std::fs::read(&path) {
-            Ok(data) => Some((key, data)),
-            Err(e) => {
-                tracing::warn!(path = %path.display(),
-                    error = %e, "Failed to read MDD file for seeding, skipping");
-                None
+pub async fn seed_storage_if_empty_from_mdd_files(storage_dir: &str, mdd_files: &[PathBuf]) {
+    let entries: Vec<(String, Vec<u8>)> = mdd_files
+        .iter()
+        .filter_map(|path| {
+            let key = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(str::to_lowercase)
+                .unwrap_or_default();
+            if key.is_empty() {
+                return None;
             }
-        }
-    });
+            match std::fs::read(path) {
+                Ok(data) => Some((key, data)),
+                Err(e) => {
+                    tracing::warn!(path = %path.display(),
+                    error = %e, "Failed to read MDD file for seeding, skipping");
+                    None
+                }
+            }
+        })
+        .collect();
 
     let storage = match cda_storage::LocalStorage::new(storage_dir) {
         Ok(s) => s,
@@ -349,9 +338,8 @@ pub async fn seed_storage_if_empty_from_database_dir(storage_dir: &str, database
     {
         tracing::info!(
             count,
-            database_dir,
             storage_dir,
-            "Seeded DiagnosticDatabase collection from database directory"
+            "Seeded DiagnosticDatabase collection from MDD files"
         );
     }
 }
@@ -697,35 +685,28 @@ fn insert_or_update_ecu<S: SecurityPlugin>(
 
 #[cfg(test)]
 mod tests {
-    use cda_interfaces::storage_api::{Collection as _, CollectionName, DirectFileAccess, Storage};
+    use std::path::PathBuf;
+
+    use cda_interfaces::storage_api::{CollectionName, DirectFileAccess, Storage};
     use cda_storage::LocalStorage;
+    use tempfile::TempDir;
 
-    use super::{resolve_mdd_paths, seed_storage_if_empty_from_database_dir};
-
-    /// Helper: create a temp dir with `.mdd` files containing given data.
-    fn create_database_dir(files: &[(&str, &[u8])]) -> tempfile::TempDir {
-        let dir = tempfile::tempdir().expect("create temp dir");
-        for (name, data) in files {
-            std::fs::write(dir.path().join(name), data).expect("write file");
-        }
-        dir
-    }
+    use super::*;
 
     #[tokio::test]
     async fn seed_copies_mdd_files_into_empty_storage() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
-        let db_dir = create_database_dir(&[
+        let fixture = Fixture::new_with_mdd_files(&[
             ("ecu_a.mdd", b"MDD_CONTENT_A"),
             ("ecu_b.mdd", b"MDD_CONTENT_B"),
         ]);
 
-        seed_storage_if_empty_from_database_dir(
-            storage_dir.path().to_str().unwrap(),
-            db_dir.path().to_str().unwrap(),
+        seed_storage_if_empty_from_mdd_files(
+            fixture.storage_dir.path().to_str().unwrap(),
+            &fixture.mdd_files,
         )
         .await;
 
-        let storage = LocalStorage::new(storage_dir.path()).unwrap();
+        let storage = LocalStorage::new(fixture.storage_dir.path()).unwrap();
         let collection = storage
             .get_or_create_collection(&CollectionName::DiagnosticDatabase)
             .await
@@ -738,11 +719,10 @@ mod tests {
 
     #[tokio::test]
     async fn seed_skips_when_collection_already_populated() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
-        let db_dir = create_database_dir(&[("new.mdd", b"NEW_DATA")]);
+        let fixture = Fixture::new_with_mdd_files(&[("new.mdd", b"NEW_DATA")]);
 
         // Pre-populate storage with an existing entry.
-        let storage = LocalStorage::new(storage_dir.path()).unwrap();
+        let storage = LocalStorage::new(fixture.storage_dir.path()).unwrap();
         let collection = storage
             .get_or_create_collection(&CollectionName::DiagnosticDatabase)
             .await
@@ -756,14 +736,14 @@ mod tests {
         tx.commit().await.unwrap();
         drop(storage);
 
-        seed_storage_if_empty_from_database_dir(
-            storage_dir.path().to_str().unwrap(),
-            db_dir.path().to_str().unwrap(),
+        seed_storage_if_empty_from_mdd_files(
+            fixture.storage_dir.path().to_str().unwrap(),
+            &fixture.mdd_files,
         )
         .await;
 
         // Verify collection was NOT modified.
-        let storage = LocalStorage::new(storage_dir.path()).unwrap();
+        let storage = LocalStorage::new(fixture.storage_dir.path()).unwrap();
         let collection = storage
             .get_or_create_collection(&CollectionName::DiagnosticDatabase)
             .await
@@ -773,60 +753,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn seed_ignores_non_mdd_files() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
-        let db_dir = create_database_dir(&[
-            ("valid.mdd", b"MDD_DATA"),
-            ("readme.txt", b"TEXT"),
-            ("data.bin", b"BIN"),
-        ]);
+    async fn seed_handles_no_database_files() {
+        let fixture = Fixture::new_with_mdd_files(&[]);
 
-        seed_storage_if_empty_from_database_dir(
-            storage_dir.path().to_str().unwrap(),
-            db_dir.path().to_str().unwrap(),
+        seed_storage_if_empty_from_mdd_files(
+            fixture.storage_dir.path().to_str().unwrap(),
+            &fixture.mdd_files,
         )
         .await;
 
-        let storage = LocalStorage::new(storage_dir.path()).unwrap();
-        let collection = storage
-            .get_or_create_collection(&CollectionName::DiagnosticDatabase)
-            .await
-            .unwrap();
-        let keys = collection.list().await.unwrap();
-        assert_eq!(keys, vec!["valid.mdd"]);
-    }
-
-    #[tokio::test]
-    async fn seed_handles_empty_database_dir() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
-        let db_dir = tempfile::tempdir().expect("empty db dir");
-
-        seed_storage_if_empty_from_database_dir(
-            storage_dir.path().to_str().unwrap(),
-            db_dir.path().to_str().unwrap(),
-        )
-        .await;
-
-        let storage = LocalStorage::new(storage_dir.path()).unwrap();
-        let collection = storage
-            .get_or_create_collection(&CollectionName::DiagnosticDatabase)
-            .await
-            .unwrap();
-        assert!(collection.is_empty().await.unwrap());
-    }
-
-    #[tokio::test]
-    async fn seed_handles_nonexistent_database_dir() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
-
-        // Should not panic, just return early.
-        seed_storage_if_empty_from_database_dir(
-            storage_dir.path().to_str().unwrap(),
-            "/tmp/nonexistent_cda_test_path_12345",
-        )
-        .await;
-
-        let storage = LocalStorage::new(storage_dir.path()).unwrap();
+        let storage = LocalStorage::new(fixture.storage_dir.path()).unwrap();
         let collection = storage
             .get_or_create_collection(&CollectionName::DiagnosticDatabase)
             .await
@@ -836,16 +772,15 @@ mod tests {
 
     #[tokio::test]
     async fn seed_lowercases_mdd_filenames_as_keys() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
-        let db_dir = create_database_dir(&[("ECU_UPPER.mdd", b"UPPER_DATA")]);
+        let fixture = Fixture::new_with_mdd_files(&[("ECU_UPPER.mdd", b"UPPER_DATA")]);
 
-        seed_storage_if_empty_from_database_dir(
-            storage_dir.path().to_str().unwrap(),
-            db_dir.path().to_str().unwrap(),
+        seed_storage_if_empty_from_mdd_files(
+            fixture.storage_dir.path().to_str().unwrap(),
+            &fixture.mdd_files,
         )
         .await;
 
-        let storage = LocalStorage::new(storage_dir.path()).unwrap();
+        let storage = LocalStorage::new(fixture.storage_dir.path()).unwrap();
         let collection = storage
             .get_or_create_collection(&CollectionName::DiagnosticDatabase)
             .await
@@ -856,17 +791,16 @@ mod tests {
 
     #[tokio::test]
     async fn seed_preserves_file_content_through_storage_roundtrip() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
         let original_data = b"MDD_BINARY_PAYLOAD_1234567890";
-        let db_dir = create_database_dir(&[("FLXC1000.mdd", original_data)]);
+        let fixture = Fixture::new_with_mdd_files(&[("FLXC1000.mdd", original_data)]);
 
-        seed_storage_if_empty_from_database_dir(
-            storage_dir.path().to_str().unwrap(),
-            db_dir.path().to_str().unwrap(),
+        seed_storage_if_empty_from_mdd_files(
+            fixture.storage_dir.path().to_str().unwrap(),
+            &fixture.mdd_files,
         )
         .await;
 
-        let storage = LocalStorage::new(storage_dir.path()).unwrap();
+        let storage = LocalStorage::new(fixture.storage_dir.path()).unwrap();
         let collection = storage
             .get_or_create_collection(&CollectionName::DiagnosticDatabase)
             .await
@@ -881,14 +815,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolve_mdd_paths_ignores_non_mdd_files() {
+        let fixture = Fixture::new_with_mdd_files(&[
+            ("valid.mdd", b"MDD_DATA"),
+            ("readme.txt", b"TEXT"),
+            ("data.bin", b"BIN"),
+        ]);
+
+        let mdd_files = resolve_mdd_paths(
+            fixture.storage_dir.path().to_str().unwrap(),
+            fixture.db_dir.path().to_str().unwrap(),
+        )
+        .await;
+
+        let [valid_file] = mdd_files.as_slice() else {
+            panic!("Exactly one file expected.");
+        };
+        assert_eq!(valid_file.file_name().unwrap(), "valid.mdd");
+    }
+
+    #[tokio::test]
     async fn resolve_mdd_paths_returns_storage_paths_after_seed() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
-        let db_dir = create_database_dir(&[("FLXC1000.mdd", b"MDD_A"), ("FSNR2000.mdd", b"MDD_B")]);
+        let fixture =
+            Fixture::new_with_mdd_files(&[("FLXC1000.mdd", b"MDD_A"), ("FSNR2000.mdd", b"MDD_B")]);
 
-        let storage_str = storage_dir.path().to_str().unwrap();
-        let db_str = db_dir.path().to_str().unwrap();
+        let storage_str = fixture.storage_dir.path().to_str().unwrap();
+        let db_str = fixture.db_dir.path().to_str().unwrap();
 
-        seed_storage_if_empty_from_database_dir(storage_str, db_str).await;
+        seed_storage_if_empty_from_mdd_files(storage_str, &fixture.mdd_files).await;
         let paths = resolve_mdd_paths(storage_str, db_str).await;
 
         assert_eq!(paths.len(), 2, "Expected 2 MDD paths from storage");
@@ -896,7 +850,7 @@ mod tests {
             assert!(p.exists(), "Resolved path must exist: {}", p.display());
             // Paths should come from storage, not from the original database dir.
             assert!(
-                !p.starts_with(db_dir.path()),
+                !p.starts_with(fixture.db_dir.path()),
                 "Path should come from storage, not the database dir: {}",
                 p.display()
             );
@@ -905,13 +859,12 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_mdd_paths_falls_back_when_storage_empty() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
-        let db_dir = create_database_dir(&[("ECU.mdd", b"DATA")]);
+        let fixture = Fixture::new_with_mdd_files(&[("ECU.mdd", b"DATA")]);
 
         // Do NOT seed - storage remains empty.
         let paths = resolve_mdd_paths(
-            storage_dir.path().to_str().unwrap(),
-            db_dir.path().to_str().unwrap(),
+            fixture.storage_dir.path().to_str().unwrap(),
+            fixture.db_dir.path().to_str().unwrap(),
         )
         .await;
 
@@ -919,9 +872,36 @@ mod tests {
 
         assert_eq!(paths.len(), 1, "Expected 1 MDD path from fallback");
         assert!(
-            first.starts_with(db_dir.path()),
+            first.starts_with(fixture.db_dir.path()),
             "Path should come from database dir when storage is empty: {}",
             first.display()
         );
+    }
+
+    struct Fixture {
+        mdd_files: Vec<PathBuf>,
+        storage_dir: TempDir,
+        db_dir: TempDir,
+    }
+    impl Fixture {
+        fn new_with_mdd_files(mdd_files: &[(&str, &[u8])]) -> Self {
+            let storage_dir = tempfile::tempdir().expect("storage dir");
+            let db_dir = tempfile::tempdir().expect("DB dir");
+
+            let mdd_files = mdd_files
+                .iter()
+                .map(|(name, data)| (db_dir.path().join(name), *data))
+                .collect::<Vec<_>>();
+
+            for (path, data) in &mdd_files {
+                std::fs::write(path, data).expect("write MDD file");
+            }
+
+            Self {
+                mdd_files: mdd_files.into_iter().map(|(path, _)| path).collect(),
+                storage_dir,
+                db_dir,
+            }
+        }
     }
 }

--- a/cda-main/src/mdd.rs
+++ b/cda-main/src/mdd.rs
@@ -299,27 +299,26 @@ async fn load_mdd_paths_from_storage(storage_dir: &str) -> Option<Vec<PathBuf>> 
 /// is empty. This copies the passed file paths into storage so that the runtime
 /// update plugin has a populated baseline to work with.
 pub async fn seed_storage_if_empty_from_mdd_files(storage_dir: &str, mdd_files: &[PathBuf]) {
-    let entries: Vec<(String, Vec<u8>)> = mdd_files
-        .iter()
-        .filter_map(|path| {
-            let key = path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .map(str::to_lowercase)
-                .unwrap_or_default();
-            if key.is_empty() {
-                return None;
-            }
-            match std::fs::read(path) {
-                Ok(data) => Some((key, data)),
-                Err(e) => {
-                    tracing::warn!(path = %path.display(),
-                    error = %e, "Failed to read MDD file for seeding, skipping");
-                    None
+    let mut seed_entries = vec![];
+
+    for path in mdd_files {
+        let key = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(str::to_lowercase)
+            .unwrap_or_default();
+
+        if key.is_empty() {
+            tracing::warn!(path = %path.display(), "Unable to determine filename of MDD file as key for seeding. Skipping.");
+        } else {
+            match tokio::fs::File::open(path).await {
+                Ok(file) => seed_entries.push((key, file)),
+                Err(error) => {
+                    tracing::warn!(path = %path.display(), error = %error, "Failed to open MDD file for seeding. Skipping.");
                 }
             }
-        })
-        .collect();
+        }
+    }
 
     let storage = match cda_storage::LocalStorage::new(storage_dir) {
         Ok(s) => s,
@@ -332,7 +331,7 @@ pub async fn seed_storage_if_empty_from_mdd_files(storage_dir: &str, mdd_files: 
     if let Some(count) = cda_storage::storage_seed::seed_storage_collection_if_empty(
         &storage,
         &CollectionName::DiagnosticDatabase,
-        entries,
+        seed_entries,
     )
     .await
     {

--- a/cda-main/src/mdd.rs
+++ b/cda-main/src/mdd.rs
@@ -246,7 +246,7 @@ pub async fn resolve_mdd_paths(storage_dir: &str, database_dir: &str) -> Vec<Pat
                 vec![]
             }
         };
-        seed_storage_if_empty_from_mdd_files(storage_dir, &mdd_files).await;
+        seed_storage_if_nonexistent_from_mdd_files(storage_dir, &mdd_files).await;
         mdd_files
     }
 }
@@ -296,9 +296,9 @@ async fn load_mdd_paths_from_storage(storage_dir: &str) -> Option<Vec<PathBuf>> 
 }
 
 /// Seeds the `DiagnosticDatabase` storage collection from `mdd_files` when the collection
-/// is empty. This copies the passed file paths into storage so that the runtime
+/// does not exist. This copies the passed file paths into storage so that the runtime
 /// update plugin has a populated baseline to work with.
-pub async fn seed_storage_if_empty_from_mdd_files(storage_dir: &str, mdd_files: &[PathBuf]) {
+pub async fn seed_storage_if_nonexistent_from_mdd_files(storage_dir: &str, mdd_files: &[PathBuf]) {
     let mut seed_entries = vec![];
 
     for path in mdd_files {
@@ -328,7 +328,7 @@ pub async fn seed_storage_if_empty_from_mdd_files(storage_dir: &str, mdd_files: 
         }
     };
 
-    if let Some(count) = cda_storage::storage_seed::seed_storage_collection_if_empty(
+    if let Some(count) = cda_storage::storage_seed::seed_storage_collection_if_nonexistent(
         &storage,
         &CollectionName::DiagnosticDatabase,
         seed_entries,
@@ -693,13 +693,13 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn seed_copies_mdd_files_into_empty_storage() {
+    async fn seed_copies_mdd_files_into_nonexistent_storage() {
         let fixture = Fixture::new_with_mdd_files(&[
             ("ecu_a.mdd", b"MDD_CONTENT_A"),
             ("ecu_b.mdd", b"MDD_CONTENT_B"),
         ]);
 
-        seed_storage_if_empty_from_mdd_files(
+        seed_storage_if_nonexistent_from_mdd_files(
             fixture.storage_dir.path().to_str().unwrap(),
             &fixture.mdd_files,
         )
@@ -735,7 +735,7 @@ mod tests {
         tx.commit().await.unwrap();
         drop(storage);
 
-        seed_storage_if_empty_from_mdd_files(
+        seed_storage_if_nonexistent_from_mdd_files(
             fixture.storage_dir.path().to_str().unwrap(),
             &fixture.mdd_files,
         )
@@ -755,7 +755,7 @@ mod tests {
     async fn seed_handles_no_database_files() {
         let fixture = Fixture::new_with_mdd_files(&[]);
 
-        seed_storage_if_empty_from_mdd_files(
+        seed_storage_if_nonexistent_from_mdd_files(
             fixture.storage_dir.path().to_str().unwrap(),
             &fixture.mdd_files,
         )
@@ -773,7 +773,7 @@ mod tests {
     async fn seed_lowercases_mdd_filenames_as_keys() {
         let fixture = Fixture::new_with_mdd_files(&[("ECU_UPPER.mdd", b"UPPER_DATA")]);
 
-        seed_storage_if_empty_from_mdd_files(
+        seed_storage_if_nonexistent_from_mdd_files(
             fixture.storage_dir.path().to_str().unwrap(),
             &fixture.mdd_files,
         )
@@ -793,7 +793,7 @@ mod tests {
         let original_data = b"MDD_BINARY_PAYLOAD_1234567890";
         let fixture = Fixture::new_with_mdd_files(&[("FLXC1000.mdd", original_data)]);
 
-        seed_storage_if_empty_from_mdd_files(
+        seed_storage_if_nonexistent_from_mdd_files(
             fixture.storage_dir.path().to_str().unwrap(),
             &fixture.mdd_files,
         )
@@ -841,7 +841,7 @@ mod tests {
         let storage_str = fixture.storage_dir.path().to_str().unwrap();
         let db_str = fixture.db_dir.path().to_str().unwrap();
 
-        seed_storage_if_empty_from_mdd_files(storage_str, &fixture.mdd_files).await;
+        seed_storage_if_nonexistent_from_mdd_files(storage_str, &fixture.mdd_files).await;
         let paths = resolve_mdd_paths(storage_str, db_str).await;
 
         assert_eq!(paths.len(), 2, "Expected 2 MDD paths from storage");
@@ -857,10 +857,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_mdd_paths_falls_back_when_storage_empty() {
+    async fn resolve_mdd_paths_falls_back_when_storage_nonexistent() {
         let fixture = Fixture::new_with_mdd_files(&[("ECU.mdd", b"DATA")]);
 
-        // Do NOT seed - storage remains empty.
+        // Do NOT seed - storage remains nonexistent.
         let paths = resolve_mdd_paths(
             fixture.storage_dir.path().to_str().unwrap(),
             fixture.db_dir.path().to_str().unwrap(),
@@ -872,7 +872,7 @@ mod tests {
         assert_eq!(paths.len(), 1, "Expected 1 MDD path from fallback");
         assert!(
             first.starts_with(fixture.db_dir.path()),
-            "Path should come from database dir when storage is empty: {}",
+            "Path should come from database dir when storage is nonexistent: {}",
             first.display()
         );
     }

--- a/cda-main/src/mdd.rs
+++ b/cda-main/src/mdd.rs
@@ -219,8 +219,8 @@ pub async fn load_databases<S: SecurityPlugin>(
 }
 
 /// Returns paths to MDD files, preferring files found in the CDA storage at `storage_dir`.
-/// Falls back to the configured `database_path` directory if storage is unavailable or empty.
-pub async fn resolve_mdd_paths(storage_dir: &str, database_path: &str) -> Vec<PathBuf> {
+/// Falls back to the configured `database_dir` directory if storage is unavailable or empty.
+pub async fn resolve_mdd_paths(storage_dir: &str, database_dir: &str) -> Vec<PathBuf> {
     let storage_paths = load_mdd_paths_from_storage(storage_dir).await;
     if let Some(storage_paths) = storage_paths
         && !storage_paths.is_empty()
@@ -228,15 +228,15 @@ pub async fn resolve_mdd_paths(storage_dir: &str, database_path: &str) -> Vec<Pa
         tracing::info!(
             count = storage_paths.len(),
             storage_dir,
-            "Using MDD files from CDA storage (overrides configured database path)"
+            "Using MDD files from CDA storage (overrides configured database dir)"
         );
         storage_paths
     } else {
         tracing::info!(
-            configured_path = %database_path,
-            "No MDD files found in storage, falling back to configured database path"
+            configured_dir = %database_dir,
+            "No MDD files found in storage, falling back to configured database dir"
         );
-        match std::fs::read_dir(database_path) {
+        match std::fs::read_dir(database_dir) {
             Ok(files) => get_mdd_files_and_size(files)
                 .into_iter()
                 .map(|(p, _)| p)
@@ -293,20 +293,23 @@ async fn load_mdd_paths_from_storage(storage_dir: &str) -> Option<Vec<PathBuf>> 
     )
 }
 
-/// Seeds the `DiagnosticDatabase` storage collection from `database_path` when the collection
+/// Seeds the `DiagnosticDatabase` storage collection from `database_dir` when the collection
 /// is empty. This copies all `.mdd` files from the filesystem into storage so that the runtime
 /// update plugin has a populated baseline to work with.
-pub async fn seed_storage_from_database_path(storage_dir: &str, database_path: &str) {
-    let mdd_files = match std::fs::read_dir(database_path) {
+pub async fn seed_storage_if_empty_from_database_dir(storage_dir: &str, database_dir: &str) {
+    let mdd_files = match std::fs::read_dir(database_dir) {
         Ok(entries) => get_mdd_files_and_size(entries),
         Err(e) => {
-            tracing::warn!(error = %e, database_path, "Cannot read database path for seeding");
+            tracing::warn!(error = %e, database_dir, "Cannot read database directory for seeding");
             return;
         }
     };
 
     if mdd_files.is_empty() {
-        tracing::debug!(database_path, "No MDD files found in database path to seed");
+        tracing::debug!(
+            database_dir,
+            "No MDD files found in database directory to seed"
+        );
         return;
     }
 
@@ -337,7 +340,7 @@ pub async fn seed_storage_from_database_path(storage_dir: &str, database_path: &
         }
     };
 
-    if let Some(count) = cda_storage::storage_seed::seed_storage_collection(
+    if let Some(count) = cda_storage::storage_seed::seed_storage_collection_if_empty(
         &storage,
         &CollectionName::DiagnosticDatabase,
         entries,
@@ -346,9 +349,9 @@ pub async fn seed_storage_from_database_path(storage_dir: &str, database_path: &
     {
         tracing::info!(
             count,
-            database_path,
+            database_dir,
             storage_dir,
-            "Seeded DiagnosticDatabase collection from database path"
+            "Seeded DiagnosticDatabase collection from database directory"
         );
     }
 }
@@ -697,7 +700,7 @@ mod tests {
     use cda_interfaces::storage_api::{Collection as _, CollectionName, DirectFileAccess, Storage};
     use cda_storage::LocalStorage;
 
-    use super::{resolve_mdd_paths, seed_storage_from_database_path};
+    use super::{resolve_mdd_paths, seed_storage_if_empty_from_database_dir};
 
     /// Helper: create a temp dir with `.mdd` files containing given data.
     fn create_database_dir(files: &[(&str, &[u8])]) -> tempfile::TempDir {
@@ -716,7 +719,7 @@ mod tests {
             ("ecu_b.mdd", b"MDD_CONTENT_B"),
         ]);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -753,7 +756,7 @@ mod tests {
         tx.commit().await.unwrap();
         drop(storage);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -778,7 +781,7 @@ mod tests {
             ("data.bin", b"BIN"),
         ]);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -798,7 +801,7 @@ mod tests {
         let storage_dir = tempfile::tempdir().expect("storage dir");
         let db_dir = tempfile::tempdir().expect("empty db dir");
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -813,11 +816,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn seed_handles_nonexistent_database_path() {
+    async fn seed_handles_nonexistent_database_dir() {
         let storage_dir = tempfile::tempdir().expect("storage dir");
 
         // Should not panic, just return early.
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             "/tmp/nonexistent_cda_test_path_12345",
         )
@@ -836,7 +839,7 @@ mod tests {
         let storage_dir = tempfile::tempdir().expect("storage dir");
         let db_dir = create_database_dir(&[("ECU_UPPER.mdd", b"UPPER_DATA")]);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -857,7 +860,7 @@ mod tests {
         let original_data = b"MDD_BINARY_PAYLOAD_1234567890";
         let db_dir = create_database_dir(&[("FLXC1000.mdd", original_data)]);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -885,7 +888,7 @@ mod tests {
         let storage_str = storage_dir.path().to_str().unwrap();
         let db_str = db_dir.path().to_str().unwrap();
 
-        seed_storage_from_database_path(storage_str, db_str).await;
+        seed_storage_if_empty_from_database_dir(storage_str, db_str).await;
         let paths = resolve_mdd_paths(storage_str, db_str).await;
 
         assert_eq!(paths.len(), 2, "Expected 2 MDD paths from storage");

--- a/cda-main/src/mdd.rs
+++ b/cda-main/src/mdd.rs
@@ -236,7 +236,7 @@ pub async fn resolve_mdd_paths(storage_dir: &str, database_dir: &str) -> Vec<Pat
             seed_dir = %database_dir,
             "No MDD files found in storage, falling back to configured database dir"
         );
-        match std::fs::read_dir(database_dir) {
+        let mdd_files = match std::fs::read_dir(database_dir) {
             Ok(files) => get_mdd_files_and_size(files)
                 .into_iter()
                 .map(|(p, _)| p)
@@ -245,7 +245,9 @@ pub async fn resolve_mdd_paths(storage_dir: &str, database_dir: &str) -> Vec<Pat
                 tracing::error!(error = %e, "Failed to read directory");
                 vec![]
             }
-        }
+        };
+        seed_storage_if_empty_from_mdd_files(storage_dir, &mdd_files).await;
+        mdd_files
     }
 }
 
@@ -293,44 +295,31 @@ async fn load_mdd_paths_from_storage(storage_dir: &str) -> Option<Vec<PathBuf>> 
     )
 }
 
-/// Seeds the `DiagnosticDatabase` storage collection from `database_dir` when the collection
-/// is empty. This copies all `.mdd` files from the filesystem into storage so that the runtime
+/// Seeds the `DiagnosticDatabase` storage collection from `mdd_files` when the collection
+/// is empty. This copies the passed file paths into storage so that the runtime
 /// update plugin has a populated baseline to work with.
-pub async fn seed_storage_if_empty_from_database_dir(storage_dir: &str, database_dir: &str) {
-    let mdd_files = match std::fs::read_dir(database_dir) {
-        Ok(entries) => get_mdd_files_and_size(entries),
-        Err(e) => {
-            tracing::warn!(error = %e, database_dir, "Cannot read database directory for seeding");
-            return;
-        }
-    };
-
-    if mdd_files.is_empty() {
-        tracing::debug!(
-            database_dir,
-            "No MDD files found in database directory to seed"
-        );
-        return;
-    }
-
-    let entries = mdd_files.into_iter().filter_map(|(path, _)| {
-        let key = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .map(str::to_lowercase)
-            .unwrap_or_default();
-        if key.is_empty() {
-            return None;
-        }
-        match std::fs::read(&path) {
-            Ok(data) => Some((key, data)),
-            Err(e) => {
-                tracing::warn!(path = %path.display(),
-                    error = %e, "Failed to read MDD file for seeding, skipping");
-                None
+pub async fn seed_storage_if_empty_from_mdd_files(storage_dir: &str, mdd_files: &[PathBuf]) {
+    let entries: Vec<(String, Vec<u8>)> = mdd_files
+        .iter()
+        .filter_map(|path| {
+            let key = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(str::to_lowercase)
+                .unwrap_or_default();
+            if key.is_empty() {
+                return None;
             }
-        }
-    });
+            match std::fs::read(path) {
+                Ok(data) => Some((key, data)),
+                Err(e) => {
+                    tracing::warn!(path = %path.display(),
+                    error = %e, "Failed to read MDD file for seeding, skipping");
+                    None
+                }
+            }
+        })
+        .collect();
 
     let storage = match cda_storage::LocalStorage::new(storage_dir) {
         Ok(s) => s,
@@ -349,9 +338,8 @@ pub async fn seed_storage_if_empty_from_database_dir(storage_dir: &str, database
     {
         tracing::info!(
             count,
-            database_dir,
             storage_dir,
-            "Seeded DiagnosticDatabase collection from database directory"
+            "Seeded DiagnosticDatabase collection from MDD files"
         );
     }
 }
@@ -697,35 +685,28 @@ fn insert_or_update_ecu<S: SecurityPlugin>(
 
 #[cfg(test)]
 mod tests {
-    use cda_interfaces::storage_api::{Collection as _, CollectionName, DirectFileAccess, Storage};
+    use std::path::PathBuf;
+
+    use cda_interfaces::storage_api::{CollectionName, DirectFileAccess, Storage};
     use cda_storage::LocalStorage;
+    use tempfile::TempDir;
 
-    use super::{resolve_mdd_paths, seed_storage_if_empty_from_database_dir};
-
-    /// Helper: create a temp dir with `.mdd` files containing given data.
-    fn create_database_dir(files: &[(&str, &[u8])]) -> tempfile::TempDir {
-        let dir = tempfile::tempdir().expect("create temp dir");
-        for (name, data) in files {
-            std::fs::write(dir.path().join(name), data).expect("write file");
-        }
-        dir
-    }
+    use super::*;
 
     #[tokio::test]
     async fn seed_copies_mdd_files_into_empty_storage() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
-        let db_dir = create_database_dir(&[
+        let fixture = Fixture::new_with_mdd_files(&[
             ("ecu_a.mdd", b"MDD_CONTENT_A"),
             ("ecu_b.mdd", b"MDD_CONTENT_B"),
         ]);
 
-        seed_storage_if_empty_from_database_dir(
-            storage_dir.path().to_str().unwrap(),
-            db_dir.path().to_str().unwrap(),
+        seed_storage_if_empty_from_mdd_files(
+            fixture.storage_dir.path().to_str().unwrap(),
+            &fixture.mdd_files,
         )
         .await;
 
-        let storage = LocalStorage::new(storage_dir.path()).unwrap();
+        let storage = LocalStorage::new(fixture.storage_dir.path()).unwrap();
         let collection = storage
             .get_or_create_collection(&CollectionName::DiagnosticDatabase)
             .await
@@ -738,11 +719,10 @@ mod tests {
 
     #[tokio::test]
     async fn seed_skips_when_collection_already_populated() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
-        let db_dir = create_database_dir(&[("new.mdd", b"NEW_DATA")]);
+        let fixture = Fixture::new_with_mdd_files(&[("new.mdd", b"NEW_DATA")]);
 
         // Pre-populate storage with an existing entry.
-        let storage = LocalStorage::new(storage_dir.path()).unwrap();
+        let storage = LocalStorage::new(fixture.storage_dir.path()).unwrap();
         let collection = storage
             .get_or_create_collection(&CollectionName::DiagnosticDatabase)
             .await
@@ -756,14 +736,14 @@ mod tests {
         tx.commit().await.unwrap();
         drop(storage);
 
-        seed_storage_if_empty_from_database_dir(
-            storage_dir.path().to_str().unwrap(),
-            db_dir.path().to_str().unwrap(),
+        seed_storage_if_empty_from_mdd_files(
+            fixture.storage_dir.path().to_str().unwrap(),
+            &fixture.mdd_files,
         )
         .await;
 
         // Verify collection was NOT modified.
-        let storage = LocalStorage::new(storage_dir.path()).unwrap();
+        let storage = LocalStorage::new(fixture.storage_dir.path()).unwrap();
         let collection = storage
             .get_or_create_collection(&CollectionName::DiagnosticDatabase)
             .await
@@ -773,60 +753,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn seed_ignores_non_mdd_files() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
-        let db_dir = create_database_dir(&[
-            ("valid.mdd", b"MDD_DATA"),
-            ("readme.txt", b"TEXT"),
-            ("data.bin", b"BIN"),
-        ]);
+    async fn seed_handles_no_database_files() {
+        let fixture = Fixture::new_with_mdd_files(&[]);
 
-        seed_storage_if_empty_from_database_dir(
-            storage_dir.path().to_str().unwrap(),
-            db_dir.path().to_str().unwrap(),
+        seed_storage_if_empty_from_mdd_files(
+            fixture.storage_dir.path().to_str().unwrap(),
+            &fixture.mdd_files,
         )
         .await;
 
-        let storage = LocalStorage::new(storage_dir.path()).unwrap();
-        let collection = storage
-            .get_or_create_collection(&CollectionName::DiagnosticDatabase)
-            .await
-            .unwrap();
-        let keys = collection.list().await.unwrap();
-        assert_eq!(keys, vec!["valid.mdd"]);
-    }
-
-    #[tokio::test]
-    async fn seed_handles_empty_database_dir() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
-        let db_dir = tempfile::tempdir().expect("empty db dir");
-
-        seed_storage_if_empty_from_database_dir(
-            storage_dir.path().to_str().unwrap(),
-            db_dir.path().to_str().unwrap(),
-        )
-        .await;
-
-        let storage = LocalStorage::new(storage_dir.path()).unwrap();
-        let collection = storage
-            .get_or_create_collection(&CollectionName::DiagnosticDatabase)
-            .await
-            .unwrap();
-        assert!(collection.is_empty().await.unwrap());
-    }
-
-    #[tokio::test]
-    async fn seed_handles_nonexistent_database_dir() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
-
-        // Should not panic, just return early.
-        seed_storage_if_empty_from_database_dir(
-            storage_dir.path().to_str().unwrap(),
-            "/tmp/nonexistent_cda_test_path_12345",
-        )
-        .await;
-
-        let storage = LocalStorage::new(storage_dir.path()).unwrap();
+        let storage = LocalStorage::new(fixture.storage_dir.path()).unwrap();
         let collection = storage
             .get_or_create_collection(&CollectionName::DiagnosticDatabase)
             .await
@@ -836,16 +772,15 @@ mod tests {
 
     #[tokio::test]
     async fn seed_lowercases_mdd_filenames_as_keys() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
-        let db_dir = create_database_dir(&[("ECU_UPPER.mdd", b"UPPER_DATA")]);
+        let fixture = Fixture::new_with_mdd_files(&[("ECU_UPPER.mdd", b"UPPER_DATA")]);
 
-        seed_storage_if_empty_from_database_dir(
-            storage_dir.path().to_str().unwrap(),
-            db_dir.path().to_str().unwrap(),
+        seed_storage_if_empty_from_mdd_files(
+            fixture.storage_dir.path().to_str().unwrap(),
+            &fixture.mdd_files,
         )
         .await;
 
-        let storage = LocalStorage::new(storage_dir.path()).unwrap();
+        let storage = LocalStorage::new(fixture.storage_dir.path()).unwrap();
         let collection = storage
             .get_or_create_collection(&CollectionName::DiagnosticDatabase)
             .await
@@ -856,17 +791,16 @@ mod tests {
 
     #[tokio::test]
     async fn seed_preserves_file_content_through_storage_roundtrip() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
         let original_data = b"MDD_BINARY_PAYLOAD_1234567890";
-        let db_dir = create_database_dir(&[("FLXC1000.mdd", original_data)]);
+        let fixture = Fixture::new_with_mdd_files(&[("FLXC1000.mdd", original_data)]);
 
-        seed_storage_if_empty_from_database_dir(
-            storage_dir.path().to_str().unwrap(),
-            db_dir.path().to_str().unwrap(),
+        seed_storage_if_empty_from_mdd_files(
+            fixture.storage_dir.path().to_str().unwrap(),
+            &fixture.mdd_files,
         )
         .await;
 
-        let storage = LocalStorage::new(storage_dir.path()).unwrap();
+        let storage = LocalStorage::new(fixture.storage_dir.path()).unwrap();
         let collection = storage
             .get_or_create_collection(&CollectionName::DiagnosticDatabase)
             .await
@@ -881,14 +815,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolve_mdd_paths_ignores_non_mdd_files() {
+        let fixture = Fixture::new_with_mdd_files(&[
+            ("valid.mdd", b"MDD_DATA"),
+            ("readme.txt", b"TEXT"),
+            ("data.bin", b"BIN"),
+        ]);
+
+        let mdd_files = resolve_mdd_paths(
+            fixture.storage_dir.path().to_str().unwrap(),
+            fixture.db_dir.path().to_str().unwrap(),
+        )
+        .await;
+
+        let [valid_file] = mdd_files.as_slice() else {
+            panic!("Exactly one file expected.");
+        };
+        assert_eq!(valid_file.file_name().unwrap(), "valid.mdd");
+    }
+
+    #[tokio::test]
     async fn resolve_mdd_paths_returns_storage_paths_after_seed() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
-        let db_dir = create_database_dir(&[("FLXC1000.mdd", b"MDD_A"), ("FSNR2000.mdd", b"MDD_B")]);
+        let fixture =
+            Fixture::new_with_mdd_files(&[("FLXC1000.mdd", b"MDD_A"), ("FSNR2000.mdd", b"MDD_B")]);
 
-        let storage_str = storage_dir.path().to_str().unwrap();
-        let db_str = db_dir.path().to_str().unwrap();
+        let storage_str = fixture.storage_dir.path().to_str().unwrap();
+        let db_str = fixture.db_dir.path().to_str().unwrap();
 
-        seed_storage_if_empty_from_database_dir(storage_str, db_str).await;
+        seed_storage_if_empty_from_mdd_files(storage_str, &fixture.mdd_files).await;
         let paths = resolve_mdd_paths(storage_str, db_str).await;
 
         assert_eq!(paths.len(), 2, "Expected 2 MDD paths from storage");
@@ -896,7 +850,7 @@ mod tests {
             assert!(p.exists(), "Resolved path must exist: {}", p.display());
             // Paths should come from storage, not from the original database dir.
             assert!(
-                !p.starts_with(db_dir.path()),
+                !p.starts_with(fixture.db_dir.path()),
                 "Path should come from storage, not the database dir: {}",
                 p.display()
             );
@@ -905,13 +859,12 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_mdd_paths_falls_back_when_storage_empty() {
-        let storage_dir = tempfile::tempdir().expect("storage dir");
-        let db_dir = create_database_dir(&[("ECU.mdd", b"DATA")]);
+        let fixture = Fixture::new_with_mdd_files(&[("ECU.mdd", b"DATA")]);
 
         // Do NOT seed - storage remains empty.
         let paths = resolve_mdd_paths(
-            storage_dir.path().to_str().unwrap(),
-            db_dir.path().to_str().unwrap(),
+            fixture.storage_dir.path().to_str().unwrap(),
+            fixture.db_dir.path().to_str().unwrap(),
         )
         .await;
 
@@ -919,9 +872,36 @@ mod tests {
 
         assert_eq!(paths.len(), 1, "Expected 1 MDD path from fallback");
         assert!(
-            first.starts_with(db_dir.path()),
+            first.starts_with(fixture.db_dir.path()),
             "Path should come from database dir when storage is empty: {}",
             first.display()
         );
+    }
+
+    struct Fixture {
+        mdd_files: Vec<PathBuf>,
+        storage_dir: TempDir,
+        db_dir: TempDir,
+    }
+    impl Fixture {
+        fn new_with_mdd_files(mdd_files: &[(&str, &[u8])]) -> Self {
+            let storage_dir = tempfile::tempdir().expect("storage dir");
+            let db_dir = tempfile::tempdir().expect("DB dir");
+
+            let mdd_files = mdd_files
+                .iter()
+                .map(|(name, data)| (db_dir.path().join(name), *data))
+                .collect::<Vec<_>>();
+
+            for (path, data) in &mdd_files {
+                std::fs::write(path, data).expect("write MDD file");
+            }
+
+            Self {
+                mdd_files: mdd_files.into_iter().map(|(path, _)| path).collect(),
+                storage_dir,
+                db_dir,
+            }
+        }
     }
 }

--- a/cda-main/src/mdd.rs
+++ b/cda-main/src/mdd.rs
@@ -219,8 +219,8 @@ pub async fn load_databases<S: SecurityPlugin>(
 }
 
 /// Returns paths to MDD files, preferring files found in the CDA storage at `storage_dir`.
-/// Falls back to the configured `database_path` directory if storage is unavailable or empty.
-pub async fn resolve_mdd_paths(storage_dir: &str, database_path: &str) -> Vec<PathBuf> {
+/// Falls back to the configured `database.seed_dir` directory if storage is unavailable or empty.
+pub async fn resolve_mdd_paths(storage_dir: &str, database_dir: &str) -> Vec<PathBuf> {
     let storage_paths = load_mdd_paths_from_storage(storage_dir).await;
     if let Some(storage_paths) = storage_paths
         && !storage_paths.is_empty()
@@ -228,15 +228,15 @@ pub async fn resolve_mdd_paths(storage_dir: &str, database_path: &str) -> Vec<Pa
         tracing::info!(
             count = storage_paths.len(),
             storage_dir,
-            "Using MDD files from CDA storage (overrides configured database path)"
+            "Using MDD files from CDA storage (overrides configured database dir)"
         );
         storage_paths
     } else {
         tracing::info!(
-            configured_path = %database_path,
-            "No MDD files found in storage, falling back to configured database path"
+            seed_dir = %database_dir,
+            "No MDD files found in storage, falling back to configured database dir"
         );
-        match std::fs::read_dir(database_path) {
+        match std::fs::read_dir(database_dir) {
             Ok(files) => get_mdd_files_and_size(files)
                 .into_iter()
                 .map(|(p, _)| p)
@@ -293,20 +293,23 @@ async fn load_mdd_paths_from_storage(storage_dir: &str) -> Option<Vec<PathBuf>> 
     )
 }
 
-/// Seeds the `DiagnosticDatabase` storage collection from `database_path` when the collection
+/// Seeds the `DiagnosticDatabase` storage collection from `database_dir` when the collection
 /// is empty. This copies all `.mdd` files from the filesystem into storage so that the runtime
 /// update plugin has a populated baseline to work with.
-pub async fn seed_storage_from_database_path(storage_dir: &str, database_path: &str) {
-    let mdd_files = match std::fs::read_dir(database_path) {
+pub async fn seed_storage_if_empty_from_database_dir(storage_dir: &str, database_dir: &str) {
+    let mdd_files = match std::fs::read_dir(database_dir) {
         Ok(entries) => get_mdd_files_and_size(entries),
         Err(e) => {
-            tracing::warn!(error = %e, database_path, "Cannot read database path for seeding");
+            tracing::warn!(error = %e, database_dir, "Cannot read database directory for seeding");
             return;
         }
     };
 
     if mdd_files.is_empty() {
-        tracing::debug!(database_path, "No MDD files found in database path to seed");
+        tracing::debug!(
+            database_dir,
+            "No MDD files found in database directory to seed"
+        );
         return;
     }
 
@@ -337,7 +340,7 @@ pub async fn seed_storage_from_database_path(storage_dir: &str, database_path: &
         }
     };
 
-    if let Some(count) = cda_storage::storage_seed::seed_storage_collection(
+    if let Some(count) = cda_storage::storage_seed::seed_storage_collection_if_empty(
         &storage,
         &CollectionName::DiagnosticDatabase,
         entries,
@@ -346,9 +349,9 @@ pub async fn seed_storage_from_database_path(storage_dir: &str, database_path: &
     {
         tracing::info!(
             count,
-            database_path,
+            database_dir,
             storage_dir,
-            "Seeded DiagnosticDatabase collection from database path"
+            "Seeded DiagnosticDatabase collection from database directory"
         );
     }
 }
@@ -697,7 +700,7 @@ mod tests {
     use cda_interfaces::storage_api::{Collection as _, CollectionName, DirectFileAccess, Storage};
     use cda_storage::LocalStorage;
 
-    use super::{resolve_mdd_paths, seed_storage_from_database_path};
+    use super::{resolve_mdd_paths, seed_storage_if_empty_from_database_dir};
 
     /// Helper: create a temp dir with `.mdd` files containing given data.
     fn create_database_dir(files: &[(&str, &[u8])]) -> tempfile::TempDir {
@@ -716,7 +719,7 @@ mod tests {
             ("ecu_b.mdd", b"MDD_CONTENT_B"),
         ]);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -753,7 +756,7 @@ mod tests {
         tx.commit().await.unwrap();
         drop(storage);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -778,7 +781,7 @@ mod tests {
             ("data.bin", b"BIN"),
         ]);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -798,7 +801,7 @@ mod tests {
         let storage_dir = tempfile::tempdir().expect("storage dir");
         let db_dir = tempfile::tempdir().expect("empty db dir");
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -813,11 +816,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn seed_handles_nonexistent_database_path() {
+    async fn seed_handles_nonexistent_database_dir() {
         let storage_dir = tempfile::tempdir().expect("storage dir");
 
         // Should not panic, just return early.
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             "/tmp/nonexistent_cda_test_path_12345",
         )
@@ -836,7 +839,7 @@ mod tests {
         let storage_dir = tempfile::tempdir().expect("storage dir");
         let db_dir = create_database_dir(&[("ECU_UPPER.mdd", b"UPPER_DATA")]);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -857,7 +860,7 @@ mod tests {
         let original_data = b"MDD_BINARY_PAYLOAD_1234567890";
         let db_dir = create_database_dir(&[("FLXC1000.mdd", original_data)]);
 
-        seed_storage_from_database_path(
+        seed_storage_if_empty_from_database_dir(
             storage_dir.path().to_str().unwrap(),
             db_dir.path().to_str().unwrap(),
         )
@@ -885,7 +888,7 @@ mod tests {
         let storage_str = storage_dir.path().to_str().unwrap();
         let db_str = db_dir.path().to_str().unwrap();
 
-        seed_storage_from_database_path(storage_str, db_str).await;
+        seed_storage_if_empty_from_database_dir(storage_str, db_str).await;
         let paths = resolve_mdd_paths(storage_str, db_str).await;
 
         assert_eq!(paths.len(), 2, "Expected 2 MDD paths from storage");

--- a/cda-storage/src/storage_seed.rs
+++ b/cda-storage/src/storage_seed.rs
@@ -11,49 +11,51 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use cda_interfaces::storage_api::{Collection, CollectionName, ReadableStream, Storage};
+use cda_interfaces::storage_api::{
+    Collection, CollectionName, ReadableStream, Storage, StorageError,
+};
 
-/// Seeds a storage collection from an iterator of `(key, data)` pairs when the collection is
-/// empty.  No-op if the collection is already populated or the iterator yields no items.
+/// Seeds a storage collection from an iterator of `(key, data)` pairs when the collection does
+/// not exist yet. No-op if the collection already exists.
 ///
 /// Returns the number of entries written, or `None` when seeding was skipped.
-pub async fn seed_storage_collection_if_empty(
+pub async fn seed_storage_collection_if_nonexistent(
     storage: &impl Storage,
     collection_name: &CollectionName,
     entries: impl IntoIterator<Item = (String, impl ReadableStream)>,
 ) -> Option<usize> {
-    let collection = match storage.get_or_create_collection(collection_name).await {
-        Ok(c) => c,
+    let mut tx = match storage.begin_transaction() {
+        Ok(tx) => tx,
         Err(e) => {
-            tracing::warn!(
-                collection = %collection_name,
-                error = %e,
-                "Cannot access collection, skipping seed"
-            );
+            tracing::warn!(error = %e, "Cannot begin transaction for seeding");
             return None;
         }
     };
 
-    match collection.is_empty().await {
-        Ok(true) => {}
-        Ok(false) => {
-            tracing::debug!(collection = %collection_name, "Collection already populated, skipping seed");
+    match storage.get_collection(collection_name).await {
+        Err(StorageError::CollectionNotFound(_)) => {} // continue
+        Ok(_) => {
+            tracing::debug!(collection = %collection_name, "Collection already exists, skipping seed.");
             return None;
         }
-        Err(e) => {
+        Err(error) => {
             tracing::warn!(
                 collection = %collection_name,
-                error = %e,
+                error = %error,
                 "Failed to check collection, skipping seed"
             );
             return None;
         }
     }
 
-    let mut tx = match storage.begin_transaction() {
-        Ok(tx) => tx,
-        Err(e) => {
-            tracing::warn!(error = %e, "Cannot begin transaction for seeding");
+    let collection = match storage.create_collection(&mut tx, collection_name).await {
+        Ok(collection) => collection,
+        Err(source) => {
+            tracing::warn!(
+                collection = %collection_name,
+                error = %source,
+                "Cannot create collection, skipping seed"
+            );
             return None;
         }
     };

--- a/cda-storage/src/storage_seed.rs
+++ b/cda-storage/src/storage_seed.rs
@@ -17,7 +17,7 @@ use cda_interfaces::storage_api::{Collection, CollectionName, Storage};
 /// empty.  No-op if the collection is already populated or the iterator yields no items.
 ///
 /// Returns the number of entries written, or `None` when seeding was skipped.
-pub async fn seed_storage_collection(
+pub async fn seed_storage_collection_if_empty(
     storage: &impl Storage,
     collection_name: &CollectionName,
     entries: impl IntoIterator<Item = (String, Vec<u8>)>,

--- a/cda-storage/src/storage_seed.rs
+++ b/cda-storage/src/storage_seed.rs
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use cda_interfaces::storage_api::{Collection, CollectionName, Storage};
+use cda_interfaces::storage_api::{Collection, CollectionName, ReadableStream, Storage};
 
 /// Seeds a storage collection from an iterator of `(key, data)` pairs when the collection is
 /// empty.  No-op if the collection is already populated or the iterator yields no items.
@@ -20,7 +20,7 @@ use cda_interfaces::storage_api::{Collection, CollectionName, Storage};
 pub async fn seed_storage_collection_if_empty(
     storage: &impl Storage,
     collection_name: &CollectionName,
-    entries: impl IntoIterator<Item = (String, Vec<u8>)>,
+    entries: impl IntoIterator<Item = (String, impl ReadableStream)>,
 ) -> Option<usize> {
     let collection = match storage.get_or_create_collection(collection_name).await {
         Ok(c) => c,
@@ -59,9 +59,8 @@ pub async fn seed_storage_collection_if_empty(
     };
 
     let mut count = 0usize;
-    for (key, data) in entries {
-        let mut cursor = std::io::Cursor::new(data);
-        if let Err(e) = collection.write(&mut tx, &key, &mut cursor).await {
+    for (key, mut data) in entries {
+        if let Err(e) = collection.write(&mut tx, &key, &mut data).await {
             tracing::warn!(key, collection = %collection_name, error = %e, "Failed to write entry to storage, skipping");
             continue;
         }

--- a/integration-tests/tests/sovd/configuration.rs
+++ b/integration-tests/tests/sovd/configuration.rs
@@ -26,7 +26,7 @@ async fn cda_stays_running_when_no_database_loaded_and_exit_flag_is_false() {
 
     let mut config = Configuration {
         database: DatabaseConfig {
-            path: empty_db_dir.path().to_string_lossy().into_owned(),
+            seed_dir: empty_db_dir.path().to_string_lossy().into_owned(),
             exit_no_database_loaded: false,
             ..Default::default()
         },

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -335,7 +335,7 @@ fn base_test_config(
         },
         can: None,
         database: DatabaseConfig {
-            path: mdd_file_path()?,
+            seed_dir: mdd_file_path()?,
             naming_convention: DatabaseNamingConvention::default(),
             exit_no_database_loaded: true,
             fallback_to_base_variant: true,
@@ -775,7 +775,7 @@ fn write_config_toml(
     config.functional_description.description_database = "functional_groups".into();
 
     "0.0.0.0".clone_into(&mut config.server.address);
-    "/app/odx".clone_into(&mut config.database.path);
+    "/app/odx".clone_into(&mut config.database.seed_dir);
 
     // In docker the socketcand daemon runs in its own service, reachable by
     // service name over the bridge network (not the host loopback used locally).

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -273,7 +273,7 @@ fn base_test_config(
         },
         can: None,
         database: DatabaseConfig {
-            path: mdd_file_path()?,
+            seed_dir: mdd_file_path()?,
             naming_convention: DatabaseNamingConvention::default(),
             exit_no_database_loaded: true,
             fallback_to_base_variant: true,
@@ -770,7 +770,7 @@ fn write_config_toml(
     config.functional_description.description_database = "functional_groups".into();
 
     "0.0.0.0".clone_into(&mut config.server.address);
-    "/app/odx".clone_into(&mut config.database.path);
+    "/app/odx".clone_into(&mut config.database.seed_dir);
 
     // In docker the socketcand daemon runs in its own service, reachable by
     // service name over the bridge network (not the host loopback used locally).

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -452,8 +452,8 @@
 # attempting a lookup with this flag set against a multi-protocol database
 # returns `DiagServiceError::InvalidDatabase`.
 # ignore_protocol = false
-# Path to load the databases from, this must be a directory.
-# path = "."
+# Directory to load the databases from, if none have been loaded into storage before.
+# seed_dir = "."
 
 # Holds configuration for diagnostic service naming conventions.
 #

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -481,8 +481,8 @@
 # attempting a lookup with this flag set against a multi-protocol database
 # returns `DiagServiceError::InvalidDatabase`.
 # ignore_protocol = false
-# Path to load the databases from, this must be a directory.
-# path = "."
+# Directory to load the databases from, if none have been loaded into storage before.
+# seed_dir = "."
 
 # Holds configuration for diagnostic service naming conventions.
 #


### PR DESCRIPTION
Up until now, the function for seeding the storage from the MDD files in the database directory was never actually called.
This meant that during the first update that came in through the Update-plugin, there was nothing to rollback to, in case of an error.

This PR fixes that and includes some minor code cleanups as well.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->
Came out of the work on issue #479.
Prerequisite for merging: #501

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
---

Frank Märkle [frank.maerkle@mercedes-benz.com](mailto:frank.maerkle@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)