### PR TITLE
refactor(uds): gate the remaining UDS entry points

### DIFF
--- a/cda-comm-uds/src/data_transfer.rs
+++ b/cda-comm-uds/src/data_transfer.rs
@@ -191,6 +191,7 @@ impl<S: EcuGateway, T: EcuManager> UdsDataTransfer for UdsManager<S, T> {
         security_plugin: &DynamicPlugin,
         parameters: FlashTransferStartParams<'_>,
     ) -> Result<(), DiagServiceError> {
+        let communication_guard = self.require_communication_ready()?;
         let ecu = self.uds_ecu_variant_detection_concluded(ecu_name).await?;
 
         let FlashTransferStartParams {
@@ -244,14 +245,6 @@ impl<S: EcuGateway, T: EcuManager> UdsDataTransfer for UdsManager<S, T> {
         let ecu_name_clone = ecu_name.clone();
 
         let (sender, receiver) = watch::channel::<bool>(false);
-
-        // Shared access keeps this transfer from overlapping an exclusive
-        // operation, e.g. a communication shutdown or a flash transfer.
-        let communication_guard = self.communication_access.acquire().map_err(|error| {
-            self.build_communication_not_ready_err(format!(
-                "Diagnostic communication unavailable: {error}"
-            ))
-        })?;
 
         // Check-and-insert under a single mutex hold, so concurrent requests for
         // the same ECU are serialized.

--- a/cda-comm-uds/src/dtc.rs
+++ b/cda-comm-uds/src/dtc.rs
@@ -216,6 +216,7 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
         ),
         DiagServiceError,
     > {
+        let _communication_guard = self.require_communication_ready()?;
         let ecu = self.uds_ecu_db(ecu_name)?;
         let (read_func, extended_data_lookup) = ecu
             .read()
@@ -463,6 +464,7 @@ impl<S: EcuGateway, T: EcuManager> UdsDtc for UdsManager<S, T> {
         scope: Option<String>,
         memory_selection: Option<u8>,
     ) -> Result<HashMap<DtcCode, DtcRecordAndStatus>, DiagServiceError> {
+        let _communication_guard = self.require_communication_ready()?;
         let ecu = self.uds_ecu_variant_detection_concluded(ecu_name).await?;
         let mut all_dtcs = HashMap::new();
         let scoped_services: Vec<_> = ecu
@@ -644,6 +646,7 @@ impl<S: EcuGateway, T: EcuManager> UdsDtc for UdsManager<S, T> {
         security_plugin: &DynamicPlugin,
         fault_code: Option<String>,
     ) -> Result<Self::Response, DiagServiceError> {
+        let _communication_guard = self.require_communication_ready()?;
         let ecu = self.uds_ecu_variant_detection_concluded(ecu_name).await?;
 
         let delete_dtc_service = ecu.read().await.lookup_service_through_func_class(
@@ -703,36 +706,37 @@ impl<S: EcuGateway, T: EcuManager> UdsDtc for UdsManager<S, T> {
         security_plugin: &DynamicPlugin,
         scope: &str,
     ) -> Result<Self::Response, DiagServiceError> {
+        let _communication_guard = self.require_communication_ready()?;
         let ecu = self.uds_ecu_variant_detection_concluded(ecu_name).await?;
+        let fault_config = &self.fault_config;
 
         // If the requested scope is the default scope, delegate to the standard delete_dtcs path.
-        if scope.eq_ignore_ascii_case(&self.fault_config.default_scope) {
+        if scope.eq_ignore_ascii_case(&fault_config.default_scope) {
             return self.delete_dtcs(ecu_name, security_plugin, None).await;
         }
 
         // When a user-defined scope is provided, use the configured custom
         // clear service (e.g. RoutineControl 31 01 42 00) via `self.send`
         // which does not require any additional parameters, per definition.
-        if !scope.eq_ignore_ascii_case(&self.fault_config.user_memory_scope) {
+        if !scope.eq_ignore_ascii_case(&fault_config.user_memory_scope) {
             return Err(DiagServiceError::InvalidParameter {
                 possible_values: HashSet::from_iter([
-                    self.fault_config.default_scope.clone(),
-                    self.fault_config.user_memory_scope.clone(),
+                    fault_config.default_scope.clone(),
+                    fault_config.user_memory_scope.clone(),
                 ]),
             });
         }
 
-        let user_defined_dtc_clear_service = self
-            .fault_config
+        let user_defined_dtc_clear_service = fault_config
             .user_defined_dtc_clear_service
             .as_ref()
             .ok_or_else(|| {
-                DiagServiceError::InvalidConfiguration(
-                    "User defined DTC scope name is not set in the configuration, but custom \
-                     scope clear is requested"
-                        .to_owned(),
-                )
-            })?;
+            DiagServiceError::InvalidConfiguration(
+                "User defined DTC scope name is not set in the configuration, but custom scope \
+                 clear is requested"
+                    .to_owned(),
+            )
+        })?;
 
         let delete_dtc_service = ecu
             .read()

--- a/cda-comm-uds/src/lib.rs
+++ b/cda-comm-uds/src/lib.rs
@@ -238,6 +238,7 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
         params: HashMap<String, serde_json::Value>,
         map_to_json: bool,
     ) -> Result<<T as cda_interfaces::PayloadDecoder>::Response, DiagServiceError> {
+        let _communication_guard = self.require_communication_ready()?;
         // Look up the service definition in the MDD database using the same
         // approach as lookup_diagcomms_by_request_prefix - matches against
         // coded constant parameter values in the database.
@@ -298,6 +299,7 @@ impl<S: EcuGateway, T: EcuManager> UdsManager<S, T> {
         params: HashMap<String, serde_json::Value>,
         map_to_json: bool,
     ) -> Result<<T as cda_interfaces::PayloadDecoder>::Response, DiagServiceError> {
+        let _communication_guard = self.require_communication_ready()?;
         let ecu = self.uds_ecu_db(ecu_name)?;
         let diag_comm = ecu
             .read()


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

DTC read, extended-data read, and both DTC clear paths sent requests without checking that diagnostic communication was enabled, and the flash transfer acquired `communication_access` directly and built its own error message.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Part 2 in the series of pull requests to refactor the CDA runtime update plugin infrastructure. 
This commit prepares correctness of the UDS communication gate, which will be required to make sure the ECU database can be updated / replaced, without affecting publicly visible components. 
It is required, to make sure that no one tries further communication during the 'disable' stage of communication. 
Strictly speaking this is a correctness fix for #503 


Also note that although the pull requests in this stack build upon each other, they can be merged independent or together. I am mainly splitting this into multiple PRs to have more digestible review hunks instead of one rather large pull request.  


Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)