### PR TITLE
fix(uds): use tester-present communication parameters

### DIFF
--- a/cda-comm-uds/src/test_helpers.rs
+++ b/cda-comm-uds/src/test_helpers.rs
@@ -35,6 +35,8 @@ pub(crate) struct TestEcuDb {
     /// receive errors. Defaults to 2 to match the `CP_RepeatReqCountApp`
     /// comparam default.
     repeat_req_count_app: u32,
+    tester_present_message: Vec<u8>,
+    tester_present_response_expected: bool,
 }
 
 impl TestEcuDb {
@@ -43,6 +45,8 @@ impl TestEcuDb {
             service_states: tokio::sync::Mutex::new(std::collections::HashMap::new()),
             timeout_default: Duration::from_secs(5),
             repeat_req_count_app: 2,
+            tester_present_message: vec![0x3E, 0x00],
+            tester_present_response_expected: true,
         }
     }
 
@@ -52,6 +56,8 @@ impl TestEcuDb {
             service_states: tokio::sync::Mutex::new(std::collections::HashMap::new()),
             timeout_default,
             repeat_req_count_app: 2,
+            tester_present_message: vec![0x3E, 0x00],
+            tester_present_response_expected: true,
         }
     }
 
@@ -65,6 +71,22 @@ impl TestEcuDb {
             service_states: tokio::sync::Mutex::new(std::collections::HashMap::new()),
             timeout_default,
             repeat_req_count_app,
+            tester_present_message: vec![0x3E, 0x00],
+            tester_present_response_expected: true,
+        }
+    }
+
+    /// Create a test double with explicit tester-present communication parameters.
+    pub fn with_tester_present_config(
+        tester_present_message: Vec<u8>,
+        tester_present_response_expected: bool,
+    ) -> Self {
+        Self {
+            service_states: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            timeout_default: Duration::from_secs(5),
+            repeat_req_count_app: 2,
+            tester_present_message,
+            tester_present_response_expected,
         }
     }
 }
@@ -131,14 +153,14 @@ impl UdsComParams for TestEcuDb {
     fn tester_present_addr_mode(self) -> AddressingMode {
         unimplemented!()
     }
-    fn tester_present_response_expected(self) -> bool {
-        unimplemented!()
+    fn tester_present_response_expected(&self) -> bool {
+        self.tester_present_response_expected
     }
     fn tester_present_send_type(self) -> TesterPresentSendType {
         unimplemented!()
     }
-    fn tester_present_message(self) -> Vec<u8> {
-        unimplemented!()
+    fn tester_present_message(&self) -> Vec<u8> {
+        self.tester_present_message.clone()
     }
     fn tester_present_exp_pos_resp(self) -> Vec<u8> {
         unimplemented!()

--- a/cda-comm-uds/src/tester_present.rs
+++ b/cda-comm-uds/src/tester_present.rs
@@ -14,8 +14,8 @@
 use async_trait::async_trait;
 use cda_interfaces::{
     Connectivity, DiagServiceError, EcuGateway, EcuManager, SUPPRESS_POSITIVE_RESPONSE_BIT,
-    ServicePayload, TesterPresentControlMessage, TesterPresentMode, TesterPresentType,
-    UdsFunctionalGroup, UdsTesterPresent, dlt_ctx, service_ids,
+    ServicePayload, TesterPresentControlMessage, TesterPresentMode, TesterPresentType, UdsEcuDb,
+    UdsFunctionalGroup, UdsTesterPresent, VariantDetection, dlt_ctx,
 };
 use tokio::time::{MissedTickBehavior, interval as tokio_interval};
 
@@ -138,29 +138,50 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
             }
         }
     }
+}
 
+impl<S: EcuGateway, T: UdsEcuDb + VariantDetection> UdsManager<S, T> {
     /// Send a single tester present message to the ECU.
     async fn send_tester_present(
         &self,
         control_msg: &TesterPresentControlMessage,
     ) -> Result<(), DiagServiceError> {
-        let payload = {
+        let (mut data, expect_response, source_address, target_address) = {
             let ecu = self.uds_ecu_db(&control_msg.ecu)?;
+            let ecu = ecu.read().await;
             let target_address = match &control_msg.type_ {
-                TesterPresentType::Functional(_) => ecu.read().await.logical_functional_address(),
-                TesterPresentType::Ecu(_) => ecu.read().await.logical_address(),
+                TesterPresentType::Functional(_) => ecu.logical_functional_address(),
+                TesterPresentType::Ecu(_) => ecu.logical_address(),
             };
-            ServicePayload {
-                data: vec![service_ids::TESTER_PRESENT, SUPPRESS_POSITIVE_RESPONSE_BIT],
-                source_address: ecu.read().await.tester_address(),
+            (
+                ecu.tester_present_message(),
+                ecu.tester_present_response_expected(),
+                ecu.tester_address(),
                 target_address,
-                new_session: None,
-                new_security: None,
-            }
+            )
+        };
+
+        let subfunction = data.get_mut(1).ok_or_else(|| {
+            DiagServiceError::BadPayload(
+                "Configured tester present message must contain a subfunction byte".to_owned(),
+            )
+        })?;
+        if expect_response {
+            *subfunction &= !SUPPRESS_POSITIVE_RESPONSE_BIT;
+        } else {
+            *subfunction |= SUPPRESS_POSITIVE_RESPONSE_BIT;
+        }
+
+        let payload = ServicePayload {
+            data,
+            source_address,
+            target_address,
+            new_session: None,
+            new_security: None,
         };
 
         match self
-            .send_with_raw_payload(&control_msg.ecu, payload, None, false)
+            .send_with_raw_payload(&control_msg.ecu, payload, None, expect_response)
             .await
         {
             Ok(_) => Ok(()),
@@ -263,5 +284,178 @@ impl<S: EcuGateway, T: EcuManager> UdsTesterPresent for UdsManager<S, T> {
                     .all(|ecu| tester_presents.get(ecu).is_some())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex as StdMutex, atomic::AtomicBool};
+
+    use cda_interfaces::{
+        DiagServiceError, EcuAddresses, EcuRuntimeState, FunctionalTransport, HashMap,
+        HashMapExtensions, NetworkTopology, PhysicalTransport, ServicePayload,
+        TransmissionParameters, TransportResponse, UDS_ID_RESPONSE_BITMASK, datatypes::FaultConfig,
+        service_ids,
+    };
+    use tokio::sync::{RwLock, mpsc};
+
+    use super::*;
+    use crate::{EcuStateCoordinator, test_helpers::TestEcuDb};
+
+    type CapturedSends = Arc<StdMutex<Vec<(Vec<u8>, bool)>>>;
+
+    #[derive(Clone, Default)]
+    struct CaptureGateway {
+        sends: CapturedSends,
+    }
+
+    impl PhysicalTransport for CaptureGateway {
+        fn send(
+            &self,
+            _transmission_params: TransmissionParameters,
+            message: ServicePayload,
+            response_sender: mpsc::Sender<Result<Option<TransportResponse>, DiagServiceError>>,
+            expect_uds_reply: bool,
+        ) -> impl Future<Output = Result<tokio::task::JoinHandle<()>, DiagServiceError>> + Send
+        {
+            let sends = Arc::clone(&self.sends);
+            async move {
+                sends
+                    .lock()
+                    .unwrap()
+                    .push((message.data.clone(), expect_uds_reply));
+
+                let response = if expect_uds_reply {
+                    let subfunction = message.data.get(1).copied().unwrap_or_default();
+                    Some(TransportResponse::UdsResponse(ServicePayload {
+                        data: vec![
+                            service_ids::TESTER_PRESENT | UDS_ID_RESPONSE_BITMASK,
+                            subfunction & !SUPPRESS_POSITIVE_RESPONSE_BIT,
+                        ],
+                        source_address: message.target_address,
+                        target_address: message.source_address,
+                        new_session: None,
+                        new_security: None,
+                    }))
+                } else {
+                    None
+                };
+                response_sender.try_send(Ok(response)).unwrap();
+                Ok(tokio::task::spawn(std::future::ready(())))
+            }
+        }
+
+        fn ecu_online<T: EcuAddresses>(
+            &self,
+            _ecu_name: &str,
+            _ecu_db: &RwLock<T>,
+        ) -> impl Future<Output = Result<(), DiagServiceError>> + Send {
+            std::future::ready(Ok(()))
+        }
+    }
+
+    impl FunctionalTransport for CaptureGateway {
+        fn send_functional(
+            &self,
+            _transmission_params: TransmissionParameters,
+            _message: ServicePayload,
+            _expected_ecu_logical_addrs: HashMap<u16, String>,
+            _timeout: std::time::Duration,
+            _expect_positive_response: bool,
+        ) -> impl Future<
+            Output = Result<
+                HashMap<String, Result<ServicePayload, DiagServiceError>>,
+                DiagServiceError,
+            >,
+        > + Send {
+            std::future::ready(Ok(HashMap::new()))
+        }
+    }
+
+    impl NetworkTopology for CaptureGateway {
+        fn get_gateway_network_address(
+            &self,
+            _logical_address: u16,
+        ) -> impl Future<Output = Option<String>> + Send {
+            std::future::ready(None)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl cda_interfaces::Shutdown for CaptureGateway {
+        async fn shutdown(&self) {}
+    }
+
+    fn make_manager(
+        gateway: CaptureGateway,
+        ecu: TestEcuDb,
+    ) -> UdsManager<CaptureGateway, TestEcuDb> {
+        let ecus = Arc::new(HashMap::from_iter([(
+            "TestECU".to_string(),
+            RwLock::new(ecu),
+        )]));
+        let runtime_states = HashMap::from_iter([("TestECU".to_string(), EcuRuntimeState::new())]);
+        let (redetect_tx, _redetect_rx) = mpsc::channel(1);
+
+        UdsManager {
+            ecus,
+            gateway,
+            data_transfers: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            ecu_semaphores: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            tester_present_tasks: Arc::new(RwLock::new(HashMap::new())),
+            session_reset_tasks: Arc::new(RwLock::new(HashMap::new())),
+            security_reset_tasks: Arc::new(RwLock::new(HashMap::new())),
+            state_coordinator: EcuStateCoordinator::new(runtime_states, redetect_tx),
+            functional_description_database: String::new(),
+            fault_config: FaultConfig::default(),
+            update_in_progress: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    fn tester_present_control() -> TesterPresentControlMessage {
+        TesterPresentControlMessage {
+            mode: TesterPresentMode::Start,
+            type_: TesterPresentType::Ecu("TestECU".to_string()),
+            ecu: "TestECU".to_string(),
+            interval: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn tester_present_uses_configured_message_when_response_is_expected() {
+        let gateway = CaptureGateway::default();
+        let manager = make_manager(
+            gateway.clone(),
+            TestEcuDb::with_tester_present_config(vec![0x3E, 0x00], true),
+        );
+
+        manager
+            .send_tester_present(&tester_present_control())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *gateway.sends.lock().unwrap(),
+            vec![(vec![0x3E, 0x00], true)]
+        );
+    }
+
+    #[tokio::test]
+    async fn tester_present_sets_suppress_bit_when_response_is_not_expected() {
+        let gateway = CaptureGateway::default();
+        let manager = make_manager(
+            gateway.clone(),
+            TestEcuDb::with_tester_present_config(vec![0x3E, 0x00], false),
+        );
+
+        manager
+            .send_tester_present(&tester_present_control())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *gateway.sends.lock().unwrap(),
+            vec![(vec![0x3E, 0x80], false)]
+        );
     }
 }

--- a/cda-core/src/diag_kernel/comparam.rs
+++ b/cda-core/src/diag_kernel/comparam.rs
@@ -33,13 +33,13 @@ impl<S: SecurityPlugin> cda_interfaces::UdsComParams for EcuManager<S> {
     fn tester_present_addr_mode(self) -> AddressingMode {
         self.tester_present_addr_mode.clone()
     }
-    fn tester_present_response_expected(self) -> bool {
+    fn tester_present_response_expected(&self) -> bool {
         self.tester_present_response_expected
     }
     fn tester_present_send_type(self) -> TesterPresentSendType {
         self.tester_present_send_type.clone()
     }
-    fn tester_present_message(self) -> Vec<u8> {
+    fn tester_present_message(&self) -> Vec<u8> {
         self.tester_present_message.clone()
     }
     fn tester_present_exp_pos_resp(self) -> Vec<u8> {

--- a/cda-interfaces/src/com_param_handling.rs
+++ b/cda-interfaces/src/com_param_handling.rs
@@ -24,11 +24,11 @@ pub trait UdsComParams: Send + Sync + 'static {
     #[must_use]
     fn tester_present_addr_mode(self) -> AddressingMode;
     #[must_use]
-    fn tester_present_response_expected(self) -> bool;
+    fn tester_present_response_expected(&self) -> bool;
     #[must_use]
     fn tester_present_send_type(self) -> TesterPresentSendType;
     #[must_use]
-    fn tester_present_message(self) -> Vec<u8>;
+    fn tester_present_message(&self) -> Vec<u8>;
     #[must_use]
     fn tester_present_exp_pos_resp(self) -> Vec<u8>;
     #[must_use]


### PR DESCRIPTION
## Summary

* Build tester-present requests from `CP_TesterPresentMessage`
* Derive the suppress-positive-response bit and transport response expectation from `CP_TesterPresentReqResp`
* Reject configured tester-present messages without a subfunction byte
* Add transport-boundary coverage for both response modes

Fixes #412.

## Reproduction

On current `main`, the transport-boundary probe captured:

```text
actual:   [([0x3E, 0x80], false)]
expected: [([0x3E, 0x00], true)]
```

The hard-coded request ignored the ECU communication parameters.

## Verification

Targeted regression tests:

```text
cargo test --locked -p cda-comm-uds tester_present::tests
2 passed; 0 failed
```

Adjacent unit tests:

```text
cargo test --locked -p cda-interfaces -p cda-core -p cda-comm-uds --lib
378 passed; 0 failed
```

Additional checks:

```text
cargo +nightly-2026-07-21 fmt --all -- --check
cargo +nightly-2026-07-21 clippy --locked -p cda-interfaces -p cda-core -p cda-comm-uds --all-targets
```

Both completed successfully.

This was verified at CDA’s software transport boundary. No physical ECU or vehicle was used.
