### PR TITLE
feat(sovd-api): implement data categories, mapping, and category filtering

### DIFF
--- a/cda-core/src/diag_kernel/component_info.rs
+++ b/cda-core/src/diag_kernel/component_info.rs
@@ -63,29 +63,23 @@ impl<S: SecurityPlugin> ComponentInfos for EcuManager<S> {
 
     /// Returns all services in /configuration,
     /// i.e. 0x22 (`ReadDataByIdentifier`) and 0x2E (`WriteDataByIdentifier`)
-    /// that are in the functional group varcoding.
+    /// that belong to one of the configured `configuration_functional_classes`.
     fn get_components_configurations_info(
         &self,
         security_plugin: &DynamicPlugin,
     ) -> Result<Vec<ComponentConfigurationsInfo>, DiagServiceError> {
         let diag_layers = self.get_diag_layers_from_variant_and_parent_refs();
-        let var_coding_func_class_short_name = diag_layers
+        let configuration_func_class_short_names: HashSet<&str> = diag_layers
             .iter()
             .filter_map(|dl| dl.funct_classes())
             .flat_map(|fc_vec| fc_vec.iter())
-            .find_map(|fc| {
+            .filter_map(|fc| {
                 fc.short_name().filter(|name| {
-                    name.eq_ignore_ascii_case(
-                        &self.database_naming_convention.functional_class_varcoding,
-                    )
+                    self.database_naming_convention
+                        .is_configuration_functional_class(name)
                 })
             })
-            .ok_or_else(|| {
-                DiagServiceError::NotFound(format!(
-                    "Functional class '{}' for varcoding not found in any diagnostic layer",
-                    self.database_naming_convention.functional_class_varcoding
-                ))
-            })?;
+            .collect();
 
         let configuration_sids = [
             service_ids::READ_DATA_BY_IDENTIFIER,
@@ -120,7 +114,7 @@ impl<S: SecurityPlugin> ComponentInfos for EcuManager<S> {
                 dc.funct_class().is_some_and(|fc| {
                     fc.iter().any(|fc| {
                         fc.short_name()
-                            .is_some_and(|n| n == var_coding_func_class_short_name)
+                            .is_some_and(|n| configuration_func_class_short_names.contains(n))
                     })
                 })
             })
@@ -551,12 +545,33 @@ impl<S: SecurityPlugin> ComponentInfos for EcuManager<S> {
 }
 
 impl<S: SecurityPlugin> EcuManager<S> {
+    /// Resolves the `/data` category for a 0x22/0x2E `DiagComm` by looking at its functional
+    /// classes and matching them against the configured `category_mapping`. Falls back to
+    /// `default_category` if none of the service's functional classes have a mapping entry.
+    fn category_for_diag_comm(&self, diag_comm: &datatypes::DiagComm<'_>) -> String {
+        diag_comm
+            .funct_class()
+            .and_then(|fc_vec| {
+                fc_vec
+                    .iter()
+                    .filter_map(|fc| fc.short_name())
+                    .find_map(|name| {
+                        self.database_naming_convention
+                            .category_mapping
+                            .iter()
+                            .find(|mapping| mapping.functional_class.eq_ignore_ascii_case(name))
+                            .map(|mapping| mapping.category.clone())
+                    })
+            })
+            .unwrap_or_else(|| self.database_naming_convention.default_category.clone())
+    }
+
     fn diag_comm_to_component_data_info(
         &self,
         diag_comm: &datatypes::DiagComm<'_>,
     ) -> ComponentDataInfo {
         ComponentDataInfo {
-            category: diag_comm.semantic().unwrap_or_default().to_owned(),
+            category: self.category_for_diag_comm(diag_comm),
             id: diag_comm.short_name().map_or(<_>::default(), |s| {
                 self.database_naming_convention.trim_short_name_affixes(s)
             }),
@@ -679,7 +694,8 @@ mod tests {
         database_builder::{DiagClassType, DiagCommParams, DiagLayerParams, EcuDataBuilder},
     };
     use cda_interfaces::{
-        Connectivity, DiagComm, DiagCommType, Protocol, VariantState, util::std_ext,
+        Connectivity, DiagComm, DiagCommType, Protocol, VariantState,
+        datatypes::DatabaseNamingConvention, util::std_ext,
     };
     use cda_plugin_security::DefaultSecurityPluginData;
 
@@ -1606,6 +1622,268 @@ mod tests {
         assert!(
             result.is_ok(),
             "Expected clean subfunction to still match with default mask, got: {result:?}"
+        );
+    }
+
+    /// Builds an [`EcuManager`] with a custom [`DatabaseNamingConvention`] and a single RDBI
+    /// (0x22) service named `service_name`, optionally associated with a functional class named
+    /// `funct_class_name`.
+    fn build_ecu_manager_with_rdbi_service_and_funct_class(
+        service_name: &str,
+        funct_class_name: Option<&str>,
+        naming_convention: DatabaseNamingConvention,
+    ) -> super::super::ecumanager::EcuManager<DefaultSecurityPluginData> {
+        let mut db_builder = EcuDataBuilder::new();
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
+
+        let request = create_sid_only_request!(db_builder, service_ids::READ_DATA_BY_IDENTIFIER);
+        let funct_class = funct_class_name.map(|name| vec![db_builder.create_funct_class(name)]);
+        let diag_comm = db_builder.create_diag_comm(DiagCommParams {
+            short_name: service_name,
+            diag_class_type: DiagClassType::START_COMM,
+            protocols: Some(vec![protocol]),
+            funct_class,
+            ..Default::default()
+        });
+        let service = new_diag_service!(db_builder, diag_comm, request, vec![], vec![]);
+        let db = finish_db!(db_builder, protocol, vec![service]);
+
+        let manager = super::super::ecumanager::EcuManager::new(
+            db,
+            Protocol::default(),
+            &cda_interfaces::datatypes::ComParams::default(),
+            naming_convention,
+            super::super::ecumanager::EcuManagerConfig {
+                type_: cda_interfaces::EcuManagerType::Ecu,
+                fallback_to_base_variant: true,
+                strict_parameter_validation: false,
+            },
+            &cda_interfaces::FunctionalDescriptionConfig {
+                description_database: "functional_groups".to_owned(),
+                enabled_functional_groups: None,
+                protocol_position: DiagnosticServiceAffixPosition::Suffix,
+            },
+        )
+        .expect("Failed to create EcuManager");
+
+        {
+            let mut ecu_state = std_ext::lock_write(&manager.runtime_state.ecu_state);
+            ecu_state.connectivity = Connectivity::Online;
+            ecu_state.variant_state = VariantState::Detected {
+                name: crate::diag_kernel::test_utils::ecu_manager_builder::TEST_DIAG_LAYER
+                    .to_owned(),
+                is_base_variant: true,
+                is_fallback: false,
+            };
+            ecu_state.variant_index = Some(0);
+        }
+
+        manager
+    }
+
+    #[test]
+    fn test_get_components_data_info_resolves_category_via_mapping() {
+        let naming_convention = DatabaseNamingConvention {
+            category_mapping: vec![cda_interfaces::datatypes::FunctionalClassCategoryMapping {
+                functional_class: "sensors".to_owned(),
+                category: "identData".to_owned(),
+            }],
+            default_category: "x-sovd2uds-unmapped".to_owned(),
+            ..Default::default()
+        };
+        let ecu_manager = build_ecu_manager_with_rdbi_service_and_funct_class(
+            "EngineTemp",
+            Some("sensors"),
+            naming_convention,
+        );
+
+        let result = ecu_manager.get_components_data_info(&skip_sec_plugin!());
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result.first().expect("Expected one data item").category,
+            "identData"
+        );
+    }
+
+    #[test]
+    fn test_get_components_data_info_falls_back_to_default_category() {
+        let naming_convention = DatabaseNamingConvention {
+            category_mapping: vec![cda_interfaces::datatypes::FunctionalClassCategoryMapping {
+                functional_class: "sensors".to_owned(),
+                category: "identData".to_owned(),
+            }],
+            default_category: "x-sovd2uds-unmapped".to_owned(),
+            ..Default::default()
+        };
+        let ecu_manager = build_ecu_manager_with_rdbi_service_and_funct_class(
+            "EngineTemp",
+            Some("unrelated_class"),
+            naming_convention,
+        );
+
+        let result = ecu_manager.get_components_data_info(&skip_sec_plugin!());
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result.first().expect("Expected one data item").category,
+            "x-sovd2uds-unmapped"
+        );
+    }
+
+    #[test]
+    fn test_get_components_data_info_no_funct_class_uses_default_category() {
+        let naming_convention = DatabaseNamingConvention {
+            category_mapping: vec![cda_interfaces::datatypes::FunctionalClassCategoryMapping {
+                functional_class: "sensors".to_owned(),
+                category: "identData".to_owned(),
+            }],
+            default_category: "x-sovd2uds-unmapped".to_owned(),
+            ..Default::default()
+        };
+        let ecu_manager = build_ecu_manager_with_rdbi_service_and_funct_class(
+            "EngineTemp",
+            None,
+            naming_convention,
+        );
+
+        let result = ecu_manager.get_components_data_info(&skip_sec_plugin!());
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result.first().expect("Expected one data item").category,
+            "x-sovd2uds-unmapped"
+        );
+    }
+
+    /// Builds an `EcuManager` whose diag layer defines a functional class named
+    /// `funct_class_name`, and which has one 0x22 (`ReadDataByIdentifier`) service named
+    /// `service_name` associated with that same functional class.
+    fn build_ecu_manager_with_configuration_service(
+        service_name: &str,
+        funct_class_name: &str,
+        naming_convention: DatabaseNamingConvention,
+    ) -> super::super::ecumanager::EcuManager<DefaultSecurityPluginData> {
+        use cda_database::datatypes::database_builder::EcuDataParams;
+
+        let mut db_builder = EcuDataBuilder::new();
+        let protocol_name = Protocol::default().to_string();
+        let protocol = db_builder.create_protocol(&protocol_name, None, None, None);
+
+        let sid_param = db_builder.create_coded_const_param(
+            "SID_RQ",
+            &service_ids::READ_DATA_BY_IDENTIFIER.to_string(),
+            0,
+            0,
+            8,
+            DataType::UInt32,
+        );
+        let did_param = db_builder.create_coded_const_param("DID", "1", 1, 0, 16, DataType::UInt32);
+        let request = db_builder.create_request(Some(vec![sid_param, did_param]), None);
+        let funct_class = db_builder.create_funct_class(funct_class_name);
+        let diag_comm = db_builder.create_diag_comm(DiagCommParams {
+            short_name: service_name,
+            diag_class_type: DiagClassType::START_COMM,
+            protocols: Some(vec![protocol]),
+            funct_class: Some(vec![funct_class]),
+            ..Default::default()
+        });
+        let service = new_diag_service!(db_builder, diag_comm, request, vec![], vec![]);
+
+        let cp_ref = db_builder.create_com_param_ref(None, None, None, Some(protocol), None);
+        let diag_layer = db_builder.create_diag_layer(DiagLayerParams {
+            short_name: crate::diag_kernel::test_utils::ecu_manager_builder::TEST_DIAG_LAYER,
+            com_param_refs: Some(vec![cp_ref]),
+            diag_services: Some(vec![service]),
+            funct_classes: Some(vec![funct_class]),
+            ..Default::default()
+        });
+        let variant = db_builder.create_variant(diag_layer, true, None, None);
+        let db = db_builder.finish(EcuDataParams {
+            ecu_name: "TestEcu",
+            revision: "1",
+            version: "1.0.0",
+            variants: Some(vec![variant]),
+            ..Default::default()
+        });
+
+        let manager = super::super::ecumanager::EcuManager::new(
+            db,
+            Protocol::default(),
+            &cda_interfaces::datatypes::ComParams::default(),
+            naming_convention,
+            super::super::ecumanager::EcuManagerConfig {
+                type_: cda_interfaces::EcuManagerType::Ecu,
+                fallback_to_base_variant: true,
+                strict_parameter_validation: false,
+            },
+            &cda_interfaces::FunctionalDescriptionConfig {
+                description_database: "functional_groups".to_owned(),
+                enabled_functional_groups: None,
+                protocol_position: DiagnosticServiceAffixPosition::Suffix,
+            },
+        )
+        .expect("Failed to create EcuManager");
+
+        {
+            let mut ecu_state = std_ext::lock_write(&manager.runtime_state.ecu_state);
+            ecu_state.connectivity = Connectivity::Online;
+            ecu_state.variant_state = VariantState::Detected {
+                name: crate::diag_kernel::test_utils::ecu_manager_builder::TEST_DIAG_LAYER
+                    .to_owned(),
+                is_base_variant: true,
+                is_fallback: false,
+            };
+            ecu_state.variant_index = Some(0);
+        }
+
+        manager
+    }
+
+    #[test]
+    fn test_get_components_configurations_info_uses_configured_functional_classes_list() {
+        let naming_convention = DatabaseNamingConvention {
+            configuration_functional_classes: vec![
+                "varcoding".to_owned(),
+                "calibration".to_owned(),
+            ],
+            ..Default::default()
+        };
+        let ecu_manager = build_ecu_manager_with_configuration_service(
+            "Calibration1",
+            "calibration",
+            naming_convention,
+        );
+
+        let result = ecu_manager
+            .get_components_configurations_info(&skip_sec_plugin!())
+            .expect("should return Ok");
+        assert_eq!(
+            result.len(),
+            1,
+            "Service belonging to a functional class in the configured list should be routed to \
+             /configurations"
+        );
+        assert_eq!(
+            result.first().expect("Expected one item").id,
+            "Calibration1"
+        );
+    }
+
+    #[test]
+    fn test_get_components_configurations_info_ignores_unlisted_functional_class() {
+        let naming_convention = DatabaseNamingConvention {
+            configuration_functional_classes: vec!["varcoding".to_owned()],
+            ..Default::default()
+        };
+        let ecu_manager =
+            build_ecu_manager_with_configuration_service("Sensor1", "sensors", naming_convention);
+
+        let result = ecu_manager
+            .get_components_configurations_info(&skip_sec_plugin!())
+            .expect("should return Ok");
+        assert!(
+            result.is_empty(),
+            "Service whose functional class is not in configuration_functional_classes must not \
+             be routed to /configurations"
         );
     }
 }

--- a/cda-interfaces/src/datatypes/database_naming_convention.rs
+++ b/cda-interfaces/src/datatypes/database_naming_convention.rs
@@ -26,7 +26,13 @@ use crate::{
 /// - `long_name_affix_position`: Position of affixes in long names (prefix or suffix).
 /// - `configuration_service_parameter_semantic_id`: Parameter semantic used to distinguish
 ///   between different services in configurations
-/// - `functional_class_varcoding`: Functional class name for filtering varcoding services.
+/// - `configuration_functional_classes`: Functional class names for filtering services that
+///   are routed to `/configurations` instead of `/data`.
+/// - `category_mapping`: Maps a functional class name to a `/data` category for 0x22/0x2E
+///   services that are *not* routed to `/configurations`. A functional class must not appear
+///   both here and in `configuration_functional_classes`.
+/// - `default_category`: Fallback category used for 0x22/0x2E services whose functional class
+///   is not present in `category_mapping` (and not in `configuration_functional_classes`).
 /// - `short_name_affixes`: List of lowercase affixes for short names.
 ///   **Each affix must match the specified `short_name_affix_position`
 ///   (i.e., be a prefix if `Prefix`, or a suffix if `Suffix`).**
@@ -55,8 +61,17 @@ pub struct DatabaseNamingConvention {
     pub long_name_affix_position: DiagnosticServiceAffixPosition,
     /// Semantic ID used to identify the distinguishing parameter of a service.
     pub configuration_service_parameter_semantic_id: String,
-    /// Functional class name used to filter varcoding services.
-    pub functional_class_varcoding: String,
+    /// Functional class names used to route 0x22/0x2E services to `/configurations`.
+    pub configuration_functional_classes: Vec<String>,
+    /// Maps a functional class name to a `/data` category for 0x22/0x2E services that are not
+    /// routed to `/configurations`. A functional class must not appear both here and in
+    /// `configuration_functional_classes`.
+    #[serde(default)]
+    pub category_mapping: Vec<FunctionalClassCategoryMapping>,
+    /// Fallback category for 0x22/0x2E services whose functional class has no entry in
+    /// `category_mapping`.
+    #[serde(default = "default_category")]
+    pub default_category: String,
     /// Ordered list of lowercase affixes to strip from short names during service lookup.
     ///
     /// Compound affixes (e.g. `_read_dump`) must come before general ones (e.g. `_dump`).
@@ -94,6 +109,19 @@ pub struct DatabaseNamingConvention {
     pub action_affixes: DiagCommActionAffixes,
     /// Database semantics to identify the type of service
     pub semantics: Semantics,
+}
+
+/// Maps a single ODX functional class name to a `/data` category.
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, schemars::JsonSchema)]
+pub struct FunctionalClassCategoryMapping {
+    /// The ODX functional class short name (case-insensitive match).
+    pub functional_class: String,
+    /// The category to assign to 0x22/0x2E services belonging to this functional class.
+    pub category: String,
+}
+
+fn default_category() -> String {
+    "x-sovd2uds-unmapped".to_owned()
 }
 
 /// Defines the name for the database semantics. Although they should follow the labels
@@ -174,11 +202,56 @@ impl ConfigSanity for DatabaseNamingConvention {
             }
         }
 
+        // A functional class must not be routed to /configurations and also have a category
+        // mapping to /data at the same time.
+        for mapping in &self.category_mapping {
+            if self
+                .configuration_functional_classes
+                .iter()
+                .any(|fc| fc.eq_ignore_ascii_case(&mapping.functional_class))
+            {
+                return Err(ConfigSanityError::InvalidValue {
+                    field: "database_naming_convention.category_mapping".to_owned(),
+                    reason: format!(
+                        "functional class '{}' is present in both \
+                         'configuration_functional_classes' and 'category_mapping'",
+                        mapping.functional_class
+                    ),
+                });
+            }
+        }
+
         Ok(())
     }
 }
 
 impl DatabaseNamingConvention {
+    /// Returns `true` if the given functional class name is configured to route 0x22/0x2E
+    /// services to `/configurations` instead of `/data`.
+    #[must_use]
+    pub fn is_configuration_functional_class(&self, functional_class_name: &str) -> bool {
+        self.configuration_functional_classes
+            .iter()
+            .any(|fc| fc.eq_ignore_ascii_case(functional_class_name))
+    }
+
+    /// Resolves the `/data` category for a 0x22/0x2E service belonging to the given functional
+    /// class, using the configured `category_mapping`, falling back to `default_category` if no
+    /// entry matches.
+    #[must_use]
+    pub fn category_for_functional_class(&self, functional_class_name: &str) -> &str {
+        self.category_mapping
+            .iter()
+            .find(|mapping| {
+                mapping
+                    .functional_class
+                    .eq_ignore_ascii_case(functional_class_name)
+            })
+            .map_or(self.default_category.as_str(), |mapping| {
+                mapping.category.as_str()
+            })
+    }
+
     /// Trims a diagnostic service long name using the configured affixes and naming position.
     /// The first matching affix is removed and the result is returned.
     /// Affixes must be lowercase for correct matching.
@@ -304,7 +377,9 @@ impl Default for DatabaseNamingConvention {
             short_name_affix_position: DiagnosticServiceAffixPosition::Suffix,
             long_name_affix_position: DiagnosticServiceAffixPosition::Suffix,
             configuration_service_parameter_semantic_id: "ID".to_owned(),
-            functional_class_varcoding: "varcoding".to_owned(),
+            configuration_functional_classes: vec!["varcoding".to_owned()],
+            category_mapping: Vec::new(),
+            default_category: default_category(),
             short_name_affixes: vec![
                 "_read".to_owned(),
                 "_write".to_owned(),
@@ -444,7 +519,9 @@ mod tests {
                 DiagnosticServiceAffixPosition::Suffix
             },
             configuration_service_parameter_semantic_id: "ID".to_owned(),
-            functional_class_varcoding: "varcoding".to_owned(),
+            configuration_functional_classes: vec!["varcoding".to_owned()],
+            category_mapping: Vec::new(),
+            default_category: default_category(),
             short_name_affixes: if prefix {
                 vec!["pre_".to_owned(), "s_".to_owned()]
             } else {
@@ -548,7 +625,9 @@ mod tests {
             short_name_affixes: vec!["pre_".to_owned()],
             long_name_affixes: vec![" post".to_owned()],
             configuration_service_parameter_semantic_id: "ID".to_owned(),
-            functional_class_varcoding: "varcoding".to_owned(),
+            configuration_functional_classes: vec!["varcoding".to_owned()],
+            category_mapping: Vec::new(),
+            default_category: default_category(),
             service_affixes: HashMap::default(),
             action_affixes: DiagCommActionAffixes::default(),
             semantics: Semantics::default(),
@@ -603,7 +682,7 @@ mod tests {
             "short_name_affix_position": "Suffix",
             "long_name_affix_position": "Suffix",
             "configuration_service_parameter_semantic_id": "ID",
-            "functional_class_varcoding": "varcoding",
+            "configuration_functional_classes": ["varcoding"],
             "short_name_affixes": [],
             "long_name_affixes": [],
             "service_affixes": {
@@ -708,6 +787,98 @@ mod tests {
         assert_eq!(
             conv.apply_action_affix("Data", &DiagCommAction::Read),
             "Data"
+        );
+    }
+
+    #[test]
+    fn test_is_configuration_functional_class_case_insensitive() {
+        let conv = DatabaseNamingConvention {
+            configuration_functional_classes: vec![
+                "VarCoding".to_owned(),
+                "calibration".to_owned(),
+            ],
+            ..make_convention(false)
+        };
+        assert!(conv.is_configuration_functional_class("varcoding"));
+        assert!(conv.is_configuration_functional_class("CALIBRATION"));
+        assert!(!conv.is_configuration_functional_class("sensors"));
+    }
+
+    #[test]
+    fn test_category_for_functional_class_uses_mapping() {
+        let conv = DatabaseNamingConvention {
+            category_mapping: vec![
+                FunctionalClassCategoryMapping {
+                    functional_class: "Sensors".to_owned(),
+                    category: "identData".to_owned(),
+                },
+                FunctionalClassCategoryMapping {
+                    functional_class: "measurements".to_owned(),
+                    category: "currentData".to_owned(),
+                },
+            ],
+            default_category: "x-sovd2uds-unmapped".to_owned(),
+            ..make_convention(false)
+        };
+        assert_eq!(conv.category_for_functional_class("sensors"), "identData");
+        assert_eq!(
+            conv.category_for_functional_class("MEASUREMENTS"),
+            "currentData"
+        );
+    }
+
+    #[test]
+    fn test_category_for_functional_class_falls_back_to_default() {
+        let conv = DatabaseNamingConvention {
+            category_mapping: vec![FunctionalClassCategoryMapping {
+                functional_class: "sensors".to_owned(),
+                category: "identData".to_owned(),
+            }],
+            default_category: "x-sovd2uds-unmapped".to_owned(),
+            ..make_convention(false)
+        };
+        assert_eq!(
+            conv.category_for_functional_class("unknown_class"),
+            "x-sovd2uds-unmapped"
+        );
+    }
+
+    #[test]
+    fn test_validate_sanity_rejects_functional_class_in_both_lists() {
+        let conv = DatabaseNamingConvention {
+            configuration_functional_classes: vec!["varcoding".to_owned()],
+            category_mapping: vec![FunctionalClassCategoryMapping {
+                functional_class: "VarCoding".to_owned(),
+                category: "identData".to_owned(),
+            }],
+            ..make_convention(false)
+        };
+        let result = conv.validate_sanity();
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(ConfigSanityError::InvalidValue { .. })
+        ));
+    }
+
+    #[test]
+    fn test_validate_sanity_accepts_disjoint_lists() {
+        let conv = DatabaseNamingConvention {
+            configuration_functional_classes: vec!["varcoding".to_owned()],
+            category_mapping: vec![FunctionalClassCategoryMapping {
+                functional_class: "sensors".to_owned(),
+                category: "identData".to_owned(),
+            }],
+            ..make_convention(false)
+        };
+        assert!(conv.validate_sanity().is_ok());
+    }
+
+    #[test]
+    fn test_default_category_is_unmapped_marker() {
+        assert_eq!(
+            DatabaseNamingConvention::default().default_category,
+            "x-sovd2uds-unmapped"
         );
     }
 }

--- a/cda-sovd-interfaces/src/components/ecu.rs
+++ b/cda-sovd-interfaces/src/components/ecu.rs
@@ -189,7 +189,60 @@ pub mod data {
 
     pub mod get {
         use super::ComponentData;
+
         pub type Response = ComponentData;
+
+        /// Query parameters for `GET /data`.
+        #[derive(serde::Deserialize, schemars::JsonSchema)]
+        pub struct Query {
+            #[serde(rename = "include-schema", default)]
+            pub include_schema: bool,
+            /// Optional comma-separated list of categories. When present, only data resources
+            /// whose `category` is one of the given values are returned.
+            ///
+            /// Matching is case-insensitive: incoming request URIs (including the query
+            /// string) are lowercased by CDA's request normalization middleware before
+            /// reaching this handler, so category names must be compared case-insensitively
+            /// against the (potentially mixed-case) `category` values produced by
+            /// `category_mapping`/`default_category`.
+            #[serde(default)]
+            pub categories: Option<String>,
+        }
+
+        impl Query {
+            /// Returns the parsed, trimmed list of requested categories, or `None` if the
+            /// `categories` query parameter was not provided.
+            ///
+            /// Comparisons against a `category` value must be done case-insensitively;
+            /// see the field documentation on [`Query::categories`].
+            #[must_use]
+            pub fn categories(&self) -> Option<Vec<&str>> {
+                self.categories
+                    .as_deref()
+                    .map(|c| c.split(',').map(str::trim).collect())
+            }
+        }
+    }
+}
+
+pub mod data_categories {
+    /// A single entry of the `/data-categories` response.
+    /// Spec ISO 17978-3 Section 7.9.2.1 (`DataCategoryInformation`).
+    #[derive(serde::Deserialize, serde::Serialize, Debug, schemars::JsonSchema)]
+    pub struct DataCategoryInformation {
+        /// The category name, e.g. `identData`, `currentData`, `storedData`, `sysInfo`, or a
+        /// custom `x-<ext>-...` category.
+        pub item: String,
+        /// Optional identifier for translating the category name. CDA does not currently
+        /// support translation, so this is always omitted.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub category_translation_id: Option<String>,
+    }
+
+    pub mod get {
+        use super::DataCategoryInformation;
+
+        pub type Response = crate::Items<DataCategoryInformation>;
         pub type Query = crate::IncludeSchemaQuery;
     }
 }

--- a/cda-sovd/src/sovd.rs
+++ b/cda-sovd/src/sovd.rs
@@ -58,8 +58,8 @@ use uuid::Uuid;
 use crate::{
     VendorErrorCode,
     sovd::components::ecu::{
-        configurations, data, faults, genericservice, modes, operations, x_single_ecu_jobs,
-        x_sovd2uds_bulk_data, x_sovd2uds_download,
+        configurations, data, data_categories, faults, genericservice, modes, operations,
+        x_single_ecu_jobs, x_sovd2uds_bulk_data, x_sovd2uds_download,
     },
 };
 
@@ -743,6 +743,10 @@ fn ecu_route<T: UdsEcu + SchemaProvider + Clone, U: FileManager + 'static>(
             ),
         )
         .api_route("/data", routing::get_with(data::get, data::docs_get))
+        .api_route(
+            "/data-categories",
+            routing::get_with(data_categories::get, data_categories::docs_get),
+        )
         .api_route(
             "/data/{service}",
             routing::get_with(data::diag_service::get, data::diag_service::docs_get)

--- a/cda-sovd/src/sovd/components/ecu.rs
+++ b/cda-sovd/src/sovd/components/ecu.rs
@@ -40,6 +40,7 @@ use crate::{
 
 pub(crate) mod configurations;
 pub(crate) mod data;
+pub(crate) mod data_categories;
 pub(crate) mod faults;
 pub(crate) mod genericservice;
 pub(crate) mod modes;

--- a/cda-sovd/src/sovd/components/ecu/data.rs
+++ b/cda-sovd/src/sovd/components/ecu/data.rs
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use aide::UseApi;
+use aide::{UseApi, transform::TransformParameter};
 use cda_plugin_security::Secured;
 use sovd_interfaces::error::ApiErrorResponse;
 
@@ -41,6 +41,13 @@ pub(crate) async fn get<T: UdsEcu + Clone, U: FileManager>(
         .await
     {
         Ok(mut items) => {
+            if let Some(categories) = query.categories() {
+                items.retain(|item| {
+                    categories
+                        .iter()
+                        .any(|c| c.eq_ignore_ascii_case(&item.category))
+                });
+            }
             let sovd_component_data = sovd_interfaces::components::ecu::data::get::Response {
                 items: items
                     .drain(0..)
@@ -60,6 +67,12 @@ pub(crate) async fn get<T: UdsEcu + Clone, U: FileManager>(
 
 pub(crate) fn docs_get(op: TransformOperation) -> TransformOperation {
     op.description("Get all ECU data.")
+        .parameter("categories", |op: TransformParameter<String>| {
+            op.description(
+                "Optional comma-separated list of categories. When present, only data resources \
+                 whose category is one of the given values are returned.",
+            )
+        })
         .response_with::<200, Json<sovd_interfaces::components::ecu::data::get::Response>, _>(
             |res| {
                 res.description("Response with all data.").example(
@@ -85,6 +98,187 @@ pub(crate) fn docs_get(op: TransformOperation) -> TransformOperation {
                     schema: None,
                 })
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use aide::UseApi;
+    use axum::extract::State;
+    use axum_extra::extract::WithRejection;
+    use cda_interfaces::{
+        datatypes::ComponentDataInfo, file_manager::mock::MockFileManager, mock::MockUdsEcu,
+    };
+    use cda_plugin_security::{Secured, mock::TestSecurityPlugin};
+
+    use super::*;
+    use crate::sovd::tests::create_test_webserver_state;
+
+    fn three_items() -> Vec<ComponentDataInfo> {
+        vec![
+            ComponentDataInfo {
+                category: "identData".to_owned(),
+                id: "Foo".to_owned(),
+                name: "Foo".to_owned(),
+            },
+            ComponentDataInfo {
+                category: "currentData".to_owned(),
+                id: "Bar".to_owned(),
+                name: "Bar".to_owned(),
+            },
+            ComponentDataInfo {
+                category: "identData".to_owned(),
+                id: "Baz".to_owned(),
+                name: "Baz".to_owned(),
+            },
+        ]
+    }
+
+    async fn call_get(
+        mock_uds: MockUdsEcu,
+        query: sovd_interfaces::components::ecu::data::get::Query,
+    ) -> Response {
+        let state = create_test_webserver_state::<MockUdsEcu, MockFileManager>(
+            "TestECU".to_owned(),
+            mock_uds,
+            MockFileManager::new(),
+        );
+
+        get::<MockUdsEcu, MockFileManager>(
+            UseApi(
+                Secured(Box::new(TestSecurityPlugin)),
+                std::marker::PhantomData,
+            ),
+            WithRejection(Query(query), std::marker::PhantomData),
+            State(state),
+        )
+        .await
+    }
+
+    /// Asserts the response is a `200 OK` and returns its parsed `items` array.
+    async fn ok_items(response: Response) -> Vec<serde_json::Value> {
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let doc: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        doc.get("items").unwrap().as_array().unwrap().clone()
+    }
+
+    #[tokio::test]
+    async fn returns_all_items_when_no_categories_filter() {
+        let mut mock_uds = MockUdsEcu::new();
+        mock_uds
+            .expect_get_components_data_info()
+            .returning(|_, _| Ok(three_items()));
+
+        let items = ok_items(
+            call_get(
+                mock_uds,
+                sovd_interfaces::components::ecu::data::get::Query {
+                    include_schema: false,
+                    categories: None,
+                },
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(items.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn filters_items_by_single_category() {
+        let mut mock_uds = MockUdsEcu::new();
+        mock_uds
+            .expect_get_components_data_info()
+            .returning(|_, _| Ok(three_items()));
+
+        let items = ok_items(
+            call_get(
+                mock_uds,
+                sovd_interfaces::components::ecu::data::get::Query {
+                    include_schema: false,
+                    categories: Some("identData".to_owned()),
+                },
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(items.len(), 2);
+        assert!(items.iter().all(|i| i["category"] == "identData"));
+    }
+
+    #[tokio::test]
+    async fn filters_items_by_multiple_comma_separated_categories() {
+        let mut mock_uds = MockUdsEcu::new();
+        mock_uds
+            .expect_get_components_data_info()
+            .returning(|_, _| Ok(three_items()));
+
+        let items = ok_items(
+            call_get(
+                mock_uds,
+                sovd_interfaces::components::ecu::data::get::Query {
+                    include_schema: false,
+                    categories: Some("identData, currentData".to_owned()),
+                },
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(items.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn returns_empty_when_category_does_not_match() {
+        let mut mock_uds = MockUdsEcu::new();
+        mock_uds
+            .expect_get_components_data_info()
+            .returning(|_, _| Ok(three_items()));
+
+        let items = ok_items(
+            call_get(
+                mock_uds,
+                sovd_interfaces::components::ecu::data::get::Query {
+                    include_schema: false,
+                    categories: Some("storedData".to_owned()),
+                },
+            )
+            .await,
+        )
+        .await;
+
+        assert!(items.is_empty());
+    }
+
+    /// Request URIs (including their query string) are lowercased by CDA's request
+    /// normalization middleware (`rewrite_request_uri` in `cda-sovd::lib`) before reaching
+    /// this handler, so a category name requested as e.g. `identdata` must still match an
+    /// item whose `category` is the mixed-case `identData`.
+    #[tokio::test]
+    async fn filters_items_by_category_case_insensitively() {
+        let mut mock_uds = MockUdsEcu::new();
+        mock_uds
+            .expect_get_components_data_info()
+            .returning(|_, _| Ok(three_items()));
+
+        let items = ok_items(
+            call_get(
+                mock_uds,
+                sovd_interfaces::components::ecu::data::get::Query {
+                    include_schema: false,
+                    categories: Some("identdata".to_owned()),
+                },
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(items.len(), 2);
+        assert!(items.iter().all(|i| i["category"] == "identData"));
+    }
 }
 
 pub(crate) mod diag_service {

--- a/cda-sovd/src/sovd/components/ecu/data_categories.rs
+++ b/cda-sovd/src/sovd/components/ecu/data_categories.rs
@@ -1,0 +1,209 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Copyright (c) Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::collections::BTreeSet;
+
+use aide::UseApi;
+use axum::{
+    Json,
+    extract::{Query, State},
+    response::{IntoResponse, Response},
+};
+use axum_extra::extract::WithRejection;
+use cda_plugin_security::Secured;
+use http::StatusCode;
+use sovd_interfaces::components::ecu::data_categories as sovd_data_categories;
+
+use super::{ApiError, DynamicPlugin, ErrorWrapper, FileManager, UdsEcu, WebserverEcuState};
+use crate::sovd::create_schema;
+
+pub(crate) async fn get<T: UdsEcu + Clone, U: FileManager>(
+    UseApi(Secured(security_plugin), _): UseApi<Secured, ()>,
+    WithRejection(Query(query), _): WithRejection<
+        Query<sovd_data_categories::get::Query>,
+        ApiError,
+    >,
+    State(WebserverEcuState { ecu_name, uds, .. }): State<WebserverEcuState<T, U>>,
+) -> Response {
+    let schema = if query.include_schema {
+        Some(create_schema!(sovd_data_categories::get::Response))
+    } else {
+        None
+    };
+    match uds
+        .get_components_data_info(&ecu_name, &(security_plugin as DynamicPlugin))
+        .await
+    {
+        Ok(items) => {
+            let categories: BTreeSet<String> =
+                items.into_iter().map(|item| item.category).collect();
+            let response = sovd_data_categories::get::Response {
+                items: categories
+                    .into_iter()
+                    .map(|category| sovd_data_categories::DataCategoryInformation {
+                        item: category,
+                        category_translation_id: None,
+                    })
+                    .collect(),
+                schema,
+            };
+            (StatusCode::OK, Json(response)).into_response()
+        }
+        Err(e) => ErrorWrapper {
+            error: e.into(),
+            include_schema: query.include_schema,
+        }
+        .into_response(),
+    }
+}
+
+pub(crate) fn docs_get(
+    op: aide::transform::TransformOperation,
+) -> aide::transform::TransformOperation {
+    op.description(
+        "Get all data categories currently in use by this ECU component's /data resources \
+         (ISO 17978-3 Section 7.9.2.1).",
+    )
+    .response_with::<200, Json<sovd_data_categories::get::Response>, _>(|res| {
+        res.description("Response with all data categories.").example(
+            sovd_data_categories::get::Response {
+                items: vec![sovd_data_categories::DataCategoryInformation {
+                    item: "identData".to_string(),
+                    category_translation_id: None,
+                }],
+                schema: None,
+            },
+        )
+    })
+    .response_with::<400, Json<sovd_interfaces::error::ApiErrorResponse<crate::sovd::error::VendorErrorCode>>, _>(
+        |res| {
+            res.description("Error while fetching data from ECU.")
+                .example(sovd_interfaces::error::ApiErrorResponse {
+                    message: "Failed to fetch ECU data".to_string(),
+                    error_code: sovd_interfaces::error::ErrorCode::VendorSpecific,
+                    vendor_code: Some(crate::sovd::error::VendorErrorCode::BadRequest),
+                    parameters: None,
+                    error_source: Some("ECU".to_string()),
+                    schema: None,
+                })
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use aide::UseApi;
+    use axum::extract::State;
+    use cda_interfaces::{
+        datatypes::ComponentDataInfo, file_manager::mock::MockFileManager, mock::MockUdsEcu,
+    };
+    use cda_plugin_security::{Secured, mock::TestSecurityPlugin};
+
+    use super::*;
+    use crate::sovd::tests::create_test_webserver_state;
+
+    async fn call_get(mock_uds: MockUdsEcu) -> Response {
+        let state = create_test_webserver_state::<MockUdsEcu, MockFileManager>(
+            "TestECU".to_owned(),
+            mock_uds,
+            MockFileManager::new(),
+        );
+
+        get::<MockUdsEcu, MockFileManager>(
+            UseApi(
+                Secured(Box::new(TestSecurityPlugin)),
+                std::marker::PhantomData,
+            ),
+            WithRejection(
+                Query(sovd_data_categories::get::Query {
+                    include_schema: false,
+                }),
+                std::marker::PhantomData,
+            ),
+            State(state),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn returns_deduplicated_sorted_categories() {
+        let mut mock_uds = MockUdsEcu::new();
+        mock_uds
+            .expect_get_components_data_info()
+            .returning(|_, _| {
+                Ok(vec![
+                    ComponentDataInfo {
+                        category: "currentData".to_owned(),
+                        id: "Foo".to_owned(),
+                        name: "Foo".to_owned(),
+                    },
+                    ComponentDataInfo {
+                        category: "identData".to_owned(),
+                        id: "Bar".to_owned(),
+                        name: "Bar".to_owned(),
+                    },
+                    ComponentDataInfo {
+                        category: "currentData".to_owned(),
+                        id: "Baz".to_owned(),
+                        name: "Baz".to_owned(),
+                    },
+                ])
+            });
+
+        let response = call_get(mock_uds).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let doc: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let items = doc.get("items").unwrap().as_array().unwrap();
+        assert_eq!(items.len(), 2, "categories must be deduplicated");
+        assert_eq!(
+            items.first().expect("Expected item 0")["item"],
+            "currentData"
+        );
+        assert_eq!(items.get(1).expect("Expected item 1")["item"], "identData");
+    }
+
+    #[tokio::test]
+    async fn returns_empty_when_no_data_items() {
+        let mut mock_uds = MockUdsEcu::new();
+        mock_uds
+            .expect_get_components_data_info()
+            .returning(|_, _| Ok(vec![]));
+
+        let response = call_get(mock_uds).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let doc: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(doc.get("items").unwrap().as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn returns_error_when_lookup_fails() {
+        use cda_interfaces::DiagServiceError;
+
+        let mut mock_uds = MockUdsEcu::new();
+        mock_uds
+            .expect_get_components_data_info()
+            .returning(|_, _| Err(DiagServiceError::NotFound("ECU not found".to_owned())));
+
+        let response = call_get(mock_uds).await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/docs/02_requirements/02_sovd.rst
+++ b/docs/02_requirements/02_sovd.rst
@@ -122,7 +122,9 @@ Paths
            | 2E
          - | /data/{data-identifier}
            | /configurations/{data-identifier}
-         - category & classification between paths is handled by the functional class with configuration
+         - | Classification between ``/data`` and ``/configurations`` is handled by mapping the ODX functional
+           | class to a category (for ``/data``) or to the ``/configurations`` path, via configuration.
+           | See :need:`arch~sovd-api-functional-class-mapping`.
        * - 27
          - /modes/security
          -
@@ -155,6 +157,43 @@ Paths
 
     The CDA must support the optional query parameter ``x-sovd2uds-includesdgs`` (alias ``x-include-sdgs``) to be able to
     include a list of SDG/SD properties of the ECU - see :need:`req~sovd-api-component-sdgsd`.
+
+.. req:: Data Categories Endpoint
+    :id: req~sovd-api-data-categories-endpoint
+    :links: arch~sovd-api-data-categories-endpoint
+    :status: draft
+
+    The CDA must provide a ``GET /components/{ecu-name}/data-categories`` endpoint returning the list of data
+    categories supported by that ECU, as specified by ISO 17978-3.
+
+    **Rationale**
+
+    Allows an SOVD client to discover which categories are actually in use for a given ECU without having to
+    enumerate and inspect every entry of ``/data`` first.
+
+.. req:: Data Groups Endpoint
+    :id: req~sovd-api-data-groups-endpoint
+    :links: arch~sovd-api-data-groups-endpoint
+    :status: draft
+
+    The CDA must provide a ``GET /components/{ecu-name}/data-groups`` endpoint returning the list of groups defined
+    for that ECU's data resources, optionally filtered by the ``category`` query parameter, as specified by ISO
+    17978-3.
+
+    **Rationale**
+
+    Allows an SOVD client to discover related data resources (e.g. all values belonging to "engine performance")
+    without relying on category alone, and to filter that discovery by category.
+
+.. req:: Data Query Filtering
+    :id: req~sovd-api-data-query-filtering
+    :links: arch~sovd-api-data-query-filtering
+    :status: draft
+
+    The CDA must support the optional query parameters ``categories`` and ``groups`` on
+    ``GET /components/{ecu-name}/data``, to filter the returned data resources by category or by group
+    respectively, as specified by ISO 17978-3. If both are provided, ``groups`` takes precedence and
+    ``categories`` must be ignored.
 
 .. req:: Component SDG/SDs
     :id: req~sovd-api-component-sdgsd

--- a/docs/03_architecture/02_sovd-api/02_sovd-api.rst
+++ b/docs/03_architecture/02_sovd-api/02_sovd-api.rst
@@ -326,8 +326,6 @@ Categories
     :id: arch~sovd-api-data-identifier-categories
     :status: draft
 
-    The category of a data identifier must be mappable with configuration, in which the functional class name is mapped to a category name.
-
     The following standard categories are defined by the standard:
 
     .. list-table:: Standard categories
@@ -336,17 +334,204 @@ Categories
        * - Name
          - Description
        * - identData
-         - Identification data -- everything related to the identification of an ECU/vehicle
+         - Identifications -- read access to fixed parameters that identify an ECU/vehicle, e.g. part number or VIN.
+           Write access may be possible for ECU manufacturing / vehicle production purposes, but is typically not
+           possible after final vehicle production.
        * - currentData
-         - Measurement data that can dynamically change
+         - Measurements -- read access to dynamically changing values, e.g. battery voltage.
        * - storedData
-         - Parameters stored in the ECU
+         - Parameters -- read and write access to parameters in the ECU/vehicle.
        * - sysInfo
-         - System information - data related to system resources that can change dynamically (e.g. memory consumption)
+         - System information -- read access to dynamically changing system resources, e.g. memory/CPU load.
 
-    Additional custom categories must be prefixed with ``x-sovd2uds-``, or, in custom vendor configuration, with a vendor-specific prefix different from ``x-sovd2uds``.
+    Additional custom categories must be prefixed with ``x-sovd2uds-``, or, in custom vendor configuration, with a
+    vendor-specific prefix different from ``x-sovd2uds-``. The prefix ``x-sovd-`` is reserved by the standard and
+    must never be used for custom categories.
 
-    Services without a mapping should be ignored to allow a separation between configuration and data services.
+    .. note::
+       The SOVD standard also defines the resources ``GET /{entity-path}/data-categories`` (see
+       :need:`arch~sovd-api-data-categories-endpoint`), ``GET /{entity-path}/data-groups`` (see
+       :need:`arch~sovd-api-data-groups-endpoint`), and ``categories``/``groups`` query parameters on
+       ``GET /{entity-path}/data`` (see :need:`arch~sovd-api-data-query-filtering`). These are **not yet
+       implemented** by the CDA; the following subsections specify their target design.
+
+.. arch:: Data Categories Endpoint
+    :id: arch~sovd-api-data-categories-endpoint
+    :status: draft
+
+    .. note::
+       Not yet implemented.
+
+    ``GET /components/{ecu-name}/data-categories`` returns the categories actually in use by the ECU's ``/data``
+    resource collection, i.e. the distinct set of values returned as ``category`` on the ``/data`` items -- not
+    necessarily every standard category defined by :need:`arch~sovd-api-data-identifier-categories`.
+
+    .. list-table:: Data categories response
+       :header-rows: 1
+
+       * - Attribute
+         - Description
+       * - items
+         - Array of ``DataCategoryInformation`` (see below).
+
+    .. list-table:: DataCategoryInformation
+       :header-rows: 1
+
+       * - Attribute
+         - Description
+       * - item
+         - The category name.
+       * - category_translation_id
+         - Optional identifier for translating the category name (CDA does not currently support translation and
+           may omit this attribute).
+
+    Example::
+
+       GET /components/WindowControl/data-categories
+
+       {
+           "items": [
+               { "item": "currentData" },
+               { "item": "identData" }
+           ]
+       }
+
+.. arch:: Data Groups Endpoint
+    :id: arch~sovd-api-data-groups-endpoint
+    :status: draft
+
+    .. note::
+       Not yet implemented.
+
+    ``GET /components/{ecu-name}/data-groups`` returns the groups defined for the ECU's ``/data`` resources. Groups
+    are an optional, orthogonal grouping mechanism to categories -- a data resource may belong to zero or more
+    groups, in addition to having exactly one category. Groups are not intended to be used to partition data
+    across subcomponents; subcomponent data must instead be exposed via the corresponding subcomponent's own
+    ``/data`` resource collection.
+
+    **Query Parameters**
+
+    .. list-table:: Data groups query parameters
+       :header-rows: 1
+
+       * - Parameter Name
+         - Description
+       * - category
+         - Optional. Filters the returned groups to those associated with the given category. If omitted, all
+           groups of the entity are returned.
+
+    **Response**
+
+    .. list-table:: ValueGroup
+       :header-rows: 1
+
+       * - Attribute
+         - Description
+       * - id
+         - Unique identifier for the group, unique across all categories.
+       * - category
+         - The category the group is associated with.
+       * - category_translation_id
+         - Optional identifier for translating the category name.
+       * - group
+         - Optional display name of the group.
+       * - group_translation_id
+         - Optional identifier for translating the group name.
+
+    Example::
+
+       GET /components/WindowControl/data-groups?category=currentData
+
+       {
+           "items": [
+               { "id": "front", "category": "currentData" },
+               { "id": "rear", "category": "currentData" }
+           ]
+       }
+
+    Group membership for a given data resource must itself be configurable per functional-class / per-service,
+    analogous to the category mapping in :need:`arch~sovd-api-functional-class-mapping`; the exact configuration
+    mechanism for assigning groups is left open for a future architecture change once this endpoint is
+    implemented.
+
+.. arch:: Data Query Filtering
+    :id: arch~sovd-api-data-query-filtering
+    :status: draft
+
+    .. note::
+       Not yet implemented.
+
+    ``GET /components/{ecu-name}/data`` must support the following additional query parameters:
+
+    .. list-table:: Data query parameters
+       :header-rows: 1
+
+       * - Parameter Name
+         - Description
+       * - categories
+         - Optional array. Filters the returned data resources to those whose ``category`` is one of the given
+           values.
+       * - groups
+         - Optional array. Filters the returned data resources to those belonging to at least one of the given
+           groups. If both ``groups`` and ``categories`` are provided, ``groups`` takes precedence and
+           ``categories`` must be ignored by the CDA, since ``groups`` is the more restrictive filter.
+
+    If the existing ``tags`` query parameter is combined with either ``groups`` or ``categories``, the two filters
+    must be logically AND-combined.
+
+.. arch:: Functional Class to Category and Configuration Mapping
+    :id: arch~sovd-api-functional-class-mapping
+    :status: draft
+
+    Whether a diag-service defined for 22\ :sub:`16` / 2E\ :sub:`16` is exposed as a ``/data`` resource (with a
+    category) or as a ``/configurations`` resource is determined by configuration, based on the ODX functional
+    class the service belongs to. The mapping has two parts:
+
+    1. **Configuration routing list** -- a configurable list of functional class names. Any 22\ :sub:`16`/2E\
+       :sub:`16` service belonging to one of these functional classes is exposed under ``/configurations`` instead
+       of ``/data`` (see :need:`arch~sovd-api-configuration-resources`). This generalizes the previous single
+       ``functional_class_varcoding`` name to a list, allowing multiple functional classes (e.g. varcoding,
+       calibration, ...) to be routed to ``/configurations``.
+    2. **Category mapping table** -- for services *not* routed to ``/configurations``, a configurable table maps
+       functional class names to a standard or custom category (see :need:`arch~sovd-api-data-identifier-categories`).
+       A functional class may only appear in the configuration routing list, or in the category mapping table, but
+       not both.
+
+    **Precedence**: for each 22\ :sub:`16`/2E\ :sub:`16` service, the functional class is first checked against
+    the configuration routing list. If it matches, the service is exposed under ``/configurations``. Otherwise,
+    the category mapping table is consulted to determine the ``category`` attribute of the ``/data`` resource.
+
+    **Fallback / default category**: if a service's functional class (or a service without any functional class)
+    has no matching entry in the category mapping table, a configurable default category is used instead of
+    rejecting or silently mis-categorizing the service. This default must itself be a valid standard or
+    ``x-sovd2uds-``-prefixed custom category (e.g. ``x-sovd2uds-unmapped``), so that unmapped services remain
+    clearly identifiable to integrators and testers rather than being bucketed into a standard category by
+    accident.
+
+    **Configuration shape** (illustrative, see ``[database.naming_convention]`` in the sample configuration file):
+
+    .. code-block:: toml
+
+       [database.naming_convention]
+       # Functional classes routed to /configurations instead of /data.
+       functional_classes_configuration = ["varcoding"]
+       # Default category for /data services whose functional class (or lack thereof)
+       # has no entry in `category_mapping`.
+       default_data_category = "x-sovd2uds-unmapped"
+
+       # Functional class -> category mapping for /data services.
+       [[database.naming_convention.category_mapping]]
+       functional_class = "identification"
+       category = "identData"
+
+       [[database.naming_convention.category_mapping]]
+       functional_class = "measurements"
+       category = "currentData"
+
+    .. note::
+       ``/configurations`` resources do not have a ``category`` attribute in the standard (see
+       :need:`arch~sovd-api-configuration-resources`); the functional class is only used there to decide
+       *which* services are routed to ``/configurations``, not to categorize them further.
 
 
 Configurations -- SID 22\ :sub:`16` & 2E\ :sub:`16`
@@ -357,7 +542,8 @@ Configurations -- SID 22\ :sub:`16` & 2E\ :sub:`16`
     :status: draft
 
     Names for data resources are determined by taking all diag-services defined for 22\ :sub:`16` and 2E\ :sub:`16`, and filtering
-    them for a configurable functional class name. Their short name is taken as a base and processed by removing
+    them for one of the configurable functional class names in ``functional_classes_configuration`` (see
+    :need:`arch~sovd-api-functional-class-mapping`). Their short name is taken as a base and processed by removing
     configurable prefixes/suffixes, to determine the data identifier within the ``/configurations/{data-identifier}`` path.
 
     The returned item properties for the ``/configurations`` item list are:

--- a/docs/03_architecture/02_sovd-api/02_sovd-api.rst
+++ b/docs/03_architecture/02_sovd-api/02_sovd-api.rst
@@ -352,15 +352,14 @@ Categories
        The SOVD standard also defines the resources ``GET /{entity-path}/data-categories`` (see
        :need:`arch~sovd-api-data-categories-endpoint`), ``GET /{entity-path}/data-groups`` (see
        :need:`arch~sovd-api-data-groups-endpoint`), and ``categories``/``groups`` query parameters on
-       ``GET /{entity-path}/data`` (see :need:`arch~sovd-api-data-query-filtering`). These are **not yet
-       implemented** by the CDA; the following subsections specify their target design.
+       ``GET /{entity-path}/data`` (see :need:`arch~sovd-api-data-query-filtering`). ``data-categories`` and the
+       ``categories`` query parameter are implemented; ``data-groups`` and the ``groups`` query parameter are
+       **not yet implemented** by the CDA (their configuration mechanism is left open for a future architecture
+       change, see :need:`arch~sovd-api-data-groups-endpoint`).
 
 .. arch:: Data Categories Endpoint
     :id: arch~sovd-api-data-categories-endpoint
     :status: draft
-
-    .. note::
-       Not yet implemented.
 
     ``GET /components/{ecu-name}/data-categories`` returns the categories actually in use by the ECU's ``/data``
     resource collection, i.e. the distinct set of values returned as ``category`` on the ``/data`` items -- not
@@ -459,7 +458,9 @@ Categories
     :status: draft
 
     .. note::
-       Not yet implemented.
+       The ``categories`` query parameter is implemented. The ``groups`` query parameter is **not yet
+       implemented**, since it depends on the group-assignment configuration mechanism described in
+       :need:`arch~sovd-api-data-groups-endpoint`, which is also not yet implemented.
 
     ``GET /components/{ecu-name}/data`` must support the following additional query parameters:
 
@@ -469,15 +470,13 @@ Categories
        * - Parameter Name
          - Description
        * - categories
-         - Optional array. Filters the returned data resources to those whose ``category`` is one of the given
-           values.
+         - Optional. Comma-separated list of categories. Filters the returned data resources to those whose
+           ``category`` is one of the given values.
        * - groups
-         - Optional array. Filters the returned data resources to those belonging to at least one of the given
-           groups. If both ``groups`` and ``categories`` are provided, ``groups`` takes precedence and
-           ``categories`` must be ignored by the CDA, since ``groups`` is the more restrictive filter.
-
-    If the existing ``tags`` query parameter is combined with either ``groups`` or ``categories``, the two filters
-    must be logically AND-combined.
+         - Optional. Comma-separated list of groups. Filters the returned data resources to those belonging to at
+           least one of the given groups. If both ``groups`` and ``categories`` are provided, ``groups`` takes
+           precedence and ``categories`` must be ignored by the CDA, since ``groups`` is the more restrictive
+           filter.
 
 .. arch:: Functional Class to Category and Configuration Mapping
     :id: arch~sovd-api-functional-class-mapping
@@ -508,16 +507,16 @@ Categories
     clearly identifiable to integrators and testers rather than being bucketed into a standard category by
     accident.
 
-    **Configuration shape** (illustrative, see ``[database.naming_convention]`` in the sample configuration file):
+    **Configuration shape** (see ``[database.naming_convention]`` in the sample configuration file):
 
     .. code-block:: toml
 
        [database.naming_convention]
        # Functional classes routed to /configurations instead of /data.
-       functional_classes_configuration = ["varcoding"]
+       configuration_functional_classes = ["varcoding"]
        # Default category for /data services whose functional class (or lack thereof)
        # has no entry in `category_mapping`.
-       default_data_category = "x-sovd2uds-unmapped"
+       default_category = "x-sovd2uds-unmapped"
 
        # Functional class -> category mapping for /data services.
        [[database.naming_convention.category_mapping]]
@@ -542,7 +541,7 @@ Configurations -- SID 22\ :sub:`16` & 2E\ :sub:`16`
     :status: draft
 
     Names for data resources are determined by taking all diag-services defined for 22\ :sub:`16` and 2E\ :sub:`16`, and filtering
-    them for one of the configurable functional class names in ``functional_classes_configuration`` (see
+    them for one of the configurable functional class names in ``configuration_functional_classes`` (see
     :need:`arch~sovd-api-functional-class-mapping`). Their short name is taken as a base and processed by removing
     configurable prefixes/suffixes, to determine the data identifier within the ``/configurations/{data-identifier}`` path.
 

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -534,6 +534,11 @@
 # Semantic ID used to identify the distinguishing parameter of a service.
 # configuration_service_parameter_semantic_id = "ID"
 # Functional class name used to filter varcoding services.
+# NOTE: this is currently the only functional class routed to `/configurations`, and there is no
+# functional-class-to-category mapping for `/data` yet. See `arch~sovd-api-functional-class-mapping`
+# in docs/03_architecture/02_sovd-api/02_sovd-api.rst for the target design (a configurable list of
+# functional classes routed to `/configurations`, plus a functional-class-to-category mapping table
+# with a configurable default/fallback category for `/data`).
 # functional_class_varcoding = "varcoding"
 # Position of affixes in diagnostic service long names.
 # long_name_affix_position = "Suffix"

--- a/opensovd-cda.toml
+++ b/opensovd-cda.toml
@@ -491,7 +491,13 @@
 # - `long_name_affix_position`: Position of affixes in long names (prefix or suffix).
 # - `configuration_service_parameter_semantic_id`: Parameter semantic used to distinguish
 #   between different services in configurations
-# - `functional_class_varcoding`: Functional class name for filtering varcoding services.
+# - `configuration_functional_classes`: Functional class names for filtering services that
+#   are routed to `/configurations` instead of `/data`.
+# - `category_mapping`: Maps a functional class name to a `/data` category for 0x22/0x2E
+#   services that are *not* routed to `/configurations`. A functional class must not appear
+#   both here and in `configuration_functional_classes`.
+# - `default_category`: Fallback category used for 0x22/0x2E services whose functional class
+#   is not present in `category_mapping` (and not in `configuration_functional_classes`).
 # - `short_name_affixes`: List of lowercase affixes for short names.
 #   **Each affix must match the specified `short_name_affix_position`
 #   (i.e., be a prefix if `Prefix`, or a suffix if `Suffix`).**
@@ -531,15 +537,17 @@
 #     "CAN",
 #     "ISO_11898",
 # ]
+# Maps a functional class name to a `/data` category for 0x22/0x2E services that are not
+# routed to `/configurations`. A functional class must not appear both here and in
+# `configuration_functional_classes`.
+# category_mapping = []
+# Functional class names used to route 0x22/0x2E services to `/configurations`.
+# configuration_functional_classes = ["varcoding"]
 # Semantic ID used to identify the distinguishing parameter of a service.
 # configuration_service_parameter_semantic_id = "ID"
-# Functional class name used to filter varcoding services.
-# NOTE: this is currently the only functional class routed to `/configurations`, and there is no
-# functional-class-to-category mapping for `/data` yet. See `arch~sovd-api-functional-class-mapping`
-# in docs/03_architecture/02_sovd-api/02_sovd-api.rst for the target design (a configurable list of
-# functional classes routed to `/configurations`, plus a functional-class-to-category mapping table
-# with a configurable default/fallback category for `/data`).
-# functional_class_varcoding = "varcoding"
+# Fallback category for 0x22/0x2E services whose functional class has no entry in
+# `category_mapping`.
+# default_category = "x-sovd2uds-unmapped"
 # Position of affixes in diagnostic service long names.
 # long_name_affix_position = "Suffix"
 # Ordered list of lowercase affixes to strip from long names during service lookup.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->
Implements SOVD data-categories design:
   
- database_naming_convention: replace functional_class_varcoding with
  configuration_functional_classes (list-based /configurations routing),
  category_mapping (functional class -> /data category), and
  default_category (fallback for unmapped functional classes), plus
  config sanity validation that a functional class isn't listed in both.
- cda-core: route 22h/2Eh services to /configurations based on
  configuration_functional_classes membership, and resolve a service's
  /data category via category_mapping with fallback to default_category.
- cda-sovd: add GET /components/{ecu}/data-categories, returning the
  dynamic, deduplicated set of categories currently in use by the ECU's
  /data resources.
- cda-sovd: add a categories query parameter to GET /data that filters
  items whose category matches one of a comma-separated list of values.
  Matching is case-insensitive because CDA's request normalization
  middleware lowercases the full request URI, including the query
  string, before handlers see it.
- docs: correct sovd-api.rst to reflect the above as implemented,
  removing a stale note referencing a nonexistent 'tags' query
  parameter and aligning the functional-class-mapping example with the
  actual configuration field names.
- opensovd-cda.toml: regenerated to match the new config fields.
    
/data-groups and the groups query parameter remain unimplemented


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)