### PR TITLE
fix(doip): recover ECUs that are unreachable during discovery

### DIFF
--- a/cda-comm-doip/src/vir_vam.rs
+++ b/cda-comm-doip/src/vir_vam.rs
@@ -29,6 +29,31 @@ use crate::{
     connections::{GatewayState, handle_gateway_connection},
     socket::DoIPUdpSocket,
 };
+
+/// Delay between VIR re-broadcasts while a gateway is unconnected.
+const GATEWAY_REDISCOVERY_INTERVAL: Duration = Duration::from_secs(10);
+
+/// How often to re-broadcast before giving up. A gateway that stays silent this
+/// long is absent rather than slow, and announces itself when it boots.
+const GATEWAY_REDISCOVERY_ATTEMPTS: u8 = 3;
+
+/// Broadcasts a VIR on `gateway_port`. Entities answer with a VAM.
+async fn broadcast_vir(
+    socket: &mut DoIPUdpSocket,
+    gateway_port: u16,
+) -> Result<(), DiagServiceError> {
+    let target = format!("255.255.255.255:{gateway_port}")
+        .parse()
+        .map_err(|_| DiagServiceError::SendFailed("Invalid port".to_owned()))?;
+    socket
+        .send(
+            DoipPayload::VehicleIdentificationRequest(VehicleIdentificationRequest {}),
+            target,
+        )
+        .await
+        .map_err(|e| DiagServiceError::SendFailed(format!("Failed to send VIR: {e:?}")))
+}
+
 pub(crate) async fn get_vehicle_identification<T, F>(
     socket: &mut DoIPUdpSocket,
     netmask: u32,
@@ -40,18 +65,8 @@ where
     T: EcuAddresses,
     F: Future<Output = ()> + Send + 'static,
 {
-    // send VIR
     tracing::info!("Broadcasting VIR");
-    let broadcast_ip = "255.255.255.255";
-    socket
-        .send(
-            DoipPayload::VehicleIdentificationRequest(VehicleIdentificationRequest {}),
-            format!("{broadcast_ip}:{gateway_port}")
-                .parse()
-                .map_err(|_| DiagServiceError::SendFailed("Invalid port".to_owned()))?,
-        )
-        .await
-        .map_err(|e| DiagServiceError::SendFailed(format!("Failed to send VIR: {e:?}")))?;
+    broadcast_vir(socket, gateway_port).await?;
 
     let mut gateways = Vec::new();
 
@@ -292,6 +307,14 @@ where
                 }
             };
 
+            // `start()` broadcasts a VIR once. A gateway whose response is lost
+            // would otherwise stay unconnected until it announces itself. Every
+            // entity answers a broadcast, so this is bounded: it covers a lost
+            // response, not an absent gateway.
+            let mut rediscovery = tokio::time::interval(GATEWAY_REDISCOVERY_INTERVAL);
+            rediscovery.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            let mut rediscovery_left = GATEWAY_REDISCOVERY_ATTEMPTS;
+
             loop {
                 let mut socket_guard = broadcast_socket.lock().await;
                 // `start()` binds `state.socket` before spawning this task, so
@@ -306,6 +329,28 @@ where
                     biased;
                     () = &mut shutdown_signal => {
                         break
+                    },
+                    _ = rediscovery.tick(), if rediscovery_left > 0 => {
+                        let all_connected = {
+                            let connected = state.logical_address_to_connection.read().await;
+                            gateway_ecu_map
+                                .keys()
+                                .all(|addr| connected.contains_key(addr))
+                        };
+                        // Connections are only added, never dropped, so once
+                        // every gateway is known there is nothing left to find.
+                        if all_connected {
+                            rediscovery_left = 0;
+                        } else {
+                            rediscovery_left = rediscovery_left.saturating_sub(1);
+                            tracing::debug!(
+                                attempts_left = rediscovery_left,
+                                "Gateway unconnected, re-broadcasting VIR"
+                            );
+                            if let Err(error) = broadcast_vir(socket, transport_config.port).await {
+                                tracing::warn!(%error, "Failed to re-broadcast VIR");
+                            }
+                        }
                     },
                     response = socket.recv() => {
                         match response {

--- a/cda-comm-uds/src/variant.rs
+++ b/cda-comm-uds/src/variant.rs
@@ -274,7 +274,9 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
                     ecu_name = %ecu_name,
                     "Skip variant detection for functional description"
                 );
-                continue;
+                // No `continue`: the ECU is still scheduled below to pick up the
+                // offline-verdict retries. Without them a transient
+                // unreachability here is never re-checked.
             }
             if let Err(DiagServiceError::EcuOffline(_)) =
                 self.gateway.ecu_online(ecu_name, db).await
@@ -644,15 +646,18 @@ impl<S: EcuGateway, T: EcuManager> CommunicationVariantDetection for UdsManager<
 #[cfg(test)]
 mod tests {
     use cda_interfaces::{Connectivity, VariantState};
+    use tokio::{sync::OwnedMutexGuard, task::JoinHandle};
 
     use super::{DetectionPermit, DetectionTrigger, claim_detection};
     use crate::coordinator::EcuCoordinatorHandle;
 
-    #[tokio::test]
-    async fn queued_automatic_detection_is_skipped_after_success() {
+    async fn queue_automatic_detection() -> (
+        EcuCoordinatorHandle,
+        OwnedMutexGuard<()>,
+        JoinHandle<DetectionPermit>,
+    ) {
         let handle = EcuCoordinatorHandle::spawn("TestECU".to_owned());
         let in_flight = handle.begin_detection().await.expect("first entrant");
-
         let queued_handle = handle.clone();
         let queued = tokio::spawn(async move {
             claim_detection(
@@ -663,6 +668,12 @@ mod tests {
             .await
         });
         tokio::task::yield_now().await;
+        (handle, in_flight, queued)
+    }
+
+    #[tokio::test]
+    async fn queued_automatic_detection_is_skipped_after_success() {
+        let (handle, in_flight, queued) = queue_automatic_detection().await;
 
         {
             let mut state = handle.state.ecu_state.write().unwrap();
@@ -683,19 +694,7 @@ mod tests {
 
     #[tokio::test]
     async fn queued_automatic_detection_runs_when_still_needed() {
-        let handle = EcuCoordinatorHandle::spawn("TestECU".to_owned());
-        let in_flight = handle.begin_detection().await.expect("first entrant");
-
-        let queued_handle = handle.clone();
-        let queued = tokio::spawn(async move {
-            claim_detection(
-                Some(&queued_handle),
-                Some(&queued_handle),
-                DetectionTrigger::IfNeeded,
-            )
-            .await
-        });
-        tokio::task::yield_now().await;
+        let (_, in_flight, queued) = queue_automatic_detection().await;
         drop(in_flight);
 
         assert!(


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Two discovery paths could permanently latch a transient ECU unreachability:

- Re-broadcast the DoIP Vehicle Identification Request every 10 seconds, up to three attempts, while a gateway remains unconnected.
- Continue scheduling an ECU after it is marked offline during variant detection so its configured offline-verdict retry budget can recover transient failures.

## Checklist

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related


## Notes for Reviewers

This _should_ fix a flaky integration tests where some ECUs in the mixed case are not detected properly. I was not able to reproduce the issue locally or in the CI so far again. 

---

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
