### PR TITLE
fix(ci): support duplicate-code comments for fork PRs

### DIFF
--- a/.github/workflows/duplicate-code-check.yml
+++ b/.github/workflows/duplicate-code-check.yml
@@ -118,6 +118,7 @@ jobs:
             }
 
       - name: Create check run
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/duplicate-code-check.yml
+++ b/.github/workflows/duplicate-code-check.yml
@@ -72,7 +72,22 @@ jobs:
             changed-files.txt \
             --outdir /tmp
 
+      - name: Prepare duplicate-code comment artifact
+        run: |
+          mkdir -p pr-comment-duplicate-code
+          echo "${{ github.event.number }}" > pr-comment-duplicate-code/pr_number
+          cp /tmp/body.md pr-comment-duplicate-code/body.md
+
+      - name: Upload duplicate-code comment artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-comment-duplicate-code
+          path: pr-comment-duplicate-code/
+
+      # Post directly for non-fork PRs (instant feedback). Fork PRs lack write
+      # permissions and are handled by the workflow_run workflow in pr-comment.yml.
       - name: Post PR comment
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -9,7 +9,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Post PR comments from artifacts produced by the "Rust CI" workflow.
+# Post PR comments from artifacts produced by PR workflows.
 # This workflow_run trigger runs in the context of the base repository, so
 # it has write permissions even when the PR originates from a fork.
 
@@ -17,7 +17,7 @@ name: Post PR Comments
 
 on:
   workflow_run:
-    workflows: ["Rust CI"]
+    workflows: ["Rust CI", "Duplicate Code Check"]
     types: [completed]
 
 jobs:
@@ -26,6 +26,10 @@ jobs:
     uses: eclipse-opensovd/cicd-workflows/.github/workflows/post-pr-comments.yml@07140bdd84f20b66fd4aff58a83c5148deec388c
     with:
       run-id: ${{ github.event.workflow_run.id }}
+      comment-artifacts: >-
+        ${{ github.event.workflow_run.name == 'Duplicate Code Check'
+          && 'pr-comment-duplicate-code'
+          || 'pr-comment-coverage pr-comment-crap' }}
     permissions:
       actions: read
       pull-requests: write


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Adds artifact-based duplicate-code comments for fork PRs, following the approach described in the linked issue. Fork PRs skip direct write operations and use the trusted `workflow_run` workflow instead.

## Checklist

- [x] I have tested my changes locally
- [x] I have linked related issues or discussions

## Related

Fixes #509

## Notes for Reviewers

The behavior was verified using pull requests originating from a fork:

- [Run #1](https://github.com/gh-sandbox-42/classic-diagnostic-adapter/actions/runs/32402044915) uploads the comment artifact but fails when the custom check-run step attempts to use unavailable write permissions.

- [Run #2](https://github.com/gh-sandbox-42/classic-diagnostic-adapter/actions/runs/32402169062) completes successfully, skips the direct write operations, and posts the comment through the trusted Post PR Comments workflow.