### PR TITLE
fix(cda-sovd): use RAII instead of manually tracking states

### DIFF
--- a/cda-sovd/src/sovd.rs
+++ b/cda-sovd/src/sovd.rs
@@ -157,9 +157,12 @@ pub(crate) fn acquire_communication_activity(
 /// operations, `FgServiceExecution` for functional-group operations).
 pub(crate) trait ExecutionStatus {
     fn execution_status(&self) -> &sovd_ecu::operations::ExecutionStatus;
-    /// Returns `true` if a request for this execution is currently being processed.
-    /// Used to avoid sending multiple UDS requests simultaneously for the same execution.
+    /// Returns `true` if an HTTP handler currently has exclusive processing access to this
+    /// execution. Used to avoid sending multiple UDS requests simultaneously for the same
+    /// execution.
     fn is_in_flight(&self) -> bool;
+    /// Sets whether an HTTP handler currently has exclusive processing access to this execution.
+    /// This is independent of the diagnostic execution status.
     fn set_in_flight(&mut self, in_flight: bool);
     /// Should return `false` if an execution was created as a placeholder,
     /// but not finalized.
@@ -273,6 +276,8 @@ impl std::ops::DerefMut for ComparamExecution {
 pub(crate) struct ServiceExecution {
     pub parameters: serde_json::Map<String, serde_json::Value>,
     pub status: sovd_ecu::operations::ExecutionStatus,
+    /// Whether an HTTP handler currently has exclusive processing access to this execution.
+    /// This is independent of the diagnostic execution status.
     pub in_flight: bool,
     pub is_created: bool,
     communication_lease: Option<ExecutionLease>,
@@ -333,6 +338,8 @@ impl ExecutionStatus for ServiceExecution {
 pub(crate) struct FgServiceExecution {
     pub parameters: HashMap<String, serde_json::Map<String, serde_json::Value>>,
     pub status: sovd_ecu::operations::ExecutionStatus,
+    /// Whether an HTTP handler currently has exclusive processing access to this execution.
+    /// This is independent of the diagnostic execution status.
     pub in_flight: bool,
     pub is_created: bool,
     communication_lease: Option<ExecutionLease>,
@@ -437,39 +444,75 @@ impl LockStateProvider for SovdLockStateProvider {
     }
 }
 
+/// Resets an execution's request-level concurrency marker when processing ends or is cancelled.
+pub(crate) struct ExecutionRequestGuard<'a, T: ExecutionStatus> {
+    executions: &'a ExecutionLock<T>,
+    service: String,
+    exec_id: Uuid,
+    snapshot: T,
+}
+
+impl<T: ExecutionStatus> ExecutionRequestGuard<'_, T> {
+    pub(crate) fn snapshot(&self) -> &T {
+        &self.snapshot
+    }
+}
+
+impl<T: ExecutionStatus> Drop for ExecutionRequestGuard<'_, T> {
+    fn drop(&mut self) {
+        if let Some(exec) = lock_write(self.executions)
+            .get_mut(&self.service)
+            .and_then(|entries| entries.get_mut(&self.exec_id))
+        {
+            exec.set_in_flight(false);
+        }
+    }
+}
+
 /// Acquires a write lock on `executions`, looks up `exec_id` under the given
-/// `service` key, marks it `in_flight = true`, and returns a clone of the
-/// execution.  Returns `Err(ErrorWrapper)` (with the lock released) on
-/// not-found or in-flight conflict.
-pub(crate) fn guard_execution<T: ExecutionStatus + Clone>(
-    executions: &ExecutionLock<T>,
+/// `service` key, marks it `in_flight = true`, and returns a guard containing a
+/// snapshot of the execution. Returns `Err(ErrorWrapper)` on not-found or conflict.
+pub(crate) fn guard_execution<'a, T: ExecutionStatus + Clone>(
+    executions: &'a ExecutionLock<T>,
     service: &str,
     exec_id: Uuid,
     include_schema: bool,
     conflict_msg: &str,
-) -> Result<T, error::ErrorWrapper> {
-    let mut guard = lock_write(executions);
-    let op_map = guard
-        .get_mut(service)
-        .and_then(|m| m.get_mut(&exec_id))
-        // Treat placeholders (is_created == false) as non-existent.
-        .filter(|e| e.is_created());
-    match op_map {
-        None => Err(error::ErrorWrapper {
-            error: error::ApiError::NotFound(Some(format!(
-                "Execution with id {exec_id} not found"
-            ))),
-            include_schema,
-        }),
-        Some(exec) if exec.is_in_flight() => Err(error::ErrorWrapper {
-            error: error::ApiError::Conflict(conflict_msg.to_owned()),
-            include_schema,
-        }),
-        Some(exec) => {
-            exec.set_in_flight(true);
-            Ok(exec.clone())
+) -> Result<ExecutionRequestGuard<'a, T>, error::ErrorWrapper> {
+    let snapshot = {
+        let mut guard = lock_write(executions);
+        let op_map = guard
+            .get_mut(service)
+            .and_then(|m| m.get_mut(&exec_id))
+            // Treat placeholders (is_created == false) as non-existent.
+            .filter(|e| e.is_created());
+        match op_map {
+            None => {
+                return Err(error::ErrorWrapper {
+                    error: error::ApiError::NotFound(Some(format!(
+                        "Execution with id {exec_id} not found"
+                    ))),
+                    include_schema,
+                });
+            }
+            Some(exec) if exec.is_in_flight() => {
+                return Err(error::ErrorWrapper {
+                    error: error::ApiError::Conflict(conflict_msg.to_owned()),
+                    include_schema,
+                });
+            }
+            Some(exec) => {
+                exec.set_in_flight(true);
+                exec.clone()
+            }
         }
-    }
+    };
+    Ok(ExecutionRequestGuard {
+        executions,
+        service: service.to_owned(),
+        exec_id,
+        snapshot,
+    })
 }
 
 /// Checks for a running-execution conflict and, if none exists,
@@ -1425,6 +1468,48 @@ pub(crate) mod tests {
         };
         assert_eq!(retry_after, Some(Duration::from_secs(7)));
         assert_eq!(vendor_code, Some(VendorErrorCode::CommunicationNotReady));
+    }
+
+    #[test]
+    fn request_guard_drop_resets_in_flight() {
+        let exec_id = Uuid::new_v4();
+        let mut entries = IndexMap::new();
+        entries.insert(
+            exec_id,
+            ServiceExecution {
+                parameters: serde_json::Map::new(),
+                status: sovd_ecu::operations::ExecutionStatus::Running,
+                in_flight: false,
+                is_created: true,
+                communication_lease: None,
+            },
+        );
+        let executions = StdRwLock::new(HashMap::from_iter([("routine".to_owned(), entries)]));
+
+        let Ok(request_guard) = guard_execution(
+            &executions,
+            "routine",
+            exec_id,
+            false,
+            "execution already in flight",
+        ) else {
+            panic!("execution must be guarded");
+        };
+        assert!(
+            lock_read(&executions)
+                .get("routine")
+                .and_then(|entries| entries.get(&exec_id))
+                .is_some_and(|execution| execution.in_flight)
+        );
+
+        drop(request_guard);
+
+        assert!(
+            lock_read(&executions)
+                .get("routine")
+                .and_then(|entries| entries.get(&exec_id))
+                .is_some_and(|execution| !execution.in_flight)
+        );
     }
 
     #[test]

--- a/cda-sovd/src/sovd.rs
+++ b/cda-sovd/src/sovd.rs
@@ -11,7 +11,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    path::PathBuf,
+    sync::{Arc, RwLock as StdRwLock},
+    time::Duration,
+};
 
 pub mod request_guard;
 
@@ -40,6 +44,7 @@ use cda_interfaces::{
     diagservices::{FieldParseError, UdsPayloadData},
     file_manager::FileManager,
     runtime_update_api::LockStateProvider,
+    util::std_ext::lock_write,
 };
 use cda_plugin_security::{SecurityPluginLoader, security_plugin_middleware};
 use error::{ApiError, api_error_from_diag_response};
@@ -52,7 +57,7 @@ use sovd_interfaces::{
     components::{ComponentsResponse, ecu as sovd_ecu},
     error::DataError,
 };
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::RwLock;
 use uuid::Uuid;
 
 use crate::{
@@ -103,28 +108,22 @@ pub(crate) enum SovdError {
     RouteError(String),
 }
 
+/// Synchronous lock for short execution-map operations so reservation cleanup can run in `Drop`.
+/// Lock guards must never be held across an `.await`.
+pub(crate) type ExecutionLock<E> = StdRwLock<HashMap<String, IndexMap<Uuid, E>>>;
+
 #[derive(Clone)]
 pub(crate) struct WebserverEcuState<T: UdsEcu + Clone, U: FileManager> {
     ecu_name: String,
     uds: T,
     locks: Arc<Locks>,
     // Map of Execution Id -> ComParamMap
-    comparam_executions: Arc<RwLock<IndexMap<Uuid, sovd_ecu::operations::comparams::Execution>>>,
-    // Guards replace sampled execution activity as the source of update exclusion.
-    communication_activities: Arc<Mutex<HashMap<Uuid, CommunicationGuard>>>,
+    comparam_executions: Arc<RwLock<IndexMap<Uuid, ComparamExecution>>>,
     communication_access: Arc<dyn CommunicationAccess>,
     // Map of Service Name -> (Execution Id -> ServiceExecution) for ECU routine operations
-    pub(crate) service_executions: Arc<RwLock<HashMap<String, IndexMap<Uuid, ServiceExecution>>>>,
+    pub(crate) service_executions: Arc<ExecutionLock<ServiceExecution>>,
     flash_data: Arc<RwLock<sovd_interfaces::sovd2uds::FileList>>,
     mdd_embedded_files: Arc<U>,
-}
-
-async fn release_communication_activity(
-    activities: &Mutex<HashMap<Uuid, CommunicationGuard>>,
-    id: &Uuid,
-) {
-    let activity = activities.lock().await.remove(id);
-    drop(activity);
 }
 
 pub(crate) fn with_retry_after(mut response: Response, retry_after: Option<Duration>) -> Response {
@@ -168,47 +167,134 @@ pub(crate) trait ExecutionStatus {
     fn set_created(&mut self, created: bool);
     /// Creates a placeholder entry used to reserve a slot in the executions map
     /// before the UDS command is sent.
-    fn placeholder() -> Self
+    fn placeholder(communication_guard: CommunicationGuard) -> Self
     where
         Self: Sized;
 }
 
-/// Owns cleanup for a reserved async operation execution and its communication lease.
-pub(crate) struct ExecutionGuard<E> {
-    executions: Arc<RwLock<HashMap<String, IndexMap<Uuid, E>>>>,
-    communication_activities: Arc<Mutex<HashMap<Uuid, CommunicationGuard>>>,
+/// Rolls back a newly inserted execution unless it is committed as asynchronous.
+/// The execution entry owns the communication lease; rollback releases it by removing the entry.
+pub(crate) struct ExecutionReservation<E> {
+    executions: Arc<ExecutionLock<E>>,
     service: String,
     exec_id: Uuid,
+    state: ReservationState,
 }
 
-impl<E: ExecutionStatus> ExecutionGuard<E> {
-    fn new(
-        executions: Arc<RwLock<HashMap<String, IndexMap<Uuid, E>>>>,
-        communication_activities: Arc<Mutex<HashMap<Uuid, CommunicationGuard>>>,
-        service: String,
-        exec_id: Uuid,
-    ) -> Self {
+#[derive(PartialEq)]
+enum ReservationState {
+    Pending,
+    Committed,
+}
+
+impl<E> ExecutionReservation<E> {
+    fn new(executions: Arc<ExecutionLock<E>>, service: String, exec_id: Uuid) -> Self {
         Self {
             executions,
-            communication_activities,
             service,
             exec_id,
+            state: ReservationState::Pending,
         }
     }
 
-    pub(crate) async fn cleanup(&self) {
-        remove_reserved_execution(&self.executions, &self.service, &self.exec_id).await;
-        release_communication_activity(&self.communication_activities, &self.exec_id).await;
+    /// Commits the reserved entry as a persistent asynchronous execution.
+    ///
+    /// The entry already owns the communication lease. While the reservation is pending, its
+    /// `Drop` removes that entry as a rollback. Committing disables only that rollback; the entry
+    /// remains stored and releases its lease automatically when it is completed or removed.
+    pub(crate) fn commit_async(mut self, update_fn: impl FnOnce(&mut E)) -> Uuid
+    where
+        E: ExecutionStatus,
+    {
+        finalize_execution(&self.executions, &self.service, &self.exec_id, update_fn);
+        self.state = ReservationState::Committed;
+        self.exec_id
+    }
+}
+
+impl<E> Drop for ExecutionReservation<E> {
+    fn drop(&mut self) {
+        if self.state == ReservationState::Pending {
+            remove_reserved_execution(&self.executions, &self.service, &self.exec_id);
+        }
+    }
+}
+
+/// Owns a communication-use slot; dropping it releases that slot.
+struct ExecutionLease {
+    _guard: CommunicationGuard,
+}
+
+impl std::fmt::Debug for ExecutionLease {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ExecutionLease")
+    }
+}
+
+pub(crate) struct ComparamExecution {
+    execution: sovd_ecu::operations::comparams::Execution,
+    _lease: ExecutionLease,
+}
+
+impl ComparamExecution {
+    pub(crate) fn new(
+        execution: sovd_ecu::operations::comparams::Execution,
+        communication_guard: CommunicationGuard,
+    ) -> Self {
+        Self {
+            execution,
+            _lease: ExecutionLease {
+                _guard: communication_guard,
+            },
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> sovd_ecu::operations::comparams::Execution {
+        self.execution.clone()
+    }
+}
+
+impl std::ops::Deref for ComparamExecution {
+    type Target = sovd_ecu::operations::comparams::Execution;
+
+    fn deref(&self) -> &Self::Target {
+        &self.execution
+    }
+}
+
+impl std::ops::DerefMut for ComparamExecution {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.execution
     }
 }
 
 /// Stored state for a single ECU routine execution (async lifecycle).
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct ServiceExecution {
     pub parameters: serde_json::Map<String, serde_json::Value>,
     pub status: sovd_ecu::operations::ExecutionStatus,
     pub in_flight: bool,
     pub is_created: bool,
+    communication_lease: Option<ExecutionLease>,
+}
+
+impl Clone for ServiceExecution {
+    fn clone(&self) -> Self {
+        Self {
+            parameters: self.parameters.clone(),
+            status: self.status.clone(),
+            in_flight: self.in_flight,
+            is_created: self.is_created,
+            communication_lease: None,
+        }
+    }
+}
+
+impl ServiceExecution {
+    pub(crate) fn complete(&mut self) {
+        self.status = sovd_ecu::operations::ExecutionStatus::Completed;
+        self.communication_lease = None;
+    }
 }
 
 impl ExecutionStatus for ServiceExecution {
@@ -227,12 +313,15 @@ impl ExecutionStatus for ServiceExecution {
     fn set_created(&mut self, created: bool) {
         self.is_created = created;
     }
-    fn placeholder() -> Self {
+    fn placeholder(communication_guard: CommunicationGuard) -> Self {
         ServiceExecution {
             parameters: serde_json::Map::new(),
             status: sovd_ecu::operations::ExecutionStatus::Running,
             in_flight: false,
             is_created: false,
+            communication_lease: Some(ExecutionLease {
+                _guard: communication_guard,
+            }),
         }
     }
 }
@@ -240,12 +329,32 @@ impl ExecutionStatus for ServiceExecution {
 /// Stored state for a functional-group routine execution (async lifecycle).
 /// Unlike `ServiceExecution`, parameters are keyed by ECU name so that
 /// per-ECU identity is preserved across the execution lifecycle.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct FgServiceExecution {
     pub parameters: HashMap<String, serde_json::Map<String, serde_json::Value>>,
     pub status: sovd_ecu::operations::ExecutionStatus,
     pub in_flight: bool,
     pub is_created: bool,
+    communication_lease: Option<ExecutionLease>,
+}
+
+impl Clone for FgServiceExecution {
+    fn clone(&self) -> Self {
+        Self {
+            parameters: self.parameters.clone(),
+            status: self.status.clone(),
+            in_flight: self.in_flight,
+            is_created: self.is_created,
+            communication_lease: None,
+        }
+    }
+}
+
+impl FgServiceExecution {
+    pub(crate) fn complete(&mut self) {
+        self.status = sovd_ecu::operations::ExecutionStatus::Completed;
+        self.communication_lease = None;
+    }
 }
 
 impl ExecutionStatus for FgServiceExecution {
@@ -264,12 +373,15 @@ impl ExecutionStatus for FgServiceExecution {
     fn set_created(&mut self, created: bool) {
         self.is_created = created;
     }
-    fn placeholder() -> Self {
+    fn placeholder(communication_guard: CommunicationGuard) -> Self {
         FgServiceExecution {
             parameters: HashMap::new(),
             status: sovd_ecu::operations::ExecutionStatus::Running,
             in_flight: false,
             is_created: false,
+            communication_lease: Some(ExecutionLease {
+                _guard: communication_guard,
+            }),
         }
     }
 }
@@ -329,14 +441,14 @@ impl LockStateProvider for SovdLockStateProvider {
 /// `service` key, marks it `in_flight = true`, and returns a clone of the
 /// execution.  Returns `Err(ErrorWrapper)` (with the lock released) on
 /// not-found or in-flight conflict.
-pub(crate) async fn guard_execution<T: ExecutionStatus + Clone>(
-    executions: &RwLock<HashMap<String, IndexMap<Uuid, T>>>,
+pub(crate) fn guard_execution<T: ExecutionStatus + Clone>(
+    executions: &ExecutionLock<T>,
     service: &str,
     exec_id: Uuid,
     include_schema: bool,
     conflict_msg: &str,
 ) -> Result<T, error::ErrorWrapper> {
-    let mut guard = executions.write().await;
+    let mut guard = lock_write(executions);
     let op_map = guard
         .get_mut(service)
         .and_then(|m| m.get_mut(&exec_id))
@@ -365,20 +477,20 @@ pub(crate) async fn guard_execution<T: ExecutionStatus + Clone>(
 /// operation will see a `409 Conflict`.
 ///
 /// On success the returned [`Uuid`] identifies the reserved execution slot.
-/// The caller **must** later call either [`finalize_execution`] (async
-/// success) or [`remove_reserved_execution`] (sync success / any error).
+/// The inserted placeholder owns the communication guard and releases it when
+/// the execution is completed or removed.
 ///
-/// The caller must already hold a communication guard. Runtime-update admission
-/// is enforced by the request guard and communication access, so this function
-/// only reserves a per-service execution slot.
-pub(crate) async fn reserve_execution<E: ExecutionStatus>(
-    executions: &RwLock<HashMap<String, IndexMap<Uuid, E>>>,
+/// Runtime-update admission is enforced by the request guard and communication
+/// access, so this function only reserves a per-service execution slot.
+pub(crate) fn reserve_execution<E: ExecutionStatus>(
+    executions: &ExecutionLock<E>,
     service: &str,
     display_name: &str,
     include_schema: bool,
     id: Uuid,
+    communication_guard: CommunicationGuard,
 ) -> Result<Uuid, error::ErrorWrapper> {
-    let mut guard = executions.write().await;
+    let mut guard = lock_write(executions);
     let has_running = guard.get(service).is_some_and(|m| {
         m.values()
             .any(|e| *e.execution_status() == sovd_ecu::operations::ExecutionStatus::Running)
@@ -391,7 +503,7 @@ pub(crate) async fn reserve_execution<E: ExecutionStatus>(
             include_schema,
         });
     }
-    let mut entry = E::placeholder();
+    let mut entry = E::placeholder(communication_guard);
     entry.set_in_flight(true);
     guard
         .entry(service.to_owned())
@@ -402,15 +514,14 @@ pub(crate) async fn reserve_execution<E: ExecutionStatus>(
 
 /// Publishes a communication lease before making its execution visible, so every
 /// visible execution has an owner that can release the lease.
-pub(crate) async fn acquire_and_reserve_execution<E: ExecutionStatus>(
+pub(crate) fn acquire_and_reserve_execution<E: ExecutionStatus>(
     communication_access: &dyn CommunicationAccess,
-    executions: Arc<RwLock<HashMap<String, IndexMap<Uuid, E>>>>,
-    communication_activities: Arc<Mutex<HashMap<Uuid, CommunicationGuard>>>,
+    executions: Arc<ExecutionLock<E>>,
     service: &str,
     display_name: &str,
     include_schema: bool,
-) -> Result<(Uuid, ExecutionGuard<E>), error::ErrorWrapper> {
-    let communication_activity =
+) -> Result<ExecutionReservation<E>, error::ErrorWrapper> {
+    let communication_guard =
         acquire_communication_activity(communication_access).map_err(|error| {
             error::ErrorWrapper {
                 error,
@@ -418,35 +529,31 @@ pub(crate) async fn acquire_and_reserve_execution<E: ExecutionStatus>(
             }
         })?;
     let exec_id = Uuid::new_v4();
-    communication_activities
-        .lock()
-        .await
-        .insert(exec_id, communication_activity);
-    if let Err(error) =
-        reserve_execution(&executions, service, display_name, include_schema, exec_id).await
-    {
-        release_communication_activity(&communication_activities, &exec_id).await;
-        return Err(error);
-    }
-    let guard = ExecutionGuard::new(
+    reserve_execution(
+        &executions,
+        service,
+        display_name,
+        include_schema,
+        exec_id,
+        communication_guard,
+    )?;
+    Ok(ExecutionReservation::new(
         executions,
-        communication_activities,
         service.to_owned(),
         exec_id,
-    );
-    Ok((exec_id, guard))
+    ))
 }
 
 /// Updates a previously reserved execution with the received parameters,
 /// sets `is_created(true)`, and clears the `in_flight` flag.
 /// After this step GET/DELETE requests can be called for this execution.
-pub(crate) async fn finalize_execution<E: ExecutionStatus>(
-    executions: &RwLock<HashMap<String, IndexMap<Uuid, E>>>,
+pub(crate) fn finalize_execution<E: ExecutionStatus>(
+    executions: &ExecutionLock<E>,
     service: &str,
     exec_id: &Uuid,
     update_fn: impl FnOnce(&mut E),
 ) {
-    let mut guard = executions.write().await;
+    let mut guard = lock_write(executions);
     if let Some(exec) = guard.get_mut(service).and_then(|m| m.get_mut(exec_id)) {
         update_fn(exec);
         exec.set_created(true);
@@ -454,15 +561,15 @@ pub(crate) async fn finalize_execution<E: ExecutionStatus>(
     }
 }
 
-/// Removes a previously reserved execution slot.  Called on error or after
+/// Removes a previously reserved execution slot. Called on error or after
 /// a synchronous operation completes (sync operations do not persist
 /// execution state).
-pub(crate) async fn remove_reserved_execution<E: ExecutionStatus>(
-    executions: &RwLock<HashMap<String, IndexMap<Uuid, E>>>,
+pub(crate) fn remove_reserved_execution<E>(
+    executions: &ExecutionLock<E>,
     service: &str,
     exec_id: &Uuid,
 ) {
-    let mut guard = executions.write().await;
+    let mut guard = lock_write(executions);
     if let Some(map) = guard.get_mut(service) {
         map.shift_remove(exec_id);
         if map.is_empty() {
@@ -693,9 +800,8 @@ fn ecu_route<T: UdsEcu + SchemaProvider + Clone, U: FileManager + 'static>(
         uds: state.uds.clone(),
         locks: Arc::<Locks>::clone(&state.locks),
         comparam_executions: Arc::new(RwLock::new(IndexMap::new())),
-        communication_activities: Arc::new(Mutex::new(HashMap::default())),
         communication_access: Arc::clone(&state.communication_access),
-        service_executions: Arc::new(RwLock::new(HashMap::default())),
+        service_executions: Arc::new(StdRwLock::new(HashMap::default())),
         flash_data: Arc::clone(&state.flash_data),
         mdd_embedded_files: Arc::new(file_manager.remove(&ecu_lower).ok_or_else(|| {
             SovdError::RouteError(format!(
@@ -1226,6 +1332,7 @@ pub(crate) mod tests {
             VariantDetectionMode,
         },
         file_manager::FileManager,
+        util::std_ext::lock_read,
     };
     use cda_plugin_communication_management::lifecycle::enabled_communication_access_for_test;
     use sovd_interfaces::sovd2uds::FileList;
@@ -1235,6 +1342,43 @@ pub(crate) mod tests {
 
     struct DeferredCommunicationAccess {
         activation_requests: AtomicUsize,
+    }
+
+    struct CountingCommunicationAccess {
+        active: Arc<AtomicUsize>,
+    }
+
+    struct CountingGuard(Arc<AtomicUsize>);
+
+    impl Drop for CountingGuard {
+        fn drop(&mut self) {
+            self.0.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    impl CommunicationAccess for CountingCommunicationAccess {
+        fn state(&self) -> CommunicationState {
+            CommunicationState::Enabled
+        }
+
+        fn acquire(&self) -> Result<CommunicationGuard, CommunicationError> {
+            self.active.fetch_add(1, Ordering::SeqCst);
+            Ok(CommunicationGuard::new(CountingGuard(Arc::clone(
+                &self.active,
+            ))))
+        }
+
+        fn request_activate(&self, _cause: ActivationCause) -> CommunicationState {
+            CommunicationState::Enabled
+        }
+
+        fn retry_after(&self) -> Duration {
+            Duration::ZERO
+        }
+
+        fn variant_detection(&self) -> VariantDetectionMode {
+            VariantDetectionMode::Always
+        }
     }
 
     impl CommunicationAccess for DeferredCommunicationAccess {
@@ -1283,42 +1427,109 @@ pub(crate) mod tests {
         assert_eq!(vendor_code, Some(VendorErrorCode::CommunicationNotReady));
     }
 
-    #[tokio::test]
-    async fn reservation_publishes_lease_with_execution_and_cleans_up_both() {
-        let executions = Arc::new(RwLock::new(HashMap::default()));
-        let activities = Arc::new(Mutex::new(HashMap::default()));
-        let access = enabled_communication_access_for_test();
+    #[test]
+    fn reservation_drop_releases_execution_and_lease() {
+        let executions = Arc::new(StdRwLock::new(HashMap::default()));
+        let active = Arc::new(AtomicUsize::new(0));
+        let access = CountingCommunicationAccess {
+            active: Arc::clone(&active),
+        };
 
-        let result = acquire_and_reserve_execution::<ServiceExecution>(
-            &*access,
+        let Ok(reservation) = acquire_and_reserve_execution::<ServiceExecution>(
+            &access,
             Arc::clone(&executions),
-            Arc::clone(&activities),
             "routine",
             "routine",
             false,
-        )
-        .await;
-        let Ok((id, guard)) = result else {
+        ) else {
             panic!("enabled communication must reserve execution");
         };
+        let id = reservation.exec_id;
 
-        assert!(activities.lock().await.contains_key(&id));
+        assert_eq!(active.load(Ordering::SeqCst), 1);
         assert!(
-            executions
-                .read()
-                .await
+            lock_read(&executions)
                 .get("routine")
                 .is_some_and(|entries| entries.contains_key(&id))
         );
 
-        guard.cleanup().await;
+        drop(reservation);
 
-        assert!(!activities.lock().await.contains_key(&id));
-        assert!(executions.read().await.get("routine").is_none());
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+        assert!(lock_read(&executions).get("routine").is_none());
     }
 
-    #[tokio::test]
-    async fn failed_reservation_releases_published_lease() {
+    #[test]
+    fn comparam_execution_removal_releases_lease() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let access = CountingCommunicationAccess {
+            active: Arc::clone(&active),
+        };
+        let Ok(communication_guard) = access.acquire() else {
+            panic!("enabled communication must provide a guard");
+        };
+        let id = Uuid::new_v4();
+        let mut executions = IndexMap::new();
+        executions.insert(
+            id,
+            ComparamExecution::new(
+                sovd_ecu::operations::comparams::Execution {
+                    capability: sovd_ecu::operations::comparams::executions::Capability::Execute,
+                    status: sovd_ecu::operations::comparams::executions::Status::Running,
+                    comparam_override: HashMap::default(),
+                },
+                communication_guard,
+            ),
+        );
+
+        assert_eq!(active.load(Ordering::SeqCst), 1);
+        executions.shift_remove(&id);
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn async_handoff_preserves_execution_and_releases_lease_on_completion() {
+        let executions = Arc::new(StdRwLock::new(HashMap::default()));
+        let active = Arc::new(AtomicUsize::new(0));
+        let access = CountingCommunicationAccess {
+            active: Arc::clone(&active),
+        };
+        let Ok(reservation) = acquire_and_reserve_execution::<ServiceExecution>(
+            &access,
+            Arc::clone(&executions),
+            "routine",
+            "routine",
+            false,
+        ) else {
+            panic!("enabled communication must reserve execution");
+        };
+
+        let id = reservation.commit_async(|execution| {
+            execution
+                .parameters
+                .insert("result".to_owned(), serde_json::json!("ok"));
+        });
+
+        assert_eq!(active.load(Ordering::SeqCst), 1);
+        let mut executions_guard = lock_write(&executions);
+        let execution = executions_guard
+            .get_mut("routine")
+            .and_then(|entries| entries.get_mut(&id))
+            .expect("async execution");
+        assert!(execution.is_created && !execution.in_flight);
+        execution.complete();
+        drop(executions_guard);
+
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+        assert!(
+            lock_read(&executions)
+                .get("routine")
+                .is_some_and(|entries| entries.contains_key(&id))
+        );
+    }
+
+    #[test]
+    fn failed_reservation_releases_acquired_lease() {
         let mut entries = IndexMap::new();
         entries.insert(
             Uuid::new_v4(),
@@ -1327,29 +1538,26 @@ pub(crate) mod tests {
                 status: sovd_ecu::operations::ExecutionStatus::Running,
                 in_flight: false,
                 is_created: true,
+                communication_lease: None,
             },
         );
         let mut execution_map = HashMap::default();
         execution_map.insert("routine".to_owned(), entries);
-        let executions = Arc::new(RwLock::new(execution_map));
-        let activities = Arc::new(Mutex::new(HashMap::default()));
-        let access = enabled_communication_access_for_test();
+        let executions = Arc::new(StdRwLock::new(execution_map));
+        let active = Arc::new(AtomicUsize::new(0));
+        let access = CountingCommunicationAccess {
+            active: Arc::clone(&active),
+        };
 
         let result = acquire_and_reserve_execution::<ServiceExecution>(
-            &*access,
-            executions,
-            Arc::clone(&activities),
-            "routine",
-            "routine",
-            false,
-        )
-        .await;
+            &access, executions, "routine", "routine", false,
+        );
         let Err(error) = result else {
             panic!("second running execution must be rejected");
         };
 
         assert!(matches!(error.error, ApiError::Conflict(_)));
-        assert!(activities.lock().await.is_empty());
+        assert_eq!(active.load(Ordering::SeqCst), 0);
     }
 
     pub fn create_test_webserver_state<T: UdsEcu + Clone, U: FileManager>(
@@ -1370,9 +1578,8 @@ pub(crate) mod tests {
                 ))),
             }),
             comparam_executions: Arc::new(RwLock::new(IndexMap::new())),
-            communication_activities: Arc::new(Mutex::new(HashMap::default())),
             communication_access: enabled_communication_access_for_test(),
-            service_executions: Arc::new(RwLock::new(HashMap::default())),
+            service_executions: Arc::new(StdRwLock::new(HashMap::default())),
             flash_data: Arc::new(RwLock::new(FileList {
                 files: Vec::new(),
                 path: Some(PathBuf::new()),

--- a/cda-sovd/src/sovd/components/ecu/operations.rs
+++ b/cda-sovd/src/sovd/components/ecu/operations.rs
@@ -1638,15 +1638,9 @@ pub(crate) mod service {
 
                 // suppress_service: skip the UDS send, return stored state directly
                 if query.suppress_service {
-                    if let Some(exec) = lock_write(&service_executions)
-                        .get_mut(&service)
-                        .and_then(|m| m.get_mut(&exec_id))
-                    {
-                        exec.in_flight = false;
-                    }
                     return get_by_id_response(
-                        stored.status,
-                        stored.parameters,
+                        stored.snapshot().status.clone(),
+                        stored.snapshot().parameters.clone(),
                         vec![],
                         include_schema,
                     );
@@ -1668,13 +1662,6 @@ pub(crate) mod service {
                         true,
                     )
                     .await;
-
-                if let Some(exec) = lock_write(&service_executions)
-                    .get_mut(&service)
-                    .and_then(|m| m.get_mut(&exec_id))
-                {
-                    exec.in_flight = false;
-                }
 
                 match uds_result {
                     Err(e) => {
@@ -1739,15 +1726,16 @@ pub(crate) mod service {
                     Err(e) => return e.into_response(),
                 };
 
-                if let Err(e) = guard_execution(
+                let _request_guard = match guard_execution(
                     &service_executions,
                     &service,
                     exec_id,
                     include_schema,
                     &format!("Execution {exec_id} is already being stopped"),
                 ) {
-                    return e.into_response();
-                }
+                    Ok(guard) => guard,
+                    Err(error) => return error.into_response(),
+                };
 
                 let diag_service = DiagComm {
                     name: service.clone(),
@@ -1817,12 +1805,6 @@ pub(crate) mod service {
                                 op_map.shift_remove(&exec_id);
                             }
                             return StatusCode::NO_CONTENT.into_response();
-                        } else if let Some(exec) = lock_write(&service_executions)
-                            .get_mut(&service)
-                            .and_then(|m| m.get_mut(&exec_id))
-                        {
-                            // reset in_flight flag of the execution
-                            exec.in_flight = false;
                         }
 
                         match result {

--- a/cda-sovd/src/sovd/components/ecu/operations.rs
+++ b/cda-sovd/src/sovd/components/ecu/operations.rs
@@ -96,18 +96,18 @@ pub(crate) mod comparams {
         };
         use axum_extra::extract::WithRejection;
         use cda_interfaces::{
-            HashMap, HashMapExtensions, UdsEcu,
-            communication_control::{CommunicationAccess, CommunicationGuard},
+            HashMap, HashMapExtensions, UdsEcu, communication_control::CommunicationAccess,
             file_manager::FileManager,
         };
         use indexmap::IndexMap;
         use opensovd_axum_extra::ExtractHost;
         use sovd_interfaces::components::ecu::operations::comparams as sovd_comparams;
-        use tokio::sync::{Mutex, RwLock};
+        use tokio::sync::RwLock;
         use uuid::Uuid;
 
         use crate::sovd::{
-            IntoSovd, WebserverEcuState, acquire_communication_activity, create_schema,
+            ComparamExecution, IntoSovd, WebserverEcuState, acquire_communication_activity,
+            create_schema,
             error::{ApiError, ErrorWrapper},
         };
 
@@ -151,7 +151,6 @@ pub(crate) mod comparams {
             >,
             State(WebserverEcuState {
                 comparam_executions,
-                communication_activities,
                 communication_access,
                 ..
             }): State<WebserverEcuState<T, U>>,
@@ -167,7 +166,6 @@ pub(crate) mod comparams {
             };
             handler_write(
                 comparam_executions,
-                communication_activities,
                 communication_access,
                 path,
                 body,
@@ -191,7 +189,7 @@ pub(crate) mod comparams {
         }
 
         pub(crate) async fn handler_read(
-            executions: Arc<RwLock<IndexMap<Uuid, sovd_comparams::Execution>>>,
+            executions: Arc<RwLock<IndexMap<Uuid, ComparamExecution>>>,
             include_schema: bool,
         ) -> Response {
             let schema = if include_schema {
@@ -214,8 +212,7 @@ pub(crate) mod comparams {
                 .into_response()
         }
         async fn handler_write(
-            executions: Arc<RwLock<IndexMap<Uuid, sovd_comparams::Execution>>>,
-            communication_activities: Arc<Mutex<HashMap<Uuid, CommunicationGuard>>>,
+            executions: Arc<RwLock<IndexMap<Uuid, ComparamExecution>>>,
             communication_access: Arc<dyn CommunicationAccess>,
             base_path: String,
             request: Option<sovd_comparams::executions::update::Request>,
@@ -260,18 +257,17 @@ pub(crate) mod comparams {
                 schema,
             };
             // Publish the lease before the execution becomes observable to DELETE.
-            communication_activities
-                .lock()
-                .await
-                .insert(id, communication_activity);
             let mut executions = executions.write().await;
             executions.insert(
                 id,
-                sovd_comparams::Execution {
-                    capability: sovd_comparams::executions::Capability::Execute,
-                    status: create_execution_response.status.clone(),
-                    comparam_override,
-                },
+                ComparamExecution::new(
+                    sovd_comparams::Execution {
+                        capability: sovd_comparams::executions::Capability::Execute,
+                        status: create_execution_response.status.clone(),
+                        comparam_override,
+                    },
+                    communication_activity,
+                ),
             );
             (
                 StatusCode::ACCEPTED,
@@ -311,7 +307,7 @@ pub(crate) mod comparams {
                     .ok_or_else(|| {
                         ApiError::NotFound(Some(format!("Execution with id {id} not found")))
                     }) {
-                    Ok((idx, _, v)) => (idx, v.clone()),
+                    Ok((idx, _, exec)) => (idx, exec.snapshot()),
                     Err(e) => {
                         return ErrorWrapper {
                             error: e,
@@ -325,7 +321,7 @@ pub(crate) mod comparams {
 
                 // put in all executions with lower index than this one
                 for (_, v) in &comparam_executions.read().await.as_slice()[..idx] {
-                    executions.push(v.clone());
+                    executions.push(v.snapshot());
                 }
                 executions.push(execution);
 
@@ -384,7 +380,6 @@ pub(crate) mod comparams {
                 Path(id): Path<IdPathParam>,
                 State(WebserverEcuState {
                     comparam_executions,
-                    communication_activities,
                     ..
                 }): State<WebserverEcuState<T, U>>,
             ) -> Response {
@@ -405,7 +400,6 @@ pub(crate) mod comparams {
                     }
                     .into_response();
                 }
-                crate::sovd::release_communication_activity(&communication_activities, &id).await;
                 StatusCode::NO_CONTENT.into_response()
             }
 
@@ -449,7 +443,7 @@ pub(crate) mod comparams {
                 // };
 
                 let mut executions_lock = comparam_executions.write().await;
-                let execution: &mut sovd_comparams::Execution =
+                let execution: &mut ComparamExecution =
                     match executions_lock.get_mut(&id).ok_or_else(|| {
                         ApiError::NotFound(Some(format!("Execution with id {id} not found")))
                     }) {
@@ -766,7 +760,7 @@ pub(crate) mod service {
     }
 
     pub(crate) mod executions {
-        use std::sync::Arc;
+        use std::sync::{Arc, RwLock};
 
         use aide::{UseApi, transform::TransformOperation};
         use axum::{
@@ -779,10 +773,11 @@ pub(crate) mod service {
         use axum_extra::extract::{Host, WithRejection};
         use cda_interfaces::{
             DiagComm, DiagCommType, DynamicPlugin, SchemaProvider, UdsEcu,
-            communication_control::{CommunicationAccess, CommunicationGuard},
+            communication_control::CommunicationAccess,
             diagservices::{DiagServiceJsonResponse, DiagServiceResponse, DiagServiceResponseType},
             file_manager::FileManager,
             subfunction_ids,
+            util::std_ext::{lock_read, lock_write},
         };
         use cda_plugin_security::{Secured, SecurityPlugin};
         use sovd_interfaces::{
@@ -792,18 +787,17 @@ pub(crate) mod service {
                 OperationQuery, service::executions as sovd_executions,
             },
         };
-        use tokio::sync::{Mutex, RwLock};
         use uuid::Uuid;
 
         use crate::{
             openapi,
             sovd::{
-                self, ServiceExecution, WebserverEcuState, acquire_and_reserve_execution,
-                api_error_from_diag_response,
+                self, ExecutionReservation, ServiceExecution, WebserverEcuState,
+                acquire_and_reserve_execution, api_error_from_diag_response,
                 components::get_content_type_and_accept,
                 create_response_schema, create_schema,
                 error::{ApiError, ErrorWrapper, VendorErrorCode},
-                field_parse_errors_to_json, finalize_execution, guard_execution,
+                field_parse_errors_to_json, guard_execution,
                 locks::validate_lock,
             },
         };
@@ -837,9 +831,7 @@ pub(crate) mod service {
             } else {
                 None
             };
-            let ids: Vec<OperationIdItem> = service_executions
-                .read()
-                .await
+            let ids: Vec<OperationIdItem> = lock_read(&service_executions)
                 .get(&service)
                 .map(|op_map| {
                     op_map
@@ -876,7 +868,6 @@ pub(crate) mod service {
                 uds,
                 locks,
                 service_executions,
-                communication_activities,
                 communication_access,
                 ..
             }): State<WebserverEcuState<T, U>>,
@@ -891,11 +882,7 @@ pub(crate) mod service {
             {
                 return response;
             }
-            let ctx = OperationWriteContext::new(
-                service_executions,
-                communication_activities,
-                communication_access,
-            );
+            let ctx = OperationWriteContext::new(service_executions, communication_access);
             ecu_operation_write_handler_with_activity::<T>(
                 WriteHandlerRequest {
                     service,
@@ -978,7 +965,6 @@ pub(crate) mod service {
             service_executions: Arc<
                 RwLock<cda_interfaces::HashMap<String, indexmap::IndexMap<Uuid, ServiceExecution>>>,
             >,
-            communication_activities: Arc<Mutex<cda_interfaces::HashMap<Uuid, CommunicationGuard>>>,
             communication_access: Arc<dyn CommunicationAccess>,
         }
 
@@ -989,14 +975,10 @@ pub(crate) mod service {
                         cda_interfaces::HashMap<String, indexmap::IndexMap<Uuid, ServiceExecution>>,
                     >,
                 >,
-                communication_activities: Arc<
-                    Mutex<cda_interfaces::HashMap<Uuid, CommunicationGuard>>,
-                >,
                 communication_access: Arc<dyn CommunicationAccess>,
             ) -> Self {
                 Self {
                     service_executions,
-                    communication_activities,
                     communication_access,
                 }
             }
@@ -1014,7 +996,6 @@ pub(crate) mod service {
         ) -> Response {
             let OperationWriteContext {
                 service_executions,
-                communication_activities,
                 communication_access,
             } = ctx;
             let WriteHandlerRequest {
@@ -1051,16 +1032,13 @@ pub(crate) mod service {
             // concurrent POST for the same operation sees 409 Conflict.
             // The lease is the active-execution marker for update arbitration. It is
             // published with the reservation and retained until the entry is removed.
-            let (exec_id, guard) = match acquire_and_reserve_execution(
+            let reservation = match acquire_and_reserve_execution(
                 &*communication_access,
                 Arc::clone(&service_executions),
-                Arc::clone(&communication_activities),
                 &service,
                 &service,
                 include_schema,
-            )
-            .await
-            {
+            ) {
                 Ok(v) => v,
                 Err(e) => return e.into_response(),
             };
@@ -1072,7 +1050,6 @@ pub(crate) mod service {
                 match check_if_async(uds, ecu_name, &service, &security_plugin).await {
                     Ok(v) => v,
                     Err(e) => {
-                        guard.cleanup().await;
                         return err_response(e);
                     }
                 }
@@ -1081,7 +1058,6 @@ pub(crate) mod service {
             let (data, map_to_json) = match validate_and_parse_write_request(&headers, &body) {
                 Ok(v) => v,
                 Err(e) => {
-                    guard.cleanup().await;
                     return err_response(e);
                 }
             };
@@ -1108,7 +1084,6 @@ pub(crate) mod service {
                 {
                     Ok(r) => r,
                     Err(e) => {
-                        guard.cleanup().await;
                         return *e;
                     }
                 }
@@ -1119,14 +1094,11 @@ pub(crate) mod service {
                     response,
                     map_to_json,
                     include_schema,
-                    base_path,
-                    service,
-                    service_executions,
-                    exec_id,
+                    &base_path,
+                    reservation,
                 )
-                .await
             } else {
-                guard.cleanup().await;
+                drop(reservation);
                 handle_sync_post::<T>(
                     response,
                     map_to_json,
@@ -1285,18 +1257,12 @@ pub(crate) mod service {
         /// Handles the async (Stop/RequestResults) POST path: finalises the
         /// previously reserved execution with the Start-response parameters,
         /// then returns 202 Accepted with only `id` and `status` per spec Table 184.
-        async fn handle_async_post<T: UdsEcu>(
+        fn handle_async_post<T: UdsEcu>(
             response: Option<T::Response>,
             map_to_json: bool,
             include_schema: bool,
-            base_path: String,
-            service: String,
-            service_executions: std::sync::Arc<
-                tokio::sync::RwLock<
-                    cda_interfaces::HashMap<String, indexmap::IndexMap<Uuid, ServiceExecution>>,
-                >,
-            >,
-            exec_id: Uuid,
+            base_path: &str,
+            reservation: ExecutionReservation<ServiceExecution>,
         ) -> Response {
             let parameters = match response {
                 Some(r) if map_to_json && !r.is_empty() => match r.into_json() {
@@ -1308,10 +1274,9 @@ pub(crate) mod service {
                 },
                 _ => serde_json::Map::new(),
             };
-            finalize_execution(&service_executions, &service, &exec_id, |exec| {
+            let exec_id = reservation.commit_async(|exec| {
                 exec.parameters = parameters;
-            })
-            .await;
+            });
             let schema = if include_schema {
                 Some(create_schema!(AsyncPostResponse))
             } else {
@@ -1604,14 +1569,13 @@ pub(crate) mod service {
 
             /// Process a successful UDS `RequestResults` response: parse it, update stored
             /// execution state, and return the `200 OK` response body.
-            async fn get_operations_response<T: UdsEcu>(
+            fn get_operations_response<T: UdsEcu>(
                 response: T::Response,
                 service: &str,
                 exec_id: Uuid,
-                service_executions: &tokio::sync::RwLock<
+                service_executions: &std::sync::RwLock<
                     cda_interfaces::HashMap<String, indexmap::IndexMap<Uuid, ServiceExecution>>,
                 >,
-                communication_activities: &Mutex<cda_interfaces::HashMap<Uuid, CommunicationGuard>>,
                 include_schema: bool,
             ) -> Response {
                 if let DiagServiceResponseType::Negative = response.response_type() {
@@ -1628,15 +1592,13 @@ pub(crate) mod service {
                     parse_json_response_params::<T::Response>(response, "RequestResults")
                 };
 
-                if let Some(stored_mut) = service_executions
-                    .write()
-                    .await
+                if let Some(stored_mut) = lock_write(service_executions)
                     .get_mut(service)
                     .and_then(|m| m.get_mut(&exec_id))
                 {
                     stored_mut.parameters.clone_from(&parameters);
+                    stored_mut.complete();
                 }
-                sovd::release_communication_activity(communication_activities, &exec_id).await;
 
                 get_by_id_response(
                     ExecutionStatus::Completed,
@@ -1654,7 +1616,6 @@ pub(crate) mod service {
                     ecu_name,
                     uds,
                     service_executions,
-                    communication_activities,
                     ..
                 }): State<WebserverEcuState<T, U>>,
             ) -> Response {
@@ -1670,18 +1631,14 @@ pub(crate) mod service {
                     exec_id,
                     include_schema,
                     &format!("Execution {exec_id} is already in progress"),
-                )
-                .await
-                {
+                ) {
                     Ok(v) => v,
                     Err(e) => return e.into_response(),
                 };
 
                 // suppress_service: skip the UDS send, return stored state directly
                 if query.suppress_service {
-                    if let Some(exec) = service_executions
-                        .write()
-                        .await
+                    if let Some(exec) = lock_write(&service_executions)
                         .get_mut(&service)
                         .and_then(|m| m.get_mut(&exec_id))
                     {
@@ -1712,9 +1669,7 @@ pub(crate) mod service {
                     )
                     .await;
 
-                if let Some(exec) = service_executions
-                    .write()
-                    .await
+                if let Some(exec) = lock_write(&service_executions)
                     .get_mut(&service)
                     .and_then(|m| m.get_mut(&exec_id))
                 {
@@ -1735,17 +1690,13 @@ pub(crate) mod service {
                         }
                         .into_response()
                     }
-                    Ok(response) => {
-                        get_operations_response::<T>(
-                            response,
-                            &service,
-                            exec_id,
-                            &service_executions,
-                            &communication_activities,
-                            include_schema,
-                        )
-                        .await
-                    }
+                    Ok(response) => get_operations_response::<T>(
+                        response,
+                        &service,
+                        exec_id,
+                        &service_executions,
+                        include_schema,
+                    ),
                 }
             }
 
@@ -1773,7 +1724,6 @@ pub(crate) mod service {
                     uds,
                     locks,
                     service_executions,
-                    communication_activities,
                     ..
                 }): State<WebserverEcuState<T, U>>,
             ) -> Response {
@@ -1795,9 +1745,7 @@ pub(crate) mod service {
                     exec_id,
                     include_schema,
                     &format!("Execution {exec_id} is already being stopped"),
-                )
-                .await
-                {
+                ) {
                     return e.into_response();
                 }
 
@@ -1819,14 +1767,9 @@ pub(crate) mod service {
 
                 match uds_result {
                     Ok(r) if matches!(r.response_type(), DiagServiceResponseType::Positive) => {
-                        if let Some(op_map) = service_executions.write().await.get_mut(&service) {
+                        if let Some(op_map) = lock_write(&service_executions).get_mut(&service) {
                             op_map.shift_remove(&exec_id);
                         }
-                        crate::sovd::release_communication_activity(
-                            &communication_activities,
-                            &exec_id,
-                        )
-                        .await;
                         if r.is_empty() {
                             StatusCode::NO_CONTENT.into_response()
                         } else {
@@ -1848,14 +1791,9 @@ pub(crate) mod service {
                             exec_id = %exec_id,
                             "Stop service not found (suppress_service=true), removing execution"
                         );
-                        if let Some(op_map) = service_executions.write().await.get_mut(&service) {
+                        if let Some(op_map) = lock_write(&service_executions).get_mut(&service) {
                             op_map.shift_remove(&exec_id);
                         }
-                        crate::sovd::release_communication_activity(
-                            &communication_activities,
-                            &exec_id,
-                        )
-                        .await;
                         StatusCode::NO_CONTENT.into_response()
                     }
                     result => {
@@ -1874,19 +1812,12 @@ pub(crate) mod service {
                             );
                         }
                         if query.force {
-                            if let Some(op_map) = service_executions.write().await.get_mut(&service)
+                            if let Some(op_map) = lock_write(&service_executions).get_mut(&service)
                             {
                                 op_map.shift_remove(&exec_id);
                             }
-                            crate::sovd::release_communication_activity(
-                                &communication_activities,
-                                &exec_id,
-                            )
-                            .await;
                             return StatusCode::NO_CONTENT.into_response();
-                        } else if let Some(exec) = service_executions
-                            .write()
-                            .await
+                        } else if let Some(exec) = lock_write(&service_executions)
                             .get_mut(&service)
                             .and_then(|m| m.get_mut(&exec_id))
                         {
@@ -2177,6 +2108,7 @@ mod tests {
             },
             file_manager::mock::MockFileManager,
             mock::MockUdsEcu,
+            util::std_ext::{lock_read, lock_write},
         };
         use cda_plugin_communication_management::lifecycle::enabled_communication_access_for_test;
         use cda_plugin_security::{Secured, mock::TestSecurityPlugin};
@@ -2234,7 +2166,7 @@ mod tests {
             ecu_name: &str,
             uds: &T,
             service_executions: Arc<
-                tokio::sync::RwLock<
+                std::sync::RwLock<
                     cda_interfaces::HashMap<
                         String,
                         indexmap::IndexMap<uuid::Uuid, ServiceExecution>,
@@ -2246,7 +2178,6 @@ mod tests {
         ) -> axum::response::Response {
             let ctx = handlers::OperationWriteContext::new(
                 service_executions,
-                Arc::new(tokio::sync::Mutex::new(cda_interfaces::HashMap::default())),
                 enabled_communication_access_for_test(),
             );
             handlers::ecu_operation_write_handler_with_activity::<T>(
@@ -2313,10 +2244,7 @@ mod tests {
 
             // Pre-populate an execution
             let exec_id = uuid::Uuid::new_v4();
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -2326,6 +2254,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -2431,10 +2360,7 @@ mod tests {
             );
 
             let exec_id = uuid::Uuid::new_v4();
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -2444,6 +2370,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -2513,10 +2440,7 @@ mod tests {
                 m.insert("stored".to_string(), serde_json::json!("value"));
                 m
             };
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -2526,6 +2450,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -2590,10 +2515,7 @@ mod tests {
             );
 
             let exec_id = uuid::Uuid::new_v4();
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -2603,6 +2525,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -2698,10 +2621,7 @@ mod tests {
             insert_test_ecu_lock(&state.locks, "TestECU").await;
 
             let exec_id = uuid::Uuid::new_v4();
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -2711,6 +2631,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -2743,9 +2664,7 @@ mod tests {
             assert_eq!(response.status(), StatusCode::NO_CONTENT);
             // Verify execution was removed
             assert!(
-                service_executions_ref
-                    .read()
-                    .await
+                lock_read(&service_executions_ref)
                     .values()
                     .all(IndexMap::is_empty)
             );
@@ -2781,10 +2700,7 @@ mod tests {
             insert_test_ecu_lock(&state.locks, "TestECU").await;
 
             let exec_id = uuid::Uuid::new_v4();
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -2794,6 +2710,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -2842,9 +2759,7 @@ mod tests {
             );
             // Execution must be removed regardless
             assert!(
-                service_executions_ref
-                    .read()
-                    .await
+                lock_read(&service_executions_ref)
                     .values()
                     .all(IndexMap::is_empty)
             );
@@ -2876,10 +2791,7 @@ mod tests {
             insert_test_ecu_lock(&state.locks, "TestECU").await;
 
             let exec_id = uuid::Uuid::new_v4();
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -2889,6 +2801,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -2932,9 +2845,7 @@ mod tests {
                 "parameters should be absent when Stop returns Null"
             );
             assert!(
-                service_executions_ref
-                    .read()
-                    .await
+                lock_read(&service_executions_ref)
                     .values()
                     .all(IndexMap::is_empty)
             );
@@ -2968,10 +2879,7 @@ mod tests {
             insert_test_ecu_lock(&state.locks, "TestECU").await;
 
             let exec_id = uuid::Uuid::new_v4();
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -2981,6 +2889,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -3022,9 +2931,7 @@ mod tests {
             let errors = result.get("error").expect("missing error field");
             assert!(errors.is_array() && !errors.as_array().unwrap().is_empty());
             assert!(
-                service_executions_ref
-                    .read()
-                    .await
+                lock_read(&service_executions_ref)
                     .values()
                     .all(IndexMap::is_empty)
             );
@@ -3067,10 +2974,7 @@ mod tests {
             insert_test_ecu_lock(&state.locks, "TestECU").await;
 
             let exec_id = uuid::Uuid::new_v4();
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -3080,6 +2984,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -3120,9 +3025,7 @@ mod tests {
             let errors = result.get("error").expect("missing error field");
             assert!(errors.is_array() && !errors.as_array().unwrap().is_empty());
             assert!(
-                service_executions_ref
-                    .read()
-                    .await
+                lock_read(&service_executions_ref)
                     .values()
                     .all(IndexMap::is_empty)
             );
@@ -3147,10 +3050,7 @@ mod tests {
             insert_test_ecu_lock(&state.locks, "TestECU").await;
 
             let exec_id = uuid::Uuid::new_v4();
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -3160,6 +3060,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -3192,9 +3093,7 @@ mod tests {
             // force=true -> removes execution even on error
             assert_eq!(response.status(), StatusCode::NO_CONTENT);
             assert!(
-                service_executions_ref
-                    .read()
-                    .await
+                lock_read(&service_executions_ref)
                     .values()
                     .all(IndexMap::is_empty)
             );
@@ -3219,10 +3118,7 @@ mod tests {
             insert_test_ecu_lock(&state.locks, "TestECU").await;
 
             let exec_id = uuid::Uuid::new_v4();
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -3232,6 +3128,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -3263,9 +3160,7 @@ mod tests {
             // force=true -> removes execution even on negative ECU response
             assert_eq!(response.status(), StatusCode::NO_CONTENT);
             assert!(
-                service_executions_ref
-                    .read()
-                    .await
+                lock_read(&service_executions_ref)
                     .values()
                     .all(IndexMap::is_empty)
             );
@@ -3289,10 +3184,7 @@ mod tests {
             insert_test_ecu_lock(&state.locks, "TestECU").await;
 
             let exec_id = uuid::Uuid::new_v4();
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -3302,6 +3194,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -3333,7 +3226,7 @@ mod tests {
 
             // force=false -> error should be returned, execution should remain
             assert!(response.status().is_client_error() || response.status().is_server_error());
-            assert_eq!(service_executions_ref.read().await.len(), 1);
+            assert_eq!(lock_read(&service_executions_ref).len(), 1);
         }
 
         #[tokio::test]
@@ -3355,10 +3248,7 @@ mod tests {
             insert_test_ecu_lock(&state.locks, "TestECU").await;
 
             let exec_id = uuid::Uuid::new_v4();
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -3368,6 +3258,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -3398,7 +3289,7 @@ mod tests {
 
             // Negative ECU response without force -> error returned, in_flight reset
             assert!(response.status().is_client_error() || response.status().is_server_error());
-            let guard = service_executions_ref.read().await;
+            let guard = lock_read(&service_executions_ref);
             let exec = guard
                 .get("CalibrateSensor")
                 .and_then(|m| m.get(&exec_id))
@@ -3426,10 +3317,7 @@ mod tests {
             insert_test_ecu_lock(&state.locks, "TestECU").await;
 
             let exec_id = uuid::Uuid::new_v4();
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -3439,6 +3327,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -3471,9 +3360,7 @@ mod tests {
             // suppress_service=true on NotFound -> removes execution, returns 204
             assert_eq!(response.status(), StatusCode::NO_CONTENT);
             assert!(
-                service_executions_ref
-                    .read()
-                    .await
+                lock_read(&service_executions_ref)
                     .values()
                     .all(IndexMap::is_empty)
             );
@@ -3491,10 +3378,7 @@ mod tests {
             );
 
             let exec_id = uuid::Uuid::new_v4();
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -3504,6 +3388,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: true,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -3545,10 +3430,7 @@ mod tests {
             insert_test_ecu_lock(&state.locks, &ecu_name).await;
 
             let exec_id = uuid::Uuid::new_v4();
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -3558,6 +3440,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: true,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -3613,10 +3496,7 @@ mod tests {
             );
 
             // Pre-populate a running execution for CalibrateSensor
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -3626,6 +3506,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -3678,10 +3559,7 @@ mod tests {
             );
 
             // Pre-populate a running execution for a DIFFERENT service
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("OtherService".to_string())
                 .or_default()
                 .insert(
@@ -3691,6 +3569,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 
@@ -3853,7 +3732,7 @@ mod tests {
             .await;
 
             assert_eq!(response.status(), StatusCode::ACCEPTED);
-            assert_eq!(service_executions_ref.read().await.len(), 1);
+            assert_eq!(lock_read(&service_executions_ref).len(), 1);
         }
 
         #[tokio::test]
@@ -3894,7 +3773,7 @@ mod tests {
 
             assert_eq!(response.status(), StatusCode::ACCEPTED);
             // execution still tracked even though UDS was not called
-            assert_eq!(service_executions_ref.read().await.len(), 1);
+            assert_eq!(lock_read(&service_executions_ref).len(), 1);
         }
 
         #[tokio::test]
@@ -3955,7 +3834,7 @@ mod tests {
             // Must be 202, not 500 - spec Table 184 body has only id + status
             assert_eq!(response.status(), StatusCode::ACCEPTED);
             // Execution must still be tracked
-            assert_eq!(service_executions_ref.read().await.len(), 1);
+            assert_eq!(lock_read(&service_executions_ref).len(), 1);
             // Body must contain id and status, no errors field
             let body = axum::body::to_bytes(response.into_body(), usize::MAX)
                 .await
@@ -4027,7 +3906,7 @@ mod tests {
 
             // Must be 202, not 500 - spec Table 184 body has only id + status
             assert_eq!(response.status(), StatusCode::ACCEPTED);
-            assert_eq!(service_executions_ref.read().await.len(), 1);
+            assert_eq!(lock_read(&service_executions_ref).len(), 1);
             let body = axum::body::to_bytes(response.into_body(), usize::MAX)
                 .await
                 .unwrap();
@@ -4067,10 +3946,7 @@ mod tests {
             );
 
             let exec_id = uuid::Uuid::new_v4();
-            state
-                .service_executions
-                .write()
-                .await
+            lock_write(&state.service_executions)
                 .entry("CalibrateSensor".to_string())
                 .or_default()
                 .insert(
@@ -4080,6 +3956,7 @@ mod tests {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
 

--- a/cda-sovd/src/sovd/functions/functional_groups.rs
+++ b/cda-sovd/src/sovd/functions/functional_groups.rs
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock as StdRwLock};
 
 use aide::{
     axum::{ApiRouter as Router, routing},
@@ -25,18 +25,15 @@ use axum::{
 use axum_extra::extract::WithRejection;
 use cda_interfaces::{
     FunctionalDescriptionConfig, HashMap, SchemaProvider, UdsEcu,
-    communication_control::{CommunicationAccess, CommunicationGuard},
+    communication_control::CommunicationAccess,
     diagservices::{DiagServiceResponse, DiagServiceResponseType},
 };
 use http::StatusCode;
-use indexmap::IndexMap;
-use tokio::sync::{Mutex, RwLock};
-use uuid::Uuid;
 
 use crate::{
     create_schema,
     sovd::{
-        FgServiceExecution, WebserverState,
+        ExecutionLock, FgServiceExecution, WebserverState,
         error::{ApiError, ErrorWrapper, VendorErrorCode, nrc_to_api_error_response},
         field_parse_errors_to_json,
         locks::Locks,
@@ -53,8 +50,7 @@ pub(crate) struct WebserverFgState<T: UdsEcu + Clone> {
     uds: T,
     locks: Arc<Locks>,
     functional_group_name: String,
-    fg_executions: Arc<RwLock<HashMap<String, IndexMap<Uuid, FgServiceExecution>>>>,
-    communication_activities: Arc<tokio::sync::Mutex<HashMap<Uuid, CommunicationGuard>>>,
+    fg_executions: Arc<ExecutionLock<FgServiceExecution>>,
     communication_access: Arc<dyn CommunicationAccess>,
 }
 
@@ -144,8 +140,7 @@ pub(crate) async fn create_functional_group_routes<T: UdsEcu + SchemaProvider + 
             uds: state.uds.clone(),
             locks: Arc::clone(&state.locks),
             functional_group_name: group.clone(),
-            fg_executions: Arc::new(RwLock::new(HashMap::default())),
-            communication_activities: Arc::new(Mutex::new(HashMap::default())),
+            fg_executions: Arc::new(StdRwLock::new(HashMap::default())),
             communication_access: Arc::clone(&state.communication_access),
         };
         functional_groups_router = functional_groups_router.nest_api_service(
@@ -512,8 +507,7 @@ pub(crate) mod tests {
                 ))),
             }),
             functional_group_name,
-            fg_executions: Arc::new(RwLock::new(HashMap::default())),
-            communication_activities: Arc::new(tokio::sync::Mutex::new(HashMap::default())),
+            fg_executions: Arc::new(std::sync::RwLock::new(HashMap::default())),
             communication_access: enabled_communication_access_for_test(),
         }
     }

--- a/cda-sovd/src/sovd/functions/functional_groups/operations.rs
+++ b/cda-sovd/src/sovd/functions/functional_groups/operations.rs
@@ -577,15 +577,16 @@ pub(crate) mod diag_service {
             }
         };
 
-        if let Err(e) = guard_execution(
+        let _request_guard = match guard_execution(
             &fg_executions,
             &operation,
             exec_id,
             include_schema,
             &format!("Execution {exec_id} is already in flight"),
         ) {
-            return e.into_response();
-        }
+            Ok(guard) => guard,
+            Err(error) => return error.into_response(),
+        };
 
         // If suppress_service, skip sending STOP to ECUs - just remove and return 204.
         if suppress_service {
@@ -635,12 +636,7 @@ pub(crate) mod diag_service {
             }
             build_operation_response(response_data, errors, include_schema)
         } else {
-            // force=false and Stop had errors - reset in_flight, keep execution alive for retry.
-            if let Some(op_map) = lock_write(&fg_executions).get_mut(&operation)
-                && let Some(exec) = op_map.get_mut(&exec_id)
-            {
-                exec.in_flight = false;
-            }
+            // force=false and Stop had errors - keep execution alive for retry.
             build_operation_response(response_data, errors, include_schema)
         }
     }
@@ -738,6 +734,7 @@ pub(crate) mod diag_service {
             sovd::{
                 FgServiceExecution,
                 error::{ApiError, ErrorWrapper, VendorErrorCode},
+                guard_execution,
                 locks::validate_fg_lock,
             },
         };
@@ -803,50 +800,22 @@ pub(crate) mod diag_service {
                 }
             };
 
-            // Guard: look up execution and mark in_flight.
-            let stored = {
-                let mut guard = lock_write(&fg_executions);
-                let Some(op_map) = guard.get_mut(&operation) else {
-                    return ErrorWrapper {
-                        error: ApiError::NotFound(Some(format!(
-                            "Execution with id {exec_id} not found"
-                        ))),
-                        include_schema,
-                    }
-                    .into_response();
-                };
-                match op_map.get_mut(&exec_id) {
-                    None => {
-                        return ErrorWrapper {
-                            error: ApiError::NotFound(Some(format!(
-                                "Execution with id {exec_id} not found"
-                            ))),
-                            include_schema,
-                        }
-                        .into_response();
-                    }
-                    Some(exec) if exec.in_flight => {
-                        return ErrorWrapper {
-                            error: ApiError::Conflict(format!(
-                                "Execution {exec_id} is already in flight"
-                            )),
-                            include_schema,
-                        }
-                        .into_response();
-                    }
-                    Some(exec) => {
-                        exec.in_flight = true;
-                        exec.clone()
-                    }
-                }
+            let stored = match guard_execution(
+                &fg_executions,
+                &operation,
+                exec_id,
+                include_schema,
+                &format!("Execution {exec_id} is already in flight"),
+            ) {
+                Ok(guard) => guard,
+                Err(error) => return error.into_response(),
             };
 
             // suppress_service: skip UDS send, return stored state directly.
             if query.suppress_service {
-                clear_in_flight(&fg_executions, &operation, exec_id);
                 return fg_get_by_id_response(
-                    stored.status,
-                    stored.parameters,
+                    stored.snapshot().status.clone(),
+                    stored.snapshot().parameters.clone(),
                     vec![],
                     include_schema,
                 );
@@ -865,7 +834,6 @@ pub(crate) mod diag_service {
             {
                 Ok(sf) => sf.has_request_results,
                 Err(e) => {
-                    clear_in_flight(&fg_executions, &operation, exec_id);
                     return ErrorWrapper {
                         error: e.into(),
                         include_schema,
@@ -877,10 +845,9 @@ pub(crate) mod diag_service {
             // When there is no RequestResults subfunction, return the stored
             // execution state together with an error entry.
             if !has_request_results {
-                clear_in_flight(&fg_executions, &operation, exec_id);
                 return fg_get_by_id_response(
-                    stored.status,
-                    stored.parameters,
+                    stored.snapshot().status.clone(),
+                    stored.snapshot().parameters.clone(),
                     vec![sovd_interfaces::error::DataError {
                         path: "/".to_owned(),
                         error: sovd_interfaces::error::ApiErrorResponse {
@@ -909,19 +876,6 @@ pub(crate) mod diag_service {
                 include_schema,
             )
             .await
-        }
-
-        /// Marks the execution as no longer in flight.
-        fn clear_in_flight(
-            fg_executions: &RwLock<HashMap<String, IndexMap<Uuid, FgServiceExecution>>>,
-            operation: &str,
-            exec_id: Uuid,
-        ) {
-            if let Some(op_map) = lock_write(fg_executions).get_mut(operation)
-                && let Some(exec) = op_map.get_mut(&exec_id)
-            {
-                exec.in_flight = false;
-            }
         }
 
         /// Context for functional group request results, grouping execution-related state.
@@ -983,7 +937,6 @@ pub(crate) mod diag_service {
                     && let Some(exec) = op_map.get_mut(&exec_id)
                 {
                     exec.parameters.clone_from(&response_data);
-                    exec.in_flight = false;
                     if status == ExecutionStatus::Completed {
                         exec.complete();
                     }

--- a/cda-sovd/src/sovd/functions/functional_groups/operations.rs
+++ b/cda-sovd/src/sovd/functions/functional_groups/operations.rs
@@ -198,22 +198,19 @@ pub(crate) mod diag_service {
     use axum_extra::extract::{Host, WithRejection};
     use cda_interfaces::{
         DiagComm, DiagCommType, DynamicPlugin, HashMap, UdsEcu, diagservices::DiagServiceResponse,
-        subfunction_ids,
+        subfunction_ids, util::std_ext::lock_write,
     };
     use cda_plugin_security::Secured;
-    use indexmap::IndexMap;
     use sovd_interfaces::components::ecu::operations::{AsyncPostResponse, ExecutionStatus};
-    use tokio::sync::RwLock;
     use uuid::Uuid;
 
     use super::super::WebserverFgState;
     use crate::{
         create_schema, openapi,
         sovd::{
-            FgServiceExecution, acquire_and_reserve_execution,
+            ExecutionReservation, FgServiceExecution, acquire_and_reserve_execution,
             components::{ecu::DiagServicePathParam, get_content_type_and_accept},
             error::{ApiError, ErrorWrapper, VendorErrorCode},
-            finalize_execution,
             functions::functional_groups::{handle_ecu_response, map_to_json},
             get_payload_data, guard_execution,
             locks::validate_fg_lock,
@@ -261,20 +258,16 @@ pub(crate) mod diag_service {
 
     /// Finalises the previously reserved execution with per-ECU response
     /// parameters and builds the `202 Accepted` response.
-    async fn build_async_response(
-        fg_executions: &RwLock<HashMap<String, IndexMap<Uuid, FgServiceExecution>>>,
-        operation: &str,
+    fn build_async_response(
         response_data: HashMap<String, serde_json::Map<String, serde_json::Value>>,
         host: &str,
         uri: &Uri,
         include_schema: bool,
-        exec_id: Uuid,
+        reservation: ExecutionReservation<FgServiceExecution>,
     ) -> Response {
-        let operation = operation.to_lowercase();
-        finalize_execution(fg_executions, &operation, &exec_id, |exec| {
+        let exec_id = reservation.commit_async(|exec| {
             exec.parameters = response_data;
-        })
-        .await;
+        });
 
         let exec_url = format!("http://{host}{uri}/executions/{exec_id}");
         let schema = if include_schema {
@@ -302,7 +295,7 @@ pub(crate) mod diag_service {
             response::{IntoResponse, Response},
         };
         use axum_extra::extract::WithRejection;
-        use cda_interfaces::UdsEcu;
+        use cda_interfaces::{UdsEcu, util::std_ext::lock_read};
         use cda_plugin_security::Secured;
         use http::StatusCode;
         use sovd_interfaces::common::operations::OperationIdItem;
@@ -325,7 +318,7 @@ pub(crate) mod diag_service {
             } else {
                 None
             };
-            let executions = fg_executions.read().await;
+            let executions = lock_read(&fg_executions);
 
             let ids: Vec<_> = executions
                 .get(&operation)
@@ -373,7 +366,6 @@ pub(crate) mod diag_service {
             locks,
             functional_group_name,
             fg_executions,
-            communication_activities,
             communication_access,
             ..
         }): State<WebserverFgState<T>>,
@@ -406,16 +398,13 @@ pub(crate) mod diag_service {
         // conflict and, if none, inserts a placeholder so that a second
         // concurrent POST for the same operation sees 409 Conflict.
         let operation_lower = operation.to_lowercase();
-        let (exec_id, guard) = match acquire_and_reserve_execution(
+        let reservation = match acquire_and_reserve_execution(
             &*communication_access,
             Arc::clone(&fg_executions),
-            Arc::clone(&communication_activities),
             &operation_lower,
             &operation,
             include_schema,
-        )
-        .await
-        {
+        ) {
             Ok(v) => v,
             Err(e) => return e.into_response(),
         };
@@ -435,7 +424,6 @@ pub(crate) mod diag_service {
             {
                 Ok(is_async) => is_async,
                 Err(e) => {
-                    guard.cleanup().await;
                     return e.into_response();
                 }
             }
@@ -444,7 +432,6 @@ pub(crate) mod diag_service {
         let (content_type, _) = match get_content_type_and_accept(&headers) {
             Ok(v) => v,
             Err(e) => {
-                guard.cleanup().await;
                 return ErrorWrapper {
                     error: e,
                     include_schema,
@@ -463,7 +450,6 @@ pub(crate) mod diag_service {
             {
                 Ok(value) => value,
                 Err(e) => {
-                    guard.cleanup().await;
                     return ErrorWrapper {
                         error: e,
                         include_schema,
@@ -476,7 +462,6 @@ pub(crate) mod diag_service {
         let map_to_json = match map_to_json(include_schema, &accept) {
             Ok(value) => value,
             Err(e) => {
-                guard.cleanup().await;
                 return e.into_response();
             }
         };
@@ -508,18 +493,9 @@ pub(crate) mod diag_service {
         } = handle_ecu_responses(results);
 
         if is_async {
-            build_async_response(
-                &fg_executions,
-                &operation,
-                response_data,
-                &host,
-                &uri,
-                include_schema,
-                exec_id,
-            )
-            .await
+            build_async_response(response_data, &host, &uri, include_schema, reservation)
         } else {
-            guard.cleanup().await;
+            drop(reservation);
             build_operation_response(response_data, errors, include_schema)
         }
     }
@@ -577,7 +553,6 @@ pub(crate) mod diag_service {
             locks,
             functional_group_name,
             fg_executions,
-            communication_activities,
             ..
         }): State<WebserverFgState<T>>,
     ) -> Response {
@@ -608,9 +583,7 @@ pub(crate) mod diag_service {
             exec_id,
             include_schema,
             &format!("Execution {exec_id} is already in flight"),
-        )
-        .await
-        {
+        ) {
             return e.into_response();
         }
 
@@ -621,10 +594,9 @@ pub(crate) mod diag_service {
                 exec_id = %exec_id,
                 "Stop skipped (suppress_service=true), removing execution"
             );
-            if let Some(op_map) = fg_executions.write().await.get_mut(&operation) {
+            if let Some(op_map) = lock_write(&fg_executions).get_mut(&operation) {
                 op_map.shift_remove(&exec_id);
             }
-            crate::sovd::release_communication_activity(&communication_activities, &exec_id).await;
             return StatusCode::NO_CONTENT.into_response();
         }
 
@@ -652,21 +624,19 @@ pub(crate) mod diag_service {
 
         if errors.is_empty() {
             // All ECUs succeeded - remove execution and return 204.
-            if let Some(op_map) = fg_executions.write().await.get_mut(&operation) {
+            if let Some(op_map) = lock_write(&fg_executions).get_mut(&operation) {
                 op_map.shift_remove(&exec_id);
             }
-            crate::sovd::release_communication_activity(&communication_activities, &exec_id).await;
             StatusCode::NO_CONTENT.into_response()
         } else if query.force {
             // force=true - remove execution even though Stop had errors, return 200 with errors.
-            if let Some(op_map) = fg_executions.write().await.get_mut(&operation) {
+            if let Some(op_map) = lock_write(&fg_executions).get_mut(&operation) {
                 op_map.shift_remove(&exec_id);
             }
-            crate::sovd::release_communication_activity(&communication_activities, &exec_id).await;
             build_operation_response(response_data, errors, include_schema)
         } else {
             // force=false and Stop had errors - reset in_flight, keep execution alive for retry.
-            if let Some(op_map) = fg_executions.write().await.get_mut(&operation)
+            if let Some(op_map) = lock_write(&fg_executions).get_mut(&operation)
                 && let Some(exec) = op_map.get_mut(&exec_id)
             {
                 exec.in_flight = false;
@@ -737,6 +707,8 @@ pub(crate) mod diag_service {
     }
 
     pub(crate) mod id {
+        use std::sync::RwLock;
+
         use aide::{UseApi, transform::TransformOperation};
         use axum::{
             Json,
@@ -745,8 +717,8 @@ pub(crate) mod diag_service {
         };
         use axum_extra::extract::WithRejection;
         use cda_interfaces::{
-            DiagComm, DiagCommType, DynamicPlugin, HashMap, UdsEcu,
-            communication_control::CommunicationGuard, subfunction_ids,
+            DiagComm, DiagCommType, DynamicPlugin, HashMap, UdsEcu, subfunction_ids,
+            util::std_ext::lock_write,
         };
         use cda_plugin_security::Secured;
         use http::StatusCode;
@@ -755,7 +727,6 @@ pub(crate) mod diag_service {
             components::ecu::operations::{ExecutionStatus, GetByIdCapability, OperationQuery},
             functions::functional_groups::operations::FgAsyncGetByIdResponse,
         };
-        use tokio::sync::RwLock;
         use uuid::Uuid;
 
         use super::{
@@ -805,7 +776,6 @@ pub(crate) mod diag_service {
                 locks,
                 functional_group_name,
                 fg_executions,
-                communication_activities,
                 ..
             }): State<WebserverFgState<T>>,
         ) -> Response {
@@ -835,7 +805,7 @@ pub(crate) mod diag_service {
 
             // Guard: look up execution and mark in_flight.
             let stored = {
-                let mut guard = fg_executions.write().await;
+                let mut guard = lock_write(&fg_executions);
                 let Some(op_map) = guard.get_mut(&operation) else {
                     return ErrorWrapper {
                         error: ApiError::NotFound(Some(format!(
@@ -873,7 +843,7 @@ pub(crate) mod diag_service {
 
             // suppress_service: skip UDS send, return stored state directly.
             if query.suppress_service {
-                clear_in_flight(&fg_executions, &operation, exec_id).await;
+                clear_in_flight(&fg_executions, &operation, exec_id);
                 return fg_get_by_id_response(
                     stored.status,
                     stored.parameters,
@@ -895,7 +865,7 @@ pub(crate) mod diag_service {
             {
                 Ok(sf) => sf.has_request_results,
                 Err(e) => {
-                    clear_in_flight(&fg_executions, &operation, exec_id).await;
+                    clear_in_flight(&fg_executions, &operation, exec_id);
                     return ErrorWrapper {
                         error: e.into(),
                         include_schema,
@@ -907,7 +877,7 @@ pub(crate) mod diag_service {
             // When there is no RequestResults subfunction, return the stored
             // execution state together with an error entry.
             if !has_request_results {
-                clear_in_flight(&fg_executions, &operation, exec_id).await;
+                clear_in_flight(&fg_executions, &operation, exec_id);
                 return fg_get_by_id_response(
                     stored.status,
                     stored.parameters,
@@ -928,7 +898,7 @@ pub(crate) mod diag_service {
                 );
             }
 
-            let ctx = RequestResultsContext::new(&fg_executions, &communication_activities);
+            let ctx = RequestResultsContext::new(&fg_executions);
             send_request_results(
                 &uds,
                 &security_plugin,
@@ -942,12 +912,12 @@ pub(crate) mod diag_service {
         }
 
         /// Marks the execution as no longer in flight.
-        async fn clear_in_flight(
+        fn clear_in_flight(
             fg_executions: &RwLock<HashMap<String, IndexMap<Uuid, FgServiceExecution>>>,
             operation: &str,
             exec_id: Uuid,
         ) {
-            if let Some(op_map) = fg_executions.write().await.get_mut(operation)
+            if let Some(op_map) = lock_write(fg_executions).get_mut(operation)
                 && let Some(exec) = op_map.get_mut(&exec_id)
             {
                 exec.in_flight = false;
@@ -957,18 +927,13 @@ pub(crate) mod diag_service {
         /// Context for functional group request results, grouping execution-related state.
         struct RequestResultsContext<'a> {
             fg_executions: &'a RwLock<HashMap<String, IndexMap<Uuid, FgServiceExecution>>>,
-            communication_activities: &'a tokio::sync::Mutex<HashMap<Uuid, CommunicationGuard>>,
         }
 
         impl<'a> RequestResultsContext<'a> {
             fn new(
                 fg_executions: &'a RwLock<HashMap<String, IndexMap<Uuid, FgServiceExecution>>>,
-                communication_activities: &'a tokio::sync::Mutex<HashMap<Uuid, CommunicationGuard>>,
             ) -> Self {
-                Self {
-                    fg_executions,
-                    communication_activities,
-                }
+                Self { fg_executions }
             }
         }
 
@@ -984,10 +949,7 @@ pub(crate) mod diag_service {
             ctx: RequestResultsContext<'_>,
             include_schema: bool,
         ) -> Response {
-            let RequestResultsContext {
-                fg_executions,
-                communication_activities,
-            } = ctx;
+            let RequestResultsContext { fg_executions } = ctx;
             let results = uds
                 .send_functional_group(
                     functional_group_name,
@@ -1016,20 +978,17 @@ pub(crate) mod diag_service {
                 ExecutionStatus::Running
             };
             {
-                let mut guard = fg_executions.write().await;
+                let mut guard = lock_write(fg_executions);
                 if let Some(op_map) = guard.get_mut(operation)
                     && let Some(exec) = op_map.get_mut(&exec_id)
                 {
                     exec.parameters.clone_from(&response_data);
-                    exec.status = status.clone();
                     exec.in_flight = false;
+                    if status == ExecutionStatus::Completed {
+                        exec.complete();
+                    }
                 }
             }
-            if status == ExecutionStatus::Completed {
-                crate::sovd::release_communication_activity(communication_activities, &exec_id)
-                    .await;
-            }
-
             fg_get_by_id_response(status, response_data, errors, include_schema)
         }
 
@@ -1078,7 +1037,7 @@ pub(crate) mod diag_service {
 
     #[cfg(test)]
     mod tests {
-        use std::sync::Arc;
+        use std::sync::{Arc, RwLock};
 
         use aide::UseApi;
         use axum::{body::Bytes, extract::State, http::StatusCode};
@@ -1089,12 +1048,12 @@ pub(crate) mod diag_service {
             diagservices::{DiagServiceJsonResponse, mock::MockDiagServiceResponse},
             mock::MockUdsEcu,
             subfunction_ids,
+            util::std_ext::{lock_read, lock_write},
         };
         use cda_plugin_security::{Secured, mock::TestSecurityPlugin};
         use http::HeaderMap;
         use indexmap::IndexMap;
         use sovd_interfaces::components::ecu::operations::ExecutionStatus;
-        use tokio::sync::RwLock;
 
         use super::*;
         use crate::sovd::{
@@ -1269,9 +1228,7 @@ pub(crate) mod diag_service {
             assert!(result.get("id").is_some(), "202 body must have id");
             assert_eq!(result.get("status"), Some(&serde_json::json!("running")));
             assert_eq!(
-                fg_executions_ref
-                    .read()
-                    .await
+                lock_read(&fg_executions_ref)
                     .get("brakeselftest")
                     .map_or(0, IndexMap::len),
                 1
@@ -1321,9 +1278,7 @@ pub(crate) mod diag_service {
 
             assert_eq!(response.status(), StatusCode::ACCEPTED);
             assert_eq!(
-                fg_executions_ref
-                    .read()
-                    .await
+                lock_read(&fg_executions_ref)
                     .get("brakeselftest")
                     .map_or(0, IndexMap::len),
                 1
@@ -1541,16 +1496,16 @@ pub(crate) mod diag_service {
             );
         }
 
-        async fn insert_async_execution(
+        fn insert_async_execution(
             fg_executions: &Arc<
                 RwLock<cda_interfaces::HashMap<String, IndexMap<Uuid, FgServiceExecution>>>,
             >,
             operation: &str,
         ) -> Uuid {
-            insert_async_execution_with_params(fg_executions, operation, HashMap::default()).await
+            insert_async_execution_with_params(fg_executions, operation, HashMap::default())
         }
 
-        async fn insert_async_execution_with_params(
+        fn insert_async_execution_with_params(
             fg_executions: &Arc<
                 RwLock<cda_interfaces::HashMap<String, IndexMap<Uuid, FgServiceExecution>>>,
             >,
@@ -1558,9 +1513,7 @@ pub(crate) mod diag_service {
             parameters: HashMap<String, serde_json::Map<String, serde_json::Value>>,
         ) -> Uuid {
             let id = Uuid::new_v4();
-            fg_executions
-                .write()
-                .await
+            lock_write(fg_executions)
                 .entry(operation.to_owned())
                 .or_default()
                 .insert(
@@ -1570,6 +1523,7 @@ pub(crate) mod diag_service {
                         status: ExecutionStatus::Running,
                         in_flight: false,
                         is_created: true,
+                        communication_lease: None,
                     },
                 );
             id
@@ -1580,7 +1534,7 @@ pub(crate) mod diag_service {
             let mock_uds = MockUdsEcu::new();
             // state has no lock set up
             let state = create_test_fg_state(mock_uds, "AllECUs".to_string());
-            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest").await;
+            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest");
 
             let response = delete::<MockUdsEcu>(
                 UseApi(
@@ -1650,7 +1604,7 @@ pub(crate) mod diag_service {
 
             let state = create_test_fg_state(mock_uds, "AllECUs".to_string());
             insert_test_fg_lock(&state.locks, "AllECUs").await;
-            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest").await;
+            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest");
             let fg_executions_ref = Arc::clone(&state.fg_executions);
 
             let response = delete::<MockUdsEcu>(
@@ -1672,9 +1626,7 @@ pub(crate) mod diag_service {
 
             assert_eq!(response.status(), StatusCode::NO_CONTENT);
             assert!(
-                fg_executions_ref
-                    .read()
-                    .await
+                lock_read(&fg_executions_ref)
                     .get("BrakeSelfTest")
                     .is_none_or(IndexMap::is_empty),
                 "execution should be removed"
@@ -1701,7 +1653,7 @@ pub(crate) mod diag_service {
 
             let state = create_test_fg_state(mock_uds, "AllECUs".to_string());
             insert_test_fg_lock(&state.locks, "AllECUs").await;
-            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest").await;
+            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest");
             let fg_executions_ref = Arc::clone(&state.fg_executions);
 
             let response = delete::<MockUdsEcu>(
@@ -1735,9 +1687,7 @@ pub(crate) mod diag_service {
                 "Expected errors in partial failure response"
             );
             assert!(
-                fg_executions_ref
-                    .read()
-                    .await
+                lock_read(&fg_executions_ref)
                     .get("BrakeSelfTest")
                     .is_none_or(IndexMap::is_empty),
                 "execution should be removed"
@@ -1752,7 +1702,7 @@ pub(crate) mod diag_service {
 
             let state = create_test_fg_state(mock_uds, "AllECUs".to_string());
             insert_test_fg_lock(&state.locks, "AllECUs").await;
-            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest").await;
+            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest");
             let fg_executions_ref = Arc::clone(&state.fg_executions);
 
             let response = delete::<MockUdsEcu>(
@@ -1774,9 +1724,7 @@ pub(crate) mod diag_service {
 
             assert_eq!(response.status(), StatusCode::NO_CONTENT);
             assert!(
-                fg_executions_ref
-                    .read()
-                    .await
+                lock_read(&fg_executions_ref)
                     .get("BrakeSelfTest")
                     .is_none_or(IndexMap::is_empty),
                 "execution should be removed"
@@ -1840,9 +1788,7 @@ pub(crate) mod diag_service {
 
             assert_eq!(response.status(), StatusCode::ACCEPTED);
             assert_eq!(
-                fg_executions_ref
-                    .read()
-                    .await
+                lock_read(&fg_executions_ref)
                     .get("somediag")
                     .map_or(0, IndexMap::len),
                 1,
@@ -1859,7 +1805,7 @@ pub(crate) mod diag_service {
             insert_test_fg_lock(&state.locks, "AllECUs").await;
 
             // Pre-populate a running execution for BrakeSelfTest
-            insert_async_execution(&state.fg_executions, "brakeselftest").await;
+            insert_async_execution(&state.fg_executions, "brakeselftest");
 
             let response = post::<MockUdsEcu>(
                 make_post_headers(),
@@ -1929,7 +1875,7 @@ pub(crate) mod diag_service {
             insert_test_fg_lock(&state.locks, "AllECUs").await;
 
             // Pre-populate a running execution for a DIFFERENT operation
-            insert_async_execution(&state.fg_executions, "otherservice").await;
+            insert_async_execution(&state.fg_executions, "otherservice");
 
             let response = post::<MockUdsEcu>(
                 make_post_headers(),
@@ -1993,7 +1939,7 @@ pub(crate) mod diag_service {
 
             let state = create_test_fg_state(mock_uds, "AllECUs".to_string());
             insert_test_fg_lock(&state.locks, "AllECUs").await;
-            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest").await;
+            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest");
             let fg_executions_ref = Arc::clone(&state.fg_executions);
 
             let response = delete::<MockUdsEcu>(
@@ -2026,7 +1972,7 @@ pub(crate) mod diag_service {
                     .is_some_and(|e| !e.is_empty()),
                 "Expected errors in response"
             );
-            let guard = fg_executions_ref.read().await;
+            let guard = lock_read(&fg_executions_ref);
             let op_map = guard
                 .get("BrakeSelfTest")
                 .expect("operation map must exist");
@@ -2061,7 +2007,7 @@ pub(crate) mod diag_service {
 
             let state = create_test_fg_state(mock_uds, "AllECUs".to_string());
             insert_test_fg_lock(&state.locks, "AllECUs").await;
-            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest").await;
+            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest");
             let fg_executions_ref = Arc::clone(&state.fg_executions);
 
             let response = delete::<MockUdsEcu>(
@@ -2095,9 +2041,7 @@ pub(crate) mod diag_service {
                 "Expected errors in response"
             );
             assert!(
-                fg_executions_ref
-                    .read()
-                    .await
+                lock_read(&fg_executions_ref)
                     .get("BrakeSelfTest")
                     .is_none_or(IndexMap::is_empty),
                 "execution must be removed when force=true"
@@ -2156,7 +2100,7 @@ pub(crate) mod diag_service {
 
             let state = create_test_fg_state(mock_uds, "AllECUs".to_string());
             insert_test_fg_lock(&state.locks, "AllECUs").await;
-            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest").await;
+            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest");
             let fg_executions_ref = Arc::clone(&state.fg_executions);
 
             let response = id::get::<MockUdsEcu>(
@@ -2190,7 +2134,7 @@ pub(crate) mod diag_service {
                 Some(&serde_json::json!("pass"))
             );
             // Verify stored execution was updated to Completed
-            let guard = fg_executions_ref.read().await;
+            let guard = lock_read(&fg_executions_ref);
             let exec = guard
                 .get("BrakeSelfTest")
                 .and_then(|m| m.get(&exec_id))
@@ -2224,8 +2168,7 @@ pub(crate) mod diag_service {
             params.insert("ECU2".to_string(), ecu2_params);
 
             let exec_id =
-                insert_async_execution_with_params(&state.fg_executions, "BrakeSelfTest", params)
-                    .await;
+                insert_async_execution_with_params(&state.fg_executions, "BrakeSelfTest", params);
 
             let response = id::get::<MockUdsEcu>(
                 UseApi(
@@ -2329,7 +2272,7 @@ pub(crate) mod diag_service {
 
             let state = create_test_fg_state(mock_uds, "AllECUs".to_string());
             insert_test_fg_lock(&state.locks, "AllECUs").await;
-            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest").await;
+            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest");
             let fg_executions_ref = Arc::clone(&state.fg_executions);
 
             let response = id::get::<MockUdsEcu>(
@@ -2368,7 +2311,7 @@ pub(crate) mod diag_service {
                 "Expected errors for ECU2 failure"
             );
             // Verify stored execution is still Running and in_flight is reset
-            let guard = fg_executions_ref.read().await;
+            let guard = lock_read(&fg_executions_ref);
             let exec = guard
                 .get("BrakeSelfTest")
                 .and_then(|m| m.get(&exec_id))
@@ -2402,7 +2345,7 @@ pub(crate) mod diag_service {
 
             let state = create_test_fg_state(mock_uds, "AllECUs".to_string());
             insert_test_fg_lock(&state.locks, "AllECUs").await;
-            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest").await;
+            let exec_id = insert_async_execution(&state.fg_executions, "BrakeSelfTest");
             let fg_executions_ref = Arc::clone(&state.fg_executions);
 
             let response = id::get::<MockUdsEcu>(
@@ -2458,7 +2401,7 @@ pub(crate) mod diag_service {
             );
 
             // Verify in_flight was reset so the execution is still usable
-            let guard = fg_executions_ref.read().await;
+            let guard = lock_read(&fg_executions_ref);
             let exec = guard
                 .get("BrakeSelfTest")
                 .and_then(|m| m.get(&exec_id))


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
[fix(cda-sovd): make execution cleanup cancellation-safe](https://github.com/eclipse-opensovd/classic-diagnostic-adapter/commit/c4ac5693129e077737638e624209443931c11acd)

Store communication leases with their executions and roll back pending
reservations on drop so early returns cannot block runtime updates.


[fix(cda-sovd): reset in-flight state on cancellation](https://github.com/eclipse-opensovd/classic-diagnostic-adapter/commit/3a0fb02dcfe16e018fbb72ac4ccc6e49a6218760)

Use an RAII request guard so interrupted GET and STOP handlers cannot leave
executions permanently marked as busy.

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

Closes #525 

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->


---- 

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
