### PR TITLE
fix(flash_files): log directory/entry read errors instead of silently skipping

### DIFF
--- a/cda-sovd/src/sovd/apps/sovd2uds/bulk_data/flash_files.rs
+++ b/cda-sovd/src/sovd/apps/sovd2uds/bulk_data/flash_files.rs
@@ -46,12 +46,43 @@ async fn process_directory(
         relative_sub_dir: Option<&PathBuf>,
     ) -> Vec<sovd_interfaces::sovd2uds::BulkDataDescriptor> {
         std::fs::read_dir(dir)
+            .inspect_err(|e| {
+                tracing::warn!(
+                    dir = %dir.display(),
+                    error = %e,
+                    "Failed to read directory while listing flash files"
+                );
+            })
             .into_iter()
-            .flat_map(|entries| entries.filter_map(Result::ok))
+            .flat_map(|entries| {
+                entries.filter_map(|entry| {
+                    entry
+                        .inspect_err(|e| {
+                            tracing::warn!(
+                                dir = %dir.display(),
+                                error = %e,
+                                "Failed to read directory entry while listing flash files"
+                            );
+                        })
+                        .ok()
+                })
+            })
             .filter_map(|entry| {
-                let file_type = entry.file_type().ok()?;
+                let file_type = entry.file_type().ok().or_else(|| {
+                    tracing::warn!(
+                        path = %entry.path().display(),
+                        "Failed to determine file type of directory entry, skipping"
+                    );
+                    None
+                })?;
                 if file_type.is_file() {
-                    let metadata = entry.metadata().ok()?;
+                    let metadata = entry.metadata().ok().or_else(|| {
+                        tracing::warn!(
+                            path = %entry.path().display(),
+                            "Failed to read metadata of file, skipping"
+                        );
+                        None
+                    })?;
                     let file_name = relative_sub_dir.as_ref().map_or_else(
                         || entry.file_name().to_string_lossy().to_string(),
                         |rel| rel.join(entry.file_name()).to_string_lossy().to_string(),
@@ -74,6 +105,10 @@ async fn process_directory(
                         new_relative_sub_dir.push(entry.file_name());
                         Some(process(&path, Some(&new_relative_sub_dir)))
                     } else {
+                        tracing::warn!(
+                            path = %path.display(),
+                            "Failed to read subdirectory while listing flash files, skipping"
+                        );
                         None
                     }
                 } else {


### PR DESCRIPTION
## Summary

`process_directory` in `cda-sovd/src/sovd/apps/sovd2uds/bulk_data/flash_files.rs` recursively walks the flash files directory tree. Several failure paths (directory read errors, entry read errors, `file_type()`/`metadata()` failures, and failed reads of subdirectories) were silently discarded, which could hide operational issues in deeply nested or partially inaccessible directory structures.

This PR adds `tracing::warn!` logging for those previously-silent error paths, with no change to the recursion logic or output behavior otherwise.

## Changes
- Log a warning when the top-level `read_dir` for a directory fails.
- Log a warning when reading an individual directory entry fails.
- Log a warning when `file_type()` cannot be determined for an entry.
- Log a warning when `metadata()` cannot be read for a file.
- Log a warning when a subdirectory can't be read before recursing into it.

## Testing
- `cargo build -p cda-sovd`
- `cargo clippy -p cda-sovd --all-targets`
- `cargo fmt -p cda-sovd`

---

Florian Roks <florian.roks@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)