### PR TITLE
feat(server): support binding the SOVD webserver to a Unix domain socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,7 +604,12 @@ dependencies = [
  "cda-plugin-communication-management",
  "cda-plugin-security",
  "chrono",
+ "futures",
  "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "hyperlocal",
  "indexmap",
  "mime",
  "mockall",
@@ -616,6 +621,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sovd-interfaces",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "tower",
@@ -1741,6 +1747,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,6 +1917,7 @@ version = "0.1.0"
 dependencies = [
  "aide",
  "axum",
+ "bytes",
  "cda-build",
  "cda-comm-doip",
  "cda-comm-uds",
@@ -1912,6 +1934,10 @@ dependencies = [
  "figment",
  "futures",
  "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "hyperlocal",
  "libc",
  "mime",
  "opensovd-cda",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,15 @@ axum = { version = "0.8", default-features = false }
 axum-extra = { version = "0.12.2" }
 serde_qs = "1.0.0-rc.3"
 urlencoding = "2.1.3"
+# unix-domain-socket-capable HTTP client, used in tests only. `hyperlocal`
+# uses `tokio::net::UnixStream` unconditionally (no internal `cfg(unix)`
+# guard) and thus doesn't compile on Windows, so consumers must depend on
+# these under `[target.'cfg(unix)'.(dev-)dependencies]` rather than
+# unconditionally.
+hyper = { version = "1.8", default-features = false }
+hyper-util = { version = "0.1", default-features = false }
+hyperlocal = { version = "0.9", default-features = false }
+http-body-util = "0.1"
 
 # ---- utility crates ----
 const_format = "0.2.35" # compile time string formatting

--- a/cda-main/src/config/configfile.rs
+++ b/cda-main/src/config/configfile.rs
@@ -135,12 +135,20 @@ pub struct ServerConfig {
     pub address: String,
     /// TCP port the server listens on.
     pub port: u16,
+    /// Path to a Unix domain socket to bind the server to, e.g. `/run/cda.sock`.
+    ///
+    /// When set, the server binds only to this Unix socket and `address`/`port`
+    /// are silently ignored - the two transports are mutually exclusive, with
+    /// the Unix socket taking priority.
+    #[serde(default)]
+    pub unix_socket: Option<String>,
 }
 impl Default for ServerConfig {
     fn default() -> Self {
         Self {
             address: "0.0.0.0".to_owned(),
             port: 20002,
+            unix_socket: None,
         }
     }
 }
@@ -413,6 +421,41 @@ description_database = "teapot"
                 vec!["Control_".to_string()]
             ))
         );
+        Ok(())
+    }
+
+    /// `server.unix_socket` defaults to `None`, keeping today's TCP-only
+    /// behavior unchanged when the field is absent from the TOML file.
+    #[tokio::test]
+    async fn load_config_toml_server_unix_socket_defaults_to_none()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let config_str = r#"
+[server]
+address = "127.0.0.1"
+port = 12345
+"#;
+        let figment = Figment::from(Serialized::defaults(Configuration::default()))
+            .merge(Toml::string(config_str));
+        let config: Configuration = figment.extract()?;
+        assert_eq!(config.server.address, "127.0.0.1");
+        assert_eq!(config.server.port, 12345);
+        assert_eq!(config.server.unix_socket, None);
+        Ok(())
+    }
+
+    /// `server.unix_socket` can be set via TOML, alongside `address`/`port`
+    /// (the two are not mutually exclusive at the parsing level - the Unix
+    /// socket simply takes priority at bind time in `cda-sovd`).
+    #[tokio::test]
+    async fn load_config_toml_server_unix_socket() -> Result<(), Box<dyn std::error::Error>> {
+        let config_str = r#"
+[server]
+unix_socket = "/run/cda.sock"
+"#;
+        let figment = Figment::from(Serialized::defaults(Configuration::default()))
+            .merge(Toml::string(config_str));
+        let config: Configuration = figment.extract()?;
+        assert_eq!(config.server.unix_socket, Some("/run/cda.sock".to_owned()));
         Ok(())
     }
 

--- a/cda-main/src/config/generate.rs
+++ b/cda-main/src/config/generate.rs
@@ -67,6 +67,10 @@ fn reference_config_instance() -> Configuration {
         ..config.functional_description
     };
 
+    // Example value so the optional `server.unix_socket` field appears
+    // (commented out) in the generated reference config.
+    config.server.unix_socket = Some("/run/cda.sock".to_owned());
+
     // We're defining a partial toml here, because we want the default config only to contain
     // a few examples. The full object is build during parsing with figment.
     // If we started off with `let mut ecu_params = ComParams::default();`

--- a/cda-main/src/lib.rs
+++ b/cda-main/src/lib.rs
@@ -120,6 +120,11 @@ pub struct AppArgs {
     #[arg(long)]
     pub listen_port: Option<u16>,
 
+    /// Path to a Unix domain socket to bind the server to. Takes priority over
+    /// `listen_address`/`listen_port` when set.
+    #[arg(long)]
+    pub unix_socket: Option<String>,
+
     #[arg(short, long)]
     pub flash_files_path: Option<String>,
 
@@ -200,6 +205,9 @@ impl AppArgs {
         }
         if let Some(listen_port) = self.listen_port {
             config.server.port = listen_port;
+        }
+        if let Some(unix_socket) = self.unix_socket {
+            config.server.unix_socket = Some(unix_socket);
         }
         if let Some(file_logging) = self.file_logging {
             config.logging.log_file_config.enabled = file_logging;
@@ -449,6 +457,7 @@ async fn init_webserver(
     let webserver_config = cda_sovd::WebServerConfig {
         host: config.server.address.clone(),
         port: config.server.port,
+        unix_socket: config.server.unix_socket.clone(),
     };
 
     let clonable_shutdown_signal = shutdown_signal
@@ -1033,6 +1042,31 @@ pub fn setup_tracing(config: &Configuration) -> Result<TracingGuards, TracingSet
 #[must_use]
 pub fn cda_version() -> &'static str {
     option_env!("CDA_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))
+}
+
+#[cfg(test)]
+mod cli_args_tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[test]
+    fn unix_socket_flag_updates_server_config() {
+        let args = AppArgs::parse_from(["cda", "--unix-socket", "/run/cda.sock"]);
+        let mut config = crate::config::configfile::Configuration::default();
+        args.update_config(&mut config);
+
+        assert_eq!(config.server.unix_socket, Some("/run/cda.sock".to_owned()));
+    }
+
+    #[test]
+    fn without_unix_socket_flag_server_config_unix_socket_stays_none() {
+        let args = AppArgs::parse_from(["cda"]);
+        let mut config = crate::config::configfile::Configuration::default();
+        args.update_config(&mut config);
+
+        assert_eq!(config.server.unix_socket, None);
+    }
 }
 
 #[cfg(test)]

--- a/cda-sovd/Cargo.toml
+++ b/cda-sovd/Cargo.toml
@@ -108,3 +108,13 @@ cda-interfaces = { workspace = true, features = ["test-utils"] }
 cda-plugin-communication-management = { workspace = true, features = ["test-utils"] }
 cda-plugin-security = { workspace = true, features = ["test-utils"] }
 mockall = { workspace = true }
+futures = { workspace = true }
+tempfile = { workspace = true }
+
+# unix-domain-socket-capable HTTP client, unix-only - see the root Cargo.toml
+# for why this is scoped to `cfg(unix)`.
+[target.'cfg(unix)'.dev-dependencies]
+hyper = { workspace = true, features = ["client", "http1"] }
+hyper-util = { workspace = true, features = ["client-legacy", "http1", "tokio"] }
+hyperlocal = { workspace = true, features = ["client"] }
+http-body-util = { workspace = true }

--- a/cda-sovd/src/lib.rs
+++ b/cda-sovd/src/lib.rs
@@ -31,6 +31,8 @@ pub use http::Method;
 use opensovd_axum_extra::ExtractHost;
 use sovd::apps::sovd2uds::bulk_data::runtimefiles::RuntimeUpdateRouteState;
 use tokio::net::TcpListener;
+#[cfg(unix)]
+use tokio::net::UnixListener;
 use tower::{Layer, ServiceExt as TowerServiceExt};
 use tower_http::{normalize_path::NormalizePathLayer, trace::TraceLayer};
 
@@ -50,6 +52,10 @@ pub const OPENAPI_JSON_ROUTE: &str = "/openapi.json";
 pub struct WebServerConfig {
     pub host: String,
     pub port: u16,
+    /// When set, the server binds to this Unix domain socket path instead of
+    /// `host`/`port`. Takes priority silently over the TCP settings when
+    /// present - the two are not combined.
+    pub unix_socket: Option<String>,
 }
 
 /// Static configuration for vehicle SOVD routes.
@@ -84,6 +90,7 @@ pub struct VehicleResources<T, M> {
     fields(
         host = %config.host,
         port = %config.port,
+        unix_socket = config.unix_socket.as_deref().unwrap_or(""),
     )
 )]
 pub async fn launch_webserver<F>(
@@ -94,32 +101,73 @@ where
     F: Future<Output = ()> + Clone + Send + 'static,
 {
     let dynamic_router = DynamicRouter::new();
-    let listen_address = format!("{}:{}", config.host, config.port);
-    let listener = TcpListener::bind(&listen_address).await.map_err(|e| {
-        DoipGatewaySetupError::ServerError(format!("Failed to bind to {listen_address}: {e}"))
-    })?;
-
     let dynamic_router_for_service = dynamic_router.clone();
-    let webserver_task = cda_interfaces::spawn_named!("webserver", async move {
-        let service = tower::service_fn(move |request: Request<axum::body::Body>| {
-            let dr = dynamic_router_for_service.clone();
-            async move {
-                let router = dr.get_router().await;
-                TowerServiceExt::oneshot(router, request).await
-            }
-        });
-
-        let middleware = tower::util::MapRequestLayer::new(rewrite_request_uri);
-        let trim_trailing_slash_middleware = NormalizePathLayer::trim_trailing_slash();
-        let service_with_middleware =
-            middleware.layer(trim_trailing_slash_middleware.layer(service));
-
-        let _ = axum::serve(listener, tower::make::Shared::new(service_with_middleware))
-            .with_graceful_shutdown(shutdown_signal)
-            .await;
+    let service = tower::service_fn(move |request: Request<axum::body::Body>| {
+        let dr = dynamic_router_for_service.clone();
+        async move {
+            let router = dr.get_router().await;
+            TowerServiceExt::oneshot(router, request).await
+        }
     });
 
+    let middleware = tower::util::MapRequestLayer::new(rewrite_request_uri);
+    let trim_trailing_slash_middleware = NormalizePathLayer::trim_trailing_slash();
+    let service_with_middleware = middleware.layer(trim_trailing_slash_middleware.layer(service));
+
+    let webserver_task = if let Some(socket_path) = config.unix_socket {
+        #[cfg(unix)]
+        {
+            remove_stale_unix_socket(&socket_path)?;
+            let listener = UnixListener::bind(&socket_path).map_err(|e| {
+                DoipGatewaySetupError::ServerError(format!(
+                    "Failed to bind to unix socket {socket_path}: {e}"
+                ))
+            })?;
+            tracing::info!("SOVD HTTP server listening on unix socket {socket_path}");
+            cda_interfaces::spawn_named!("webserver", async move {
+                let _ = axum::serve(listener, tower::make::Shared::new(service_with_middleware))
+                    .with_graceful_shutdown(shutdown_signal)
+                    .await;
+            })
+        }
+        #[cfg(not(unix))]
+        {
+            return Err(DoipGatewaySetupError::ServerError(format!(
+                "Unix domain sockets are not supported on this platform (requested path: \
+                 {socket_path})"
+            )));
+        }
+    } else {
+        let listen_address = format!("{}:{}", config.host, config.port);
+        let listener = TcpListener::bind(&listen_address).await.map_err(|e| {
+            DoipGatewaySetupError::ServerError(format!("Failed to bind to {listen_address}: {e}"))
+        })?;
+        tracing::info!("SOVD HTTP server listening on {listen_address}");
+        cda_interfaces::spawn_named!("webserver", async move {
+            let _ = axum::serve(listener, tower::make::Shared::new(service_with_middleware))
+                .with_graceful_shutdown(shutdown_signal)
+                .await;
+        })
+    };
+
     Ok((dynamic_router, webserver_task))
+}
+
+/// Removes a pre-existing file at `socket_path`, if any, so that binding a
+/// fresh `UnixListener` there doesn't fail with `AddrInUse` because of a
+/// socket file left behind by a previous unclean shutdown.
+#[cfg(unix)]
+fn remove_stale_unix_socket(socket_path: &str) -> Result<(), DoipGatewaySetupError> {
+    match std::fs::remove_file(socket_path) {
+        Ok(()) => {
+            tracing::debug!("Removed stale unix socket file at {socket_path}");
+            Ok(())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(DoipGatewaySetupError::ServerError(format!(
+            "Failed to remove stale unix socket file at {socket_path}: {e}"
+        ))),
+    }
 }
 
 /// Add vehicle routes to the dynamic router
@@ -339,5 +387,164 @@ pub(crate) mod test_utils {
             .await
             .unwrap();
         serde_json::from_slice::<T>(body.as_ref())
+    }
+}
+
+#[cfg(all(test, unix))]
+mod webserver_bind_tests {
+    use std::time::Duration;
+
+    use futures::FutureExt;
+    use http_body_util::Empty;
+    use hyper_util::{client::legacy::Client, rt::TokioExecutor};
+    use hyperlocal::UnixConnector;
+
+    use super::*;
+
+    /// Sends a GET request over a Unix domain socket using a real HTTP
+    /// client (`hyperlocal` on top of `hyper-util`) and returns the response
+    /// status code. Used instead of parsing raw bytes off a `UnixStream`, so
+    /// the tests exercise a spec-compliant HTTP client the same way a real
+    /// consumer of the Unix socket transport would.
+    async fn get_over_unix_socket(socket_path: &str, path: &str) -> http::StatusCode {
+        let client: Client<UnixConnector, Empty<bytes::Bytes>> =
+            Client::builder(TokioExecutor::new()).build(UnixConnector);
+        let uri: http::Uri = hyperlocal::Uri::new(socket_path, path).into();
+
+        let response = client
+            .get(uri)
+            .await
+            .expect("failed to send request over unix socket");
+        response.status()
+    }
+
+    fn shutdown_channel() -> (
+        tokio::sync::broadcast::Sender<()>,
+        impl Future<Output = ()> + Clone + Send + 'static,
+    ) {
+        let (tx, mut rx) = tokio::sync::broadcast::channel::<()>(1);
+        let signal = async move {
+            rx.recv().await.ok();
+        }
+        .shared();
+        (tx, signal)
+    }
+
+    /// Asserts that `socket_path` is reachable (a request gets routed through
+    /// the dynamic router, even if it 404s because no routes are registered),
+    /// then signals shutdown and waits for `webserver_task` to finish.
+    async fn assert_reachable_then_shutdown(
+        socket_path: &str,
+        shutdown_tx: tokio::sync::broadcast::Sender<()>,
+        webserver_task: tokio::task::JoinHandle<()>,
+    ) {
+        // No routes are registered, so the dynamic router responds with 404 -
+        // that's fine, we only need to confirm the connection was accepted
+        // and routed.
+        let status = get_over_unix_socket(socket_path, "/").await;
+        assert_eq!(status, http::StatusCode::NOT_FOUND);
+
+        let _ = shutdown_tx.send(());
+        tokio::time::timeout(Duration::from_secs(5), webserver_task)
+            .await
+            .expect("webserver task didn't shut down in time")
+            .expect("webserver task panicked");
+    }
+
+    #[tokio::test]
+    async fn launch_webserver_binds_unix_socket() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let socket_path = dir.path().join("cda.sock").to_string_lossy().to_string();
+
+        let config = WebServerConfig {
+            host: "127.0.0.1".to_owned(),
+            port: 0,
+            unix_socket: Some(socket_path.clone()),
+        };
+        let (shutdown_tx, shutdown_signal) = shutdown_channel();
+
+        let (_dynamic_router, webserver_task) = launch_webserver(config, shutdown_signal)
+            .await
+            .expect("failed to launch webserver on unix socket");
+
+        assert_reachable_then_shutdown(&socket_path, shutdown_tx, webserver_task).await;
+    }
+
+    #[tokio::test]
+    async fn launch_webserver_unix_socket_takes_priority_over_tcp() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let socket_path = dir.path().join("cda.sock").to_string_lossy().to_string();
+
+        // Deliberately bind the TCP host/port too, to confirm it's ignored.
+        let tcp_listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to reserve a tcp port");
+        let tcp_port = tcp_listener.local_addr().unwrap().port();
+        drop(tcp_listener);
+
+        let config = WebServerConfig {
+            host: "127.0.0.1".to_owned(),
+            port: tcp_port,
+            unix_socket: Some(socket_path.clone()),
+        };
+        let (shutdown_tx, shutdown_signal) = shutdown_channel();
+
+        let (_dynamic_router, webserver_task) = launch_webserver(config, shutdown_signal)
+            .await
+            .expect("failed to launch webserver");
+
+        // The TCP port must remain free, proving TCP was never bound (the
+        // unix socket reachability itself is checked below).
+        let retry_listener = TcpListener::bind(("127.0.0.1", tcp_port)).await;
+        assert!(
+            retry_listener.is_ok(),
+            "TCP port should not have been bound when unix_socket is set"
+        );
+
+        assert_reachable_then_shutdown(&socket_path, shutdown_tx, webserver_task).await;
+    }
+
+    #[tokio::test]
+    async fn launch_webserver_removes_stale_unix_socket_file() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let socket_path = dir.path().join("cda.sock").to_string_lossy().to_string();
+
+        // Simulate a leftover socket file from a previous unclean shutdown.
+        std::fs::write(&socket_path, b"stale").expect("failed to create stale socket file");
+
+        let config = WebServerConfig {
+            host: "127.0.0.1".to_owned(),
+            port: 0,
+            unix_socket: Some(socket_path.clone()),
+        };
+        let (shutdown_tx, shutdown_signal) = shutdown_channel();
+
+        let (_dynamic_router, webserver_task) = launch_webserver(config, shutdown_signal)
+            .await
+            .expect("failed to launch webserver despite stale socket file");
+
+        assert_reachable_then_shutdown(&socket_path, shutdown_tx, webserver_task).await;
+    }
+
+    #[tokio::test]
+    async fn launch_webserver_fails_if_stale_socket_cannot_be_removed() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        // A directory can't be removed with `remove_file`, so binding must fail
+        // with a clear error instead of silently misbehaving.
+        let socket_path = dir.path().join("cda.sock");
+        std::fs::create_dir(&socket_path).expect("failed to create directory");
+
+        let config = WebServerConfig {
+            host: "127.0.0.1".to_owned(),
+            port: 0,
+            unix_socket: Some(socket_path.to_string_lossy().to_string()),
+        };
+        let (_shutdown_tx, shutdown_signal) = shutdown_channel();
+
+        let result = launch_webserver(config, shutdown_signal).await;
+        assert!(
+            result.is_err(),
+            "expected launch_webserver to fail when the stale socket path is a directory"
+        );
     }
 }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -83,6 +83,15 @@ tempfile = { workspace = true }
 [build-dependencies]
 cda-build = { workspace = true }
 
+# unix-domain-socket-capable HTTP client, unix-only - see the root Cargo.toml
+# for why this is scoped to `cfg(unix)`.
+[target.'cfg(unix)'.dependencies]
+hyper = { workspace = true, features = ["client", "http1"] }
+hyper-util = { workspace = true, features = ["client-legacy", "http1", "tokio"] }
+hyperlocal = { workspace = true, features = ["client"] }
+http-body-util = { workspace = true }
+bytes = { workspace = true }
+
 [features]
 # We need the health endpoint to check if the CDA is online
 default = ["opensovd_cda_lib/health"]

--- a/integration-tests/tests/sovd/custom_routes.rs
+++ b/integration-tests/tests/sovd/custom_routes.rs
@@ -22,7 +22,8 @@ use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 use crate::util::{
-    http::response_to_t,
+    TestingError,
+    http::{Response, response_to_t},
     runtime::{find_available_tcp_port, host, wait_for_cda_online},
 };
 
@@ -75,11 +76,55 @@ async fn add_custom_routes(dynamic_router: &DynamicRouter) {
     dynamic_router.add_routes(custom_router).await;
 }
 
+fn shutdown_channel() -> (
+    tokio::sync::broadcast::Sender<()>,
+    impl Future<Output = ()> + Clone + Send + 'static,
+) {
+    let (tx, mut rx) = tokio::sync::broadcast::channel::<()>(1);
+    let signal = async move {
+        rx.recv().await.ok();
+    }
+    .shared();
+    (tx, signal)
+}
+
+async fn shutdown_and_join(
+    shutdown_tx: tokio::sync::broadcast::Sender<()>,
+    webserver_join_handle: tokio::task::JoinHandle<()>,
+) {
+    shutdown_tx.send(()).ok();
+    webserver_join_handle
+        .await
+        .expect("Failed to shutdown webserver");
+}
+
+/// Exercises the `/test` demo endpoint via `get`/`post` (parameterized so
+/// callers can send the requests over TCP or a Unix domain socket) and
+/// asserts on the round-tripped `TestData` payloads.
+async fn assert_demo_endpoint_get_post<GetFut>(
+    get: impl FnOnce() -> GetFut,
+    post: impl FnOnce(String) -> futures::future::BoxFuture<'static, Result<Response, TestingError>>,
+) where
+    GetFut: Future<Output = Result<Response, TestingError>>,
+{
+    let get_response = get().await.expect("GET request failed");
+    let demo_data: TestData = response_to_t(&get_response).expect("Failed to parse GET response");
+    assert_eq!(demo_data.oem_name, "Eclipse Foundation");
+    assert_eq!(demo_data.version, "1.0.0");
+
+    let post_payload = TestData {
+        oem_name: "Custom OEM".to_string(),
+        version: "2.0.0".to_string(),
+    };
+    let post_body = serde_json::to_string(&post_payload).expect("Failed to serialize payload");
+    let post_response = post(post_body).await.expect("POST request failed");
+
+    let response_data: TestData =
+        response_to_t(&post_response).expect("Failed to parse POST response");
+    assert_eq!(response_data, post_payload);
+}
+
 #[tokio::test]
-#[allow(
-    clippy::too_many_lines,
-    reason = "Makes sense to keep the test together"
-)]
 async fn test_custom_demo_endpoint() {
     // Use loopback since we don't need actual ECU connections for this test
     let host = host();
@@ -88,13 +133,10 @@ async fn test_custom_demo_endpoint() {
     let webserver_config = cda_sovd::WebServerConfig {
         host: host.clone(),
         port: test_port,
+        unix_socket: None,
     };
 
-    let (shutdown_tx, mut shutdown_rx) = tokio::sync::broadcast::channel::<()>(1);
-    let shutdown_signal = async move {
-        shutdown_rx.recv().await.ok();
-    }
-    .shared();
+    let (shutdown_tx, shutdown_signal) = shutdown_channel();
 
     let (dynamic_router, webserver_join_handle) =
         cda_sovd::launch_webserver(webserver_config, shutdown_signal.clone())
@@ -127,42 +169,87 @@ async fn test_custom_demo_endpoint() {
     wait_for_cda_online(&ServerConfig {
         address: host,
         port: test_port,
+        unix_socket: None,
     })
     .await
     .expect("Webserver did not start in time");
 
-    // Test GET request
-    let get_response =
-        crate::util::http::send_request(StatusCode::OK, Method::GET, None, None, url.clone())
-            .await
-            .expect("GET request failed");
-
-    let demo_data: TestData = response_to_t(&get_response).expect("Failed to parse GET response");
-    assert_eq!(demo_data.oem_name, "Eclipse Foundation");
-    assert_eq!(demo_data.version, "1.0.0");
-
-    // Test POST request
-    let post_payload = TestData {
-        oem_name: "Custom OEM".to_string(),
-        version: "2.0.0".to_string(),
-    };
-    let post_body = serde_json::to_string(&post_payload).expect("Failed to serialize payload");
-    let post_response = crate::util::http::send_request(
-        StatusCode::CREATED,
-        Method::POST,
-        Some(&post_body),
-        None,
-        url,
+    assert_demo_endpoint_get_post(
+        || crate::util::http::send_request(StatusCode::OK, Method::GET, None, None, url.clone()),
+        |body| {
+            let url = url.clone();
+            async move {
+                crate::util::http::send_request(
+                    StatusCode::CREATED,
+                    Method::POST,
+                    Some(&body),
+                    None,
+                    url,
+                )
+                .await
+            }
+            .boxed()
+        },
     )
-    .await
-    .expect("POST request failed");
+    .await;
 
-    let response_data: TestData =
-        response_to_t(&post_response).expect("Failed to parse POST response");
-    assert_eq!(response_data, post_payload);
+    shutdown_and_join(shutdown_tx, webserver_join_handle).await;
+}
 
-    shutdown_tx.send(()).ok();
-    webserver_join_handle
-        .await
-        .expect("Failed to shutdown webserver");
+#[cfg(unix)]
+#[tokio::test]
+async fn test_custom_demo_endpoint_over_unix_socket() {
+    let socket_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let socket_path = socket_dir
+        .path()
+        .join("cda.sock")
+        .to_string_lossy()
+        .to_string();
+
+    let webserver_config = cda_sovd::WebServerConfig {
+        host: host(),
+        port: 0,
+        unix_socket: Some(socket_path.clone()),
+    };
+
+    let (shutdown_tx, shutdown_signal) = shutdown_channel();
+
+    let (dynamic_router, webserver_join_handle) =
+        cda_sovd::launch_webserver(webserver_config, shutdown_signal.clone())
+            .await
+            .expect("Failed to launch webserver");
+
+    // Add custom routes directly. No vehicle routes or health checks are
+    // needed for this test since we talk to the raw socket directly instead
+    // of polling the health endpoint for readiness.
+    add_custom_routes(&dynamic_router).await;
+
+    assert_demo_endpoint_get_post(
+        || {
+            crate::util::http::send_unix_socket_request(
+                &socket_path,
+                "/test",
+                StatusCode::OK,
+                Method::GET,
+                None,
+            )
+        },
+        |body| {
+            let socket_path = socket_path.clone();
+            async move {
+                crate::util::http::send_unix_socket_request(
+                    &socket_path,
+                    "/test",
+                    StatusCode::CREATED,
+                    Method::POST,
+                    Some(&body),
+                )
+                .await
+            }
+            .boxed()
+        },
+    )
+    .await;
+
+    shutdown_and_join(shutdown_tx, webserver_join_handle).await;
 }

--- a/integration-tests/tests/util/http.rs
+++ b/integration-tests/tests/util/http.rs
@@ -274,3 +274,81 @@ impl Response {
         self.header_map.get(name)
     }
 }
+
+/// Sends a request over a Unix domain socket connection using a real HTTP
+/// client (`hyperlocal` on top of `hyper-util`), so the tests exercise a
+/// spec-compliant client the same way a real consumer of the Unix socket
+/// transport (e.g. `opensovd-gateway`) would.
+///
+/// # Errors
+/// Returns [`TestingError`] if the socket can't be reached, the response
+/// can't be read, or the status doesn't match `expected_status`.
+#[cfg(unix)]
+pub(crate) async fn send_unix_socket_request(
+    socket_path: &str,
+    endpoint: &str,
+    expected_status: StatusCode,
+    method: Method,
+    data: Option<&str>,
+) -> Result<Response, TestingError> {
+    use http_body_util::{BodyExt, Full};
+    use hyper_util::{client::legacy::Client, rt::TokioExecutor};
+    use hyperlocal::UnixConnector;
+
+    let client: Client<UnixConnector, Full<bytes::Bytes>> =
+        Client::builder(TokioExecutor::new()).build(UnixConnector);
+    let uri: http::Uri = hyperlocal::Uri::new(socket_path, endpoint).into();
+
+    let body = data.unwrap_or_default().to_owned();
+    let mut request_builder = http::Request::builder()
+        .method(method)
+        .uri(uri)
+        .header(http::header::HOST, "localhost");
+    if !body.is_empty() {
+        request_builder = request_builder
+            .header(
+                reqwest::header::CONTENT_TYPE,
+                mime::APPLICATION_JSON.essence_str(),
+            )
+            .header(http::header::CONTENT_LENGTH, body.len());
+    }
+    let request = request_builder
+        .body(Full::new(bytes::Bytes::from(body)))
+        .map_err(|e| TestingError::ProcessFailed(format!("Failed to build request: {e}")))?;
+
+    let response = client.request(request).await.map_err(|e| {
+        TestingError::ProcessFailed(format!(
+            "Failed to send request over unix socket {socket_path}: {e}"
+        ))
+    })?;
+
+    let status = response.status();
+    let header_map = response.headers().clone();
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .map_err(|e| TestingError::ProcessFailed(format!("Failed to read response body: {e}")))?
+        .to_bytes();
+    let body = if body_bytes.is_empty() {
+        None
+    } else {
+        Some(String::from_utf8_lossy(&body_bytes).into_owned())
+    };
+
+    if status != expected_status {
+        return Err(TestingError::UnexpectedResponse {
+            expected: expected_status,
+            actual: status,
+            body,
+            message: "Expected status does not match".to_owned(),
+            url: format!("unix://{socket_path}{endpoint}"),
+        });
+    }
+
+    Ok(Response {
+        status,
+        body,
+        header_map,
+    })
+}

--- a/integration-tests/tests/util/runtime.rs
+++ b/integration-tests/tests/util/runtime.rs
@@ -326,6 +326,7 @@ fn base_test_config(
         server: opensovd_cda_lib::config::configfile::ServerConfig {
             address: host.clone(),
             port: cda_port,
+            unix_socket: None,
         },
         doip: opensovd_cda_lib::config::configfile::DoipConfig {
             tester_address: host,

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -811,6 +811,12 @@
 # address = "0.0.0.0"
 # TCP port the server listens on.
 # port = 20002
+# Path to a Unix domain socket to bind the server to, e.g. `/run/cda.sock`.
+#
+# When set, the server binds only to this Unix socket and `address`/`port`
+# are silently ignored - the two transports are mutually exclusive, with
+# the Unix socket taking priority.
+# unix_socket = "/run/cda.sock"
 
 # Strict-mode validation flags.
 [strict]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
Adds Unix domain socket support as an alternative to TCP for the SOVD HTTP server, configurable via --unix-socket, [server] unix_socket in TOML, or CDA_SERVER_UNIX_SOCKET. When set, it silently takes priority over the TCP address/port (both settings ignored, no error), and the server logs how/where it is listening.

- cda-sovd: WebServerConfig gains unix_socket; launch_webserver binds a UnixListener, removing any stale socket file left behind by a previous unclean shutdown (debug-logged), failing loudly if removal is not possible.
- cda-main: ServerConfig.unix_socket (TOML), --unix-socket CLI flag, wired into update_config/init_webserver. Env var support comes for free via the existing figment Env::prefixed("CDA") layer.
- Regenerated the reference opensovd-cda.toml to include the new field.
- Tests: unit tests in cda-sovd (bind, TCP-priority, stale-socket cleanup and failure), an end-to-end integration test, and config/CLI parsing tests in cda-main. Unix-socket-capable HTTP client (hyper/hyper-util/hyperlocal/http-body-util) added as a shared workspace dev-dependency for these tests.

Closes #368


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
