### PR TITLE
fix(can): Replace the std::convert::Infallible with enum

### DIFF
--- a/cda-comm-can/src/lib.rs
+++ b/cda-comm-can/src/lib.rs
@@ -53,9 +53,7 @@ pub use gateway::{CanDiagGateway, error};
 /// needed for type-checking and is statically unreachable.
 #[cfg(not(feature = "can"))]
 #[derive(Clone)]
-pub struct CanDiagGateway {
-    _unconstructable: std::convert::Infallible,
-}
+pub enum CanDiagGateway {}
 
 #[cfg(not(feature = "can"))]
 impl PhysicalTransport for CanDiagGateway {
@@ -116,27 +114,15 @@ impl FunctionalTransport for CanDiagGateway {
 #[async_trait]
 impl TransportControl for CanDiagGateway {
     async fn enable(&self) -> Result<(), CommControlError> {
-        #[allow(
-            clippy::used_underscore_binding,
-            reason = "Type is unconstructable, this match is unreachable"
-        )]
-        match self._unconstructable {}
+        match *self {}
     }
 
     async fn disable(&self) -> Result<(), CommControlError> {
-        #[allow(
-            clippy::used_underscore_binding,
-            reason = "Type is unconstructable, this match is unreachable"
-        )]
-        match self._unconstructable {}
+        match *self {}
     }
 
     async fn state(&self) -> TransportState {
-        #[allow(
-            clippy::used_underscore_binding,
-            reason = "Type is unconstructable, this match is unreachable"
-        )]
-        match self._unconstructable {}
+        match *self {}
     }
 }
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
An empty enum expresses the uninhabited type directly and more clearly on stable Rust.

Closes #514

## Checklist
- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
Closes #514

## Notes for Reviewers

---
Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)